### PR TITLE
docs: add SECURITY.md (vulnerability disclosure policy)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,12 +26,12 @@ In scope:
 
 - The LiteBi Claude Code plugin (`plugins/agami/`) and the SQL execution pipelines it ships.
 - The plugin marketplace manifests (`.claude-plugin/marketplace.json`, `plugins/agami/.claude-plugin/plugin.json`).
-- The telemetry endpoint under `services/telemetry-endpoint/`.
 
 Out of scope:
 
 - Third-party databases, drivers, or services LiteBi connects to.
 - Vulnerabilities in Claude Code itself (report those to Anthropic).
 - Issues that require physical access to a user's machine or already-compromised credentials.
+- `services/telemetry-endpoint/` — historical artifact, not deployed; no skill posts to it (see [its README](services/telemetry-endpoint/README.md) and [docs/privacy.md](docs/privacy.md)).
 
 Thank you for helping keep LiteBi and its users safe.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately** rather than opening a public issue.
+
+- Email: [security@agami.ai](mailto:security@agami.ai)
+- Or use GitHub Security Advisories: <https://github.com/AgamiAI/LiteBi/security/advisories/new>
+
+We will acknowledge receipt within **3 business days** and aim to provide a fix or mitigation timeline within **14 days** for confirmed vulnerabilities. Please give us a reasonable window to respond before any public disclosure.
+
+When reporting, include where possible:
+
+- A description of the issue and its impact
+- Steps to reproduce (proof-of-concept welcome)
+- Affected versions / commit SHAs
+- Any suggested remediation
+
+## Supported Versions
+
+LiteBi is in early development. We only support the **latest released version**; older releases will not receive security backports.
+
+## Scope
+
+In scope:
+
+- The LiteBi Claude Code plugin (`plugins/agami/`) and the SQL execution pipelines it ships.
+- The plugin marketplace manifests (`.claude-plugin/marketplace.json`, `plugins/agami/.claude-plugin/plugin.json`).
+- The telemetry endpoint under `services/telemetry-endpoint/`.
+
+Out of scope:
+
+- Third-party databases, drivers, or services LiteBi connects to.
+- Vulnerabilities in Claude Code itself (report those to Anthropic).
+- Issues that require physical access to a user's machine or already-compromised credentials.
+
+Thank you for helping keep LiteBi and its users safe.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` at the repo root with a private vulnerability-disclosure path: email `security@agami.ai` or use GitHub Security Advisories.
- Documents acknowledgment SLA (3 business days), fix/mitigation timeline target (14 days), in-scope vs out-of-scope, and latest-only version support during early development.

## Why

Without a security policy, a researcher who finds an issue has no choice but to file a public issue — the worst possible disclosure path. GitHub auto-detects `SECURITY.md` and surfaces it on the repo's Security tab, raising the community-health score and signaling the project takes security reports seriously.

This is part of the minimum protection set for an early-stage public repo. Alongside this PR (already applied via API):

- Secret scanning enabled
- Secret scanning push protection enabled
- Dependabot security updates enabled
- `delete_branch_on_merge` enabled

## Test plan

- [ ] After merge, fetch `gh api repos/AgamiAI/LiteBi --jq '.security_policy_url'` (or re-check `community/profile`) — `securityPolicyUrl` should populate.
- [ ] `community/profile` `health_percentage` should rise from 62 → ~75.
- [ ] Verify the file renders correctly on https://github.com/AgamiAI/LiteBi/security/policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)