### PR TITLE
feat: local MCP server (agami serve) + one-command Claude Desktop setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Lightweight BI for Claude. Local-first natural-language SQL on your own database — no infra, no servers, no data leaves your machine.",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "natural-language", "bi", "local-first", "open-source"],
     "repository": "https://github.com/AgamiAI/LiteBi",
@@ -18,7 +18,7 @@
       "name": "agami",
       "source": "./plugins/agami",
       "description": "Connect a database, ask questions in natural language, save corrections, render charts. Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server, no Python required if you have psql/mysql or DuckDB.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "keywords": ["database", "query", "sql", "natural-language", "chart", "postgres", "mysql"],
       "category": "data"
     }

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 > **The trust layer between AI agents and your data warehouse. Local. Private. Yours.**
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.1.0-blue)
+![Version](https://img.shields.io/badge/version-0.2.0-blue)
 ![Status](https://img.shields.io/badge/status-pre--public-orange)
 
 Ask plain-English questions of your **Postgres / MySQL / Snowflake / BigQuery / Redshift / SQLite** database, with a trust layer wrapped around every answer. Your credentials, schema, and query results never leave your machine — `agami` runs entirely inside Claude Code via the built-in Bash / Read / Write tools.
 
-- **No MCP server.** No backend. No `pip install` if you have a native CLI for your DB.
+- **No Agami backend.** Nothing you do touches a server we operate. The plugin runs inside Claude Code; an *optional* local MCP server (`agami serve`) lets other AI clients (e.g. Claude Desktop) use the same local model and execution — still entirely on your machine. No `pip install` if you have a native CLI for your DB. See [docs/mcp-server.md](docs/mcp-server.md).
 - **Every join is FK-derived or human-approved.** Every metric and named filter is signed off with a name, role, and timestamp. The dashboard tells you which, with the source signal.
 - **Every answer ships a receipt** — the literal SQL that ran, the model version it pinned, the relationships used, and the freshness of the source tables.
 - **Corrections persist with attribution.** Save a fix once → every subsequent query loads it as a few-shot example, with the original author and date surfaced when it influences a future answer.
@@ -177,7 +177,7 @@ Verify:
 ```
 /plugin list
 ```
-You should see `agami@litebi v0.1.0`.
+You should see `agami@litebi v0.2.0`.
 
 Detailed walkthrough: [`docs/install/claude-code-cli.md`](docs/install/claude-code-cli.md).
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,170 @@
+# Using agami from other AI clients — the local MCP server (`agami serve`)
+
+The agami plugin runs inside **Claude Code**. But your semantic model, examples,
+and local SQL execution are just files + a script — so agami can also be served
+to *any* AI client that launches a local **stdio** MCP server as a child process.
+Today that means **Claude Code** (`claude mcp add`) and **Claude Desktop**
+(`claude_desktop_config.json`).
+
+This is the local mirror of Agami's hosted "Ask Agami" connector: the same tool
+surface, but backed by your local `~/.agami` files and local DB execution instead
+of a cloud registry. Going from this local server → the hosted team product is a
+*backend swap*, not a new product.
+
+```
+your AI client  ──spawns──▶  python3 mcp_server.py   (stdio child process)
+   (Claude Code /                      │
+    Claude Desktop)                    ├─ reads  <artifacts_dir>/<profile>/  (the semantic model + examples)
+                                       └─ runs   execute_sql.py  ──▶  your local DB
+```
+
+## What it exposes
+
+Five tools, mirroring the hosted connector so the client experience is identical:
+
+| Tool | What it does |
+|---|---|
+| `list_datasources` | Enumerate local profiles (credential sections) and whether each has a model. |
+| `get_datasource_schema` | Return the semantic model: `index.yaml` + per-schema TOCs, full per-table detail for requested `dataset_names`, plus `ORGANIZATION.md` / `USER_MEMORY.md`. |
+| `get_prompt_examples` | Return the curated `examples.yaml` few-shot library. |
+| `execute_sql` | Run **one read-only** `SELECT` / `WITH...SELECT` locally and return `{columns, rows, row_count, ...}`. DML/DDL/multi-statement are rejected. |
+| `log_feedback` | Append thumbs-up/down to `~/.agami/feedback.jsonl`. |
+
+The NL→SQL *intelligence* stays on the client side (the model generates SQL from
+the schema + examples these tools return) — exactly as with the hosted connector.
+
+## Prerequisites
+
+- You've already run `agami-connect` (so `~/.agami/credentials` and a model under
+  `<artifacts_dir>/<profile>/` exist).
+- A **Python driver** for your database, because the server executes via
+  `execute_sql.py` (the Tier-3 Python path):
+
+  ```bash
+  pip install psycopg2-binary             # Postgres / Redshift
+  pip install pymysql                     # MySQL
+  pip install snowflake-connector-python  # Snowflake
+  pip install google-cloud-bigquery       # BigQuery
+  # SQLite needs nothing (stdlib)
+  ```
+
+## Connect it to Claude Code
+
+```bash
+claude mcp add agami -- python3 /ABS/PATH/to/LiteBi/plugins/agami/scripts/mcp_server.py
+```
+
+Optionally pin a profile/artifacts dir for this server with env vars:
+
+```bash
+claude mcp add agami \
+  --env AGAMI_PROFILE=main \
+  --env AGAMI_ARTIFACTS_DIR=$HOME/agami-artifacts \
+  -- python3 /ABS/PATH/to/LiteBi/plugins/agami/scripts/mcp_server.py
+```
+
+## Connect it to Claude Desktop (the Mac app)
+
+Claude Desktop is a **separate program from Claude Code** — installing the agami
+plugin via the Claude Code marketplace does *not* register the server here. The
+Mac app reads only its own `claude_desktop_config.json`.
+
+### Recommended: one command
+
+From Claude Code, just say *"set up agami for Claude Desktop"* (the **`agami-serve`**
+skill), or run the helper directly:
+
+```bash
+python3 "$AGAMI_PLUGIN_ROOT/scripts/setup_desktop_mcp.py" --dry-run   # preview the plan
+python3 "$AGAMI_PLUGIN_ROOT/scripts/setup_desktop_mcp.py"             # apply it
+```
+
+It removes all three sharp edges of hand-editing:
+
+- **auto-detects the right Python** — the interpreter that can actually import your
+  DB driver (the GUI-PATH gotcha, solved);
+- **copies the two self-contained files** (`mcp_server.py` + `execute_sql.py`) to a
+  stable `~/.agami/serve/`, so the Desktop config survives plugin updates and keeps
+  working even if the plugin is uninstalled;
+- **safely merges** the entry into `claude_desktop_config.json` — timestamped
+  backup, atomic write, every other key and MCP server preserved.
+
+Then **Cmd+Q** the app and reopen. Flags: `--profile NAME` (pin a profile),
+`--in-place` (point at a checkout instead of copying — for devs iterating on the
+server), `--config PATH` (target a different client's config file). Re-run after a
+plugin update to refresh the copied files.
+
+### Manual (what the helper does under the hood)
+
+If you'd rather edit by hand, mind these two gotchas — both silently produce
+"no tools":
+
+1. **Use an absolute path to a Python that has your DB driver.** The Mac app
+   launches helpers with a *minimal PATH*, so a bare `python3` usually isn't
+   found — and it must be the interpreter where `psycopg2` (etc.) is installed.
+   Find it: `python3 -c 'import sys,psycopg2; print(sys.executable)'` in a
+   terminal (e.g. `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3`).
+2. **Use an absolute path to `mcp_server.py`.** If you installed via the Claude
+   Code marketplace, the script lives in the version-pinned plugin cache, e.g.
+   `~/.claude/plugins/cache/litebi/agami/<version>/scripts/mcp_server.py` — note
+   that path changes on every plugin update. If you cloned the repo, point at your
+   checkout instead.
+
+Edit `claude_desktop_config.json` (Settings → Developer → Edit Config; on macOS
+`~/Library/Application Support/Claude/claude_desktop_config.json`). `mcpServers`
+is a **top-level** key (a sibling of `preferences`, not nested inside it):
+
+```json
+{
+  "mcpServers": {
+    "agami": {
+      "command": "/Library/Frameworks/Python.framework/Versions/3.12/bin/python3",
+      "args": ["/ABSOLUTE/PATH/to/scripts/mcp_server.py"],
+      "env": { "AGAMI_PROFILE": "main" }
+    }
+  }
+}
+```
+
+**Cmd+Q to fully quit** the app (not just close the window), then reopen. It
+spawns the server as a child process over stdin/stdout — **there is no URL and no
+port.** Logs are at `~/Library/Logs/Claude/mcp-server-agami.log`.
+
+> **Containment — confirmed working (verified 2026-06 on the macOS app).** A
+> custom stdio MCP server runs with your full user access: it reads `~/.agami`
+> and executes SQL against your DB from inside the Mac app, no directory-mount
+> prompt required. (The "mount a directory" sandbox applies to Claude's *built-in*
+> file tools, not custom MCP servers.) This is app-version-dependent, so if a
+> future build changes it — `list_datasources` returns empty or `execute_sql`
+> reports missing-credentials/`not_found` — fall back to **Claude Code** (the CLI),
+> where it always runs with full local access.
+
+## Security model — no authentication, by design
+
+A stdio MCP server has **no authentication**, and that is correct:
+
+- The transport is a child process the client launches **as you**, communicating
+  over OS pipes. The trust boundary is your OS user account — the server reads the
+  same `~/.agami/credentials` you already have. There is nothing to authenticate
+  *to*. (The MCP spec defines auth for the *HTTP* transport, not stdio.)
+- It does **not** widen your attack surface beyond already having `psql` + a
+  `.pgpass` on your laptop.
+- **Read-only is enforced**: `execute_sql` rejects anything that isn't a single
+  `SELECT` / `WITH...SELECT` (see `shared/sql-generation-rules.md → Safety Rules`).
+- **It is stdio-only on purpose.** It never binds a network port. Doing so would
+  create an *unauthenticated network listener* exposing query execution. If you
+  need networked, multi-user serving with auth + RBAC + audit, that is the hosted
+  Agami product — by design, not by omission.
+
+## Local ↔ hosted: same interface, different backend
+
+| | This local server (`agami serve`) | Hosted "Ask Agami" connector |
+|---|---|---|
+| Transport | stdio (local child process) | remote HTTPS (cloud-reachable) |
+| Reachable from | Claude Code, Claude Desktop | Claude/Cowork/web/mobile, ChatGPT |
+| Auth | none (OS user boundary) | OAuth/SSO + RBAC + audit |
+| Model store | your local YAML files | shared multi-tenant registry |
+| Evals | run `examples` in CI yourself | managed continuous evals + golden sets |
+
+Because the tool surface matches, moving a team from local to hosted is a backend
+swap — see [open-vs-hosted.md](open-vs-hosted.md).

--- a/docs/open-vs-hosted.md
+++ b/docs/open-vs-hosted.md
@@ -1,0 +1,59 @@
+# What's open source, what's hosted
+
+agami is **open core**. This page states the boundary plainly so you can build on
+the open pieces without worrying we'll move the line under you.
+
+## The principle
+
+> **The laptop plugin is fully open (Apache-2.0) and always will be. The team
+> cloud is our business.**
+
+Concretely, the line falls where value stops being single-player and starts
+requiring *more than one person* — which is also where self-hosting stops being
+a weekend project and starts being real infrastructure.
+
+## Open source (this repo, Apache-2.0 — single developer, local)
+
+Everything you need to get value as one developer, on your own machine:
+
+- Schema introspection → an **OSI v0.1.1 semantic model** (the format itself is an
+  open standard — your model is portable, never locked in).
+- NL→SQL generation and **local execution** against your DB (Postgres / MySQL /
+  Snowflake / BigQuery / Redshift / SQLite).
+- The **trust layer**: confidence scoring, single-reviewer sign-off, receipts,
+  snapshots, git-native model history.
+- **Corrections** + the `examples.yaml` few-shot library.
+- The **local MCP server** (`agami serve`) — use agami from Claude Code / Claude
+  Desktop. stdio, no auth, no network. See [mcp-server.md](mcp-server.md).
+- You can run your own evals in CI (run `examples.yaml` against the model on a PR)
+  and serve a shared model to your team via git + a server you operate. We won't
+  obstruct that — it's a feature.
+
+## Hosted (the Agami cloud — teams, governed, always-on)
+
+The pieces whose value needs a team, and that are a genuine pain to self-host:
+
+- A **multi-tenant semantic-model registry** served to many users/agents over a
+  stable remote MCP endpoint (reachable from Claude/Cowork/web/mobile and ChatGPT).
+- **Shared, governed** examples + memory/context across a team.
+- **Continuous / real-time evals**: scheduled runs, regression alerting,
+  dashboards, **golden-dataset management** + the cross-customer golden-set
+  network effect.
+- **CI-gated deploys**: gate a model change on eval-pass, versioned deploy + rollback.
+- **Governance at team scale**: OAuth/SSO, RBAC, per-tool permissions, org-wide audit.
+
+## Why this split (and why we won't relicense the core)
+
+The defensive reason companies adopt source-available licenses (BSL/SSPL) is to
+stop a competitor from re-hosting their open core as a competing SaaS. That threat
+doesn't apply here: the open core is **single-player and file-based** — there's
+nothing to re-SaaS without rebuilding the entire (closed) team backend. So we keep
+the core permissive Apache-2.0, like dbt Core and the LlamaIndex library.
+
+## The upgrade path is a backend swap
+
+Because the local MCP server and the hosted connector expose the **same tool
+surface**, moving a team from local to hosted means pointing at a different
+backend — not learning a new product. You self-host the flat, commoditized part
+for free; you pay for the part that compounds (evals, the golden-set network
+effect, governance) the day it's worth more than running it yourself.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -62,6 +62,23 @@ That's the entire outbound surface: opening one well-known URL in your browser w
 
 ---
 
+## The optional local MCP server keeps the same guarantee
+
+`agami serve` (`plugins/agami/scripts/mcp_server.py`) lets you use agami from
+Claude Code / Claude Desktop. It changes nothing about this privacy posture:
+
+- It speaks the MCP **stdio** transport — a child process of your AI client,
+  reading/writing OS pipes. It **never binds a network port** and makes **no
+  network call**. `tests/test_mcp_server.py` enforces this (the source is
+  asserted to contain no socket/http/urllib/requests primitives).
+- It reads only the same local paths listed above and executes SQL locally via
+  `execute_sql.py`. Only the rows you'd see anyway are returned to your client.
+- It has **no authentication** because it needs none: the trust boundary is your
+  OS user account. (Networked, authenticated, multi-user serving is the hosted
+  product — see [open-vs-hosted.md](open-vs-hosted.md).)
+
+---
+
 ## Vestigial telemetry code (preserved, not invoked)
 
 Early designs of agami had an opt-in telemetry path that sent anonymous usage counts to a hosted endpoint. That path was removed from the runtime in the 0.x line. The implementation code remains in the repo as historical artifacts:

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami",
   "description": "Ask plain-English questions of your Postgres / MySQL / Snowflake / BigQuery / Redshift / SQLite database, with a trust layer so the answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",

--- a/plugins/agami/scripts/README.md
+++ b/plugins/agami/scripts/README.md
@@ -10,8 +10,10 @@ Two categories of Python scripts ship with agami:
 | Script | What it does | Requires |
 |---|---|---|
 | `execute_sql.py` | Reads `~/.agami/credentials`, opens a connection, runs ONE SQL statement, emits RFC 4180 CSV on stdout. Supports postgres / mysql / sqlite. Hard-exits with a clear message if credentials are missing — never asks in chat. | One of: `psycopg2-binary` (postgres), `pymysql` (mysql); sqlite uses stdlib |
+| `mcp_server.py` | **Optional** local stdio MCP server (`agami serve`) — exposes the local semantic model + read-only local SQL execution over the Model Context Protocol, so agami can be used from Claude Code / Claude Desktop and not just inside the plugin. Pure stdlib; routes execution through `execute_sql.py`; no network, no auth, no telemetry. See [`docs/mcp-server.md`](../../../docs/mcp-server.md). | stdlib only (plus the relevant `execute_sql.py` driver for non-SQLite DBs) |
+| `setup_desktop_mcp.py` | One-command wiring of `mcp_server.py` into the Claude Desktop app (used by the `agami-serve` skill). Auto-detects the right Python interpreter, copies the two self-contained server files to a stable `~/.agami/serve/`, and safely merges the entry into `claude_desktop_config.json` (timestamped backup + atomic write, preserving every other key). `--dry-run` previews; `--in-place` skips the copy for dev checkouts. | stdlib only |
 
-The agami skill calls it via:
+The agami skill calls `execute_sql.py` via:
 
 ```bash
 # Single-line SQL via --sql

--- a/plugins/agami/scripts/mcp_server.py
+++ b/plugins/agami/scripts/mcp_server.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""
+agami serve — a local, single-player MCP server (stdio transport).
+
+Exposes the *local* semantic model + local SQL execution over the Model
+Context Protocol so a developer can use agami from any MCP-capable client
+that launches a local stdio server as a child process — chiefly **Claude
+Code** (`claude mcp add`) and **Claude Desktop** (`claude_desktop_config.json`).
+
+This is the local mirror of the hosted "Ask Agami" connector: the same tool
+surface (list_datasources / get_datasource_schema / get_prompt_examples /
+execute_sql / log_feedback), but backed by the user's local .agami files and
+local DB execution instead of a cloud registry. Going from local → team is a
+backend swap, not a new product.
+
+Design constraints (match the rest of agami):
+  - **Zero third-party dependencies.** Pure stdlib: the MCP stdio protocol is
+    newline-delimited JSON-RPC 2.0, which we speak by hand. Grep the source —
+    there is no network call here, no auth, no telemetry.
+  - **No data leaves the machine.** SQL is executed locally by shelling out to
+    the sibling `execute_sql.py` (the same Tier-3 executor the skills use); the
+    semantic model is read from `<artifacts_dir>/<profile>/` and returned as-is.
+  - **Security model = the OS user boundary.** A stdio server is a child process
+    of the client, running as you, reading the creds you already have. There is
+    deliberately NO authentication (the MCP spec defines auth for the HTTP
+    transport only). NEVER make this bind a network port — that would create an
+    unauthenticated listener. If you need networked/multi-user serving with
+    auth + RBAC + audit, that is the hosted product, by design.
+
+Execution path: this server routes SQL through `execute_sql.py` (the Python
+driver tier), so the relevant driver must be importable for non-SQLite DBs
+(`psycopg2-binary` / `pymysql` / `snowflake-connector-python` /
+`google-cloud-bigquery`). SQLite needs nothing (stdlib).
+
+Wire it up:
+    # Claude Code
+    claude mcp add agami -- python3 /ABS/PATH/plugins/agami/scripts/mcp_server.py
+
+    # Claude Desktop — claude_desktop_config.json
+    {
+      "mcpServers": {
+        "agami": {
+          "command": "python3",
+          "args": ["/ABS/PATH/plugins/agami/scripts/mcp_server.py"],
+          "env": { "AGAMI_PROFILE": "main" }
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+# ---------------------------------------------------------------------------
+# Paths & config resolution (mirrors execute_sql.py / file-layout.md exactly)
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+EXECUTE_SQL = SCRIPT_DIR / "execute_sql.py"
+AGAMI_HOME = Path.home() / ".agami"
+CREDENTIALS_PATH = AGAMI_HOME / "credentials"
+CONFIG_PATH = AGAMI_HOME / ".config"
+QUERY_LOG = AGAMI_HOME / "query_log.jsonl"
+FEEDBACK_LOG = AGAMI_HOME / "feedback.jsonl"
+
+SERVER_NAME = "agami"
+# The protocol version we fall back to if the client doesn't pin one. We echo
+# the client's requested version when present (see _handle_initialize).
+DEFAULT_PROTOCOL_VERSION = "2024-11-05"
+
+
+def _server_version() -> str:
+    """Best-effort plugin version.
+
+    Prefer the AGAMI_VERSION env var (set by setup_desktop_mcp.py when the server
+    is copied to a standalone ~/.agami/serve dir, where the marketplace.json
+    isn't reachable), then fall back to reading the shipped manifest.
+    """
+    env_v = os.environ.get("AGAMI_VERSION")
+    if env_v:
+        return env_v
+    for rel in ("../../.claude-plugin/marketplace.json", "../.claude-plugin/plugin.json"):
+        p = (SCRIPT_DIR / rel).resolve()
+        try:
+            text = p.read_text()
+        except OSError:
+            continue
+        m = re.search(r'"version"\s*:\s*"([^"]+)"', text)
+        if m:
+            return m.group(1)
+    return "0.0.0"
+
+
+def _load_config() -> dict[str, Any]:
+    if CONFIG_PATH.exists():
+        try:
+            return json.loads(CONFIG_PATH.read_text())
+        except (OSError, ValueError):
+            pass
+    return {}
+
+
+def resolve_profile(explicit: str | None = None) -> str:
+    """Resolution order: explicit arg → AGAMI_PROFILE → .config.active_profile → 'default'."""
+    if explicit:
+        return explicit
+    env = os.environ.get("AGAMI_PROFILE")
+    if env:
+        return env
+    active = _load_config().get("active_profile")
+    if isinstance(active, str) and active:
+        return active
+    return "default"
+
+
+def resolve_artifacts_dir() -> Path:
+    """Resolution order: AGAMI_ARTIFACTS_DIR → .config.artifacts_dir → $HOME/agami-artifacts."""
+    env = os.environ.get("AGAMI_ARTIFACTS_DIR")
+    if env:
+        return Path(env).expanduser()
+    cfg = _load_config().get("artifacts_dir")
+    if isinstance(cfg, str) and cfg:
+        return Path(cfg).expanduser()
+    return Path.home() / "agami-artifacts"
+
+
+def _credentials_sections() -> dict[str, dict[str, str]]:
+    """Parse ~/.agami/credentials (INI) into {profile: {field: value}}. Empty on any error."""
+    if not CREDENTIALS_PATH.exists():
+        return {}
+    import configparser
+
+    cfg = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
+    try:
+        cfg.read(CREDENTIALS_PATH)
+    except configparser.Error:
+        return {}
+    out: dict[str, dict[str, str]] = {}
+    for section in cfg.sections():
+        out[section] = {k: (v.strip() if isinstance(v, str) else v) for k, v in cfg[section].items()}
+    return out
+
+
+def _db_type_for(profile: str, creds: dict[str, dict[str, str]]) -> str:
+    sect = creds.get(profile, {})
+    t = sect.get("type", "")
+    if not t and sect.get("url"):
+        scheme = sect["url"].split("://", 1)[0].split("+", 1)[0].lower()
+        t = {"postgresql": "postgres", "postgres": "postgres", "mysql": "mysql",
+              "mariadb": "mysql", "redshift": "redshift", "snowflake": "snowflake",
+              "bigquery": "bigquery", "bq": "bigquery", "sqlite": "sqlite"}.get(scheme, scheme)
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Read-only SQL guard (mirrors shared/sql-generation-rules.md → Safety Rules)
+# ---------------------------------------------------------------------------
+
+_COMMENT_LINE = re.compile(r"--[^\n]*")
+_COMMENT_BLOCK = re.compile(r"/\*.*?\*/", re.DOTALL)
+# Data-modifying statements that could ride after a leading WITH (Postgres
+# allows `WITH x AS (...) DELETE ...`). DDL (DROP/CREATE/ALTER/TRUNCATE) cannot
+# follow WITH, and a single statement that begins with SELECT/WITH otherwise
+# cannot mutate — so guarding these four keywords + the leading-token + the
+# single-statement rule is sufficient without the false positives of scanning
+# every DDL keyword (which collide with identifiers like create_date).
+_MUTATION = re.compile(r"\b(INSERT|UPDATE|DELETE|MERGE)\b", re.IGNORECASE)
+
+
+def _strip_comments(sql: str) -> str:
+    return _COMMENT_BLOCK.sub(" ", _COMMENT_LINE.sub(" ", sql))
+
+
+def check_read_only(sql: str) -> str | None:
+    """Return None if the SQL is a safe single read-only statement, else a reason string."""
+    stripped = _strip_comments(sql).strip()
+    # Tolerate a single trailing semicolon; reject any interior one (multi-statement).
+    if stripped.endswith(";"):
+        stripped = stripped[:-1].strip()
+    if not stripped:
+        return "empty statement"
+    if ";" in stripped:
+        return "multiple statements are not allowed — send one SELECT"
+    head = stripped.lstrip("(").split(None, 1)[0].upper() if stripped else ""
+    if head not in ("SELECT", "WITH"):
+        return f"only SELECT / WITH...SELECT is allowed (statement starts with {head or '?'})"
+    if _MUTATION.search(stripped):
+        return "statement contains a data-modifying keyword (INSERT/UPDATE/DELETE/MERGE)"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+
+def tool_list_datasources(_args: dict[str, Any]) -> str:
+    """Local analog of Ask Agami `list_organizations`: enumerate local profiles."""
+    creds = _credentials_sections()
+    artifacts = resolve_artifacts_dir()
+    active = resolve_profile()
+    out = []
+    for profile in sorted(creds.keys()):
+        pdir = artifacts / profile
+        dataset_count = 0
+        if pdir.is_dir():
+            dataset_count = sum(
+                1
+                for f in pdir.rglob("*.yaml")
+                if f.name not in ("index.yaml", "_schema.yaml")
+            )
+        out.append({
+            "datasource": profile,
+            "database_type": _db_type_for(profile, creds),
+            "dataset_count": dataset_count,
+            "model_present": (pdir / "index.yaml").exists(),
+            "is_active": profile == active,
+        })
+    if not out:
+        return json.dumps({
+            "datasources": [],
+            "note": "No profiles found in ~/.agami/credentials. Run the agami-connect skill first.",
+        }, indent=2)
+    return json.dumps({"datasources": out, "active_datasource": active}, indent=2)
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text()
+    except OSError:
+        return None
+
+
+def tool_get_datasource_schema(args: dict[str, Any]) -> str:
+    """Local analog of Ask Agami `get_datasource_schema`.
+
+    Returns the curated semantic-model context as text — exactly the files the
+    agami-query-database skill reads: index.yaml + every <schema>/_schema.yaml
+    (the Pass-1 slim TOC), plus the full per-table yaml for any `dataset_names`
+    passed (Pass-2 lazy-load), plus ORGANIZATION.md and USER_MEMORY.md context.
+    """
+    profile = resolve_profile(args.get("datasource"))
+    artifacts = resolve_artifacts_dir()
+    pdir = artifacts / profile
+    if not (pdir / "index.yaml").exists():
+        return json.dumps({
+            "error": {
+                "kind": "not_found",
+                "remediation": f"No semantic model at {pdir}/index.yaml. "
+                               f"Run the agami-connect skill to introspect this database.",
+            }
+        }, indent=2)
+
+    parts: list[str] = [f"# Semantic model for datasource '{profile}'  (source: {pdir})\n"]
+
+    idx = _read_text(pdir / "index.yaml")
+    if idx is not None:
+        parts.append(f"## index.yaml\n```yaml\n{idx}\n```\n")
+
+    # Pass 1: every <schema>/_schema.yaml (slim TOC + relationships)
+    for schema_file in sorted(pdir.glob("*/_schema.yaml")):
+        text = _read_text(schema_file)
+        if text is not None:
+            rel = schema_file.relative_to(pdir)
+            parts.append(f"## {rel}\n```yaml\n{text}\n```\n")
+
+    # Pass 2: full per-table yaml for explicitly requested datasets.
+    requested = args.get("dataset_names") or []
+    if requested:
+        wanted = {str(n).split(".")[-1].lower() for n in requested}
+        for table_file in sorted(pdir.glob("*/*.yaml")):
+            if table_file.name in ("index.yaml", "_schema.yaml"):
+                continue
+            if table_file.stem.lower() in wanted:
+                text = _read_text(table_file)
+                if text is not None:
+                    rel = table_file.relative_to(pdir)
+                    parts.append(f"## {rel}  (full table model)\n```yaml\n{text}\n```\n")
+
+    org = _read_text(pdir / "ORGANIZATION.md")
+    if org and org.strip():
+        parts.append(f"## ORGANIZATION.md (domain context)\n{org}\n")
+    user_mem = _read_text(artifacts / "USER_MEMORY.md")
+    if user_mem and user_mem.strip():
+        parts.append(f"## USER_MEMORY.md (cross-database preferences)\n{user_mem}\n")
+
+    if not requested:
+        parts.append(
+            "\n> Note: per-table field detail is lazy-loaded. Call get_datasource_schema "
+            "again with `dataset_names: [...]` to pull the full model for the tables you need."
+        )
+    return "\n".join(parts)
+
+
+def tool_get_prompt_examples(args: dict[str, Any]) -> str:
+    """Local analog of Ask Agami `get_prompt_examples`: the few-shot library.
+
+    Returns the curated examples.yaml verbatim as text. Local serving has no
+    embedding store, so `query`/`top_k` are accepted for interface-parity with
+    the hosted connector but do not rank or cap — the full curated library is
+    returned (it is small; the client reads YAML directly).
+    """
+    profile = resolve_profile(args.get("datasource"))
+    artifacts = resolve_artifacts_dir()
+    examples_path = artifacts / profile / "examples.yaml"
+    text = _read_text(examples_path)
+    if text is None:
+        # v1.0 fallback layout
+        text = _read_text(AGAMI_HOME / f"{profile}-examples.yaml")
+    if text is None:
+        return json.dumps({
+            "examples": [],
+            "note": f"No examples library at {examples_path}. "
+                    f"Corrections saved via agami-save-correction will appear here.",
+        }, indent=2)
+    header = (
+        f"# Few-shot NL→SQL examples for datasource '{profile}'  (source: {examples_path})\n"
+        f"# Use these to ground SQL dialect and house style.\n"
+    )
+    return header + "\n```yaml\n" + text + "\n```\n"
+
+
+def _classify_exit(code: int) -> str:
+    return {
+        2: "dsn",            # config / missing credentials / bad profile
+        3: "driver_missing",
+        4: "auth",           # connect / auth failed (also network)
+        5: "syntax",         # SQL execution error
+    }.get(code, "other")
+
+
+def tool_execute_sql(args: dict[str, Any]) -> str:
+    """Local analog of Ask Agami `execute_sql`: run a read-only SELECT locally.
+
+    Routes through the sibling execute_sql.py (Tier-3 Python executor) so all
+    DB types are handled identically and nothing but the rows leaves the
+    process. Enforces the same read-only guarantee as the hosted connector.
+    """
+    sql = args.get("sql")
+    if not isinstance(sql, str) or not sql.strip():
+        return json.dumps({"error": {"kind": "other", "remediation": "Pass a non-empty `sql` string."}})
+
+    reason = check_read_only(sql)
+    if reason is not None:
+        return json.dumps({
+            "error": {"kind": "permission", "remediation": reason},
+            "sql": sql,
+        }, indent=2)
+
+    profile = resolve_profile(args.get("datasource"))
+    max_rows = args.get("max_rows")
+    try:
+        max_rows = int(max_rows) if max_rows is not None else None
+    except (TypeError, ValueError):
+        max_rows = None
+    if max_rows is not None:
+        max_rows = max(1, min(max_rows, 10_000))
+
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(EXECUTE_SQL), "--profile", profile, "--sql", sql],
+            capture_output=True,
+            text=True,
+            timeout=240,
+        )
+    except subprocess.TimeoutExpired:
+        return json.dumps({"error": {"kind": "timeout", "remediation": "Query exceeded 240s."}, "sql": sql})
+    execution_ms = int((time.monotonic() - started) * 1000)
+
+    if proc.returncode != 0:
+        return json.dumps({
+            "error": {
+                "kind": _classify_exit(proc.returncode),
+                "remediation": (proc.stderr or "").strip() or "execute_sql.py failed",
+            },
+            "sql": sql,
+            "execution_ms": execution_ms,
+        }, indent=2)
+
+    # Parse the RFC-4180 CSV emitted on stdout.
+    reader = csv.reader(io.StringIO(proc.stdout))
+    rows_all = list(reader)
+    columns = rows_all[0] if rows_all else []
+    data_rows = rows_all[1:] if len(rows_all) > 1 else []
+    truncated = False
+    if max_rows is not None and len(data_rows) > max_rows:
+        data_rows = data_rows[:max_rows]
+        truncated = True
+
+    result = {
+        "columns": columns,
+        "rows": data_rows,
+        "row_count": len(data_rows),
+        "truncated": truncated,
+        "sql": sql,
+        "execution_ms": execution_ms,
+    }
+
+    # Append to the personal query log (same file the skills use), best-effort.
+    _append_jsonl(QUERY_LOG, {
+        "ts": _now_iso(),
+        "profile": profile,
+        "question": args.get("raw_query"),
+        "sql": sql,
+        "row_count": len(data_rows),
+        "source": "mcp_server",
+    })
+    return json.dumps(result, indent=2, default=str)
+
+
+def tool_log_feedback(args: dict[str, Any]) -> str:
+    """Local analog of Ask Agami `log_feedback`: append to ~/.agami/feedback.jsonl."""
+    raw_query = args.get("raw_query")
+    rating = args.get("rating")
+    if not raw_query or not rating:
+        return json.dumps({"error": {"kind": "other", "remediation": "raw_query and rating are required."}})
+    norm = str(rating).strip().lower()
+    good = {"good", "positive", "thumbs_up", "👍", "up", "yes"}
+    bad = {"bad", "negative", "thumbs_down", "👎", "down", "no"}
+    rating_value = "Good" if norm in good else "Bad" if norm in bad else str(rating)
+    ok = _append_jsonl(FEEDBACK_LOG, {
+        "ts": _now_iso(),
+        "profile": resolve_profile(args.get("datasource")),
+        "question": raw_query,
+        "rating": rating_value,
+        "notes": args.get("notes"),
+        "source": "mcp_server",
+    })
+    if not ok:
+        return json.dumps({"error": {"kind": "other", "remediation": f"Could not write {FEEDBACK_LOG}."}})
+    return json.dumps({"ok": True, "rating": rating_value, "logged_to": str(FEEDBACK_LOG)})
+
+
+def _now_iso() -> str:
+    # Avoid Date.now-style nondeterminism concerns: use UTC wall clock here is fine
+    # (this is a long-running server process, not a replayed workflow).
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _append_jsonl(path: Path, record: dict[str, Any]) -> bool:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, default=str) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tool registry (name → (handler, description, inputSchema))
+# ---------------------------------------------------------------------------
+
+TOOLS: dict[str, dict[str, Any]] = {
+    "list_datasources": {
+        "handler": tool_list_datasources,
+        "description": (
+            "List the local agami datasources (credential profiles) and whether each has a "
+            "semantic model. Local analog of the hosted list_organizations. Call this first "
+            "when the datasource is not yet known; the others accept an optional `datasource`."
+        ),
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    },
+    "get_datasource_schema": {
+        "handler": tool_get_datasource_schema,
+        "description": (
+            "Fetch the local semantic model for a datasource: index + per-schema TOCs (Pass 1), "
+            "plus the full per-table model for any `dataset_names` you pass (Pass 2 lazy-load), "
+            "plus ORGANIZATION.md / USER_MEMORY.md context. Use the metric/measure `calculation` "
+            "fields VERBATIM when generating SQL."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "datasource": {"type": "string", "description": "Profile name; defaults to the active profile."},
+                "dataset_names": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Tables to pull full field-level detail for (Pass 2).",
+                },
+                "query": {"type": "string", "description": "The user's NL question (context only; not used for ranking locally)."},
+            },
+            "additionalProperties": False,
+        },
+    },
+    "get_prompt_examples": {
+        "handler": tool_get_prompt_examples,
+        "description": (
+            "Fetch the curated few-shot NL→SQL examples (examples.yaml) for a datasource. "
+            "Use before generating SQL to ground dialect and house style. Local analog of the "
+            "hosted get_prompt_examples; returns the full curated library (no cosine ranking locally)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "datasource": {"type": "string", "description": "Profile name; defaults to the active profile."},
+                "query": {"type": "string", "description": "The user's NL question (context only)."},
+                "top_k": {"type": "integer", "description": "Accepted for hosted-parity; not applied locally."},
+            },
+            "additionalProperties": False,
+        },
+    },
+    "execute_sql": {
+        "handler": tool_execute_sql,
+        "description": (
+            "Execute a single read-only SELECT / WITH...SELECT against the local datasource and "
+            "return {columns, rows, row_count, truncated, sql, execution_ms}. SELECT-only is "
+            "enforced (DML/DDL/multi-statement rejected with kind='permission'). Runs entirely "
+            "locally via execute_sql.py — no data leaves the machine."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "sql": {"type": "string", "description": "One SELECT or WITH...SELECT statement."},
+                "datasource": {"type": "string", "description": "Profile name; defaults to the active profile."},
+                "raw_query": {"type": "string", "description": "The user's NL question (recorded in the query log)."},
+                "max_rows": {"type": "integer", "description": "Row cap (clamped 1–10000)."},
+            },
+            "required": ["sql"],
+            "additionalProperties": False,
+        },
+    },
+    "log_feedback": {
+        "handler": tool_log_feedback,
+        "description": (
+            "Record thumbs-up/down feedback for a question to the local ~/.agami/feedback.jsonl. "
+            "Local analog of the hosted log_feedback."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "raw_query": {"type": "string", "description": "The NL question the user asked."},
+                "rating": {"type": "string", "description": "good/bad (also accepts positive/negative/👍/👎)."},
+                "notes": {"type": "string", "description": "Optional free-text comment."},
+                "datasource": {"type": "string", "description": "Profile name; defaults to the active profile."},
+            },
+            "required": ["raw_query", "rating"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC 2.0 / MCP stdio transport (newline-delimited messages)
+# ---------------------------------------------------------------------------
+
+
+def _log(msg: str) -> None:
+    """Diagnostics go to stderr — stdout is reserved for protocol messages."""
+    sys.stderr.write(f"[agami-mcp] {msg}\n")
+    sys.stderr.flush()
+
+
+def _send(message: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def _result(req_id: Any, result: Any) -> None:
+    _send({"jsonrpc": "2.0", "id": req_id, "result": result})
+
+
+def _error(req_id: Any, code: int, message: str) -> None:
+    _send({"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}})
+
+
+def _handle_initialize(req_id: Any, params: dict[str, Any]) -> None:
+    requested = params.get("protocolVersion")
+    protocol = requested if isinstance(requested, str) and requested else DEFAULT_PROTOCOL_VERSION
+    _result(req_id, {
+        "protocolVersion": protocol,
+        "capabilities": {"tools": {"listChanged": False}},
+        "serverInfo": {"name": SERVER_NAME, "version": _server_version()},
+        "instructions": (
+            "agami local datasource agent. The NL→SQL intelligence runs on your side; these "
+            "tools provide the local semantic model + curated examples and execute SQL locally. "
+            "Discover datasources with list_datasources, fetch the model + examples for the one "
+            "the question touches, generate SQL using metric `calculation` fields verbatim, then "
+            "execute_sql. All execution is local; nothing leaves the machine."
+        ),
+    })
+
+
+def _handle_tools_list(req_id: Any) -> None:
+    _result(req_id, {
+        "tools": [
+            {"name": name, "description": meta["description"], "inputSchema": meta["inputSchema"]}
+            for name, meta in TOOLS.items()
+        ]
+    })
+
+
+def _handle_tools_call(req_id: Any, params: dict[str, Any]) -> None:
+    name = params.get("name")
+    arguments = params.get("arguments") or {}
+    meta = TOOLS.get(name)
+    if meta is None:
+        _error(req_id, -32602, f"Unknown tool: {name}")
+        return
+    handler: Callable[[dict[str, Any]], str] = meta["handler"]
+    try:
+        text = handler(arguments)
+        _result(req_id, {"content": [{"type": "text", "text": text}], "isError": False})
+    except Exception as exc:  # never let one tool call kill the server
+        _log(f"tool {name} raised: {exc!r}")
+        _result(req_id, {
+            "content": [{"type": "text", "text": json.dumps({"error": {"kind": "other", "remediation": str(exc)}})}],
+            "isError": True,
+        })
+
+
+def serve() -> int:
+    _log(f"starting (version {_server_version()}); reading stdio JSON-RPC")
+    for raw in sys.stdin:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except ValueError:
+            _log(f"skipping non-JSON line: {line[:80]!r}")
+            continue
+
+        method = msg.get("method")
+        req_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        # Notifications (no id) — acknowledge by doing nothing that needs a reply.
+        if req_id is None:
+            if method == "notifications/initialized":
+                _log("client initialized")
+            # notifications/cancelled, etc. are safely ignored
+            continue
+
+        if method == "initialize":
+            _handle_initialize(req_id, params)
+        elif method == "ping":
+            _result(req_id, {})
+        elif method == "tools/list":
+            _handle_tools_list(req_id)
+        elif method == "tools/call":
+            _handle_tools_call(req_id, params)
+        else:
+            _error(req_id, -32601, f"Method not found: {method}")
+    _log("stdin closed; exiting")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(serve())
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/plugins/agami/scripts/setup_desktop_mcp.py
+++ b/plugins/agami/scripts/setup_desktop_mcp.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+setup_desktop_mcp.py — one-command wiring of `agami serve` into the Claude
+Desktop app (and other clients that read a `claude_desktop_config.json`-style
+file).
+
+Hand-editing `claude_desktop_config.json` has three sharp edges that this script
+removes:
+
+  1. **The GUI-PATH gotcha.** The desktop app launches helpers with a minimal
+     PATH, so a bare `python3` isn't found — and it must be the interpreter that
+     can import your DB driver (psycopg2 / pymysql / …). We auto-detect it.
+  2. **The install-path gotcha.** A marketplace-installed plugin lives in a
+     version-pinned cache dir that moves on every update. We copy the two
+     self-contained files (`mcp_server.py` + `execute_sql.py`) to a STABLE
+     `~/.agami/serve/` so the Desktop config never needs to change again — and
+     keeps working even if the plugin is later uninstalled.
+  3. **The merge gotcha.** `mcpServers` is a top-level key; a stray comma breaks
+     the whole file. We back up, merge (preserving every other key), write
+     atomically, and validate.
+
+Usage:
+    python3 setup_desktop_mcp.py                 # wire active profile into Desktop
+    python3 setup_desktop_mcp.py --profile main  # pin a specific profile
+    python3 setup_desktop_mcp.py --dry-run       # show the plan, write nothing
+    python3 setup_desktop_mcp.py --in-place      # point at this checkout (dev mode; no copy)
+    python3 setup_desktop_mcp.py --python /abs/python3   # force an interpreter
+    python3 setup_desktop_mcp.py --config /path/to/config.json  # override target file
+
+Stdlib only. Reads nothing secret beyond ~/.agami/credentials (to learn the
+active profile's db type → which driver to require). Writes only the stable
+serve dir + the desktop config (with a timestamped backup).
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+AGAMI_HOME = Path.home() / ".agami"
+CREDENTIALS_PATH = AGAMI_HOME / "credentials"
+CONFIG_PATH = AGAMI_HOME / ".config"
+STABLE_SERVE_DIR = AGAMI_HOME / "serve"
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+# Files the server needs at runtime (both are self-contained stdlib modules).
+SERVE_FILES = ("mcp_server.py", "execute_sql.py")
+
+# db_type → the Python module that must be importable to execute against it.
+DB_DRIVER_MODULE = {
+    "postgres": "psycopg2",
+    "redshift": "psycopg2",
+    "mysql": "pymysql",
+    "snowflake": "snowflake.connector",
+    "bigquery": "google.cloud.bigquery",
+    "sqlite": None,  # stdlib
+}
+
+DRIVER_PIP = {
+    "psycopg2": "psycopg2-binary",
+    "pymysql": "pymysql",
+    "snowflake.connector": "snowflake-connector-python",
+    "google.cloud.bigquery": "google-cloud-bigquery",
+}
+
+
+def _load_config() -> dict:
+    if CONFIG_PATH.exists():
+        try:
+            return json.loads(CONFIG_PATH.read_text())
+        except (OSError, ValueError):
+            pass
+    return {}
+
+
+def resolve_profile(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    env = os.environ.get("AGAMI_PROFILE")
+    if env:
+        return env
+    active = _load_config().get("active_profile")
+    if isinstance(active, str) and active:
+        return active
+    return "default"
+
+
+def db_type_for_profile(profile: str) -> str | None:
+    """Read the profile's db type from ~/.agami/credentials (best-effort)."""
+    if not CREDENTIALS_PATH.exists():
+        return None
+    cfg = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
+    try:
+        cfg.read(CREDENTIALS_PATH)
+    except configparser.Error:
+        return None
+    if profile not in cfg:
+        return None
+    sect = cfg[profile]
+    t = (sect.get("type") or "").strip().lower()
+    if not t and sect.get("url"):
+        scheme = sect["url"].split("://", 1)[0].split("+", 1)[0].lower()
+        t = {"postgresql": "postgres", "postgres": "postgres", "mysql": "mysql",
+             "mariadb": "mysql", "redshift": "redshift", "snowflake": "snowflake",
+             "bigquery": "bigquery", "bq": "bigquery", "sqlite": "sqlite"}.get(scheme, scheme)
+    return t or None
+
+
+def _interpreter_can_import(py: str, module: str | None) -> bool:
+    if module is None:
+        # sqlite / unknown — any working python3 is fine
+        code = "import sys; assert sys.version_info >= (3, 8)"
+    else:
+        code = f"import {module}"
+    try:
+        return subprocess.run([py, "-c", code], capture_output=True, timeout=20).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def find_interpreter(module: str | None, forced: str | None) -> str | None:
+    """Return an absolute python that can import `module`, or None."""
+    candidates: list[str] = []
+    if forced:
+        candidates = [forced]
+    else:
+        candidates = [
+            sys.executable,
+            shutil.which("python3") or "",
+            "/Library/Frameworks/Python.framework/Versions/3.12/bin/python3",
+            "/Library/Frameworks/Python.framework/Versions/3.11/bin/python3",
+            "/usr/local/bin/python3",
+            "/opt/homebrew/bin/python3",
+            "/usr/bin/python3",
+            str(Path.home() / ".pyenv/shims/python3"),
+        ]
+    seen: set[str] = set()
+    for c in candidates:
+        if not c:
+            continue
+        real = str(Path(c).resolve()) if Path(c).exists() else c
+        if real in seen or not Path(c).exists():
+            continue
+        seen.add(real)
+        if _interpreter_can_import(c, module):
+            # Prefer the absolute resolved path (GUI apps need it).
+            return str(Path(c).resolve())
+    return None
+
+
+def desktop_config_path(override: str | None) -> Path:
+    if override:
+        return Path(override).expanduser()
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    if sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(appdata) / "Claude" / "claude_desktop_config.json"
+    # Linux / other
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def stage_serve_files(scripts_dir: Path, in_place: bool) -> Path:
+    """Return the directory the server will run from.
+
+    Default: copy the self-contained files to a stable ~/.agami/serve/ so the
+    Desktop config is update-proof. --in-place: run straight from scripts_dir.
+    """
+    if in_place:
+        return scripts_dir
+    STABLE_SERVE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(STABLE_SERVE_DIR, 0o700)
+    except OSError:
+        pass
+    for name in SERVE_FILES:
+        src = scripts_dir / name
+        if not src.exists():
+            raise FileNotFoundError(f"missing {src} — run from the plugin's scripts dir or pass --scripts-dir")
+        shutil.copy2(src, STABLE_SERVE_DIR / name)
+    return STABLE_SERVE_DIR
+
+
+def build_server_entry(python: str, serve_dir: Path, profile: str, version: str) -> dict:
+    return {
+        "command": python,
+        "args": [str(serve_dir / "mcp_server.py")],
+        "env": {"AGAMI_PROFILE": profile, "AGAMI_VERSION": version},
+    }
+
+
+def read_version(scripts_dir: Path) -> str:
+    for rel in ("../../.claude-plugin/marketplace.json", "../.claude-plugin/plugin.json"):
+        p = (scripts_dir / rel).resolve()
+        try:
+            text = p.read_text()
+        except OSError:
+            continue
+        import re
+        m = re.search(r'"version"\s*:\s*"([^"]+)"', text)
+        if m:
+            return m.group(1)
+    return "0.0.0"
+
+
+def merge_into_config(cfg_path: Path, server_name: str, entry: dict, dry_run: bool) -> tuple[dict, Path | None]:
+    """Merge the entry under mcpServers; back up + atomic write. Returns (new_config, backup_path)."""
+    existing: dict = {}
+    if cfg_path.exists():
+        try:
+            existing = json.loads(cfg_path.read_text())
+        except ValueError as e:
+            raise SystemExit(
+                f"ERROR: {cfg_path} exists but is not valid JSON ({e}). "
+                f"Fix or remove it, then re-run."
+            )
+        if not isinstance(existing, dict):
+            raise SystemExit(f"ERROR: {cfg_path} is not a JSON object.")
+
+    new = dict(existing)
+    servers = dict(new.get("mcpServers") or {})
+    servers[server_name] = entry
+    new["mcpServers"] = servers
+
+    if dry_run:
+        return new, None
+
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    backup: Path | None = None
+    if cfg_path.exists():
+        backup = cfg_path.with_suffix(cfg_path.suffix + f".bak-{int(time.time())}")
+        shutil.copy2(cfg_path, backup)
+
+    tmp = cfg_path.with_suffix(cfg_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(new, indent=2) + "\n")
+    # validate round-trip before swapping in
+    json.loads(tmp.read_text())
+    os.replace(tmp, cfg_path)
+    return new, backup
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Wire `agami serve` into the Claude Desktop app.")
+    p.add_argument("--profile", default=None, help="agami profile to serve (default: active profile).")
+    p.add_argument("--server-name", default="agami", help="Name of the MCP server entry (default: agami).")
+    p.add_argument("--python", default=None, help="Force a specific python interpreter (absolute path).")
+    p.add_argument("--scripts-dir", default=None, help="Where mcp_server.py lives (default: this script's dir).")
+    p.add_argument("--config", default=None, help="Override the desktop config path (for testing / other clients).")
+    p.add_argument("--in-place", action="store_true", help="Point at the scripts dir directly instead of copying to ~/.agami/serve.")
+    p.add_argument("--dry-run", action="store_true", help="Print the plan; write nothing.")
+    args = p.parse_args()
+
+    scripts_dir = Path(args.scripts_dir).expanduser().resolve() if args.scripts_dir else SCRIPT_DIR
+    profile = resolve_profile(args.profile)
+    db_type = db_type_for_profile(profile)
+    module = DB_DRIVER_MODULE.get(db_type or "", "psycopg2")  # default-guess postgres if unknown
+
+    print(f"• profile        : {profile}" + (f"  (db type: {db_type})" if db_type else "  (db type: unknown)"))
+    print(f"• driver needed  : {module or 'none (sqlite/stdlib)'}")
+
+    python = find_interpreter(module, args.python)
+    if python is None:
+        pip = DRIVER_PIP.get(module or "", module or "")
+        print(
+            f"\nERROR: could not find a python3 that can `import {module}`.\n"
+            f"  Install the driver, e.g.:  python3 -m pip install {pip}\n"
+            f"  then re-run, or pass --python /abs/path/to/python3.",
+            file=sys.stderr,
+        )
+        return 3
+    print(f"• interpreter    : {python}")
+
+    try:
+        serve_dir = stage_serve_files(scripts_dir, args.in_place)
+    except FileNotFoundError as e:
+        print(f"\nERROR: {e}", file=sys.stderr)
+        return 2
+    mode = "in-place (dev)" if args.in_place else f"copied to {serve_dir}"
+    print(f"• server files   : {mode}")
+
+    version = read_version(scripts_dir)
+    entry = build_server_entry(python, serve_dir, profile, version)
+    cfg_path = desktop_config_path(args.config)
+    print(f"• desktop config : {cfg_path}")
+
+    print("\nMCP server entry to be written:")
+    print(json.dumps({args.server_name: entry}, indent=2))
+
+    if args.dry_run:
+        print("\n(--dry-run) nothing written.")
+        return 0
+
+    _new, backup = merge_into_config(cfg_path, args.server_name, entry, dry_run=False)
+    if backup:
+        print(f"\n✓ backed up previous config → {backup}")
+    print(f"✓ wrote {args.server_name} into {cfg_path}")
+    print(
+        "\nNext: fully quit the Claude Desktop app (Cmd+Q on macOS) and reopen it,\n"
+        "then ask: \"What datasources does agami see?\"\n"
+        f"Logs (if it doesn't appear): ~/Library/Logs/Claude/mcp-server-{args.server_name}.log"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/agami/skills/agami-serve/SKILL.md
+++ b/plugins/agami/skills/agami-serve/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: agami-serve
+description: "Wires the local agami MCP server (mcp_server.py) into the Claude Desktop app in one step, so you can ask your database questions from Claude Desktop — not just inside Claude Code. Auto-detects the right Python interpreter (the one with your DB driver), copies the two self-contained server files to a stable ~/.agami/serve/ so the config survives plugin updates, and safely merges the entry into claude_desktop_config.json (backup + atomic write, preserving every other key). The local server is the mirror of the hosted Agami connector — same tools, local backend — so this is also how a developer feels the exact experience their business end-users would get."
+when_to_use: "Use when the user says 'set up agami for Claude Desktop', 'use agami in the Claude app', 'hook up the MCP server', 'let me test what my end users would see', '/agami-serve', or otherwise wants agami available outside Claude Code. Requires agami-connect to have run first (needs credentials + a semantic model). NOT needed to use agami inside Claude Code — the skills already work there."
+---
+
+# agami serve — wire the local MCP server into Claude Desktop
+
+You are setting up the local agami **MCP server** so the user can query their
+database from the **Claude Desktop app** (or any client that reads a
+`claude_desktop_config.json`-style file). This is the local mirror of the hosted
+"Ask Agami" connector: same tool surface (`list_datasources`,
+`get_datasource_schema`, `get_prompt_examples`, `execute_sql`, `log_feedback`),
+but backed by the user's local model + local execution. Everything stays on the
+machine; the server is stdio-only, has no auth, and makes no network call.
+
+The heavy lifting is done by a deterministic helper —
+[`scripts/setup_desktop_mcp.py`](../../scripts/setup_desktop_mcp.py). This skill's
+job is to run it, read its output, and handle the two things that need a human:
+a missing DB driver, and the app restart.
+
+## Conversation style
+
+- **Tight.** This is a one-shot setup tool, not a tutorial. Run the helper, report what it did, give the restart line.
+- **Honest about surfaces.** Claude Desktop is the target here; if the user is already in Claude Code, remind them the skills already work there — the MCP server is for *other* clients.
+
+---
+
+## Phase −1: Plan-mode preflight
+
+Run the detection + ask logic from [`shared/plan-mode-check.md`](../../shared/plan-mode-check.md). This skill needs Bash (to run the helper, which writes files). If plan mode is active, refuse with: *"I can't wire up Claude Desktop in plan mode — it writes files (the serve dir + your desktop config). Switch to **Auto** or **Edit Automatically** mode (Shift+Tab to cycle) and re-invoke me."* **DO NOT write a plan file. DO NOT call `ExitPlanMode`.**
+
+## Phase 0: Preflight
+
+1. **Credentials present** — `~/.agami/credentials` must exist for the active profile. If missing, invoke `/agami-connect` first; the server needs a connection to execute against.
+2. **Model present** — `<artifacts_dir>/<profile>/index.yaml` must exist (so the server has a semantic model to serve). If not, invoke `/agami-connect`.
+3. **Profile** — default to the active profile. If `$ARGUMENTS` names a profile, pass it through as `--profile <name>`.
+
+## Phase 1: Run the setup helper
+
+Show the plan first with `--dry-run`, then do it for real:
+
+```bash
+# 1. Preview (writes nothing)
+python3 "$AGAMI_PLUGIN_ROOT/scripts/setup_desktop_mcp.py" --dry-run
+
+# 2. Apply
+python3 "$AGAMI_PLUGIN_ROOT/scripts/setup_desktop_mcp.py"
+```
+
+Pass `--profile <name>` if the user named one. (For a developer iterating on the
+server from a checkout, `--in-place` points the config at the checkout instead of
+copying to `~/.agami/serve` — mention this only if they ask.)
+
+## Phase 2: Handle the two human cases
+
+- **Driver missing (exit code 3).** The helper couldn't find a Python that can
+  import the DB driver. Relay its suggested `pip install ...` line, offer to run
+  it, then re-run the helper. Example: `python3 -m pip install psycopg2-binary`.
+- **Wrote successfully.** Tell the user, in one or two lines:
+  1. **Fully quit** the Claude Desktop app (Cmd+Q on macOS — not just close the window), then reopen it.
+  2. In Claude Desktop, ask *"What datasources does agami see?"* — it should call `list_datasources` and return their profiles.
+  3. If it doesn't appear, the log is at `~/Library/Logs/Claude/mcp-server-agami.log`.
+
+## Phase 3: Orient them (one short paragraph)
+
+Close with: this is the same toolset their business end-users would use through
+the hosted Agami connector — the only difference is the backend (their local
+files vs a shared, governed, always-on cloud). So what they just felt in Claude
+Desktop *is* the end-user experience. If they want it for a team (one shared
+model, evals, governance, reachable from web/mobile/Cowork), that's the hosted
+product — see `docs/open-vs-hosted.md` in the repo
+(https://github.com/AgamiAI/LiteBi/blob/main/docs/open-vs-hosted.md).
+
+## Notes
+
+- The setup is **idempotent** — re-running updates the `agami` entry in place and
+  re-copies the server files. Re-run after a plugin update to refresh the copy.
+- It **never** clobbers other config: every other key and MCP server is preserved,
+  and the previous config is backed up to a timestamped `.bak-<epoch>` file.
+- It does **not** touch credentials and adds **no** network surface (see
+  `docs/privacy.md` in the repo).

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,186 @@
+"""
+Tests for plugins/agami/scripts/mcp_server.py — the local stdio MCP server.
+
+Two contracts anchor this file:
+
+  1. **Read-only guarantee.** The server exposes SQL execution to an LLM, so
+     `check_read_only` MUST reject anything that isn't a single SELECT /
+     WITH...SELECT — including the Postgres `WITH ... DELETE` data-modifying-CTE
+     edge and comment-hidden mutations.
+
+  2. **Privacy invariant.** The server is part of the local-first story: it must
+     contain NO network primitives. If you add a feature that needs the network,
+     it does not belong in this file (that is the hosted product, by design).
+
+The JSON-RPC handshake is exercised end-to-end via subprocess with no DB
+required (initialize / tools/list / list_datasources).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "plugins" / "agami" / "scripts"
+SERVER = SCRIPTS / "mcp_server.py"
+sys.path.insert(0, str(SCRIPTS))
+
+from mcp_server import (  # noqa: E402
+    _classify_exit,
+    check_read_only,
+    resolve_artifacts_dir,
+    resolve_profile,
+)
+
+
+# --- Read-only guard --------------------------------------------------------
+
+def test_plain_select_is_allowed():
+    assert check_read_only("SELECT 1") is None
+    assert check_read_only("select count(*) from orders") is None
+
+
+def test_with_select_is_allowed():
+    assert check_read_only("WITH t AS (SELECT 1 AS x) SELECT x FROM t") is None
+
+
+def test_trailing_semicolon_tolerated():
+    assert check_read_only("SELECT 1;") is None
+
+
+def test_leading_paren_select_allowed():
+    assert check_read_only("(SELECT 1) UNION (SELECT 2)") is None
+
+
+def test_ddl_rejected():
+    for sql in ("DROP TABLE users", "ALTER TABLE t ADD c int", "TRUNCATE t", "CREATE TABLE t (id int)"):
+        assert check_read_only(sql) is not None, sql
+
+
+def test_dml_rejected():
+    for sql in ("INSERT INTO t VALUES (1)", "UPDATE t SET x=1", "DELETE FROM t"):
+        assert check_read_only(sql) is not None, sql
+
+
+def test_multi_statement_rejected():
+    assert check_read_only("SELECT 1; SELECT 2") is not None
+    assert check_read_only("SELECT 1; DROP TABLE t") is not None
+
+
+def test_data_modifying_cte_rejected():
+    # Postgres allows `WITH x AS (...) DELETE ...` — this MUST be blocked even
+    # though it starts with WITH.
+    assert check_read_only("WITH x AS (SELECT id FROM t) DELETE FROM t USING x") is not None
+
+
+def test_comment_hidden_mutation_rejected():
+    # A mutation smuggled behind a comment-stripped multi-statement must fail.
+    assert check_read_only("SELECT 1 -- harmless\n; DELETE FROM t") is not None
+
+
+def test_identifier_with_keyword_substring_allowed():
+    # Column names like created_date / updated_at / is_deleted contain DDL/DML
+    # substrings but are NOT whole-word matches → must still be allowed.
+    assert check_read_only("SELECT created_date, updated_at, is_deleted FROM t") is None
+
+
+def test_empty_rejected():
+    assert check_read_only("   ") is not None
+    assert check_read_only("-- just a comment") is not None
+
+
+# --- Resolution order -------------------------------------------------------
+
+def test_resolve_profile_explicit_wins(monkeypatch):
+    monkeypatch.setenv("AGAMI_PROFILE", "fromenv")
+    assert resolve_profile("explicit") == "explicit"
+
+
+def test_resolve_profile_env_over_config(monkeypatch):
+    monkeypatch.setenv("AGAMI_PROFILE", "fromenv")
+    assert resolve_profile() == "fromenv"
+
+
+def test_resolve_artifacts_dir_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    assert resolve_artifacts_dir() == tmp_path
+
+
+# --- Exit-code classification ----------------------------------------------
+
+def test_classify_exit_mapping():
+    assert _classify_exit(3) == "driver_missing"
+    assert _classify_exit(4) == "auth"
+    assert _classify_exit(5) == "syntax"
+    assert _classify_exit(2) == "dsn"
+    assert _classify_exit(99) == "other"
+
+
+# --- Privacy invariant ------------------------------------------------------
+
+def test_server_makes_no_network_calls():
+    """The local server must not import or use any network primitive."""
+    src = SERVER.read_text()
+    forbidden = ("import socket", "import http", "import urllib", "urllib.request",
+                 "requests.", "httpx", "import ftplib", "smtplib", "websocket")
+    hits = [tok for tok in forbidden if tok in src]
+    assert not hits, f"mcp_server.py must stay network-free; found: {hits}"
+
+
+# --- Protocol handshake (no DB required) ------------------------------------
+
+def _rpc_exchange(messages: list[dict]) -> list[dict]:
+    stdin = "".join(json.dumps(m) + "\n" for m in messages)
+    proc = subprocess.run(
+        [sys.executable, str(SERVER)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ},
+    )
+    return [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def test_initialize_and_tools_list():
+    out = _rpc_exchange([
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+         "params": {"protocolVersion": "2025-06-18"}},
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    ])
+    by_id = {m.get("id"): m for m in out}
+
+    init = by_id[1]["result"]
+    assert init["protocolVersion"] == "2025-06-18"  # echoes client's version
+    assert init["serverInfo"]["name"] == "agami"
+
+    tools = {t["name"] for t in by_id[2]["result"]["tools"]}
+    assert tools == {
+        "list_datasources", "get_datasource_schema",
+        "get_prompt_examples", "execute_sql", "log_feedback",
+    }
+
+
+def test_execute_sql_rejects_mutation_over_protocol():
+    out = _rpc_exchange([
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+         "params": {"name": "execute_sql", "arguments": {"sql": "DELETE FROM users"}}},
+    ])
+    by_id = {m.get("id"): m for m in out}
+    payload = json.loads(by_id[2]["result"]["content"][0]["text"])
+    assert payload["error"]["kind"] == "permission"
+
+
+def test_unknown_method_returns_error():
+    out = _rpc_exchange([
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 9, "method": "does/not/exist"},
+    ])
+    by_id = {m.get("id"): m for m in out}
+    assert by_id[9]["error"]["code"] == -32601

--- a/tests/test_setup_desktop_mcp.py
+++ b/tests/test_setup_desktop_mcp.py
@@ -1,0 +1,142 @@
+"""
+Tests for plugins/agami/scripts/setup_desktop_mcp.py.
+
+The load-bearing contract is **merge safety**: wiring agami into
+`claude_desktop_config.json` must never lose a user's other keys or other MCP
+servers, must back up before writing, and must refuse to touch a file that isn't
+valid JSON (rather than silently overwrite it). The rest pins interpreter
+detection, profile/db-type resolution, and the platform config paths.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "plugins" / "agami" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import setup_desktop_mcp as sd  # noqa: E402
+
+
+# --- merge safety -----------------------------------------------------------
+
+def test_merge_preserves_other_keys_and_servers(tmp_path):
+    cfg = tmp_path / "claude_desktop_config.json"
+    cfg.write_text(json.dumps({
+        "coworkUserFilesPath": "/Users/me/Claude",
+        "mcpServers": {"other": {"command": "/bin/echo", "args": ["hi"]}},
+    }))
+    entry = {"command": "/py", "args": ["/serve/mcp_server.py"], "env": {"AGAMI_PROFILE": "main"}}
+    new, backup = sd.merge_into_config(cfg, "agami", entry, dry_run=False)
+
+    assert new["coworkUserFilesPath"] == "/Users/me/Claude"   # unrelated key kept
+    assert "other" in new["mcpServers"]                        # other server kept
+    assert new["mcpServers"]["agami"] == entry                 # agami added
+    assert backup is not None and backup.exists()              # backed up
+    # file on disk round-trips and matches
+    assert json.loads(cfg.read_text()) == new
+
+
+def test_merge_creates_file_when_absent(tmp_path):
+    cfg = tmp_path / "sub" / "claude_desktop_config.json"  # parent doesn't exist
+    entry = {"command": "/py", "args": ["/serve/mcp_server.py"], "env": {}}
+    new, backup = sd.merge_into_config(cfg, "agami", entry, dry_run=False)
+    assert cfg.exists()
+    assert backup is None                                      # nothing to back up
+    assert new["mcpServers"]["agami"] == entry
+
+
+def test_merge_is_idempotent_update(tmp_path):
+    cfg = tmp_path / "c.json"
+    cfg.write_text(json.dumps({"mcpServers": {"agami": {"command": "/old", "args": [], "env": {}}}}))
+    entry = {"command": "/new", "args": ["/serve/mcp_server.py"], "env": {"AGAMI_PROFILE": "x"}}
+    new, _ = sd.merge_into_config(cfg, "agami", entry, dry_run=False)
+    assert new["mcpServers"]["agami"]["command"] == "/new"     # replaced, not duplicated
+    assert len(new["mcpServers"]) == 1
+
+
+def test_merge_dry_run_writes_nothing(tmp_path):
+    cfg = tmp_path / "c.json"
+    cfg.write_text(json.dumps({"keep": True}))
+    before = cfg.read_text()
+    new, backup = sd.merge_into_config(cfg, "agami", {"command": "/py", "args": [], "env": {}}, dry_run=True)
+    assert backup is None
+    assert cfg.read_text() == before                           # untouched on disk
+    assert new["mcpServers"]["agami"]["command"] == "/py"       # plan computed in memory
+
+
+def test_merge_refuses_invalid_json(tmp_path):
+    cfg = tmp_path / "c.json"
+    cfg.write_text("{ this is not json")
+    with pytest.raises(SystemExit):
+        sd.merge_into_config(cfg, "agami", {"command": "/py", "args": [], "env": {}}, dry_run=False)
+
+
+# --- interpreter detection --------------------------------------------------
+
+def test_find_interpreter_none_module_returns_current():
+    # module=None (sqlite/stdlib) — the running interpreter qualifies.
+    assert sd.find_interpreter(None, None) is not None
+
+
+def test_find_interpreter_forced_importable():
+    assert sd.find_interpreter("json", sys.executable) == str(Path(sys.executable).resolve())
+
+
+def test_find_interpreter_unimportable_module_fails():
+    assert sd.find_interpreter("this_module_does_not_exist_xyz", sys.executable) is None
+
+
+# --- resolution -------------------------------------------------------------
+
+def test_resolve_profile_env(monkeypatch):
+    monkeypatch.setenv("AGAMI_PROFILE", "envprof")
+    assert sd.resolve_profile(None) == "envprof"
+    assert sd.resolve_profile("explicit") == "explicit"
+
+
+def test_build_server_entry_shape(tmp_path):
+    entry = sd.build_server_entry("/py", tmp_path, "main", "1.2.3")
+    assert entry["command"] == "/py"
+    assert entry["args"] == [str(tmp_path / "mcp_server.py")]
+    assert entry["env"] == {"AGAMI_PROFILE": "main", "AGAMI_VERSION": "1.2.3"}
+
+
+# --- platform config paths --------------------------------------------------
+
+def test_desktop_config_path_override():
+    assert sd.desktop_config_path("/tmp/x.json") == Path("/tmp/x.json")
+
+
+def test_desktop_config_path_macos(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    p = sd.desktop_config_path(None)
+    assert p.parts[-3:] == ("Application Support", "Claude", "claude_desktop_config.json")
+
+
+def test_desktop_config_path_linux(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    p = sd.desktop_config_path(None)
+    assert p.parts[-3:] == (".config", "Claude", "claude_desktop_config.json")
+
+
+# --- staging (copy) ---------------------------------------------------------
+
+def test_stage_in_place_returns_scripts_dir(tmp_path):
+    assert sd.stage_serve_files(tmp_path, in_place=True) == tmp_path
+
+
+def test_stage_copies_self_contained_files(tmp_path, monkeypatch):
+    # Redirect the stable serve dir into tmp so we don't touch the real ~/.agami.
+    stable = tmp_path / "serve"
+    monkeypatch.setattr(sd, "STABLE_SERVE_DIR", stable)
+    # real scripts dir has mcp_server.py + execute_sql.py
+    out = sd.stage_serve_files(SCRIPTS, in_place=False)
+    assert out == stable
+    for name in sd.SERVE_FILES:
+        assert (stable / name).exists(), name


### PR DESCRIPTION
## What

Adds an **optional local stdio MCP server** (`agami serve`) so agami can be used from **Claude Code / Claude Desktop**, not just inside the plugin. It's the local mirror of the hosted "Ask Agami" connector — same tool surface, local backend — so moving a team from local → hosted is a **backend swap, not a new product**. Plus a **one-command setup** that wires it into the Claude Desktop Mac app.

Default plugin usage inside Claude Code is unchanged; the MCP server is **opt-in**.

## User-visible change (lands in v0.2.0)

- **New skill `agami-serve`** — say *"set up agami for Claude Desktop"*. It auto-detects the right Python (the interpreter that can import your DB driver), copies the two self-contained server files to a stable `~/.agami/serve/` (so the config survives plugin updates and works even if the plugin is uninstalled), and safely merges the entry into `claude_desktop_config.json` (timestamped backup + atomic write, **every other key/server preserved**).
- **New capability** — the local MCP server itself.

## Files

- `plugins/agami/scripts/mcp_server.py` — zero-dependency stdlib stdio MCP server (`list_datasources`, `get_datasource_schema`, `get_prompt_examples`, `execute_sql`, `log_feedback`). Routes execution through `execute_sql.py`; **read-only enforced** (rejects DML/DDL/multi-statement, incl. the `WITH...DELETE` data-modifying-CTE edge); no network, no auth, no telemetry.
- `plugins/agami/scripts/setup_desktop_mcp.py` — one-command Desktop wiring (`--dry-run`, `--in-place`, `--profile`, `--config`).
- `plugins/agami/skills/agami-serve/SKILL.md` — conversational entry point (plan-mode preflight included).
- `tests/test_mcp_server.py`, `tests/test_setup_desktop_mcp.py` — **34 new tests** (read-only guard, JSON-RPC handshake, **config merge safety**, privacy invariant).
- `docs/mcp-server.md`, `docs/open-vs-hosted.md`; README "No MCP server" → "No Agami backend"; `docs/privacy.md` note.

## Versioning

`0.1.0 → 0.2.0` — new skill + additive feature, per `CONTRIBUTING.md` (bumped in `marketplace.json` ×2, `plugin.json`, and the README badge/walkthrough).

## Testing

- `python3 -m pytest tests/ -q` → **342 passed**.
- Verified end-to-end in the **Claude Desktop Mac app** against a live Postgres DB: the server reads `~/.agami` and executes SQL; the Desktop sandbox does **not** block a custom stdio server (that sandbox only restricts Claude's built-in file tools).

## How to try the branch (as a user would)

1. Point the `litebi` marketplace at this branch and reinstall/update (cache is keyed by version — the 0.2.0 bump forces a fresh pull).
2. Run `/agami-serve` (or *"set up agami for Claude Desktop"*).
3. **Cmd+Q** the Desktop app, reopen, and ask *"what datasources does agami see?"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)