### PR TITLE
fix: make the local MCP server + Desktop setup cross-platform (Windows)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Lightweight BI for Claude. Local-first natural-language SQL on your own database — no infra, no servers, no data leaves your machine.",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "natural-language", "bi", "local-first", "open-source"],
     "repository": "https://github.com/AgamiAI/LiteBi",
@@ -18,7 +18,7 @@
       "name": "agami",
       "source": "./plugins/agami",
       "description": "Connect a database, ask questions in natural language, save corrections, render charts. Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server, no Python required if you have psql/mysql or DuckDB.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "keywords": ["database", "query", "sql", "natural-language", "chart", "postgres", "mysql"],
       "category": "data"
     }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **The trust layer between AI agents and your data warehouse. Local. Private. Yours.**
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.2.0-blue)
+![Version](https://img.shields.io/badge/version-0.2.1-blue)
 ![Status](https://img.shields.io/badge/status-pre--public-orange)
 
 Ask plain-English questions of your **Postgres / MySQL / Snowflake / BigQuery / Redshift / SQLite** database, with a trust layer wrapped around every answer. Your credentials, schema, and query results never leave your machine — `agami` runs entirely inside Claude Code via the built-in Bash / Read / Write tools.
@@ -177,7 +177,7 @@ Verify:
 ```
 /plugin list
 ```
-You should see `agami@litebi v0.2.0`.
+You should see `agami@litebi v0.2.1`.
 
 Detailed walkthrough: [`docs/install/claude-code-cli.md`](docs/install/claude-code-cli.md).
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -63,11 +63,14 @@ claude mcp add agami \
   -- python3 /ABS/PATH/to/LiteBi/plugins/agami/scripts/mcp_server.py
 ```
 
-## Connect it to Claude Desktop (the Mac app)
+## Connect it to Claude Desktop (macOS and Windows)
 
 Claude Desktop is a **separate program from Claude Code** — installing the agami
-plugin via the Claude Code marketplace does *not* register the server here. The
-Mac app reads only its own `claude_desktop_config.json`.
+plugin via the Claude Code marketplace does *not* register the server here.
+Claude Desktop reads only its own `claude_desktop_config.json`. This works on both
+**macOS and Windows**: the server is pure-stdlib Python and the setup helper writes
+the correct config path per OS. It's been validated on the macOS app; the Windows
+path is handled in code but is lightly tested (see the note at the end of this section).
 
 ### Recommended: one command
 
@@ -89,30 +92,34 @@ It removes all three sharp edges of hand-editing:
 - **safely merges** the entry into `claude_desktop_config.json` — timestamped
   backup, atomic write, every other key and MCP server preserved.
 
-Then **Cmd+Q** the app and reopen. Flags: `--profile NAME` (pin a profile),
-`--in-place` (point at a checkout instead of copying — for devs iterating on the
-server), `--config PATH` (target a different client's config file). Re-run after a
-plugin update to refresh the copied files.
+Then **fully quit** the app (Cmd+Q on macOS; quit from the system tray on Windows)
+and reopen. Flags: `--profile NAME` (pin a profile), `--in-place` (point at a
+checkout instead of copying — for devs iterating on the server), `--config PATH`
+(target a different client's config file). Re-run after a plugin update to refresh
+the copied files. The helper auto-resolves the macOS vs Windows config path for you.
 
 ### Manual (what the helper does under the hood)
 
 If you'd rather edit by hand, mind these two gotchas — both silently produce
 "no tools":
 
-1. **Use an absolute path to a Python that has your DB driver.** The Mac app
-   launches helpers with a *minimal PATH*, so a bare `python3` usually isn't
-   found — and it must be the interpreter where `psycopg2` (etc.) is installed.
-   Find it: `python3 -c 'import sys,psycopg2; print(sys.executable)'` in a
-   terminal (e.g. `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3`).
+1. **Use an absolute path to a Python that has your DB driver.** Claude Desktop
+   launches helpers with a *minimal PATH*, so a bare `python3`/`python` usually
+   isn't found — and it must be the interpreter where `psycopg2` (etc.) is installed.
+   Find it: `python3 -c 'import sys,psycopg2; print(sys.executable)'` (Windows:
+   `python -c "import sys,psycopg2; print(sys.executable)"`). Example paths — macOS:
+   `/Library/Frameworks/Python.framework/Versions/3.12/bin/python3`; Windows:
+   `C:\Users\you\AppData\Local\Programs\Python\Python312\python.exe`.
 2. **Use an absolute path to `mcp_server.py`.** If you installed via the Claude
    Code marketplace, the script lives in the version-pinned plugin cache, e.g.
    `~/.claude/plugins/cache/litebi/agami/<version>/scripts/mcp_server.py` — note
    that path changes on every plugin update. If you cloned the repo, point at your
    checkout instead.
 
-Edit `claude_desktop_config.json` (Settings → Developer → Edit Config; on macOS
-`~/Library/Application Support/Claude/claude_desktop_config.json`). `mcpServers`
-is a **top-level** key (a sibling of `preferences`, not nested inside it):
+Edit `claude_desktop_config.json` (Settings → Developer → Edit Config). Its path is
+`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS and
+`%APPDATA%\Claude\claude_desktop_config.json` on Windows. `mcpServers` is a
+**top-level** key (a sibling of `preferences`, not nested inside it):
 
 ```json
 {
@@ -126,9 +133,11 @@ is a **top-level** key (a sibling of `preferences`, not nested inside it):
 }
 ```
 
-**Cmd+Q to fully quit** the app (not just close the window), then reopen. It
-spawns the server as a child process over stdin/stdout — **there is no URL and no
-port.** Logs are at `~/Library/Logs/Claude/mcp-server-agami.log`.
+**Fully quit** the app — Cmd+Q on macOS; quit from the system tray on Windows (not
+just closing the window) — then reopen. It spawns the server as a child process
+over stdin/stdout — **there is no URL and no port.** Logs:
+`~/Library/Logs/Claude/mcp-server-agami.log` on macOS,
+`%APPDATA%\Claude\logs\mcp-server-agami.log` on Windows.
 
 > **Containment — confirmed working (verified 2026-06 on the macOS app).** A
 > custom stdio MCP server runs with your full user access: it reads `~/.agami`
@@ -138,6 +147,13 @@ port.** Logs are at `~/Library/Logs/Claude/mcp-server-agami.log`.
 > future build changes it — `list_datasources` returns empty or `execute_sql`
 > reports missing-credentials/`not_found` — fall back to **Claude Code** (the CLI),
 > where it always runs with full local access.
+
+> **Windows status.** The wiring is cross-platform: the helper writes
+> `%APPDATA%\Claude\claude_desktop_config.json`, detects `python`/`python3`, and
+> the server is pure stdlib. `execute_sql.py` skips the POSIX `chmod 600`
+> credentials check on Windows (NTFS has no Unix mode bits; the file is guarded by
+> your user profile's ACL instead). This path is validated on macOS but **not yet
+> run end-to-end on a Windows box** — if you hit a snag there, please open an issue.
 
 ## Security model — no authentication, by design
 

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami",
   "description": "Ask plain-English questions of your Postgres / MySQL / Snowflake / BigQuery / Redshift / SQLite database, with a trust layer so the answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",

--- a/plugins/agami/scripts/execute_sql.py
+++ b/plugins/agami/scripts/execute_sql.py
@@ -100,14 +100,17 @@ def _load_credentials(profile: str) -> dict[str, str]:
         )
         sys.exit(2)
 
-    # chmod check: refuse if too permissive
-    mode = stat.S_IMODE(CREDENTIALS_PATH.stat().st_mode)
-    if mode not in ALLOWED_PERMS:
-        sys.stderr.write(
-            f"~/.agami/credentials must be chmod 600 (currently {oct(mode)[2:]})\n"
-            f"Run: chmod 600 ~/.agami/credentials\n"
-        )
-        sys.exit(2)
+    # chmod check: refuse if too permissive. POSIX only — Windows file modes don't
+    # map to Unix permission bits (NTFS ACLs guard the file; a stat() there reports
+    # ~0o666, which would wrongly trip this gate and block the credentials read).
+    if os.name == "posix":
+        mode = stat.S_IMODE(CREDENTIALS_PATH.stat().st_mode)
+        if mode not in ALLOWED_PERMS:
+            sys.stderr.write(
+                f"~/.agami/credentials must be chmod 600 (currently {oct(mode)[2:]})\n"
+                f"Run: chmod 600 ~/.agami/credentials\n"
+            )
+            sys.exit(2)
 
     # IMPORTANT: enable inline-comment stripping for both `#` and `;`. Without
     # this, a credentials line like `account = xy12345  # locator + region`

--- a/plugins/agami/scripts/setup_desktop_mcp.py
+++ b/plugins/agami/scripts/setup_desktop_mcp.py
@@ -134,6 +134,7 @@ def find_interpreter(module: str | None, forced: str | None) -> str | None:
         candidates = [
             sys.executable,
             shutil.which("python3") or "",
+            shutil.which("python") or "",   # Windows usually exposes `python`, not `python3`
             "/Library/Frameworks/Python.framework/Versions/3.12/bin/python3",
             "/Library/Frameworks/Python.framework/Versions/3.11/bin/python3",
             "/usr/local/bin/python3",


### PR DESCRIPTION
## What

You flagged that `docs/mcp-server.md` (and the framing generally) said "Claude Desktop (the Mac app)" — but Claude Desktop runs on **Windows** too, and the server is platform-neutral. This makes it genuinely cross-platform and rewrites the docs honestly.

The setup helper was already Windows-aware for the config path (`%APPDATA%\Claude\claude_desktop_config.json`), but two real gaps remained:

1. **`execute_sql.py` blocked Windows.** It enforced a POSIX `chmod 600` check on `~/.agami/credentials` unconditionally. On Windows there are no Unix mode bits (`stat` reports ~`0o666`), so the check rejected the file and exited — query execution couldn't work. **Now guarded to POSIX only** (on Windows the file is protected by the user-profile ACL). macOS/Linux enforcement is unchanged.
2. **Interpreter detection missed Windows.** `setup_desktop_mcp.py` only probed `python3`; Windows usually exposes `python`. Added it to the candidate list (`sys.executable` already covered the common case).

## Docs

`docs/mcp-server.md` rewritten cross-platform: heading + intro, both config paths, both log paths, generalized "fully quit" (Cmd+Q / system tray), Windows interpreter examples — with an explicit caveat that this is **validated on macOS but not yet run end-to-end on a Windows box** (please open an issue if you hit a snag there).

## Versioning

`0.2.0 → 0.2.1` — patch, since shipped scripts (`execute_sql.py`, `setup_desktop_mcp.py`) changed behavior. Bumped in `marketplace.json` ×2, `plugin.json`, and the README badge/walkthrough.

## Testing

- `python3 -m pytest tests/ -q` → **342 passed**.
- Verified interpreter auto-detection + `--dry-run` still resolve correctly on macOS.
- The POSIX guard preserves the macOS/Linux chmod-600 enforcement (only the Windows branch is newly skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)