### PR TITLE
feat(model): cross-schema relationships, MCP trust parity, explorer review UX + grain-probe size guard

### DIFF
--- a/plugins/agami/scripts/_interp.py
+++ b/plugins/agami/scripts/_interp.py
@@ -1,0 +1,49 @@
+"""Self-heal the interpreter for directly-invoked scripts.
+
+A renderer run as `python3 render_model_explorer.py …` inherits whatever `python3` is on
+PATH — which often lacks PyYAML / the model deps, while agami's *configured* interpreter
+(`~/.agami/.config` → `tool_paths.python3`, the same one the `sm` wrapper resolves) has them.
+Importing this module checks for the deps and, if they're missing, re-execs the current
+script under the configured interpreter — so the caller never has to remember to use `$PY`.
+
+Pure stdlib (so it imports under any interpreter); the check + at-most-one re-exec happen as
+an import side effect, before the script's real (dep-requiring) imports run.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+
+
+def _configured_interpreter() -> str:
+    env = os.environ.get("AGAMI_PYTHON")
+    if env:
+        return env
+    try:
+        cfg = json.loads(pathlib.Path("~/.agami/.config").expanduser().read_text())
+        return (cfg.get("tool_paths") or {}).get("python3") or ""
+    except Exception:
+        return ""
+
+
+def ensure_deps(canary: str = "yaml") -> None:
+    """If `canary` (default PyYAML) can't be imported, re-exec under the configured
+    interpreter. Re-execs at most once (guarded by AGAMI_REEXEC) so a genuinely-missing
+    dep surfaces its real ImportError instead of looping."""
+    try:
+        __import__(canary)
+        return
+    except ImportError:
+        pass
+    if os.environ.get("AGAMI_REEXEC"):
+        return
+    interp = _configured_interpreter()
+    if (interp and os.path.exists(interp)
+            and os.path.realpath(interp) != os.path.realpath(sys.executable)):
+        os.environ["AGAMI_REEXEC"] = "1"
+        os.execv(interp, [interp, *sys.argv])  # replace this process under the right python
+
+
+ensure_deps()

--- a/plugins/agami/scripts/mcp_server.py
+++ b/plugins/agami/scripts/mcp_server.py
@@ -243,6 +243,31 @@ def _resolve_units(profile: str, sql: str) -> dict[str, str]:
         return {}
 
 
+def _model_version(profile: str) -> str | None:
+    """The model-version pin = the newest snapshot dir name (a content hash), same as
+    the skill reads. None if there's no .snapshots/ (legacy model)."""
+    try:
+        snaps = resolve_artifacts_dir() / profile / ".snapshots"
+        dirs = sorted((p for p in snaps.iterdir() if p.is_dir()),
+                      key=lambda p: p.stat().st_mtime, reverse=True)
+        return dirs[0].name if dirs else None
+    except Exception:
+        return None
+
+
+def _resolve_receipt(profile: str, sql: str) -> dict | None:
+    """The FULL trust receipt (tables / relationships / metrics+review_state / assumptions
+    / warnings) for this query — the SAME assembler the skill uses, so the 'what did this
+    touch / what's unapproved' panel is identical in Claude Code and Claude Desktop.
+    Returns None only if the model deps aren't importable (execute_sql stays usable)."""
+    try:
+        org = _load_org(profile)
+        from semantic_model import runtime as RT
+        return RT.assemble_receipt(org, sql, model_version=_model_version(profile))
+    except Exception:
+        return None
+
+
 def tool_list_datasources(_args: dict[str, Any]) -> str:
     """Local analog of Ask Agami `list_organizations`: enumerate local profiles."""
     creds = _credentials_sections()
@@ -470,6 +495,11 @@ def tool_execute_sql(args: dict[str, Any]) -> str:
         "markdown": markdown,  # exact, full numbers (currency symbol + grouping) — render as-is
         "sql": sql,
         "execution_ms": execution_ms,
+        # Trust receipt — provenance + anything unapproved this answer used. Same assembler
+        # the agami-query skill renders, so Desktop gets the same trust panel. Clients should
+        # surface receipt.warnings and any receipt.metrics whose review_state != "approved"
+        # (offer to approve/correct via the save_correction tool).
+        "receipt": _resolve_receipt(profile, sql),
     }
 
     # Append to the personal query log (same file the skills use), best-effort.
@@ -505,6 +535,95 @@ def tool_log_feedback(args: dict[str, Any]) -> str:
     if not ok:
         return json.dumps({"error": {"kind": "other", "remediation": f"Could not write {FEEDBACK_LOG}."}})
     return json.dumps({"ok": True, "rating": rating_value, "logged_to": str(FEEDBACK_LOG)})
+
+
+def _op_summary(op: dict[str, Any]) -> str:
+    """One-line human preview of a curate op, for the confirmation gate."""
+    parts: list[str] = [str(op.get("op", "?")), str(op.get("kind", ""))]
+    if op.get("area"):
+        parts.append(f"in {op['area']}")
+    name = op.get("name")
+    if not name and op.get("items"):
+        name = "+".join(str(i.get("name", "?")) for i in op["items"])
+    if name:
+        parts.append(str(name))
+    if op.get("column"):
+        parts.append(f"· column {op['column']}")
+    if op.get("field"):
+        parts.append(f"· set {op['field']}")
+    return " ".join(p for p in parts if p)
+
+
+def tool_save_correction(args: dict[str, Any]) -> str:
+    """Local analog of the agami-save-correction skill: apply a correction through the
+    SAME validated, git-committed engine (`curate`), so a fix made in Claude Desktop lands
+    exactly like one made in Claude Code. The CLIENT does the routing (which note becomes a
+    caveat / unit / new metric / relationship edit — same decision tree as the skill); this
+    tool APPLIES the resulting ops + saves the corrected example.
+
+    **Shared-model edits are gated — ENFORCED, not advisory.** Any `ops` (which mutate the
+    shared model) apply ONLY when `confirmed: true`. Without it the tool does NOT write — it
+    returns `requires_confirmation` + a preview, so the client must show the user the exact
+    change and get an explicit OK, then re-call with `confirmed: true`. Saving a corrected
+    `example` is the safe floor (only shapes this question's few-shot) and is NOT gated.
+
+    args:
+      datasource: profile (optional; defaults to active)
+      ops:        curate ops, each {op, kind, area, name, [column], [field, value]} for
+                  approve/reject/edit/exclude/include, or {op:"add", kind, area, items:[...]}
+                  to add a metric/entity.
+      confirmed:  bool — REQUIRED to apply `ops` (the user's explicit OK to edit the model).
+      example:    optional corrected NL->SQL to save as a prompt example —
+                  {area, question, sql, [tables], [columns], [metric], [source], [status]}.
+      signer/role: stamped on approvals (a user approving here IS their sign-off).
+    """
+    profile = resolve_profile(args.get("datasource"))
+    root = resolve_artifacts_dir() / profile
+    if not (root / "org.yaml").exists():
+        return json.dumps({"error": {"kind": "other",
+                           "remediation": f"No model at {root}. Run the agami-connect skill first."}})
+    try:
+        from semantic_model import curate
+    except Exception as e:
+        return json.dumps({"error": {"kind": "other", "remediation": f"Model deps unavailable: {e}"}})
+
+    signer, role = args.get("signer"), args.get("role")
+    confirmed = bool(args.get("confirmed"))
+    out: dict[str, Any] = {"profile": profile}
+
+    ops = args.get("ops") or []
+    if ops and not confirmed:
+        # Enforced gate: never mutate the shared model without an explicit confirm.
+        preview = [_op_summary(o) for o in ops]
+        out["requires_confirmation"] = True
+        out["pending_ops"] = preview
+        out["message"] = (
+            "These edits change your shared semantic model and were NOT applied: "
+            + "; ".join(preview) + ". Show the user exactly what will change, get their OK, then "
+            "call save_correction again with the same `ops` and `confirmed: true`. "
+            "(A corrected `example` saves without confirmation — it only affects this question.)")
+    elif ops:
+        results = []
+        # {op:"add"} routes to write_items (add a metric/entity); the rest through apply().
+        for ao in [o for o in ops if o.get("op") == "add"]:
+            results.append(curate.write_items(root, ao.get("area"), ao.get("kind"),
+                                              ao.get("items") or [], signer=signer, role=role).as_dict())
+        plain = [o for o in ops if o.get("op") != "add"]
+        if plain:
+            results.append(curate.apply(root, plain, signer=signer, role=role).as_dict())
+        out["ops"] = results
+
+    ex = args.get("example")
+    if isinstance(ex, dict) and ex.get("area") and ex.get("question") and ex.get("sql"):
+        area = {k: v for k, v in ex.items() if k != "area"}
+        out["example"] = curate.add_examples(root, ex["area"], [area],
+                                              signer=signer, role=role).as_dict()
+
+    if not any(k in out for k in ("ops", "example", "requires_confirmation")):
+        return json.dumps({"error": {"kind": "other",
+                           "remediation": "Pass `ops` (curate ops) and/or a complete `example` "
+                                          "(area+question+sql)."}})
+    return json.dumps(out, indent=2, default=str)
 
 
 def _now_iso() -> str:
@@ -686,6 +805,44 @@ TOOLS: dict[str, dict[str, Any]] = {
             "additionalProperties": False,
         },
     },
+    "save_correction": {
+        "handler": tool_save_correction,
+        "description": (
+            "Apply a correction to the local semantic model AND/OR save a corrected NL→SQL "
+            "example, through the same validated, git-committed engine the agami-save-correction "
+            "skill uses — so a fix made in Claude Desktop lands identically to one in Claude Code. "
+            "Use after execute_sql when the answer was wrong or used something unapproved (see "
+            "receipt.metrics with review_state != 'approved', or receipt.warnings). YOU decide the "
+            "routing (a column's unit/meaning → an edit op; a reusable aggregation → add a metric; "
+            "an approval → an approve op); this tool applies it. Approving here IS the user's sign-off."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "datasource": {"type": "string", "description": "Profile name; defaults to the active profile."},
+                "ops": {
+                    "type": "array",
+                    "description": "Curate ops. Each: {op, kind, area, name, [column], [field], [value]} "
+                                   "for approve/reject/edit/exclude/include; or {op:'add', kind:'metric'|'entity', "
+                                   "area, items:[...]} to add one. Applied ONLY with confirmed:true.",
+                    "items": {"type": "object"},
+                },
+                "confirmed": {
+                    "type": "boolean",
+                    "description": "Set true ONLY after showing the user the exact model change and "
+                                   "getting their OK. Required to apply `ops`; ignored for `example`.",
+                },
+                "example": {
+                    "type": "object",
+                    "description": "Optional corrected NL→SQL to save as a prompt example: "
+                                   "{area, question, sql, [tables], [columns], [metric], [source], [status]}.",
+                },
+                "signer": {"type": "string", "description": "Email stamped on approvals (the user's sign-off)."},
+                "role": {"type": "string", "description": "Signer role (e.g. cfo, data_lead)."},
+            },
+            "additionalProperties": False,
+        },
+    },
     "list_subject_areas": {
         "handler": tool_list_subject_areas,
         "description": (
@@ -809,9 +966,17 @@ def _handle_initialize(req_id: Any, params: dict[str, Any]) -> None:
         "instructions": (
             "agami local datasource agent. The NL→SQL intelligence runs on your side; these "
             "tools provide the local semantic model + curated examples and execute SQL locally. "
-            "Discover datasources with list_datasources, fetch the model + examples for the one "
-            "the question touches, generate SQL using metric `calculation` fields verbatim, then "
-            "execute_sql. All execution is local; nothing leaves the machine."
+            "All execution is local; nothing leaves the machine.\n"
+            "Flow: (1) list_datasources, then fetch the model + examples for the datasource the "
+            "question touches. (2) Examples-first — call get_prompt_examples and mirror the closest "
+            "match before composing new SQL; use metric `calculation`/`bindings` verbatim. "
+            "(3) execute_sql (safety + default_filters run inside it). (4) Read the returned "
+            "`receipt`: SHOW the user `receipt.warnings` and any `receipt.metrics` whose "
+            "review_state != 'approved' — these are joins/metrics they haven't signed off; never "
+            "hide them. Don't refuse on an unreviewed metric — answer and warn. (5) If the answer "
+            "was wrong or the user approves an item, call save_correction. Model edits (its `ops`) "
+            "apply only with confirmed:true — preview the exact change, get the user's OK, then "
+            "re-call confirmed. Saving a corrected example needs no confirmation."
         ),
     })
 

--- a/plugins/agami/scripts/promote_credentials.py
+++ b/plugins/agami/scripts/promote_credentials.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Deterministically promote ~/.agami/credentials.example into ~/.agami/credentials.
+
+agami-connect Phase 0a writes a one-profile `credentials.example` for the user to fill in.
+This script consumes it deterministically — replacing the brittle skill-inline
+`if [ ! -f credentials ]; then mv ...` that ONLY handled the very first profile and trusted
+the LLM to hand-roll the append for every profile after it:
+
+  - no credentials file yet            -> MOVE the template into place (chmod 600)
+  - credentials file already exists     -> APPEND the new profile's [section]
+  - the new profile name already exists -> REFUSE (no silent [main]/[main] collision);
+                                           leave both files untouched so the user can rename
+  - template still holds placeholders   -> REFUSE (never promote an unedited template)
+
+Stdout is a single status line (first token is the machine-readable status); the skill
+reads it and acts. Stdlib only.
+
+  SECURED <profiles>          credentials created from the template (chmod 600)        [0]
+  APPENDED <profiles>         new profile(s) appended to existing credentials          [0]
+  PLACEHOLDERS_REMAIN <list>  template still has placeholder values; not promoted       [2]
+  COLLISION <profiles>        profile already in credentials; nothing changed           [3]
+  NOTHING                     no credentials.example to promote                         [1]
+  ERROR <message>             could not parse / no section / write failed               [4]
+"""
+from __future__ import annotations
+
+import argparse
+import configparser
+import os
+import re
+import sys
+from pathlib import Path
+
+# Placeholder tokens the Phase 0a templates ship with — their presence means the user
+# hasn't filled the template in yet. Mirrors the grep guard the skill used inline.
+_PLACEHOLDER_RE = re.compile(
+    r"your-(?:username|password|host|server|workspace|coordinator|database|token)"
+    r"|dapiXXX|/absolute/path/to|user:pass@host"
+)
+
+
+def _sections(path: Path) -> list[str]:
+    """Profile names ([section] headers) in an INI credentials file. strict=False so an
+    already-imperfect existing file (e.g. a pre-existing duplicate) doesn't crash the read."""
+    cfg = configparser.ConfigParser(inline_comment_prefixes=("#", ";"), strict=False)
+    cfg.read(path, encoding="utf-8")
+    return cfg.sections()
+
+
+def _section_block(text: str, name: str) -> str:
+    """The `[name]` block verbatim (header line through the line before the next header /
+    EOF) — preserves the user's exact formatting and values, dropping the template's
+    instructional comment preamble."""
+    out: list[str] = []
+    capturing = False
+    for line in text.splitlines():
+        m = re.match(r"\s*\[(.+?)\]\s*$", line)
+        if m:
+            capturing = m.group(1) == name
+        if capturing:
+            out.append(line)
+    return "\n".join(out).rstrip() + "\n"
+
+
+def promote(agami_dir: Path) -> tuple[str, int]:
+    creds = agami_dir / "credentials"
+    example = agami_dir / "credentials.example"
+
+    if not example.exists():
+        return "NOTHING", 1
+
+    text = example.read_text(encoding="utf-8")
+    placeholders = sorted({m.group(0) for m in _PLACEHOLDER_RE.finditer(text)})
+    if placeholders:
+        return "PLACEHOLDERS_REMAIN " + ", ".join(placeholders), 2
+
+    try:
+        new = _sections(example)
+    except configparser.Error as e:
+        return f"ERROR could not parse credentials.example: {e}", 4
+    if not new:
+        return "ERROR credentials.example has no [profile] section", 4
+
+    # First-ever profile: atomic move + lock down.
+    if not creds.exists():
+        os.replace(example, creds)
+        creds.chmod(0o600)
+        return "SECURED " + " ".join(new), 0
+
+    # Nth profile: refuse on a name clash, else append the new section(s).
+    try:
+        existing = set(_sections(creds))
+    except configparser.Error as e:
+        return f"ERROR could not parse existing credentials: {e}", 4
+    clash = [s for s in new if s in existing]
+    if clash:
+        return "COLLISION " + " ".join(clash), 3
+
+    blocks = [_section_block(text, s) for s in new]
+    with creds.open("a", encoding="utf-8") as fh:
+        fh.write("\n" + "\n".join(blocks))
+    creds.chmod(0o600)
+    example.unlink()  # consume the template
+    return "APPENDED " + " ".join(new), 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--agami-dir", default=os.path.expanduser("~/.agami"),
+                   help="Directory holding credentials / credentials.example (default ~/.agami).")
+    args = p.parse_args()
+    msg, code = promote(Path(args.agami_dir).expanduser())
+    print(msg)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/agami/scripts/render_model_explorer.py
+++ b/plugins/agami/scripts/render_model_explorer.py
@@ -34,6 +34,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import _interp  # noqa: F401 — re-exec under agami's configured interpreter if PyYAML is missing
+
 import yaml
 
 
@@ -137,6 +139,8 @@ def build_manifest(profile_dir: Path, profile: str) -> dict:
                 "qname": f"{sa.name}.{r.from_table}->{r.to_table}",
                 "from_table": r.from_table, "from_column": r.from_column,
                 "to_table": r.to_table, "to_column": r.to_column, "on": r.on,
+                "from_schema": r.from_schema, "to_schema": r.to_schema,
+                "cross_schema": r.cross_schema,
                 "cardinality": r.relationship, "description": r.description,
                 "review_state": r.review_state, "confidence": r.confidence,
                 "excluded": r.review_state == "rejected",
@@ -171,12 +175,23 @@ def build_manifest(profile_dir: Path, profile: str) -> dict:
     # org-level cross-area joins (edges between two subject areas)
     cross_out: list[dict] = []
     for r in getattr(org, "cross_subject_area_relationships", []) or []:
+        fa = getattr(r, "from_subject_area", "")
+        ta = getattr(r, "to_subject_area", "")
         cross_out.append({
-            "from_subject_area": getattr(r, "from_subject_area", ""),
-            "to_subject_area": getattr(r, "to_subject_area", ""),
+            "qname": f"{fa}.{r.from_table}->{ta}.{r.to_table}",
+            "from_subject_area": fa, "to_subject_area": ta,
             "from_table": r.from_table, "from_column": r.from_column,
             "to_table": r.to_table, "to_column": r.to_column, "on": r.on,
+            "from_schema": r.from_schema, "to_schema": r.to_schema,
+            "cross_schema": r.cross_schema,
             "cardinality": r.relationship, "description": r.description,
+            "review_state": r.review_state, "confidence": r.confidence,
+            "excluded": r.review_state == "rejected",
+            "signed_off_by": r.signed_off_by, "signed_off_role": r.signed_off_role,
+            # rendered as a reviewable join (Joins tab + Review queue), like intra-area joins;
+            # `area` (the from-side) is what a curate op targets — the org-level fallback in
+            # curate resolves it to cross_subject_area_relationships.
+            "rule": 2, "cross_area": True, "area": fa,
         })
 
     return {

--- a/plugins/agami/scripts/semantic_model/build.py
+++ b/plugins/agami/scripts/semantic_model/build.py
@@ -40,11 +40,33 @@ WEAK_PII_RE = re.compile(r"(\bname\b|first_?name|last_?name|full_?name|surname)"
 # Back-compat alias (some callers import SENSITIVE_RE).
 SENSITIVE_RE = STRONG_PII_RE
 
-# loan-type / segment prefixes commonly seen as column-group roots
-_KNOWN_PREFIXES = {"al", "pl", "gl", "hl", "lap", "las", "bl", "tw", "cc", "total"}
-
 # sizing thresholds mirror validator.SIZING_WARN
 SINGLE_AREA_MAX = 24
+
+
+# Numeric columns whose NAME indicates a monetary value, so curation can offer a currency
+# `unit` without callers hand-rolling (and mis-rolling) a regex. Tokens match on word
+# boundaries (`_` or string edges), so a bare `count` never matches inside `discount`:
+# `discount_amount` / `member_discount` ARE money; `order_count` / `discount_rate` are not.
+_MONEY_RE = re.compile(
+    r"(^|_)(amount|amt|price|cost|fee|revenue|sales|salary|wage|income|payment|"
+    r"charge|balance|deposit|withdrawal|refund|discount|subtotal|total|spend|spent|"
+    r"budget|invoice|mrr|arr|gmv|ltv|aov|paid|due|owed|credit|debit)s?(_|$)",
+    re.IGNORECASE,
+)
+# Tokens that flip a money-ish name back to NON-money (it's a rate / count / id / score / …).
+_MONEY_NEGATIVE_RE = re.compile(
+    r"(^|_)(rate|pct|percent|percentage|ratio|count|cnt|qty|quantity|num|number|id|"
+    r"flag|year|age|day|month|score|rank|code|status)s?(_|$)",
+    re.IGNORECASE,
+)
+
+
+def detect_money_column(column_name: str) -> bool:
+    """A column whose name looks monetary (amount/price/revenue/discount/…) and is NOT a
+    rate/count/id/score — so `discount_amount` is money while `discount_rate` and
+    `order_count` are not. Name-only; the caller restricts this to numeric columns."""
+    return bool(_MONEY_RE.search(column_name)) and not _MONEY_NEGATIVE_RE.search(column_name)
 
 
 def detect_sensitive(table_name: str, column_name: str) -> bool:
@@ -68,9 +90,7 @@ def derive_column_groups(columns: list[Column]) -> dict[str, list[str]]:
             groups["identity"].append(name)
             continue
         token = name.split("_")[0].lower()
-        if token in _KNOWN_PREFIXES:
-            groups[token].append(name)
-        elif name.upper().startswith("TOTAL"):
+        if name.upper().startswith("TOTAL"):
             groups["totals"].append(name)
         else:
             groups[token].append(name)
@@ -169,13 +189,26 @@ def make_table_ref(conn: str, table: Table) -> TableRef:
     )
 
 
+def _area_key(schema: str) -> str:
+    """A filesystem-safe area name from a schema name."""
+    return re.sub(r"[^a-z0-9_]+", "_", schema.lower()).strip("_") or "misc"
+
+
+def _rel_in_area(r: Relationship, keys: set, bare: set) -> bool:
+    """Is this relationship internal to an area? Match endpoints by (schema, table) when the
+    relationship carries schemas — so a join from billing.products and one from crm.products
+    don't both match an area just because the bare name `products` is present. Schemaless
+    relationships (SQLite / legacy) fall back to bare-name membership."""
+    def here(table: str, schema) -> bool:
+        return (schema, table) in keys if schema is not None else table in bare
+    return (here(r.from_table.split(".")[-1], r.from_schema)
+            and here(r.to_table.split(".")[-1], r.to_schema))
+
+
 def make_area(name: str, tables: list[Table], rels: list[Relationship], conn: str) -> SubjectArea:
     table_names = {t.name for t in tables}
-    area_rels = [
-        r for r in rels
-        if r.from_table.split(".")[-1] in table_names
-        and r.to_table.split(".")[-1] in table_names
-    ]
+    keys = {(t.schema_name, t.name) for t in tables}
+    area_rels = [r for r in rels if _rel_in_area(r, keys, table_names)]
     return SubjectArea(
         name=name,
         description=f"Auto-proposed subject area covering: {', '.join(sorted(table_names))}.",
@@ -188,14 +221,31 @@ def make_area(name: str, tables: list[Table], rels: list[Relationship], conn: st
 def propose_subject_areas(
     tables: list[Table], rels: list[Relationship], conn: str, profile: str
 ) -> tuple[list[SubjectArea], list[str]]:
-    """Return (areas, notes). <=SINGLE_AREA_MAX tables -> one area; else cluster
-    by prefix-family with one owning area per table."""
+    """Return (areas, notes).
+
+    A DB spanning **2+ schemas** is split **one area per schema** — the schemas are the
+    natural domains, and (critically) this keeps same-named tables in different schemas
+    (e.g. `billing.products` vs `crm.products`) in separate area dirs so neither is lost to
+    a bare-name write collision. A single-schema DB keeps the old behavior: one area when
+    small, else prefix-family clustering.
+    """
     notes: list[str] = []
+    schemas = sorted({t.schema_name for t in tables if t.schema_name})
+    if len(schemas) >= 2:
+        by_area: dict[str, list[Table]] = defaultdict(list)
+        for t in tables:
+            by_area[_area_key(t.schema_name) if t.schema_name else profile.lower()].append(t)
+        areas = [make_area(a, members, rels, conn) for a, members in sorted(by_area.items())]
+        notes.append(
+            f"{len(tables)} tables across {len(schemas)} schemas -> {len(areas)} subject areas "
+            "(one per schema); cross-schema joins become cross_subject_area_relationships."
+        )
+        return areas, notes
     if len(tables) <= SINGLE_AREA_MAX:
         notes.append(f"{len(tables)} tables -> single subject area {profile.lower()!r}")
         return [make_area(profile.lower(), tables, rels, conn)], notes
     mapping = cluster_by_family([t.name for t in tables])
-    by_area: dict[str, list[Table]] = defaultdict(list)
+    by_area = defaultdict(list)
     for t in tables:
         by_area[mapping[t.name]].append(t)
     areas = [make_area(a, members, rels, conn) for a, members in sorted(by_area.items())]
@@ -209,17 +259,22 @@ def propose_subject_areas(
 def extract_cross_area_relationships(
     areas: list[SubjectArea], rels: list[Relationship]
 ) -> list[CrossSubjectAreaRelationship]:
-    area_of: dict[str, str] = {}
+    # Key by (schema, name) so two same-named tables in different schemas resolve to their
+    # own area; keep a bare-name fallback for schemaless rels / tables.
+    area_of: dict[tuple, str] = {}
+    bare_of: dict[str, str] = {}
     for sa in areas:
         for t in sa.tables_defined:
-            area_of[t.name] = sa.name
+            area_of[(t.schema_name, t.name)] = sa.name
+            bare_of.setdefault(t.name, sa.name)
     intra_ids = {id(r) for sa in areas for r in sa.relationships}
     out: list[CrossSubjectAreaRelationship] = []
     for r in rels:
         if id(r) in intra_ids:
             continue
-        fa = area_of.get(r.from_table.split(".")[-1])
-        ta = area_of.get(r.to_table.split(".")[-1])
+        ft, tt = r.from_table.split(".")[-1], r.to_table.split(".")[-1]
+        fa = area_of.get((r.from_schema, ft)) or bare_of.get(ft)
+        ta = area_of.get((r.to_schema, tt)) or bare_of.get(tt)
         if fa and ta and fa != ta:
             data = r.model_dump(exclude_none=True, by_alias=True)
             data.update(from_subject_area=fa, to_subject_area=ta, executable="same_engine")
@@ -308,7 +363,8 @@ def write_tree(
 
 
 __all__ = [
-    "SENSITIVE_RE", "detect_sensitive", "derive_column_groups", "maybe_column_groups",
+    "SENSITIVE_RE", "detect_sensitive", "detect_money_column",
+    "derive_column_groups", "maybe_column_groups",
     "infer_cardinality", "cluster_by_family", "make_area", "make_table_ref",
     "propose_subject_areas", "extract_cross_area_relationships",
     "write_tree", "WriteReport",

--- a/plugins/agami/scripts/semantic_model/cli.py
+++ b/plugins/agami/scripts/semantic_model/cli.py
@@ -203,6 +203,24 @@ def cmd_remove_example(args) -> int:
     return 0 if (res.applied or not res.skipped) else 1
 
 
+def cmd_suggest_units(args) -> int:
+    """List the numeric **money** columns (so a currency `unit` can be stamped) using the
+    tested name matcher — never a hand-rolled regex that mis-handles `count` inside
+    `discount`. Skips columns that already carry a `unit`. Emits
+    {money_columns: [{area, table, column, type}]} for the caller to confirm + apply."""
+    from . import build as B
+    org = L.load_organization(args.root)
+    numeric = {"integer", "decimal", "float"}
+    money = []
+    for sa in org.subject_areas:
+        for t in sa.tables_defined:
+            for c in t.columns:
+                if not c.unit and c.type in numeric and B.detect_money_column(c.name):
+                    money.append({"area": sa.name, "table": t.name, "column": c.name, "type": c.type})
+    _print_json({"money_columns": money})
+    return 0
+
+
 def cmd_format_table(args) -> int:
     """Format a result CSV into a deterministic markdown table — exact numbers, full
     grouping + currency symbols, never abbreviated. The skill (and later the MCP) emits
@@ -429,6 +447,10 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--signer", default=None, help="who rejected it (recorded in the curation log)")
     sp.add_argument("--role", default=None)
     sp.set_defaults(func=cmd_remove_example)
+
+    sp = sub.add_parser("suggest-units", help="list numeric money columns (for currency-unit stamping) via the tested name matcher")
+    sp.add_argument("root")
+    sp.set_defaults(func=cmd_suggest_units)
 
     sp = sub.add_parser("format-table", help="format a result CSV into a deterministic markdown table (exact numbers)")
     sp.add_argument("--csv-file", default=None, help="result CSV (header row + rows); omit to read stdin")

--- a/plugins/agami/scripts/semantic_model/curate.py
+++ b/plugins/agami/scripts/semantic_model/curate.py
@@ -291,15 +291,55 @@ def _op_label(op: dict) -> str:
     return f"{op.get('op')} {op.get('kind')} {op.get('area','')}/{t}".strip()
 
 
+def _resolve_area(root: Path, op: dict) -> str:
+    """Which subject area owns this op's target, resolved by NAME when `area` is omitted — so
+    callers (enrichment, save-correction) don't hand-maintain a table->area map. table/metric/
+    entity resolve by file existence; relationship by matching endpoints. A name that lives in
+    two areas (e.g. a table present in two schemas) is ambiguous -> raise, asking for `area`."""
+    kind, name = op.get("kind"), op.get("name")
+    sa_root = root / "subject_areas"
+    if not sa_root.is_dir():
+        raise FileNotFoundError("model has no subject_areas/ directory")
+    areas = sorted(p.name for p in sa_root.iterdir() if p.is_dir())
+    hits: list[str] = []
+    for area in areas:
+        d = sa_root / area
+        found = False
+        if kind == "table":
+            found = (d / "tables" / f"{name}.yaml").exists()
+        elif kind == "entity":
+            found = (d / "entities" / f"{_slug(name)}.yaml").exists()
+        elif kind == "metric":
+            found = (d / "metrics" / f"{_slug(name)}.yaml").exists()
+        elif kind == "relationship":
+            relf = d / "relationships.yaml"
+            if relf.exists():
+                frm, _, to = (name or "").partition("->")
+                doc = _load(relf) or {}
+                rels = doc.get("relationships", doc if isinstance(doc, list) else [])
+                found = any(r.get("from_table") == frm and r.get("to_table") == to for r in rels)
+        if found:
+            hits.append(area)
+    if len(hits) == 1:
+        return hits[0]
+    if not hits:
+        raise FileNotFoundError(
+            f"no {kind} named {name!r} in any subject area (looked in: {', '.join(areas) or 'none'})")
+    raise ValueError(
+        f"{kind} {name!r} exists in multiple areas {hits} — pass an explicit 'area' to "
+        "disambiguate (a same-named table can live in two schemas).")
+
+
 def _apply_one(root: Path, op: dict, signer, role) -> Optional[Path]:
     action = op.get("op")
     if action not in _VALID_OPS:
         raise ValueError(f"unknown op {action!r}")
     kind = op.get("kind")
-    area = op.get("area")
     name = op.get("name")
     if not kind or not name:
         raise ValueError("op needs kind + name")
+    # `area` is optional — resolve it from the model by name when the caller omits it.
+    area = op.get("area") or _resolve_area(root, op)
 
     new_state = {"approve": "approved", "include": "unreviewed",
                  "reject": "rejected", "exclude": "rejected"}.get(action)
@@ -310,56 +350,74 @@ def _apply_one(root: Path, op: dict, signer, role) -> Optional[Path]:
         if op.get("column"):
             _set_column_field(doc, op["column"], op, new_state, signer, role)
         else:
-            _set_trust(doc, op, new_state, signer, role)
+            _set_trust(doc, op, new_state, signer, role, desc_source=True)  # table desc has provenance
         _dump(path, doc)
         return path
 
     if kind == "entity":
-        path = _area_dir(root, area) / "entities" / f"{name}.yaml"
+        # entities/metrics are stored under the SLUGGED name (write_items uses _slug), so resolve
+        # the same way — a multi-word name ("total event sales") must find total_event_sales.yaml,
+        # not a literal "total event sales.yaml". _slug is idempotent, so an already-slugged name
+        # still resolves. (Tables keep their literal name — they're written verbatim, not slugged.)
+        path = _area_dir(root, area) / "entities" / f"{_slug(name)}.yaml"
+        if not path.exists():
+            raise FileNotFoundError(f"no entity named {name!r} in area {area!r}")
         doc = _load(path)
         _set_trust(doc, op, new_state, signer, role)
         _dump(path, doc)
         return path
 
     if kind == "metric":
-        path = _area_dir(root, area) / "metrics" / f"{name}.yaml"
+        path = _area_dir(root, area) / "metrics" / f"{_slug(name)}.yaml"
+        if not path.exists():
+            raise FileNotFoundError(f"no metric named {name!r} in area {area!r}")
         doc = _load(path)
         _set_trust(doc, op, new_state, signer, role)
         _dump(path, doc)
         return path
 
     if kind == "relationship":
-        path = _area_dir(root, area) / "relationships.yaml"
-        doc = _load(path) or {}
-        rels = doc.get("relationships", doc if isinstance(doc, list) else [])
         frm, _, to = name.partition("->")
-        hit = None
-        for r in rels:
-            if r.get("from_table") == frm and r.get("to_table") == to:
-                hit = r
-                break
-        if hit is None:
-            raise ValueError(f"relationship {name} not found in {path}")
-        _set_trust(hit, op, new_state, signer, role)
-        _dump(path, {"relationships": rels})
-        return path
+        path = _area_dir(root, area) / "relationships.yaml"
+        if path.exists():
+            doc = _load(path) or {}
+            rels = doc.get("relationships", doc if isinstance(doc, list) else [])
+            hit = next((r for r in rels if r.get("from_table") == frm and r.get("to_table") == to), None)
+            if hit is not None:
+                _set_trust(hit, op, new_state, signer, role)
+                _dump(path, {"relationships": rels})
+                return path
+        # Cross-area (cross-schema / cross-datasource) join — it lives at the org level, not
+        # in an area's relationships.yaml. Fall back to org.yaml's cross_subject_area_relationships.
+        orgp = root / "org.yaml"
+        odoc = _load(orgp) or {}
+        crels = odoc.get("cross_subject_area_relationships", [])
+        chit = next((r for r in crels if r.get("from_table") == frm and r.get("to_table") == to), None)
+        if chit is None:
+            raise ValueError(f"relationship {name} not found in {path} or org cross-area relationships")
+        _set_trust(chit, op, new_state, signer, role)
+        _dump(orgp, odoc)
+        return orgp
 
     raise ValueError(f"unknown kind {kind!r}")
 
 
-def _set_trust(doc: dict, op: dict, new_state: Optional[str], signer, role) -> None:
+def _set_trust(doc: dict, op: dict, new_state: Optional[str], signer, role,
+               *, desc_source: bool = False) -> None:
     if op.get("op") == "edit":
         fld, val = op.get("field"), op.get("value")
         if not fld:
             raise ValueError("edit op needs field")
         doc[fld] = val
-        # Description provenance (advisory; see DescriptionSource in models.py).
-        # An edit that sets `description` also stamps `description_source`:
+        # Description provenance (advisory; see DescriptionSource in models.py). ONLY tables
+        # and columns carry `description_source`; relationships / metrics / entities have a
+        # `description` but no source field, so stamping it there would fail `extra=forbid`.
+        # An edit that sets a table/column `description` also stamps `description_source`:
         #   source:"ai" → ai_unvalidated (agami-connect generation)
         #   otherwise   → human (a person edited it, so it's trusted)
         #   empty value → clear it. A direct edit of `description_source` itself
         #   (e.g. confirm → "ai_validated") falls through the generic `doc[fld]=val`.
-        if fld == "description":
+        if fld == "description" and desc_source:
             doc["description_source"] = (
                 None if not (val or "").strip()
                 else ("ai_unvalidated" if op.get("source") == "ai" else "human")
@@ -381,7 +439,7 @@ def _set_trust(doc: dict, op: dict, new_state: Optional[str], signer, role) -> N
 def _set_column_field(table_doc: dict, col_name: str, op: dict, new_state, signer, role) -> None:
     for c in table_doc.get("columns", []):
         if c.get("name") == col_name:
-            _set_trust(c, op, new_state, signer, role)
+            _set_trust(c, op, new_state, signer, role, desc_source=True)  # column desc has provenance
             return
     raise ValueError(f"column {col_name} not found")
 

--- a/plugins/agami/scripts/semantic_model/dialects.py
+++ b/plugins/agami/scripts/semantic_model/dialects.py
@@ -13,6 +13,7 @@ Canonical catalog result columns the engine expects:
                                    ordinal_position, numeric_scale (nullable)
     primary_keys(s,t)-> rows with: column_name            (ordered by key position)
     foreign_keys(s)  -> rows with: from_table, from_column, to_table, to_column
+                                   (+ optional from_schema, to_schema — schema-ful dialects)
     row_estimate(s,t)-> rows with: estimated_rows         (or None to skip)
 
 Three catalog families:
@@ -171,9 +172,14 @@ class Dialect:
         )
 
     def sql_foreign_keys(self, schema: str) -> str:
+        # Also returns from_schema / to_schema so introspect can flag cross-schema joins and
+        # resolve a target unambiguously when two schemas share a table name. ccu.table_schema
+        # is the REFERENCED (to) table's schema; it may differ from the constraint's schema.
         return (
             "SELECT kcu.table_name AS from_table, kcu.column_name AS from_column, "
-            "ccu.table_name AS to_table, ccu.column_name AS to_column "
+            "kcu.table_schema AS from_schema, "
+            "ccu.table_name AS to_table, ccu.column_name AS to_column, "
+            "ccu.table_schema AS to_schema "
             "FROM information_schema.table_constraints tc "
             "JOIN information_schema.key_column_usage kcu "
             "ON tc.constraint_name = kcu.constraint_name "
@@ -237,10 +243,12 @@ class MySQL(Dialect):
         return "`" + name.replace("`", "``") + "`"
 
     def sql_foreign_keys(self, schema: str) -> str:
-        # MySQL exposes the target directly on key_column_usage.
+        # MySQL exposes the target (incl. its schema) directly on key_column_usage.
         return (
             "SELECT table_name AS from_table, column_name AS from_column, "
-            "referenced_table_name AS to_table, referenced_column_name AS to_column "
+            "table_schema AS from_schema, "
+            "referenced_table_name AS to_table, referenced_column_name AS to_column, "
+            "referenced_table_schema AS to_schema "
             "FROM information_schema.key_column_usage "
             f"WHERE table_schema = {self.quote_lit(schema)} "
             "AND referenced_table_name IS NOT NULL"

--- a/plugins/agami/scripts/semantic_model/introspect.py
+++ b/plugins/agami/scripts/semantic_model/introspect.py
@@ -36,6 +36,15 @@ from typing import Any, Callable, Optional
 # Introspection-run timestamp for system sign-offs on auto-approved structure.
 _NOW = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
+# At/above this row count a full scan is slow enough that the query path warns + suggests
+# narrowing. For such tables we record the date/time columns as `recommended_filters` (the
+# natural "narrow by date" answer) so the warning fires only when a query lacks one.
+_LARGE_TABLE_ROWS = 1_000_000
+# ...but only when there's a clear handful of date columns. A wide mart with a dozen+ date
+# columns (e.g. per-category open/close dates) has no single obvious scan key, so leave it
+# empty for the real partition/index pass rather than listing noise.
+_MAX_DATE_FILTER_COLS = 6
+
 from . import build
 from . import dialects as D
 from .models import (
@@ -227,6 +236,34 @@ def _try(runner: Runner, sql: str) -> Optional[list[dict]]:
         return None
 
 
+# Supabase (hosted Postgres) ships system schemas the user almost never wants modeled — and
+# some hold secrets (vault, pgsodium). We detect Supabase by its signature schemas and drop
+# the whole system set, so onboarding models only the user's app tables (e.g. public).
+_SUPABASE_SYS_SCHEMAS = frozenset({
+    "auth", "storage", "vault", "realtime", "_realtime", "extensions",
+    "graphql", "graphql_public", "pgsodium", "pgsodium_masks", "pgbouncer",
+    "supabase_functions", "supabase_migrations", "net", "cron", "pgtle",
+    "_analytics", "_supavisor", "supabase_admin",
+})
+# Require several signature schemas together — a plain-Postgres DB with a lone `auth` or
+# `storage` schema of its own is NOT Supabase and must not be filtered.
+_SUPABASE_SIGNATURE = ("auth", "storage", "extensions", "realtime", "vault")
+
+
+def _filter_supabase_system_schemas(schemas: list[str], report: IntrospectReport) -> list[str]:
+    low = {s.lower() for s in schemas}
+    if sum(sig in low for sig in _SUPABASE_SIGNATURE) < 3:
+        return schemas  # not Supabase — leave every schema as-is
+    kept = [s for s in schemas if s.lower() not in _SUPABASE_SYS_SCHEMAS]
+    skipped = [s for s in schemas if s.lower() in _SUPABASE_SYS_SCHEMAS]
+    if skipped:
+        report.notes.append(
+            "Supabase detected — skipped its system schemas (kept your app schemas): "
+            + ", ".join(sorted(skipped)) + ". Pass an explicit --tables allowlist to include any."
+        )
+    return kept
+
+
 def _discover_tables(
     dialect: D.Dialect, runner: Runner, allowlist: Optional[list[str]], report: IntrospectReport
 ) -> list[tuple[Optional[str], str]]:
@@ -245,7 +282,8 @@ def _discover_tables(
     schemas = _try(runner, dialect.sql_schemas())
     if schemas is not None:
         report.mode_per_capability["tables"] = "catalog"
-        report.schemas = [r["schema_name"] for r in schemas]
+        report.schemas = _filter_supabase_system_schemas(
+            [r["schema_name"] for r in schemas], report)
         pairs: list[tuple[Optional[str], str]] = []
         for s in report.schemas:
             trows = _try(runner, dialect.sql_tables(s)) or []
@@ -296,6 +334,15 @@ def _build_table(
             )
         except (ValueError, TypeError):
             perf = None
+
+    # On a large table, seed `recommended_filters` with the date/time columns — the natural
+    # way to narrow a scan. The query path's scan-risk warning then fires only when a query
+    # lacks a filter on one of these (and can name the column). Real index / partition /
+    # clustering keys are layered in per-dialect separately.
+    if perf and (perf.estimated_row_count or 0) >= _LARGE_TABLE_ROWS:
+        date_cols = [c.name for c in cols if c.type in ("date", "timestamp", "time")]
+        if 1 <= len(date_cols) <= _MAX_DATE_FILTER_COLS:
+            perf.recommended_filters = date_cols
 
     return Table(
         name=table,
@@ -393,6 +440,10 @@ def _build_relationships(
                 catalog_ok = True
                 catalog_fks.extend(rows)
 
+    tables_by_name: dict[str, list[Table]] = {}
+    for t in tables:
+        tables_by_name.setdefault(t.name, []).append(t)
+
     rels: list[Relationship] = []
     if catalog_ok and catalog_fks:
         report.mode_per_capability["relationships"] = "catalog"
@@ -400,20 +451,31 @@ def _build_relationships(
             ft, fc, tt, tc = fk.get("from_table"), fk.get("from_column"), fk.get("to_table"), fk.get("to_column")
             if not (ft and fc and tt and tc):
                 continue
+            # Schema each endpoint lives in: the dialect's FK query supplies it on schema-ful
+            # DBs (Postgres/MySQL); otherwise resolve it from the table list (same-schema first).
+            from_schema = fk.get("from_schema") or _schema_of(ft, tables_by_name)
+            to_schema = fk.get("to_schema") or _schema_of(tt, tables_by_name, prefer=from_schema, report=report)
+            cross = bool(from_schema and to_schema and from_schema != to_schema)
             card = build.infer_cardinality(ft, tt, [fc], [tc], grain_by_table)
             # declared-but-unenforced FKs (Redshift/Databricks/Trino) -> confirm by overlap
             confidence = "confirmed" if dialect.fk_enforced else "inferred"
             # enforced-FK joins are trustworthy structure -> auto-approve with a system
             # sign-off (don't flood the review queue); unenforced/probed ones need a glance.
-            kw: dict = {}
-            if dialect.fk_enforced:
-                kw = {"review_state": "approved", "signed_off_by": "agami_introspect",
-                      "signed_off_role": "system", "signed_off_at": _NOW}
+            # EXCEPTION: a join that spans two schemas is an architectural claim — the model now
+            # reaches across namespaces — so surface it for review even when the FK is enforced.
+            desc = ""
+            if dialect.fk_enforced and not cross:
+                kw: dict = {"review_state": "approved", "signed_off_by": "agami_introspect",
+                            "signed_off_role": "system", "signed_off_at": _NOW}
             else:
                 kw = {"review_state": "unreviewed"}
+            if cross:
+                desc = f"crosses schemas: {from_schema} → {to_schema} (declared FK) — confirm it belongs in this model"
+                report.notes.append(f"cross-schema relationship: {from_schema}.{ft} → {to_schema}.{tt} (declared FK)")
             rels.append(Relationship(
                 from_table=ft, from_column=fc, to_table=tt, to_column=tc,
-                relationship=card, join_type="LEFT", confidence=confidence, **kw,
+                from_schema=from_schema, to_schema=to_schema,
+                relationship=card, join_type="LEFT", confidence=confidence, description=desc, **kw,
             ))
         return rels
 
@@ -423,12 +485,51 @@ def _build_relationships(
     return rels
 
 
+def _schema_of(
+    name: str, tables_by_name: dict[str, list[Table]],
+    prefer: Optional[str] = None, report: Optional[IntrospectReport] = None,
+) -> Optional[str]:
+    """The schema a bare table name lives in. When the name exists in several schemas,
+    prefer `prefer` (the other endpoint's schema) so a same-schema FK resolves correctly;
+    otherwise pick deterministically and note the ambiguity for the user to disambiguate."""
+    schemas = sorted({t.schema_name for t in tables_by_name.get(name, []) if t.schema_name})
+    if len(schemas) == 1:
+        return schemas[0]
+    if len(schemas) > 1:
+        if prefer and prefer in schemas:
+            return prefer
+        if report is not None:
+            report.notes.append(
+                f"ambiguous table name {name!r} across schemas {schemas} — picked {schemas[0]}; "
+                "edit the relationship if it should point elsewhere")
+        return schemas[0]
+    return None
+
+
+def _pick_target(cands: list[Table], prefer: Optional[str]) -> Optional[Table]:
+    """Choose the actual target Table for a probed join, preferring the from-table's own
+    schema so a `users` in two schemas doesn't bind to the wrong one (the old bare-name dict
+    silently kept whichever was inserted last)."""
+    if not cands:
+        return None
+    if len(cands) == 1:
+        return cands[0]
+    for t in cands:
+        if t.schema_name == prefer:
+            return t
+    return sorted(cands, key=lambda t: (t.schema_name or ""))[0]
+
+
 def _probe_relationships(
     dialect: D.Dialect, runner: Runner, tables: list[Table],
     grain_by_table: dict[str, set[str]], report: IntrospectReport,
 ) -> list[Relationship]:
-    by_name = {t.name: t for t in tables}
-    # candidate target keys: single-column grains
+    tables_by_name: dict[str, list[Table]] = {}
+    for t in tables:
+        tables_by_name.setdefault(t.name, []).append(t)
+    # candidate target keys: single-column grains. (grain_by_table is bare-name-keyed, so its
+    # key column is best-effort under a cross-schema name clash — the actual target Table is
+    # resolved schema-aware below, which is what the overlap probe + schema stamp depend on.)
     targets = {name: next(iter(g)) for name, g in grain_by_table.items() if len(g) == 1}
     rels: list[Relationship] = []
     for t in tables:
@@ -443,14 +544,25 @@ def _probe_relationships(
                     continue
                 tn = tgt_name.lower()
                 if stem and (stem in tn or tn in stem or tn.rstrip("s") == stem.rstrip("s")):
-                    if _overlaps(dialect, runner, t, c.name, by_name[tgt_name], tgt_col):
+                    tgt = _pick_target(tables_by_name.get(tgt_name, []), prefer=t.schema_name)
+                    if tgt is None:
+                        continue
+                    if _overlaps(dialect, runner, t, c.name, tgt, tgt_col):
+                        cross = bool(t.schema_name and tgt.schema_name and t.schema_name != tgt.schema_name)
+                        desc = "inferred by name+type match + value-overlap probe"
+                        if cross:
+                            desc += f"; crosses schemas {t.schema_name} → {tgt.schema_name}"
+                            report.notes.append(
+                                f"cross-schema relationship: {t.schema_name}.{t.name} → "
+                                f"{tgt.schema_name}.{tgt_name} (inferred)")
                         rels.append(Relationship(
                             from_table=t.name, from_column=c.name,
                             to_table=tgt_name, to_column=tgt_col,
+                            from_schema=t.schema_name, to_schema=tgt.schema_name,
                             relationship=build.infer_cardinality(
                                 t.name, tgt_name, [c.name], [tgt_col], grain_by_table),
                             join_type="LEFT", confidence="proposed", review_state="unreviewed",
-                            description="inferred by name+type match + value-overlap probe",
+                            description=desc,
                         ))
                         break
     return rels

--- a/plugins/agami/scripts/semantic_model/introspect.py
+++ b/plugins/agami/scripts/semantic_model/introspect.py
@@ -44,6 +44,15 @@ _LARGE_TABLE_ROWS = 1_000_000
 # columns (e.g. per-category open/close dates) has no single obvious scan key, so leave it
 # empty for the real partition/index pass rather than listing noise.
 _MAX_DATE_FILTER_COLS = 6
+# Above this row count we SKIP the COUNT(DISTINCT) grain-uniqueness probe. With no catalog
+# PK, that probe full-scans the table once PER id-ish candidate column to find a unique one.
+# On a 40M-row / 40GB fact table with a dozen *_id candidates and a composite (or absent)
+# grain, that's a dozen fruitless full scans — tens of minutes of pure waste — to arrive at
+# the empty grain that is the CORRECT answer for such a table anyway (its real grain is
+# composite, which a single-column probe can't discover). A catalog PK is always honored
+# regardless of size; this guard only governs the scan-heavy fallback. Tuned to clear all
+# ordinary dimension/operational tables while catching the giant fact tables.
+_GRAIN_PROBE_MAX_ROWS = 5_000_000
 
 from . import build
 from . import dialects as D
@@ -307,9 +316,20 @@ def _build_table(
     cols, mode = _columns(dialect, runner, schema, table)
     report.mode_per_capability.setdefault("columns", mode)
 
-    # grain: catalog PKs, else uniqueness probe
-    grain, gmode = _grain(dialect, runner, schema, table, cols)
+    # Estimate row count ONCE up front (a catalog stat — instant, zero scan). Reused for
+    # the grain-probe size guard below AND for performance_hints, so we never fetch twice.
+    est_rows = _estimate_rows(dialect, runner, schema, table)
+
+    # grain: catalog PKs, else uniqueness probe (skipped on very large tables — see _grain)
+    grain, gmode = _grain(dialect, runner, schema, table, cols, est_rows=est_rows)
     report.mode_per_capability.setdefault("grain", gmode)
+    if gmode == "probe_skipped_large":
+        report.notes.append(
+            f"{table}: skipped grain probe (~{est_rows:,} rows > "
+            f"{_GRAIN_PROBE_MAX_ROWS:,}) — left grain empty rather than full-scanning "
+            f"each id column. A composite/absent grain is expected for a fact table this "
+            f"size; set it by hand if you know the key."
+        )
     pk_set = set(grain)
     for c in cols:
         c.primary_key = c.name in pk_set
@@ -325,15 +345,11 @@ def _build_table(
         report.deep_tables.append(table)
 
     perf = None
-    est = _try(runner, dialect.sql_row_estimate(schema, table)) if dialect.sql_row_estimate(schema, table) else None
-    if est and est and est[0].get("estimated_rows") not in (None, ""):
-        try:
-            perf = PerformanceHints(
-                estimated_row_count=int(float(est[0]["estimated_rows"])),
-                estimated_row_count_at=_NOW,  # so the receipt can show "estimated as of <date>"
-            )
-        except (ValueError, TypeError):
-            perf = None
+    if est_rows is not None:
+        perf = PerformanceHints(
+            estimated_row_count=est_rows,
+            estimated_row_count_at=_NOW,  # so the receipt can show "estimated as of <date>"
+        )
 
     # On a large table, seed `recommended_filters` with the date/time columns — the natural
     # way to narrow a scan. The query path's scan-risk warning then fires only when a query
@@ -394,12 +410,36 @@ def _probe_columns(
     return cols
 
 
+def _estimate_rows(
+    dialect: D.Dialect, runner: Runner, schema: Optional[str], table: str
+) -> Optional[int]:
+    """Row count from the catalog statistics (pg_class.reltuples, etc.) — instant, no scan.
+    None when the dialect has no estimate query or the stat is missing/unparseable."""
+    q = dialect.sql_row_estimate(schema, table)
+    if not q:
+        return None
+    est = _try(runner, q)
+    if not est or est[0].get("estimated_rows") in (None, ""):
+        return None
+    try:
+        return int(float(est[0]["estimated_rows"]))
+    except (ValueError, TypeError):
+        return None
+
+
 def _grain(
-    dialect: D.Dialect, runner: Runner, schema: Optional[str], table: str, cols: list[Column]
+    dialect: D.Dialect, runner: Runner, schema: Optional[str], table: str, cols: list[Column],
+    *, est_rows: Optional[int] = None,
 ) -> tuple[list[str], str]:
     pks = _try(runner, dialect.sql_primary_keys(schema, table))
     if pks:
         return [r["column_name"] for r in pks], "catalog"
+    # Size guard: the probe below COUNT(DISTINCT)-scans the table once per candidate. On a
+    # huge fact table with no catalog PK that's tens of minutes of scans yielding nothing —
+    # so skip it above the threshold and report an empty grain (the correct answer here; the
+    # real grain is composite, beyond a single-column probe). See _GRAIN_PROBE_MAX_ROWS.
+    if est_rows is not None and est_rows >= _GRAIN_PROBE_MAX_ROWS:
+        return [], "probe_skipped_large"
     # probe: a single id-ish column that is unique + non-null
     candidates = [c.name for c in cols if c.name.lower() == "id" or c.name.lower().endswith("_id")]
     candidates = candidates or [c.name for c in cols[:3]]

--- a/plugins/agami/scripts/semantic_model/models.py
+++ b/plugins/agami/scripts/semantic_model/models.py
@@ -458,6 +458,12 @@ class Relationship(_Base):
     to_table: str
     from_column: Optional[str] = None
     to_column: Optional[str] = None
+    # Schema (namespace) each endpoint lives in. Stamped at introspection so a join that
+    # spans two schemas of the same DB is visible AS cross-schema, and so two schemas that
+    # each have a same-named table don't get silently conflated. None for schema-less DBs
+    # (SQLite) or models written before schema-qualified relationships shipped.
+    from_schema: Optional[str] = None
+    to_schema: Optional[str] = None
     # SQL-expression escape hatch (CAST, compound, function-based joins).
     on: Optional[str] = None
     join_type: JoinType = "LEFT"
@@ -497,6 +503,12 @@ class Relationship(_Base):
                 "(from_column + to_column) OR (on:)"
             )
         return self
+
+    @property
+    def cross_schema(self) -> bool:
+        """True when this edge joins two different schemas (both endpoints stamped).
+        These are architectural claims worth a human glance — the Review tab badges them."""
+        return bool(self.from_schema and self.to_schema and self.from_schema != self.to_schema)
 
 
 class CrossSubjectAreaRelationship(Relationship):
@@ -544,7 +556,7 @@ class Organization(_Base):
     cross_subject_area_relationships: list[CrossSubjectAreaRelationship] = Field(
         default_factory=list
     )
-    # cross-cutting unification targets (MeridianDemo customer_health pattern)
+    # cross-cutting entities/metrics that unify multiple subject areas
     cross_subject_area_entities: list[Entity] = Field(default_factory=list)
     cross_subject_area_metrics: list[Metric] = Field(default_factory=list)
 

--- a/plugins/agami/scripts/semantic_model/runtime.py
+++ b/plugins/agami/scripts/semantic_model/runtime.py
@@ -523,6 +523,165 @@ def build_receipt(
     return receipt
 
 
+def _model_table_index(org: Organization) -> dict[str, tuple]:
+    """bare table name -> (Table, area_name). First occurrence wins (a cross-schema
+    name clash is rare and the relationships now carry schema to disambiguate)."""
+    idx: dict[str, tuple] = {}
+    for sa in org.subject_areas:
+        for t in sa.tables_defined:
+            idx.setdefault(t.name, (t, sa.name))
+    return idx
+
+
+def _norm_sql(s: Optional[str]) -> str:
+    return " ".join((s or "").split()).lower()
+
+
+def assemble_receipt(
+    org: Organization,
+    sql: str,
+    *,
+    model_version: Optional[str] = None,
+    applied_filters: Optional[list[str]] = None,
+    pre_flight: Optional[PreFlightResult] = None,
+    freshness: Optional[str] = None,
+) -> dict[str, Any]:
+    """The FULL trust receipt for a query, assembled from the model + the SQL.
+
+    This is the single source of truth shared by the agami-query skill and the MCP
+    server, so the SAME "what did this answer touch / what hasn't been approved" panel
+    surfaces in Claude Code and in Claude Desktop. Output matches the RECEIPT_JSON schema
+    the chart template renders (tables_used, relationships, metrics, named_filters,
+    assumptions, warnings, model_version).
+
+    Deterministic, no LLM: tables come from the FROM/JOIN scope; a relationship is
+    "used" when both endpoints are in scope; a metric is "used" when its binding SQL
+    appears in the query; assumptions are the load-bearing columns whose description is
+    AI-written/unknown. Unreviewed metrics surface in `metrics` (review_state) for the
+    approve/change banner — NOT duplicated as a warning. Callers may append ad-hoc
+    (LLM-discovered) metrics to `metrics` after the fact.
+    """
+    receipt: dict[str, Any] = {
+        "sql": sql, "model_version": model_version,
+        "tables_used": [], "relationships": [], "metrics": [],
+        "named_filters": [], "assumptions": [], "warnings": [],
+    }
+    if not _HAVE_SQLGLOT:
+        return receipt
+    try:
+        tree = sqlglot.parse_one(sql, error_level="ignore")
+    except Exception:
+        tree = None
+    if tree is None:
+        return receipt
+
+    scope = _tables_in_scope(tree)            # alias/name -> bare table name
+    used = set(scope.values())
+    tidx = _model_table_index(org)
+
+    for bare in sorted(used):
+        info = tidx.get(bare)
+        if not info:
+            continue
+        t, _area = info
+        ph = t.performance_hints
+        receipt["tables_used"].append({
+            "qname": f"{t.schema_name}.{t.name}" if t.schema_name else t.name,
+            "rows": (ph.estimated_row_count if ph else None),
+            "rows_as_of": (ph.estimated_row_count_at if ph else None),
+            "freshness": freshness,
+        })
+
+    warnings: list[str] = []
+    for sa in org.subject_areas:
+        for r in sa.relationships:
+            if r.from_table in used and r.to_table in used:
+                fq = (r.from_schema + ".") if (r.cross_schema and r.from_schema) else ""
+                tq = (r.to_schema + ".") if (r.cross_schema and r.to_schema) else ""
+                label = f"{fq}{r.from_table} → {tq}{r.to_table}"
+                receipt["relationships"].append({
+                    "name": f"{r.from_table}_to_{r.to_table}",
+                    "from_to": label,
+                    "cardinality": r.relationship,
+                    "confidence": r.confidence,
+                    "review_state": r.review_state,
+                    "origin": "fk" if r.confidence == "confirmed" else "introspect_heuristic",
+                    "signed_off_by": r.signed_off_by,
+                    "signed_off_role": r.signed_off_role,
+                    "signed_off_at": r.signed_off_at,
+                    "cross_schema": r.cross_schema,
+                    "on": r.on,
+                })
+                if r.review_state != "approved":
+                    warnings.append(f"Used an unreviewed join ({label}).")
+
+    nsql = _norm_sql(sql)
+    for sa in org.subject_areas:
+        for met in sa.metrics:
+            binding = next((b for b in (met.bindings or {}).values()
+                            if b and _norm_sql(b) in nsql), "")
+            if not binding:
+                continue
+            receipt["metrics"].append({
+                "name": met.name, "area": sa.name,
+                "definition_prose": met.calculation, "expression": binding,
+                "confidence": met.confidence, "review_state": met.review_state,
+                "origin": getattr(met, "source", None),
+                "signed_off_by": met.signed_off_by,
+                "signed_off_role": met.signed_off_role,
+                "signed_off_at": met.signed_off_at,
+            })
+            # metrics get their own approve/change banner — no duplicate warning line.
+
+    # assumptions: the load-bearing columns the answer leaned on whose description is
+    # AI-written (ai_unvalidated) or unknown (ai_unknown). ai_unknown first, cap 3.
+    def _tables_defining(cname: str) -> list[str]:
+        out = []
+        for b in used:
+            info = tidx.get(b)
+            if info and any(c.name == cname for c in info[0].columns):
+                out.append(b)
+        return out
+
+    ref_cols: set[tuple] = set()
+    for col in tree.find_all(exp.Column):
+        if not col.name:
+            continue
+        if col.table:                                   # qualified -> resolve via alias scope
+            ref_cols.add((scope.get(col.table, col.table), col.name))
+        else:                                           # unqualified -> attribute only if unambiguous
+            cands = _tables_defining(col.name)
+            if len(cands) == 1:
+                ref_cols.add((cands[0], col.name))
+    unknown: list[dict] = []
+    unval: list[dict] = []
+    for bare, cname in ref_cols:
+        info = tidx.get(bare)
+        if not info:
+            continue
+        t, _ = info
+        mc = next((c for c in t.columns if c.name == cname), None)
+        if not mc:
+            continue
+        q = f"{t.schema_name + '.' if t.schema_name else ''}{t.name}.{cname}"
+        if mc.description_source == "ai_unknown":
+            unknown.append({"column": q, "meaning": None, "source": "ai_unknown"})
+        elif mc.description_source == "ai_unvalidated" and (mc.description or "").strip():
+            unval.append({"column": q, "meaning": mc.description, "source": "ai_unvalidated"})
+    receipt["assumptions"] = (unknown + unval)[:3]
+
+    if warnings:
+        warnings.append("Review these unreviewed joins in the agami model explorer "
+                        "(/agami-model, or say 'open the review queue').")
+    receipt["warnings"] = warnings
+    if applied_filters:
+        receipt["default_filters_applied"] = applied_filters
+    if pre_flight and pre_flight.risk:
+        receipt["pre_flight"] = {"risk": pre_flight.risk, "action": pre_flight.action,
+                                 "reason": pre_flight.reason}
+    return receipt
+
+
 # ---------------------------------------------------------------------------
 # SQL helpers (sqlglot)
 # ---------------------------------------------------------------------------
@@ -852,4 +1011,5 @@ __all__ = [
     "pre_flight_check",
     "apply_default_filters",
     "build_receipt",
+    "assemble_receipt",
 ]

--- a/plugins/agami/shared/chart-template.html
+++ b/plugins/agami/shared/chart-template.html
@@ -33,8 +33,11 @@
       "tables_used":     [{"qname":"public.orders", "rows":5000, "freshness":"2026-05-09T23:00:00Z (nightly batch)"}, ...],
       "relationships":   [{"name":"orders_to_customers","from_to":"orders → customers",
                            "confidence":0.62,"review_state":"unreviewed","origin":"introspect_heuristic"}, ...],
-      "metrics":         [{"name":"revenue","definition_prose":"...","signed_off_by":"jane@x.com",
-                           "signed_off_role":"cfo","signed_off_at":"2026-03-15T10:00:00Z"}, ...],
+      "metrics":         [{"name":"revenue","area":"sales","definition_prose":"...","review_state":"approved",
+                           "signed_off_by":"jane@x.com","signed_off_role":"cfo","signed_off_at":"2026-03-15T10:00:00Z"},
+                          // on-the-fly calc the user hasn't approved → drives the top approve/change banner:
+                          {"name":"gross_margin","area":"sales","definition_prose":"(net_revenue - cogs) / net_revenue",
+                           "expression":"(SUM(nr)-SUM(cogs))/NULLIF(SUM(nr),0)","review_state":"unreviewed","origin":"ad_hoc"}, ...],
       "named_filters":   [{"name":"active_customer","expression":"...","definition_prose":"..."}, ...],
       "assumptions":     [{"column":"sales.orders.amount","meaning":"net revenue, USD","source":"ai_unvalidated"}, ...],
       "warnings":        ["⚠ Used 1 unreviewed join (orders → customers, conf 0.62). Review now?", ...]
@@ -260,6 +263,38 @@
         border-color: #b45309;
       }
     }
+    /* --- Unapproved-metric banner (on-the-fly metrics the user hasn't signed off) --- */
+    .metric-approval-banner {
+      margin: 16px 0 20px; padding: 14px 16px;
+      background: #fef3c7; color: #78350f; border: 1px solid #f59e0b; border-radius: 8px;
+      font-size: 14px; line-height: 1.5;
+    }
+    @media (prefers-color-scheme: dark) {
+      .metric-approval-banner { background: #422006; color: #fbbf24; border-color: #b45309; }
+    }
+    .metric-approval-banner h3 { margin: 0 0 4px; font-size: 14px; font-weight: 700; }
+    .map-intro { margin: 0 0 8px; }
+    .map-item { padding: 10px 0 4px; border-top: 1px solid rgba(245,158,11,0.45); }
+    .map-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .map-name { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-weight: 700; }
+    .map-def { font-size: 13px; margin: 4px 0 8px; opacity: 0.95; }
+    .map-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .map-actions button, .map-edit button, .map-send button {
+      font-size: 12px; padding: 5px 12px; border-radius: 6px;
+      border: 1px solid currentColor; background: transparent; color: inherit; cursor: pointer;
+    }
+    .map-actions button.queued-approve { background: #166534; color: #fff; border-color: #166534; }
+    .map-actions button.queued-change  { background: var(--accent); color: #fff; border-color: var(--accent); }
+    .map-edit { margin: 8px 0 4px; }
+    .map-edit textarea {
+      width: 100%; box-sizing: border-box; min-height: 60px; padding: 8px;
+      border: 1px solid #f59e0b; border-radius: 6px; background: var(--bg); color: var(--fg);
+      font: 13px ui-monospace, monospace;
+    }
+    .map-edit .map-edit-bar { display: flex; gap: 8px; margin-top: 6px; }
+    .map-status { font-size: 12px; margin-top: 6px; min-height: 1em; font-weight: 600; }
+    .map-send { margin-top: 12px; padding-top: 10px; border-top: 1px solid rgba(245,158,11,0.45); }
+    .map-send button { font-size: 13px; padding: 7px 14px; border-color: #92400e; }
     details.trust-receipt { margin: 24px 0 16px; }
     details.trust-receipt > summary {
       cursor: pointer;
@@ -340,7 +375,7 @@
       margin: 0;
       background: var(--code-bg);
       padding: 14px 16px;
-      padding-right: 80px;  /* leave room for the Copy button */
+      padding-right: 150px;  /* leave room for the Copy + Edit buttons */
       border-radius: 8px;
       overflow-x: auto;
       white-space: pre;
@@ -372,6 +407,36 @@
     .sql-copy:active {
       transform: translateY(1px);
     }
+    /* --- Inline SQL edit (mirrors the model explorer's edit-in-place + Save) --- */
+    .sql-toolbar { position: absolute; top: 8px; right: 8px; display: flex; gap: 6px; z-index: 1; }
+    .sql-btn {
+      padding: 4px 10px; background: var(--card); color: var(--muted);
+      border: 1px solid var(--border, rgba(255,255,255,0.12)); border-radius: 6px;
+      font-family: inherit; font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase;
+      cursor: pointer; transition: color 120ms ease, border-color 120ms ease;
+    }
+    .sql-btn:hover { color: var(--fg); border-color: var(--accent, #4dabf7); }
+    .sql-edit-area {
+      width: 100%; box-sizing: border-box; margin-top: 12px; min-height: 160px;
+      padding: 14px 16px; border: 1px solid var(--border); border-radius: 8px;
+      background: var(--code-bg); color: var(--fg);
+      font: 13px/1.55 ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace;
+      white-space: pre; overflow-x: auto; resize: vertical;
+    }
+    .sql-edit-bar { display: flex; align-items: center; gap: 8px; margin-top: 10px; }
+    .sql-edit-bar button {
+      font-size: 13px; padding: 7px 14px; border-radius: 6px;
+      border: 1px solid var(--border); background: var(--bg); color: var(--fg); cursor: pointer;
+    }
+    .sql-edit-bar button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+    .sql-edit-status { font-size: 12px; color: var(--muted); }
+    .sql-missing { font-size: 13px; color: var(--muted); margin: 0; }
+    .sql-note-label { display: block; font-size: 12px; color: var(--muted); margin: 16px 0 4px; }
+    .sql-note-area {
+      width: 100%; box-sizing: border-box; padding: 8px; border: 1px solid var(--border);
+      border-radius: 6px; background: var(--bg); color: var(--fg); font: 13px ui-monospace, monospace;
+    }
+    .sql-queued-tag { display: block; font-size: 12px; color: var(--accent); margin-top: 10px; min-height: 1em; }
     footer {
       margin-top: 32px;
       padding-top: 16px;
@@ -385,12 +450,7 @@
     footer a { color: var(--muted); text-decoration: none; }
     footer a:hover { color: var(--fg); }
 
-    /* --- Feedback to Claude (correct the SQL / add notes → /agami-save-correction) --- */
-    details.feedback { margin: 10px 0 4px; }
-    details.feedback > summary { cursor: pointer; font-size: 13px; color: var(--accent); list-style: none; padding: 6px 0; }
-    details.feedback > summary::-webkit-details-marker { display: none; }
-    .feedback-body label { display: block; font-size: 12px; color: var(--muted); margin: 10px 0 4px; }
-    .feedback-body textarea { width: 100%; box-sizing: border-box; padding: 8px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--fg); font: 13px ui-monospace, monospace; }
+    /* --- Feedback to Claude: the sticky bottom bar + paste-back modal --- */
     .feedback-bar { position: sticky; bottom: 0; display: flex; align-items: center; gap: 12px; padding: 12px 16px; margin-top: 8px; background: var(--bg-elev); border-top: 1px solid var(--border); }
     .feedback-bar #feedback-summary { font-size: 13px; color: var(--muted); margin-right: auto; }
     .feedback-bar button, .modal-actions button { font-size: 13px; padding: 8px 14px; border-radius: 6px; border: 1px solid var(--border); background: var(--bg); color: var(--fg); cursor: pointer; }
@@ -469,6 +529,14 @@
     // ---- Feedback to Claude: per-section corrected SQL + notes, queued in the browser,
     //      emitted as a paste-back block that routes to /agami-save-correction. ----
     const feedback = {};  // sectionIdx -> {title, originalSql, sql|null, note|null}
+    // Metric approve/change decisions made in the top banner, queued for the same paste-back.
+    const metricFeedback = {};  // metricName -> {name, area, definition, action:'approve'|'change', newDefinition|null}
+    // A metric the answer used but the user hasn't signed off — either unreviewed in the model
+    // or calculated on the fly (origin "ad_hoc"). approved/rejected don't need the banner.
+    function metricNeedsApproval(m) {
+      const rs = (m && m.review_state || 'unreviewed').toLowerCase();
+      return rs !== 'approved' && rs !== 'rejected';
+    }
     function storeFeedback(i, sec, sqlVal, noteVal) {
       const orig = (sec.sql || '').trim();
       const sqlChanged = (sqlVal || '').trim() && (sqlVal || '').trim() !== orig;
@@ -481,12 +549,20 @@
     }
     function refreshFeedbackBar() {
       const n = Object.keys(feedback).length;
+      const mn = Object.keys(metricFeedback).length;
       const bar = document.getElementById('feedback-bar');
       if (!bar) return;
-      document.getElementById('feedback-summary').textContent = n
-        ? n + (n === 1 ? ' section' : ' sections') + ' with a fix or note queued'
-        : 'Was this answer right?';
-      document.getElementById('btn-feedback').disabled = n === 0;
+      const parts = [];
+      if (n) parts.push(n + (n === 1 ? ' section' : ' sections') + ' with a fix or note');
+      if (mn) parts.push(mn + ' metric ' + (mn === 1 ? 'decision' : 'decisions'));
+      document.getElementById('feedback-summary').textContent =
+        parts.length ? parts.join(' + ') + ' queued' : 'Was this answer right?';
+      document.getElementById('btn-feedback').disabled = (n + mn) === 0;
+    }
+    function openFeedbackModal() {
+      document.getElementById('fb-text').value = buildFeedbackText();
+      document.getElementById('fb-modal').hidden = false;
+      document.getElementById('fb-status').textContent = '';
     }
     function buildPositiveText() {
       const lines = ['This agami answer looked correct — the query was right.', ''];
@@ -513,6 +589,29 @@
       lines.push('', 'For each section: save the corrected SQL as a prompt example, and route '
                  + 'any note (a column’s unit/meaning/encoding, table formatting, a caveat) to the '
                  + 'right home per the save-correction decision tree. Tell me where each landed.');
+
+      // Metric approve/change decisions from the top banner.
+      const mk = Object.keys(metricFeedback);
+      if (mk.length) {
+        lines.push('', '=== Metric approvals / changes (I made these choices in the report) ===');
+        mk.forEach(name => {
+          const mf = metricFeedback[name];
+          const where = mf.area ? ' (subject area: ' + mf.area + ')' : '';
+          if (mf.action === 'approve') {
+            lines.push('', 'APPROVE metric "' + name + '"' + where,
+                       'Definition: ' + (mf.definition || '(see report)'));
+          } else {
+            lines.push('', 'CHANGE metric "' + name + '"' + where,
+                       'Old definition: ' + (mf.definition || '(see report)'),
+                       'New definition: ' + (mf.newDefinition || ''));
+          }
+        });
+        lines.push('',
+          'For each metric: if it is an on-the-fly calculation not yet in the model, add it as a new '
+          + 'metric; if it already exists, apply the approve/change. Follow the agami-query Phase 4h gate — '
+          + 'show me the exact model write (name, subject area, binding/SQL) and get my OK, then approve it '
+          + 'with MY sign-off (clicking Approve here IS my sign-off). Tell me where each landed.');
+      }
       return lines.join('\n');
     }
 
@@ -648,6 +747,100 @@
       document.getElementById('toc').hidden = false;
     }
 
+    // ---- Unapproved-metric banner (top of report) ----
+    // Every metric this answer used that the user hasn't signed off — whether it's an
+    // unreviewed model metric or one agami calculated on the fly. Each gets Approve / Change
+    // controls; the choice queues into the same paste-back that goes back to Claude.
+    if (receipt && Array.isArray(receipt.metrics)) {
+      const unapproved = receipt.metrics.filter(metricNeedsApproval);
+      if (unapproved.length) {
+        const wrap = document.querySelector('.wrap');
+        const body0 = document.getElementById('report-body');
+        const banner = el('div', { class: 'metric-approval-banner' });
+        const n = unapproved.length;
+        banner.appendChild(el('h3', { text:
+          '⚠ This answer used ' + n + ' metric' + (n === 1 ? '' : 's') + ' you haven’t approved' }));
+        banner.appendChild(el('p', { class: 'map-intro', html:
+          'agami calculated ' + (n === 1 ? 'it' : 'these') + ' for this answer — ' +
+          (n === 1 ? 'it isn’t' : 'they aren’t') + ' a signed-off part of your model yet. ' +
+          '<strong>Approve</strong> to lock the definition into the model so future answers reuse it, ' +
+          'or <strong>Change</strong> if the definition is off. Your choice goes back to Claude to apply.' }));
+
+        unapproved.forEach((m, mi) => {
+          const name = m.name || ('metric_' + (mi + 1));
+          const def = m.definition_prose || m.expression || '';
+          const item = el('div', { class: 'map-item' });
+
+          const head = el('div', { class: 'map-head' });
+          head.appendChild(el('code', { class: 'map-name', text: name }));
+          const rs = (m.review_state || 'unreviewed').toLowerCase();
+          head.appendChild(el('span', { class: 'conf-badge ' + rs, text: m.review_state || 'unreviewed' }));
+          if (m.origin === 'ad_hoc') head.appendChild(el('span', { class: 'conf-badge unreviewed', text: 'calculated on the fly' }));
+          item.appendChild(head);
+
+          if (def) item.appendChild(el('div', { class: 'map-def', text: def }));
+
+          const status = el('div', { class: 'map-status', text: '' });
+          const approveBtn = el('button', { type: 'button', text: '✓ Approve' });
+          const changeBtn = el('button', { type: 'button', text: '✎ Change…' });
+          const actions = el('div', { class: 'map-actions' }, approveBtn, changeBtn);
+
+          // Change editor (hidden until "Change…")
+          const ta = el('textarea', {});
+          ta.value = def;
+          const saveBtn = el('button', { type: 'button', text: 'Save change' });
+          const cancelBtn = el('button', { type: 'button', text: 'Cancel' });
+          const edit = el('div', { class: 'map-edit' }, ta, el('div', { class: 'map-edit-bar' }, saveBtn, cancelBtn));
+          edit.style.display = 'none';
+
+          function refreshState() {
+            const mf = metricFeedback[name];
+            approveBtn.classList.toggle('queued-approve', !!mf && mf.action === 'approve');
+            changeBtn.classList.toggle('queued-change', !!mf && mf.action === 'change');
+            status.textContent = !mf ? ''
+              : mf.action === 'approve' ? '✓ Queued to approve — send it below'
+              : '✎ Change queued — send it below';
+          }
+          approveBtn.addEventListener('click', () => {
+            if (metricFeedback[name] && metricFeedback[name].action === 'approve') {
+              delete metricFeedback[name];                 // toggle off
+            } else {
+              metricFeedback[name] = { name: name, area: m.area || null, definition: def, action: 'approve', newDefinition: null };
+            }
+            edit.style.display = 'none';
+            refreshState(); refreshFeedbackBar();
+          });
+          changeBtn.addEventListener('click', () => {
+            edit.style.display = edit.style.display === 'none' ? 'block' : 'none';
+            if (edit.style.display === 'block') ta.focus();
+          });
+          cancelBtn.addEventListener('click', () => { edit.style.display = 'none'; });
+          saveBtn.addEventListener('click', () => {
+            const v = (ta.value || '').trim();
+            if (v && v !== def) {
+              metricFeedback[name] = { name: name, area: m.area || null, definition: def, action: 'change', newDefinition: v };
+            } else {
+              delete metricFeedback[name];   // no real change → unqueue
+            }
+            edit.style.display = 'none';
+            refreshState(); refreshFeedbackBar();
+          });
+
+          item.appendChild(actions);
+          item.appendChild(edit);
+          item.appendChild(status);
+          banner.appendChild(item);
+        });
+
+        const send = el('div', { class: 'map-send' });
+        send.appendChild(el('button', { type: 'button', text: 'Send my metric decisions to Claude →',
+          onclick: openFeedbackModal }));
+        banner.appendChild(send);
+
+        wrap.insertBefore(banner, body0);
+      }
+    }
+
     // ---- Trust warning banner (top of report, only if there are warnings) ----
     if (receipt && Array.isArray(receipt.warnings) && receipt.warnings.length > 0) {
       const wrap = document.querySelector('.wrap');
@@ -771,59 +964,108 @@
         sectionEl.appendChild(tableCard);
       }
 
-      // SQL — collapsible <details> with a Copy button + multi-line <pre>
-      if (sec.sql) {
-        const det = el('details', { class: 'sql card' });
-        det.appendChild(el('summary', { text: 'SQL' }));
-
-        // Copy button — copies the raw SQL to clipboard, briefly shows "Copied"
-        const wrap = el('div', { class: 'sql-wrap' });
-        const btn = el('button', { class: 'sql-copy', text: 'Copy' });
-        btn.type = 'button';
-        btn.addEventListener('click', () => {
-          const sql = sec.sql || '';
-          if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(sql).then(
-              () => { btn.textContent = 'Copied!'; setTimeout(() => { btn.textContent = 'Copy'; }, 1500); },
-              () => { btn.textContent = 'Copy failed'; setTimeout(() => { btn.textContent = 'Copy'; }, 1500); }
-            );
-          } else {
-            // Fallback for older browsers — select-text in the <pre>
-            const range = document.createRange();
-            range.selectNodeContents(pre);
-            const sel = window.getSelection();
-            sel.removeAllRanges();
-            sel.addRange(range);
-            try { document.execCommand('copy'); btn.textContent = 'Copied!'; }
-            catch (e) { btn.textContent = 'Select all + ⌘C'; }
-            setTimeout(() => { btn.textContent = 'Copy'; }, 1500);
-          }
-        });
-        wrap.appendChild(btn);
-        const pre = el('pre', { text: sec.sql });
-        wrap.appendChild(pre);
-        det.appendChild(wrap);
-        sectionEl.appendChild(det);
-      }
-
-      // Feedback: correct this section's SQL / add a note → /agami-save-correction
+      // SQL card — shows the exact executed SQL, with edit-in-place + Save and a notes
+      // field (mirrors the model explorer). Editing the SQL or adding a note queues a fix
+      // into the bottom feedback bar (the paste-back to Claude → /agami-save-correction).
       {
-        const fb = el('details', { class: 'feedback' });
-        fb.appendChild(el('summary', { text: '✎ Fix the SQL or add a note' }));
-        const inner = el('div', { class: 'feedback-body' });
-        inner.appendChild(el('label', { text: 'Corrected SQL — edit if this query was wrong:' }));
-        const sqlTa = el('textarea', { rows: '6' });
-        sqlTa.value = sec.sql || '';
-        inner.appendChild(sqlTa);
-        inner.appendChild(el('label', { text: 'Notes — a column’s meaning/units, table formatting, a caveat:' }));
-        const noteTa = el('textarea', { rows: '3',
-          placeholder: 'e.g. amounts are in INR; TOTAL can be negative for refunds; show dates as MMM D, YYYY' });
+        const det = el('details', { class: 'sql card' });
+        const summary = el('summary', { text: 'SQL' });
+        det.appendChild(summary);
+        const inner = el('div', {});
+
+        // The notes field + queued tag are shared by the SQL editor below, so declare first.
+        const queuedTag = el('span', { class: 'sql-queued-tag', text: '' });
+        const noteTa = el('textarea', { class: 'sql-note-area', rows: '3',
+          placeholder: 'e.g. amounts are in INR; cart_discount is order-level — allocate per line; show dates as MMM D, YYYY' });
+        // Holds the in-progress (un-queued) SQL edit so re-opening the editor keeps it.
+        let draftSql = sec.sql || '';
+
+        function markQueued() {
+          const q = !!feedback[i];
+          queuedTag.textContent = q
+            ? '✓ Queued — copy the block from the bar at the bottom to send it to Claude'
+            : '';
+          summary.textContent = q ? 'SQL — edit queued' : 'SQL';
+        }
+        noteTa.addEventListener('input', () => {
+          storeFeedback(i, sec, (feedback[i] && feedback[i].sql) || draftSql, noteTa.value);
+          markQueued();
+        });
+
+        if (sec.sql) {
+          const wrap = el('div', { class: 'sql-wrap' });
+          const pre = el('pre', { text: sec.sql });
+
+          // Read-mode toolbar: Copy + Edit (top-right).
+          const copyBtn = el('button', { class: 'sql-btn', text: 'Copy', type: 'button' });
+          const editBtn = el('button', { class: 'sql-btn', text: '✎ Edit', type: 'button' });
+          const toolbar = el('div', { class: 'sql-toolbar' }, copyBtn, editBtn);
+
+          // Edit-mode: textarea + Save / Cancel (hidden until Edit).
+          const ta = el('textarea', { class: 'sql-edit-area' });
+          ta.value = draftSql;
+          const saveBtn = el('button', { class: 'primary', text: 'Save', type: 'button' });
+          const cancelBtn = el('button', { text: 'Cancel', type: 'button' });
+          const status = el('span', { class: 'sql-edit-status', text: '' });
+          const editBar = el('div', { class: 'sql-edit-bar' }, saveBtn, cancelBtn, status);
+          ta.style.display = 'none';
+          editBar.style.display = 'none';
+
+          copyBtn.addEventListener('click', () => {
+            const sql = sec.sql || '';
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+              navigator.clipboard.writeText(sql).then(
+                () => { copyBtn.textContent = 'Copied!'; setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500); },
+                () => { copyBtn.textContent = 'Copy failed'; setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500); }
+              );
+            } else {
+              const range = document.createRange();
+              range.selectNodeContents(pre);
+              const sel = window.getSelection();
+              sel.removeAllRanges();
+              sel.addRange(range);
+              try { document.execCommand('copy'); copyBtn.textContent = 'Copied!'; }
+              catch (e) { copyBtn.textContent = 'Select all + ⌘C'; }
+              setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
+            }
+          });
+          editBtn.addEventListener('click', () => {
+            ta.value = (feedback[i] && feedback[i].sql) || draftSql;
+            pre.style.display = 'none'; toolbar.style.display = 'none';
+            ta.style.display = 'block'; editBar.style.display = 'flex';
+            status.textContent = ''; ta.focus();
+          });
+          cancelBtn.addEventListener('click', () => {
+            pre.style.display = ''; toolbar.style.display = 'flex';
+            ta.style.display = 'none'; editBar.style.display = 'none';
+          });
+          saveBtn.addEventListener('click', () => {
+            draftSql = ta.value;
+            storeFeedback(i, sec, draftSql, noteTa.value);
+            // reflect the edit in the read view so the card shows what will be sent
+            pre.textContent = draftSql.trim() || sec.sql;
+            pre.style.display = ''; toolbar.style.display = 'flex';
+            ta.style.display = 'none'; editBar.style.display = 'none';
+            markQueued();
+          });
+
+          wrap.appendChild(toolbar);
+          wrap.appendChild(pre);
+          wrap.appendChild(ta);
+          wrap.appendChild(editBar);
+          inner.appendChild(wrap);
+        } else {
+          // No SQL captured — don't show an empty editor; let the user flag it via a note.
+          inner.appendChild(el('p', { class: 'sql-missing',
+            text: 'No SQL was captured for this section. If this section should have a query, add a note below.' }));
+        }
+
+        inner.appendChild(el('label', { class: 'sql-note-label',
+          text: 'Notes for Claude — a column’s meaning/units, formatting, a caveat:' }));
         inner.appendChild(noteTa);
-        const onInput = () => storeFeedback(i, sec, sqlTa.value, noteTa.value);
-        sqlTa.addEventListener('input', onInput);
-        noteTa.addEventListener('input', onInput);
-        fb.appendChild(inner);
-        sectionEl.appendChild(fb);
+        inner.appendChild(queuedTag);
+        det.appendChild(inner);
+        sectionEl.appendChild(det);
       }
 
       body.appendChild(sectionEl);
@@ -1077,11 +1319,7 @@
     }
 
     // ---- Feedback bar + modal wiring ----
-    document.getElementById('btn-feedback').addEventListener('click', () => {
-      document.getElementById('fb-text').value = buildFeedbackText();
-      document.getElementById('fb-modal').hidden = false;
-      document.getElementById('fb-status').textContent = '';
-    });
+    document.getElementById('btn-feedback').addEventListener('click', openFeedbackModal);
     document.getElementById('btn-looks-good').addEventListener('click', () => {
       document.getElementById('fb-text').value = buildPositiveText();
       document.getElementById('fb-modal').hidden = false;

--- a/plugins/agami/shared/examples-validation-template.html
+++ b/plugins/agami/shared/examples-validation-template.html
@@ -274,16 +274,21 @@
     }
     .pending-summary { font-size: 14px; color: var(--fg); flex: 1; }
     .pending-summary .count { font-weight: 600; }
-    .sticky-footer button {
+    /* Footer + modal buttons share one style — so the paste-back / add-example modals match
+       the footer and the query-page / model-explorer surfaces (which the modal lacked before,
+       leaving its buttons as unstyled native controls). */
+    .sticky-footer button, .modal-actions button {
       font: inherit; font-size: 14px; font-weight: 500;
       padding: 8px 16px; border-radius: 6px; cursor: pointer;
       border: 1px solid var(--border); background: var(--bg); color: var(--fg);
     }
-    .sticky-footer button.primary {
+    .sticky-footer button:hover:not(.primary):not(:disabled),
+    .modal-actions button:hover:not(.primary) { border-color: var(--accent); color: var(--accent); }
+    .sticky-footer button.primary, .modal-actions button.primary {
       background: var(--accent); color: white; border-color: var(--accent);
     }
-    .sticky-footer button.primary:hover { background: var(--accent-hover); }
-    .sticky-footer button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .sticky-footer button.primary:hover, .modal-actions button.primary:hover { background: var(--accent-hover); }
+    .sticky-footer button:disabled, .modal-actions button:disabled { opacity: 0.5; cursor: not-allowed; }
 
     /* Modal */
     .modal-backdrop {

--- a/plugins/agami/shared/model-explorer-template.html
+++ b/plugins/agami/shared/model-explorer-template.html
@@ -33,6 +33,7 @@
       "entities":     [ { "name", "qname", "plural", "other_names", "value_pattern",
                           "maps_to":["t.c"], "description", "review_state", "excluded", "area" } ],
       "relationships":[ { "qname", "from_table", "from_column", "to_table", "to_column", "on",
+                          "from_schema", "to_schema", "cross_schema",
                           "cardinality", "description", "review_state", "excluded", "area" } ],
       "examples":     [ { "n", "qname", "question", "sql", "tables", "source", "status", "area" } ]
     }
@@ -275,6 +276,7 @@
     .card-actions button.queued-edit { border-color: var(--accent); color: var(--accent); }
     .card-actions .moot-note { font-size: 12px; color: var(--warn-fg); font-weight: 500; }
     .table-state-badge.moot-badge { background: var(--code-bg); color: var(--muted); border: 1px solid var(--border); }
+    .table-state-badge.xschema-badge { background: var(--warn-bg); color: var(--warn-fg); border: 1px solid var(--warn-fg); cursor: help; }
     /* Prominent edit button (e.g. table details) — outlined accent so it's easy to find */
     .card-actions button.btn-edit-prominent {
       background: var(--bg); color: var(--accent); border: 1px solid var(--accent); font-weight: 600;
@@ -400,6 +402,16 @@
     }
     .btn-sm.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
     .btn-sm.primary:hover { background: var(--accent-hover); }
+    /* Prominent "Add metric" buttons (the open trigger + the form submit) — easy to spot.
+       Selector outscopes the generic `.card-actions button` rule (else it gets overridden). */
+    .card-actions button.add-metric-open, .card-actions button.add-metric-go,
+    .add-metric-open, .add-metric-go {
+      font: inherit; font-size: 14px; font-weight: 600; padding: 10px 22px; margin: 8px 18px;
+      background: var(--accent); color: #fff; border: 1px solid var(--accent);
+      border-radius: 7px; cursor: pointer;
+    }
+    .card-actions button.add-metric-open:hover, .card-actions button.add-metric-go:hover,
+    .add-metric-open:hover, .add-metric-go:hover { background: var(--accent-hover); color: #fff; border-color: var(--accent-hover); }
 
     pre.code-block {
       font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px;
@@ -427,6 +439,21 @@
     .rt-editor:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--info-bg); }
     .rt-editor:empty::before { content: '(empty — add domain context so answers know what the data means)';
       color: var(--muted); font-style: italic; }
+
+    /* Per-kind sub-headers inside a Review sub-tab (Metrics / Joins / Entities) */
+    .kind-subhead {
+      display: flex; align-items: center; gap: 8px;
+      margin: 20px 0 8px; padding-bottom: 5px; border-bottom: 1px solid var(--border);
+    }
+    .kind-subhead:first-child { margin-top: 4px; }
+    .kind-subhead-label {
+      font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+      color: var(--fg);
+    }
+    .kind-count {
+      font-size: 11px; color: var(--muted); background: var(--code-bg);
+      border-radius: 999px; padding: 1px 8px; font-variant-numeric: tabular-nums;
+    }
 
     /* Queued tab */
     .queue-group { margin-bottom: 18px; }
@@ -647,7 +674,12 @@
     const STORAGE_TYPE = manifest.storage_type || '';
     const AREAS = (manifest.schemas || []).map(s => s.name);
     const ALL_TABLES = [];
-    (manifest.schemas || []).forEach(s => (s.tables || []).forEach(t => ALL_TABLES.push(t.name)));
+    const TABLE_AREA = {};   // table name -> its subject area, so a new metric's area can be inferred
+    (manifest.schemas || []).forEach(s => (s.tables || []).forEach(t => { ALL_TABLES.push(t.name); TABLE_AREA[t.name] = s.name; }));
+    // Tables named in a SQL binding (qualified like `orders.amount`) — for inferring source tables + area.
+    function tablesInSql(sql) {
+      return ALL_TABLES.filter(t => new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b', 'i').test(sql || ''));
+    }
 
     // ---- State ----
     // pending[qname] = "exclude" | "include"   (tables + columns)
@@ -832,9 +864,13 @@
     function mootReason(it) {
       const area = it.area;
       if (it.from_table) {  // relationship — moot if EITHER endpoint table is excluded
+        // A cross-area join's endpoints live in DIFFERENT areas — check each in its own
+        // (else the to-table looks "missing" in the from-area and the join is wrongly moot).
+        const fromArea = it.from_subject_area || area;
+        const toArea = it.to_subject_area || area;
         const ex = [];
-        if (tableEffExcluded(area, it.from_table)) ex.push(it.from_table);
-        if (tableEffExcluded(area, it.to_table)) ex.push(it.to_table);
+        if (tableEffExcluded(fromArea, it.from_table)) ex.push(it.from_table);
+        if (tableEffExcluded(toArea, it.to_table)) ex.push(it.to_table);
         if (ex.length) return ex.join(' & ') + ' excluded';
       } else if (it.source_tables) {  // metric — needs ALL its source tables
         const ex = (it.source_tables || []).filter(t => tableEffExcluded(area, t));
@@ -1414,6 +1450,12 @@
         header.appendChild(el('span', { class: 'conf-chip conf-' + item.confidence + ' tip', text: item.confidence,
           'data-tip': CONF_MEANING[item.confidence] || ('confidence: ' + item.confidence) }));
       }
+      // A join that spans two schemas — flag it; it's an architectural claim worth a glance.
+      if (item.cross_schema) {
+        header.appendChild(el('span', { class: 'table-state-badge xschema-badge', text: 'cross-schema',
+          title: 'Joins across schemas: ' + (item.from_schema || '?') + ' → ' + (item.to_schema || '?')
+                 + ' — confirm this link belongs in your model' }));
+      }
       if (mootReason(item)) header.appendChild(el('span', { class: 'table-state-badge moot-badge', text: 'unused', title: "Won't be used — " + mootReason(item) }));
       if (item.rule === 1 && (rs === 'unreviewed' || rs === 'stale') && !mootReason(item)) header.appendChild(el('span', { class: 'table-state-badge', style: 'background:var(--info-bg);color:var(--accent);border-color:var(--info-border);', text: 'needs sign-off' }));
       const badge = stateBadge(rs === 'approved' ? 'approved' : rs, eff);
@@ -1426,7 +1468,7 @@
       const card = el('div', { class: 'table-card' + (eff ? ' excluded' : '') + (queuedAction(m.qname) ? ' queued-' + queuedAction(m.qname) : '') });
       card.appendChild(flatCardHeader(m.name, m, eff));
       const body = el('div', { class: 'table-body' });
-      body.appendChild(labelLine('Calculation (click to edit)'));
+      body.appendChild(labelLine('What it measures (click to edit)'));
       body.appendChild(inlineBlock({ qname: m.qname, area: m.area, name: m.name, kind: 'metric',
         field: 'calculation', original: m.calculation, placeholder: '(click to add the calculation)' }));
       const bindings = m.bindings || {};
@@ -1470,8 +1512,11 @@
     function renderRelCard(r) {
       const eff = effExcluded(r);
       const card = el('div', { class: 'table-card' + (eff ? ' excluded' : '') + (queuedAction(r.qname) ? ' queued-' + queuedAction(r.qname) : '') });
-      const join = r.from_column ? `${r.from_table}.${r.from_column} → ${r.to_table}.${r.to_column}`
-                                 : `${r.from_table} → ${r.to_table}${r.on ? ' ON ' + r.on : ''}`;
+      // Schema-qualify each side when the join crosses schemas, so the label itself shows it.
+      const fq = r.cross_schema && r.from_schema ? r.from_schema + '.' : '';
+      const tq = r.cross_schema && r.to_schema ? r.to_schema + '.' : '';
+      const join = r.from_column ? `${fq}${r.from_table}.${r.from_column} → ${tq}${r.to_table}.${r.to_column}`
+                                 : `${fq}${r.from_table} → ${tq}${r.to_table}${r.on ? ' ON ' + r.on : ''}`;
       card.appendChild(flatCardHeader(join, r, eff));
       const body = el('div', { class: 'table-body' });
       if (r.cardinality) { body.appendChild(labelLine('Cardinality')); body.appendChild(descBlock(r.cardinality)); }
@@ -1531,6 +1576,34 @@
       root.appendChild(sec);
     }
 
+    // The Joins tab: one tab, but split into "In-schema joins" and "Cross-schema joins"
+    // sections so the cross-schema (cross-area) edges read distinctly. Split only when
+    // cross-schema joins exist — a single-schema DB just renders one flat list as before.
+    function renderJoinsTab(root) {
+      const all = [...(manifest.relationships || []), ...(manifest.cross_relationships || [])];
+      const hay = r => `${relName(r)} ${r.cardinality} ${r.description} ${r.area || ''} ${r.from_schema || ''} ${r.to_schema || ''}`;
+      const matched = all.filter(it => (!searchQ || hay(it).toLowerCase().includes(searchQ)) && passesFilter(it, 'relationship'));
+      setSearchCounts(`${matched.length} of ${all.length} join${all.length === 1 ? '' : 's'} shown`);
+      if (!matched.length) {
+        root.appendChild(el('div', { class: 'empty-state',
+          text: all.length === 0 ? 'No joins defined yet.' : 'No joins match the current search / filter.' }));
+        return;
+      }
+      const sec = el('div', { class: 'schema-section' });
+      const inSchema = matched.filter(r => !r.cross_schema);
+      const crossSchema = matched.filter(r => r.cross_schema);
+      if (crossSchema.length) {
+        [['In-schema joins', inSchema], ['Cross-schema joins', crossSchema]].forEach(([label, items]) => {
+          if (!items.length) return;
+          sec.appendChild(kindSubhead(label, items, false));
+          items.forEach(r => sec.appendChild(renderRelCard(r)));
+        });
+      } else {
+        matched.forEach(r => sec.appendChild(renderRelCard(r)));
+      }
+      root.appendChild(sec);
+    }
+
     // =====================================================================
     // TAB: Review (the sign-off queue) — folds in the old /agami-review surface
     // =====================================================================
@@ -1538,6 +1611,44 @@
       return it._kind === 'metric' ? renderMetricCard(it)
            : it._kind === 'entity' ? renderEntityCard(it)
            : renderRelCard(it);
+    }
+    // Render a sub-tab's cards grouped with a sub-header each, instead of one long
+    // undifferentiated list. Cross-schema joins get their own group (separate from regular
+    // intra-schema joins) — they're the architectural edges most worth a focused look.
+    // A list with only one group renders flat (no header).
+    const REVIEW_GROUPS = [
+      { label: 'Metrics',            match: it => it._kind === 'metric' },
+      { label: 'Joins',              match: it => it._kind === 'relationship' && !it.cross_schema },
+      { label: 'Cross-schema joins', match: it => it._kind === 'relationship' && it.cross_schema },
+      { label: 'Entities',           match: it => it._kind === 'entity' },
+    ];
+    function kindSubhead(label, items, bulk) {
+      const h = el('div', { class: 'kind-subhead' });
+      h.appendChild(el('span', { class: 'kind-subhead-label', text: label }));
+      h.appendChild(el('span', { class: 'kind-count', text: String(items.length) }));
+      if (bulk) {
+        const approvable = items.filter(isApprovable);
+        if (approvable.length) h.appendChild(el('button', { type: 'button', class: 'btn-sm',
+          style: 'margin-left:auto;', onclick: () => bulkApprove(items) }, `✓ Approve ${approvable.length}`));
+      }
+      return h;
+    }
+    function appendGroupedCards(sec, items, bulk) {
+      const used = new Set();
+      const groups = [];
+      REVIEW_GROUPS.forEach(gd => {
+        const gi = items.filter(it => gd.match(it));
+        gi.forEach(it => used.add(it));
+        if (gi.length) groups.push({ label: gd.label, items: gi });
+      });
+      const other = items.filter(it => !used.has(it));
+      if (other.length) groups.push({ label: 'Other', items: other });
+      // ALWAYS show the kind header — even for a single group — so "Cross-schema joins"
+      // stays labelled when it's the only pile left, instead of looking like plain joins.
+      groups.forEach(g => {
+        sec.appendChild(kindSubhead(g.label, g.items, bulk));
+        g.items.forEach(it => sec.appendChild(reviewCard(it)));
+      });
     }
     function needsEyes(it) {
       // Rule 1 (metrics — block runtime), low-confidence guesses, and drifted entries
@@ -1580,6 +1691,9 @@
       (manifest.metrics || []).forEach(m => out.push({ ...m, _kind: 'metric' }));
       (manifest.entities || []).forEach(e => out.push({ ...e, _kind: 'entity' }));
       (manifest.relationships || []).forEach(r => out.push({ ...r, _kind: 'relationship' }));
+      // cross-area (cross-schema / cross-datasource) joins are reviewable too — they're the
+      // architectural edges most worth a human glance, so they belong in the queue.
+      (manifest.cross_relationships || []).forEach(r => out.push({ ...r, _kind: 'relationship' }));
       return out;
     }
     // Columns agami couldn't read (description_source === 'ai_unknown'), still without a
@@ -1688,7 +1802,7 @@
         if (!unknown.length) sec.appendChild(el('div', { class: 'empty-state', text: 'Nothing here — agami understood every column.' }));
         else unknown.forEach(uc => sec.appendChild(describeCard(uc)));
         root.appendChild(sec);
-        root.appendChild(nextStepsCallout());
+        root.appendChild(nextStepsCallout({ looksCount: groups.looks.items.filter(isApprovable).length }));
         return;
       }
 
@@ -1696,33 +1810,42 @@
       setSearchCounts(`${g.items.length} ${g.label.toLowerCase()}`);
 
       const sec = el('div', { class: 'schema-section' });
-      if (g.bulk) {
-        const approvable = g.items.filter(isApprovable);
-        if (approvable.length) {
-          const head = el('div', { class: 'schema-header' });
-          head.appendChild(document.createTextNode(g.label));
-          head.appendChild(el('button', { type: 'button', class: 'btn-sm primary', style: 'margin:0 0 0 auto;',
-            onclick: () => bulkApprove(g.items) }, `✓ Approve all ${approvable.length}`));
-          sec.appendChild(head);
-        }
-      }
+      // No blanket "Approve all" — each kind sub-header carries its own scoped "✓ Approve N",
+      // so approving metrics can't silently approve the joins too (that was the footgun).
       if (g.hint) sec.appendChild(el('div', { class: 'field-hint', style: 'padding:0 0 8px;', text: g.hint }));
       if (!g.items.length) {
         sec.appendChild(el('div', { class: 'empty-state', text: 'Nothing in “' + g.label + '”.' }));
       } else {
-        g.items.forEach(it => sec.appendChild(reviewCard(it)));
+        appendGroupedCards(sec, g.items, g.bulk);
       }
       root.appendChild(sec);
-      root.appendChild(nextStepsCallout());
+      root.appendChild(nextStepsCallout({ looksCount: groups.looks.items.filter(isApprovable).length }));
     }
-    // Signpost: the Review tab only covers the AI-proposed layer; excluding tables and
-    // fixing column details happen on the Tables tab. Make that obvious.
-    function nextStepsCallout() {
+    // Signpost: a short "next steps" panel. Two things the untouched-review pile doesn't
+    // surface on its own — (1) eyeball the high-confidence "Looks right" pile and approve it
+    // in one click, and (2) excluding tables + fixing column details, which live on the
+    // Tables tab. Shown at the bottom of every Review sub-tab.
+    function nextStepsCallout(opts) {
+      opts = opts || {};
+      // Only nudge toward "Looks right" when there are confident items AND we're not already on it.
+      const showLooks = opts.looksCount > 0 && reviewSubTab !== 'looks';
       const c = el('div', { class: 'next-steps' });
-      c.appendChild(el('div', { class: 'ns-title', text: '✓ Reviewed the AI’s work? Two more things live on the Tables tab' }));
+      c.appendChild(el('div', { class: 'ns-title', text: 'Next steps' }));
+
+      if (showLooks) {
+        c.appendChild(el('div', { class: 'ns-body', style: 'margin-bottom:8px;', html:
+          '<strong>1. Eyeball what agami is confident of.</strong> The <strong>Looks right</strong> pile (' + opts.looksCount + ') ' +
+          'is built-in keys and strong name/type matches — usually fine. Skim it and approve them all in one click, ' +
+          'so only genuine guesses are left for you to weigh.' }));
+        c.appendChild(el('button', { type: 'button', class: 'btn-sm primary', style: 'margin:0 0 14px;',
+          onclick: () => { reviewSubTab = 'looks'; renderBody(); } },
+          'Review “Looks right” (' + opts.looksCount + ') →'));
+      }
+
       c.appendChild(el('div', { class: 'ns-body', html:
-        'This queue only covers what agami <strong>proposed</strong> — metrics, joins, entities, and columns it couldn’t read. ' +
-        'It does <em>not</em> include: <strong>excluding tables</strong> you don’t want queried (staging / scratch / temp / raw-PII tables), ' +
+        '<strong>' + (showLooks ? '2. ' : '') + 'Finish on the Tables tab.</strong> This queue only covers what agami ' +
+        '<strong>proposed</strong> — metrics, joins, entities, and columns it couldn’t read. It does <em>not</em> include ' +
+        '<strong>excluding tables</strong> you don’t want queried (staging / scratch / temp / raw-PII tables), ' +
         'or <strong>fixing column details</strong> (descriptions, units, PII flags). Those are on the <strong>Tables</strong> tab.' }));
       c.appendChild(el('button', { type: 'button', class: 'btn-sm primary', style: 'margin:10px 0 0;',
         onclick: () => { activeTab = 'tables'; const s = document.getElementById('search'); if (s) s.value = ''; searchQ = ''; renderAll(); } },
@@ -1737,48 +1860,57 @@
         el('div', { class: 'table-name' }, 'New metric')));
       const body = el('div', { class: 'table-body' });
       const inputs = {};
-      const mkInput = (label, key, ph, rows) => {
+      // label → (optional hint) → input, so a hint always sits with the field above the box
+      // it explains (never floating between two fields, which reads ambiguously).
+      const mkInput = (label, key, ph, rows, hint) => {
         body.appendChild(labelLine(label));
+        if (hint) body.appendChild(hintLine(hint));
         const t = textarea('', rows || 1); if (ph) t.setAttribute('placeholder', ph);
         body.appendChild(t); inputs[key] = t;
       };
-      mkInput('Name (letters / digits / underscore)', 'name', 'e.g. repeat_purchase_rate', 1);
-      mkInput('Description', 'description', 'one line: what it measures', 2);
-      mkInput('Calculation (prose intent — required)', 'calculation', 'e.g. share of customers with >1 order', 2);
-      mkInput(`${STORAGE_TYPE || 'SQL'} binding (the SQL — required)`, 'binding', 'e.g. COUNT_IF(order_count > 1) / NULLIF(COUNT(*),0)', 2);
-      mkInput('Unit (optional, e.g. INR / percent)', 'unit', '', 1);
-      mkInput('Also called (comma-separated, optional)', 'other_names', 'e.g. repeat rate, returning-buyer rate', 1);
-      // source tables: comma-separated free text (suggest known tables in hint)
-      body.appendChild(labelLine('Source tables (comma-separated)'));
-      body.appendChild(hintLine('Known tables: ' + ALL_TABLES.slice(0, 12).join(', ') + (ALL_TABLES.length > 12 ? ' …' : '')));
+      mkInput('Short name (letters, digits, underscores)', 'name', 'e.g. repeat_purchase_rate', 1);
+      mkInput('What does it measure?', 'calculation', 'e.g. the share of customers who ordered more than once', 2);
+      mkInput(`The SQL that computes it (${STORAGE_TYPE || 'SQL'})`, 'binding',
+              'e.g. SUM(orders.amount)   ·   COUNT(DISTINCT users.id)', 2,
+              'Just the calculation — an aggregate expression, NOT a full SELECT (no FROM/WHERE). Write the table with the column (orders.amount) and agami fills in the rest.');
+      mkInput('Unit (optional)', 'unit', 'e.g. INR, USD, percent', 1);
+      mkInput('Also called (optional, comma-separated)', 'other_names', 'e.g. repeat rate, returning-buyer rate', 1);
+      // Source tables: OPTIONAL — inferred from the SQL above when the columns are qualified.
+      body.appendChild(labelLine('Tables it uses (optional)'));
+      body.appendChild(hintLine('Leave blank if your SQL names them (e.g. orders.amount) — agami detects them. Otherwise list them, comma-separated.'));
       const stTa = textarea('', 1); inputs.source_tables = stTa; body.appendChild(stTa);
-      if (AREAS.length > 1) {
-        body.appendChild(labelLine('Subject area'));
-        const sel = el('select'); AREAS.forEach(a => { const o = el('option', { value: a }); o.textContent = a; sel.appendChild(o); });
-        body.appendChild(sel); inputs.area = sel;
-      }
       const errLine = el('div', { class: 'validate-result bad', style: 'padding:0 18px;' });
       body.appendChild(errLine);
-      body.appendChild(btnSm('Add metric', () => {
+      const actions = el('div', { class: 'card-actions' });
+      const addBtn = el('button', { type: 'button', class: 'btn-sm primary add-metric-go', onclick: () => {
         const name = inputs.name.value.trim();
         const calc = inputs.calculation.value.trim();
         const binding = inputs.binding.value.trim();
+        // source tables: typed, else inferred from the SQL binding
+        let srcTables = stTa.value.split(',').map(s => s.trim()).filter(Boolean);
+        if (!srcTables.length) srcTables = tablesInSql(binding);
+        // subject area: inferred from the tables it uses (no need to ask) — fall back to the
+        // only area, or the first if it genuinely can't be determined.
+        const inferredArea = srcTables.map(t => TABLE_AREA[t]).find(Boolean);
+        const area = inferredArea || (AREAS.length === 1 ? AREAS[0] : (AREAS[0] || ''));
         const problems = [];
-        if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(name)) problems.push('Name must start with a letter and use only letters/digits/underscore.');
-        if (!calc) problems.push('Calculation (prose) is required.');
-        if (!binding) problems.push('SQL binding is required.');
+        if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(name)) problems.push('Name must start with a letter and use only letters/digits/underscores.');
+        if (!calc) problems.push('Say what it measures.');
+        if (!binding) problems.push('Add the SQL that computes it.');
         if (manifest.metrics.some(m => m.name === name) || newMetrics.some(m => m.name === name)) problems.push('A metric with that name already exists.');
+        if (AREAS.length > 1 && !inferredArea && !srcTables.length) problems.push('Add a table it uses (or qualify your SQL like orders.amount) so agami knows where it belongs.');
         if (problems.length) { errLine.textContent = '⚠ ' + problems.join(' '); return; }
         newMetrics.push({
-          area: inputs.area ? inputs.area.value : (AREAS[0] || ''),
-          name, description: inputs.description.value.trim(), calculation: calc, binding,
+          area, name, description: calc, calculation: calc, binding,
           unit: inputs.unit.value.trim(),
           other_names: inputs.other_names.value.split(',').map(s => s.trim()).filter(Boolean),
-          source_tables: stTa.value.split(',').map(s => s.trim()).filter(Boolean),
+          source_tables: srcTables,
         });
         addMetricOpen = false; renderAll();
-      }, 'primary'));
-      body.appendChild(btnSm('Cancel', () => { addMetricOpen = false; renderAll(); }));
+      } }, '✓ Add metric');
+      actions.appendChild(addBtn);
+      actions.appendChild(btnSm('Cancel', () => { addMetricOpen = false; renderAll(); }));
+      body.appendChild(actions);
       wrap.appendChild(body);
       return wrap;
     }
@@ -1789,8 +1921,11 @@
       h.appendChild(el('span', { class: 'table-state-badge badge-approved', text: 'new' }));
       card.appendChild(h);
       const body = el('div', { class: 'table-body' });
-      if (m.calculation) { body.appendChild(labelLine('Calculation')); body.appendChild(descBlock(m.calculation)); }
-      body.appendChild(labelLine((STORAGE_TYPE || 'SQL') + ' binding')); body.appendChild(preBlock(m.binding));
+      if (m.calculation) { body.appendChild(labelLine('What it measures')); body.appendChild(descBlock(m.calculation)); }
+      body.appendChild(labelLine('The SQL')); body.appendChild(preBlock(m.binding));
+      // show the inferred placement so the user can confirm/correct (remove + redo)
+      const place = m.area + (m.source_tables && m.source_tables.length ? ' · uses ' + m.source_tables.join(', ') : '');
+      body.appendChild(hintLine('Will be added to: ' + place));
       const a = el('div', { class: 'card-actions' });
       a.appendChild(el('button', { type: 'button', class: 'queued-exclude',
         onclick: () => { newMetrics.splice(idx, 1); renderAll(); } }, 'Remove'));
@@ -1944,34 +2079,43 @@
     }
     function renderQueuedTab(root) {
       const groups = [];
-      // pending tables/columns
+      // Build a titled queue-group from a list of rows (skips empties), so each kind gets
+      // its own section instead of one long mixed list.
+      const qGroup = (title, rows) => {
+        if (!rows.length) return;
+        const g = el('div', { class: 'queue-group' });
+        g.appendChild(el('h3', { text: title }));
+        rows.forEach(r => g.appendChild(r));
+        groups.push(g);
+      };
+
+      // pending exclusions — split tables vs columns
       const pend = Object.entries(pending);
-      if (pend.length) {
-        const g = el('div', { class: 'queue-group' }); g.appendChild(el('h3', { text: 'Tables & columns' }));
-        pend.forEach(([qname, action]) => {
-          const isCol = qname.split('.').length >= 3;
-          g.appendChild(queueRow(action, action, `${action} ${isCol ? 'column' : 'table'}: ${qname}`, () => delete pending[qname]));
-        });
-        groups.push(g);
-      }
-      // ops metrics/entities/rels
+      const isCol = (qname) => qname.split('.').length >= 3;
+      qGroup('Tables', pend.filter(([q]) => !isCol(q)).map(([q, a]) =>
+        queueRow(a, a, `${a} table: ${q}`, () => delete pending[q])));
+      qGroup('Columns', pend.filter(([q]) => isCol(q)).map(([q, a]) =>
+        queueRow(a, a, `${a} column: ${q}`, () => delete pending[q])));
+
+      // approve/reject ops — split metrics / joins / entities
       const opv = Object.entries(ops);
-      if (opv.length) {
-        const g = el('div', { class: 'queue-group' }); g.appendChild(el('h3', { text: 'Metrics · entities · joins' }));
-        opv.forEach(([qname, o]) => g.appendChild(queueRow(o.op, o.op, `${o.op} ${o.kind}: ${o.area}.${o.name}`, () => delete ops[qname])));
-        groups.push(g);
-      }
-      // field/metric/entity/rel edits
+      const opRow = ([q, o]) => queueRow(o.op, o.op, `${o.op} ${o.kind}: ${o.area}.${o.name}`, () => delete ops[q]);
+      [['metric', 'Metrics'], ['relationship', 'Joins'], ['entity', 'Entities']].forEach(([kind, label]) =>
+        qGroup(label, opv.filter(([, o]) => o.kind === kind).map(opRow)));
+      qGroup('Other', opv.filter(([, o]) => !['metric', 'relationship', 'entity'].includes(o.kind)).map(opRow));
+
+      // edits — split table / column / metric / join / entity
       const ed = Object.entries(edits);
-      if (ed.length) {
-        const g = el('div', { class: 'queue-group' }); g.appendChild(el('h3', { text: 'Edits' }));
-        ed.forEach(([qname, e]) => {
-          const fields = Object.keys(e.fields).join(', ');
-          const tgt = e.column ? `${e.name}.${e.column}` : e.name;
-          g.appendChild(queueRow('edit', 'edit', `${e.kind} ${tgt} — ${fields}`, () => delete edits[qname]));
-        });
-        groups.push(g);
-      }
+      const edRow = ([q, e]) => {
+        const fields = Object.keys(e.fields).join(', ');
+        const tgt = e.column ? `${e.name}.${e.column}` : e.name;
+        return queueRow('edit', 'edit', `${tgt} — ${fields}`, () => delete edits[q]);
+      };
+      qGroup('Table edits', ed.filter(([, e]) => e.kind === 'table' && !e.column).map(edRow));
+      qGroup('Column edits', ed.filter(([, e]) => e.kind === 'table' && e.column).map(edRow));
+      qGroup('Metric edits', ed.filter(([, e]) => e.kind === 'metric').map(edRow));
+      qGroup('Join edits', ed.filter(([, e]) => e.kind === 'relationship').map(edRow));
+      qGroup('Entity edits', ed.filter(([, e]) => e.kind === 'entity').map(edRow));
       // example edits
       const ex = Object.entries(exampleEdits);
       if (ex.length) {
@@ -2063,7 +2207,7 @@
         case 'tables':   return t.tables || 0;
         case 'metrics':  return (manifest.metrics || []).length + newMetrics.length;
         case 'entities': return (manifest.entities || []).length;
-        case 'joins':    return (manifest.relationships || []).length;
+        case 'joins':    return (manifest.relationships || []).length + (manifest.cross_relationships || []).length;
         case 'examples': return (manifest.examples || []).length;
         case 'queued':   return totalQueued();
         default:         return null;
@@ -2267,7 +2411,7 @@
         case 'metrics':
           if (addMetricOpen) { root.appendChild(renderAddMetricForm()); }
           else { const a = el('div', { class: 'card-actions', style: 'padding:0 0 10px;' });
-                 a.appendChild(el('button', { type: 'button', onclick: () => { addMetricOpen = true; renderAll(); } }, '+ Add metric'));
+                 a.appendChild(el('button', { type: 'button', class: 'add-metric-open', onclick: () => { addMetricOpen = true; renderAll(); } }, '+ Add a metric'));
                  root.appendChild(a); }
           newMetrics.forEach((m, i) => root.appendChild(renderNewMetricCard(m, i)));
           renderFlatTab(root, manifest.metrics, 'metric',
@@ -2280,9 +2424,7 @@
             renderEntityCard, 'entity');
           break;
         case 'joins':
-          renderFlatTab(root, manifest.relationships, 'relationship',
-            r => `${relName(r)} ${r.cardinality} ${r.description} ${r.area}`,
-            renderRelCard, 'join');
+          renderJoinsTab(root);  // one tab, split into In-schema + Cross-schema sections
           break;
         case 'examples':
           renderFlatTab(root, manifest.examples, 'example',

--- a/plugins/agami/skills/agami-connect/SKILL.md
+++ b/plugins/agami/skills/agami-connect/SKILL.md
@@ -22,6 +22,7 @@ For DB error classification: [`shared/db_error_classifier.md`](../../shared/db_e
 
 - **Combine acknowledge + next question** — don't waste turns on "Got it!"
 - **Use AskUserQuestion for every Yes/No/Skip** — never inline-bullet options. Use `(Recommended)` only when there's a genuine recommendation. For fact-of-environment questions ("which database type?", "which schemas?"), don't mark any option Recommended — the user picks what they have.
+- **Every multiSelect needs an explicit "none / continue" option** — `AskUserQuestion` cannot be submitted with zero boxes checked, so any multiSelect where "pick nothing" is a valid answer MUST offer a selectable "Nothing — continue" (or "Keep everything") option. Never phrase the prompt as "leave all unchecked" — that's unsubmittable and traps the user.
 - **Keep the user oriented** — print one-line progress markers between phases (`✓ Introspected 12 tables`, `✓ Validator passed`, `✓ Generated 10 examples`).
 
 ## Progress tracking — set up a todo list at the very start
@@ -77,9 +78,9 @@ If you reach for a command that doesn't fit, stop and re-read this section.
 
 1. **Resolve `<profile>`**: `AGAMI_PROFILE` → `active_profile` in `~/.agami/.config` → `"main"` (older installs may have `"default"`). The model's `organization` equals `<profile>`.
 2. **Credentials check (binding).** Read `~/.agami/credentials`; look for `[<profile>]`.
-   - File present with the section → apply the chmod check (refuse if world-readable), continue.
-   - File missing **but `~/.agami/credentials.example` exists** → the user filled in the template; **run 0a.10 to promote it** (don't re-run 0a.4 — that would overwrite their edits).
-   - Neither present → **run Phase 0a and stop.** Surface: *"No credentials yet for profile `<profile>` — running setup."*
+   - The `[<profile>]` section is present → apply the chmod check (refuse if world-readable), continue.
+   - The `[<profile>]` section is **absent** (whether or not the file exists) **but `~/.agami/credentials.example` exists** → the user filled in the template; **run 0a.10 to promote it** (don't re-run 0a.4 — that would overwrite their edits). This is the *second-profile* path too: the file exists with other profiles but not this one — 0a.10's helper appends deterministically.
+   - Neither the section nor the template present → **run Phase 0a and stop.** Surface: *"No credentials yet for profile `<profile>` — running setup."*
 3. **Resolve connection fields** from the `[<profile>]` section. Field shapes per dialect are in [`shared/credentials-format.md`](../../shared/credentials-format.md). Never substitute a missing value — surface "missing field X for profile Y" and stop.
 4. **Tool detection.** Read cached tool paths from `~/.agami/.config`; if absent, run detection per Phase 0a.
 5. **Resolve `<artifacts_dir>`**: `AGAMI_ARTIFACTS_DIR` → `~/.agami/.config.artifacts_dir` → `$HOME/agami-artifacts`. The model lives in `<artifacts_dir>/<profile>/`. Create lazily (`mkdir -p … && chmod 755 …`).
@@ -123,7 +124,7 @@ Ask the user to **name** this connection — don't pick for them. The name is ho
 **AskUserQuestion**, with the **Other** free-text as the encouraged path (that's where they type their own name):
 > What should I call this database? Pick a name you'll recognize when you connect more than one — e.g. your database or product name, or an environment.
 
-Offer a few *examples* as options (`prod`, `staging`, `analytics`) but make clear in the prompt that typing their own in **Other** is the point — **don't present a `main` default that nudges them past the choice.** Bind `$PROFILE_NAME` to their answer (the Other text, or a picked example). Validate: lowercase letters/digits/dashes/underscores, 1–32 chars; if it doesn't pass, show the rule and re-ask.
+Offer a few *examples* as options (`prod`, `staging`, `analytics`) but make clear in the prompt that typing their own in **Other** is the point — **don't present a `main` default that nudges them past the choice.** Bind `$PROFILE_NAME` to their answer (the Other text, or a picked example). Validate: lowercase letters/digits/dashes/underscores, 1–32 chars; **and not already a `[section]` in `~/.agami/credentials`** (a profile name is a unique key — reusing one would clash). If it fails either rule, show the reason and re-ask. (The 0a.10 promote helper enforces the uniqueness backstop too — it returns `COLLISION` rather than overwrite — but catch it here so the user isn't surprised later.)
 
 ### 0a.4 — Write `~/.agami/credentials.example`
 
@@ -311,19 +312,20 @@ step — ~5–15 min for a sizable account. Postgres / MySQL are seconds.
 **End the turn.** Do NOT continue to Phase 1.
 
 ### 0a.10 — On re-entry: promote the filled-in template, then continue
-The user filled in `~/.agami/credentials.example` and came back (or asked a data question / said "introspect my database"). **Promote it for them** — no manual save, no `chmod` step, no helper script. One command: the `mv` consumes the template (we don't keep `.example` around); the `grep` guard refuses to promote a still-unedited template:
+The user filled in `~/.agami/credentials.example` and came back (or asked a data question / said "introspect my database"). **Promote it deterministically** with the helper — do NOT hand-roll an `mv`/append, and do NOT assume "no file yet." The script handles all four cases (first profile → move; Nth profile → append; name clash → refuse; placeholders → refuse), so the second-profile and `[main]`/`[main]` cases can't silently corrupt the file:
 
 ```bash
-if [ ! -f ~/.agami/credentials ] && [ -f ~/.agami/credentials.example ]; then
-  if grep -qE 'your-(username|password|host|server|workspace|coordinator|database|token)|dapiXXX|/absolute/path/to|user:pass@host' ~/.agami/credentials.example; then
-    echo "PLACEHOLDERS_REMAIN"
-  else
-    mv ~/.agami/credentials.example ~/.agami/credentials && chmod 600 ~/.agami/credentials && echo "SECURED"
-  fi
-fi
+python3 "$AGAMI_PLUGIN_ROOT/scripts/promote_credentials.py"
 ```
-- `PLACEHOLDERS_REMAIN` → tell the user which fields still hold template values and **stop** (never introspect against a template).
-- `SECURED` → `~/.agami/credentials` now exists (chmod 600, `.example` consumed). Preflight step 2 passes.
+
+Read the first token of stdout and act:
+- `SECURED <profile>` → credentials created from the template (chmod 600, `.example` consumed). Continue.
+- `APPENDED <profile>` → the new profile was appended to an existing credentials file (other profiles untouched, chmod 600). Continue.
+- `COLLISION <profile>` → a profile by that name **already exists**; nothing was changed. Tell the user *"You already have a profile named `<profile>` — pick a different name for this database,"* go back to **0a.3** to rename (then re-write the template in 0a.4 under the new name), and **stop**. Never overwrite or duplicate an existing profile.
+- `PLACEHOLDERS_REMAIN <fields>` → the template still holds template values; tell the user which fields to fill and **stop** (never introspect against a template).
+- `NOTHING` → no `credentials.example` to promote (already promoted, or never written) — fall back to the preflight decision.
+
+(`$AGAMI_PLUGIN_ROOT` is the plugin root; `promote_credentials.py` is stdlib-only and needs no special interpreter.)
 
 **Run `setup_pgauth.py --all`** before the first native-CLI query (writes `.pgpass` / `.mysql.cnf` so passwords never hit the command line). Idempotent. Then continue to Phase 1.
 
@@ -348,13 +350,22 @@ Surface a one-liner with per-step estimates and **narrate per-table progress** s
 
 ### 1.1 — Existing-model check
 
-If `<artifacts_dir>/<profile>/org.yaml` exists and `$ARGUMENTS != reintrospect`: the profile is already onboarded. Offer (AskUserQuestion): re-introspect (refresh structure, preserve enrichment) / open the model explorer / cancel. The engine **auto-backs-up any legacy OSI** (`index.yaml` + per-schema `_schema.yaml`) it finds at the profile root into `.osi_backup/` before writing — so a first run over an old OSI profile is safe and reversible; surface a one-liner when that happens.
+If `<artifacts_dir>/<profile>/org.yaml` exists and `$ARGUMENTS != reintrospect`: the profile is already onboarded. Offer (AskUserQuestion, no `(Recommended)` — these are equal-weight choices), capped at 4:
+- **Re-introspect `<profile>`** — refresh the structure from the live DB (new/changed tables, columns, FKs) while preserving descriptions, entities, metrics, caveats, and sign-offs (the `reintrospect` path).
+- **Open model explorer** — browse + curate the existing model and review/sign off the trust layer (`/agami-model`).
+- **Onboard another database** — set up a **different** database (a different connection) under a **new** profile, leaving `<profile>` untouched. On this choice, **start a fresh onboarding for a new profile**: jump to the profile-naming step (Phase 0a's naming question) → have the user name the new profile (must differ from `<profile>` and any existing `[section]` in `~/.agami/credentials`) and pick its DB type → write that profile's `credentials.example` → run the full flow for it. Never reuse or overwrite the current profile's credentials or model.
+- **Cancel** — do nothing; the model is ready to query.
+
+**Same DB, another *schema*? That's the Re-introspect path, not "Onboard another database."** If the user wants to add a schema that lives in the **same database** they already onboarded (e.g. they did `public`, now they want `billing` too), choose **Re-introspect** and **expand the schema selection** in Phase 1.3 to include both the old and the new schemas. The engine scans them together in one pass, so any relationship between the original and the new schema is detected as a first-class **cross-schema** join (Case 1) and surfaced for review. Picking "Onboard another database" instead would split the two schemas into separate models and demote any link between them to manual cross-profile glue (Phase 2b federation) — wrong for one DB. If you're unsure which the user means, ask: *"Is `billing` in the same database connection as `<profile>`, or a different server/database?"* — same connection → Re-introspect + expand schemas; different → new profile.
+
+The engine **auto-backs-up any legacy OSI** (`index.yaml` + per-schema `_schema.yaml`) it finds at the profile root into `.osi_backup/` before writing — so a first run over an old OSI profile is safe and reversible; surface a one-liner when that happens.
 
 ### 1.2 — Scope: schemas, and the no-catalog case
 
 Run `cli areas`/probe is not needed yet — schema discovery happens inside the engine. But **decide scope first**:
 
 - **Catalog reachable (common):** after the engine lists schemas, it introspects all of them. If the DB has many schemas (Snowflake with 50+), narrow first — ask the user which schemas matter (multi-select), then pass them as the engine's table allowlist scope. Pre-check `public` (Postgres) / `PUBLIC` (Snowflake) / the credentials' `database` (MySQL).
+  - **Supabase is handled automatically** — the engine detects it by signature and drops its system schemas (`auth`, `storage`, `vault`, `realtime`, `extensions`, …) so only the user's app schemas (e.g. `public`) are modeled (it surfaces a note saying which it skipped). **Don't hand-build a `--tables` allowlist for Supabase** to dodge the system tables — that's already done, and a manual allowlist is fragile (shell word-splitting, missed tables). Only allowlist when the user genuinely wants a subset of their *own* tables.
 - **Catalog denied (locked-down role):** if a quick probe shows the catalog isn't readable, the engine **cannot enumerate tables** — ask the user for the table list:
   > Your role can read the data but not the catalog, so I can't list tables automatically. Paste the tables to model (e.g. `sales.orders, sales.customers`) — I'll describe each from the data itself.
 
@@ -363,6 +374,12 @@ Run `cli areas`/probe is not needed yet — schema discovery happens inside the 
 ### 1.3 — Schema picker (multi-select)
 
 For non-SQLite/DuckDB with multiple schemas, **AskUserQuestion** multi-select: "Which schemas should I introspect?" One option per schema + `All schemas` + `Just <default> for now`. Record `selected_schemas`; the engine scopes to these.
+
+**On re-introspect / an existing model — pre-check the schemas already modeled, and make "add" vs "replace" explicit.** Read the schemas already in `<profile>`'s model (the distinct `schema` of its existing tables) and **pre-check those** in the picker, labelled `<schema> (already in your model)`. Tell the user plainly:
+
+> The engine re-scans exactly the schemas you check here and rebuilds the structure from them. To **add** a schema, leave the existing ones checked and tick the new one — relationships between them get found in the same pass. **Unchecking a schema removes its tables from the model** (its hand-edits are preserved only if you keep it checked).
+
+This is the union-rescan that makes Case 2 work: adding `billing` to a model that already has `public` must scan `public` ∪ `billing` together — scanning only `billing` would build the new schema's internal joins but **miss every join back to `public`** (a cross-schema edge needs both endpoints in one introspection pass). Never silently re-scan just the delta.
 
 ### 1.4 — Organization context (MANDATORY — ALWAYS ASK)
 
@@ -438,7 +455,11 @@ Build a per-schema prompt with `$DATA_MODEL_DOC_TEXT` first (dominant prior), th
 
 Don't skip a coded column because "the legend covers it" — the legend lives in a *different file*; the per-column description is what the explorer shows and what NL→SQL reads. A wide coded table (hundreds of columns) should finish at ~100% column coverage, not ~3%.
 
-**Write descriptions with `sm curate` edit ops — never hand-edit the table YAML or script a loop over `tables/*.yaml`.** Build one ops array (table = `{op:edit, kind:table, area, name, field:description, value, source:"ai"}`; column = same + `column`) and run it once; it validates the whole model + commits + reverts on failure. **Always include `"source":"ai"` on every generated description** — this stamps `description_source: ai_unvalidated` so the description earns trust through use (agami-query surfaces it in the answer receipt for confirmation the first time a query actually uses that column, instead of forcing an upfront review of hundreds of descriptions; see [`docs/design/validated-through-use-descriptions.md`](../../../../docs/design/validated-through-use-descriptions.md)). **Skip any column that already has a description** (so a partial hand-edit or a reintrospect merge is never clobbered):
+**Write descriptions with `sm curate` edit ops — never hand-edit the table YAML, and never write a throwaway generator script to build the ops.** Build one ops array and run it once; it validates the whole model + commits + reverts on failure. **The op does NOT need `area`** — curate resolves which area owns a table/column by name, so you do **not** maintain a `table → area` map (that map is exactly what used to push the LLM into writing an `enrich_gen.py`; it's gone). Shapes:
+- table: `{op:edit, kind:table, name:"<table>", field:"description", value:"<text>", source:"ai"}`
+- column: same + `column:"<col>"`
+
+Pass `area` **only** to disambiguate a bare name that exists in two schemas (curate skips an ambiguous op with a clear "pass an explicit area" reason rather than editing the wrong one). **Always include `"source":"ai"` on every generated description** — this stamps `description_source: ai_unvalidated` so the description earns trust through use (agami-query surfaces it in the answer receipt for confirmation the first time a query actually uses that column, instead of forcing an upfront review of hundreds of descriptions; see [`docs/design/validated-through-use-descriptions.md`](../../../../docs/design/validated-through-use-descriptions.md)). **Skip any column that already has a description** (so a partial hand-edit or a reintrospect merge is never clobbered):
 ```bash
 bash "$AGAMI_PLUGIN_ROOT/scripts/sm" curate "$ROOT" --ops-file /tmp/agami-descriptions.json
 ```
@@ -500,7 +521,7 @@ From samples + the domain doc, add provider-portable cleaning where evidence sup
 - **Caveats** (`caveats[]` on table/column/entity): data-quality notes, anti-patterns (e.g. "filter on the event date, not the load date"), dedup warnings.
 - **value_transform** on columns whose raw value needs cleaning (`regexp_replace(...)` for bracketed text, `TO_TIMESTAMP(...)` for epoch). Must parse as SQL (validator checks).
 - **default_filters** (`default_filters[]` on a table): soft-delete / tenancy filters AND-ed in at query time (use the `{alias}` placeholder, e.g. `{alias}.deleted_at IS NULL`).
-- **Currency (one ask per profile):** if numeric fields look like money (`amount`/`price`/`revenue`/…, no `_usd` suffix giving the answer), ask once: "What currency are these in?" (`USD`/`EUR`/`GBP`/`JPY`/`INR`/`Other`/`Mixed`). On the answer, **set the column `unit` to the ISO code** on every detected money column — via `cli curate` edit ops (`{op:edit, kind:table, area, name:<table>, column:<col>, field:unit, value:"INR"}`), one batch. The runtime + chart renderer format the symbol + grouping **deterministically** from `unit` (`semantic_model/units.py`) — no prose caveat to re-interpret. `Mixed` → leave `unit` unset, one-liner. (Non-currency units — `cents`, `percent`, `days` — set `unit` the same way when a column's scale/unit is unambiguous.)
+- **Currency (one ask per profile):** **find the money columns with `sm suggest-units "$ROOT"` — don't hand-roll a name regex** (a bare `count` pattern matches inside `discount` and silently drops `discount_amount`; the command's matcher is word-boundary-correct and tested). It returns `{money_columns: [{area, table, column, type}]}` (numeric columns named like money — amount/price/revenue/discount/… — minus rate/count/id/score, and skipping any that already have a `unit`). Glance at the list; if a `_usd`/`_inr`-suffixed column makes the currency obvious, set it directly. Otherwise ask once: "What currency are these in?" (`USD`/`EUR`/`GBP`/`JPY`/`INR`/`Other`/`Mixed`). On the answer, **set the column `unit` to the ISO code** on every returned column — via `cli curate` edit ops (`{op:edit, kind:table, area, name:<table>, column:<col>, field:unit, value:"INR"}`), one batch. The runtime + chart renderer format the symbol + grouping **deterministically** from `unit` (`semantic_model/units.py`) — no prose caveat to re-interpret. `Mixed` → leave `unit` unset, one-liner. (Non-currency units — `cents`, `percent`, `days` — set `unit` the same way when a column's scale/unit is unambiguous.)
 - **Date encodings (auto-sniffed — no question):** introspection already sets `date_format` (`epoch_s`/`ms`/`us`/`ns`, `yyyymmdd`, `iso8601`) + `timezone` on date-named columns whose sample values fit the shape, so epoch integers render as human dates (UTC) deterministically. You don't ask. **Do** glance at the result: if a time column was missed or mis-scaled (e.g. an epoch_ms tagged epoch_s), fix it with a `field:date_format`/`field:timezone` edit op in the same batch; mention any epoch columns found in the Phase 7 summary.
 
 **Write all of these with `sm curate` edit ops — never hand-edit `tables/*.yaml` or script a loop over them.** One ops array, one call (validated + committed + reverted on failure):
@@ -549,14 +570,21 @@ I split <N> tables into <A> subject areas:
 
 Seeds reference **columns, tables, metrics, and entities** — so settle those *before* generating examples (a seed that uses a column you'd later exclude breaks at query time, and a seed built on an unreviewed metric bakes in a guessed definition). **Relationships are NOT gated here** — they stay lazy: FK joins are already auto-approved by the engine (the DB declared them), and inferred joins self-approve as you query / surface as receipt warnings. So you're not asked to rubber-stamp database-declared foreign keys.
 
-**4a — Exclude columns/tables you don't want queried.** Offer the model explorer so the user drops PII / scratch / internal-only tables and columns before seeds reference them. **AskUserQuestion:**
-> Before I generate example queries, want to exclude any tables or columns from the model? (PII, scratch/temp tables, internal-only fields — anything you don't want answers built on.)
+**4a — Exclude columns/tables you don't want queried.** Two parts:
 
-`Open the model explorer (Recommended)` → invoke `/agami-model`, **end the turn**, wait for their exclude batch. `Nothing to exclude — continue` → proceed. (Exclusions apply via the model-explorer's curate path; the loader then drops them so seeds never reference them.)
+**(i) Proactively surface what introspection flagged `sensitive`** — group the flagged columns by table/kind and offer the riskiest as a **multiSelect** quick-exclude, secrets first (a plaintext password / access-code column → *"strongly recommend dropping"*). **Cap at the 3 riskiest groups** — never try to enumerate every sensitive column, the modal only holds 4 options.
+
+**(ii) ALWAYS include "Open the model explorer" as an option** — it's the real bulk-exclude surface (per-table/column Exclude toggles + Mark-PII), and there are almost always more exclusions than fit in a modal. If the user picks it **or answers Other** ("there are a bunch more I want to exclude"), **do NOT parse a free-text list of tables** — invoke `/agami-model`, **end the turn**, and wait for their exclude batch.
+
+`AskUserQuestion` shape: each detected group is a checkbox (e.g. `users.access_code_plain + _hash — plaintext/hashed login secrets, recommend dropping`), plus **Open the model explorer (to exclude more)** and **Nothing to exclude — continue**. Apply the checked groups via the model-explorer curate path; route the explorer/Other choice to `/agami-model`. The loader then drops every exclusion so seeds never reference them.
+
+> **MANDATORY: include the explicit "Nothing to exclude — continue" option, and NEVER tell the user to "leave all unchecked."** `AskUserQuestion` cannot be submitted with zero boxes checked — so "keep everything" must be a *selectable* option, not an implied empty state. A modal whose only escape is "leave it blank" traps a user who doesn't want any of the listed exclusions (they can't submit). Phrase the prompt as "check any to drop, or pick *Nothing to exclude — continue*" — do **not** write "leave all unchecked to keep everything."
 
 **4b — Sign off metrics + entities.** These define what seeds *mean* and *say*. Count via `sm review-items "$ROOT" --scope preseed` — its length is the sign-off count (metrics + named-filters + entities needing review; relationships excluded). If **0**, surface the one-liner ("Nothing to sign off before examples — proceeding") and continue to Phase 5. If **> 0**, tell the user upfront, then invoke `/agami-model preseed` (the `preseed` argument opens the dashboard on its **Review** tab, where these metrics + entities sit under "Needs your eyes"). **End the turn** and wait for their approval batch.
 
-**4c — return gate:** when they're back, recount via `--scope preseed`. If 0 → Phase 5. If > 0 (partial) → AskUserQuestion: `Continue (Recommended)` (seeds run against current state; receipts warn) / `Pause — I'll finish review first` (end; resume via `/agami-connect`).
+> **4b is NOT a choice — it OPENS the explorer.** When the count is > 0, you **open `/agami-model preseed` and end the turn**. Do **NOT** present an `AskUserQuestion` offering "continue to examples now" vs "open explorer" here, and do **NOT** mark continuing as Recommended. The explorer-first review is the designed path; a high count (dozens of items across many schema-areas) is a reason to open it, not to skip it (the user bulk-approves the *Looks right* pile and eyeballs the cross-schema joins there). The "continue anyway" option exists **only** at the 4c return gate — i.e. **after** the user has already been in the explorer at least once. Never surface the 4c choice before 4b has opened the explorer.
+
+**4c — return gate:** when they're back (they have now opened the explorer at least once), recount via `--scope preseed`. If 0 → Phase 5. If > 0 (partial — they reviewed some and stopped) → AskUserQuestion: `Continue (Recommended)` (seeds run against current state; receipts warn) / `Pause — I'll finish review first` (end; resume via `/agami-connect`). This is the **only** place "continue to examples with items still unreviewed" is offered.
 
 On `reintrospect` with no new exclusions and nothing unreviewed, skip silently.
 
@@ -564,9 +592,16 @@ On `reintrospect` with no new exclusions and nothing unreviewed, skip silently.
 
 ## Phase 5: Seed prompt examples
 
-**Surface a progress warning first** (second-longest phase): "Generating 10–12 NL→SQL seeds and EXPLAIN-validating each against the live DB. Expect 1–3 min (longer on cloud). I'll narrate per-example progress."
+**Surface a progress warning first** (second-longest phase): "Generating NL→SQL seeds (a spread across your tables, metrics, entities, and joins — including cross-schema ones) and EXPLAIN-validating each against the live DB. Expect 1–3 min (longer on cloud / a multi-schema DB). I'll narrate per-example progress."
 
-**5a — generate** (your job — the LLM step) 10–12 candidate examples grounded in the model: a count, a top-N, a time-bucketed trend, a breakdown, a recency filter, plus domain-specific ones from entities/metrics. Anchor time filters to each table's `data_range` MAX (not `NOW()`) so seeds don't return 0 rows on a stale dataset. Tag each with its `tables`, `columns`, and `metric`. Write the candidates as a JSON array to `/tmp/agami-seeds.json` — each: **required** `question`, `sql`; optional `tables`, `columns`, `metric`.
+**5a — generate** (your job — the LLM step) candidate examples grounded in the model. Aim for **coverage and a good spread**, not a fixed count:
+
+- **Shapes:** a count, a top-N, a time-bucketed trend, a breakdown, a recency filter. Anchor time filters to each table's `data_range` MAX (not `NOW()`) so seeds don't return 0 rows on a stale dataset.
+- **Spread:** across the whole set, touch each major table/family, exercise **every approved metric at least once**, use the key **entities** by their real names/synonyms, and cover **representative joins** — intra-area *and* cross-schema.
+- **Cross-schema seeds — the highest-value few-shots, include them deliberately.** Read the model's `cross_subject_area_relationships` (the cross-schema / cross-area joins). For the most meaningful ones, write a question a user would actually ask that **spans both schemas** — a fact/metric in one schema joined to the entity it references in another. Use the relationship's declared join (`on:` / from→to columns) and **schema-qualified** table names (it's one database — ordinary cross-schema SQL, fully EXPLAIN-able). Include **2–4** of these and make **1–2 genuinely complex** (3+ tables across two schemas, with an aggregation + a filter) — cross-schema SQL is exactly what NL→SQL gets wrong unaided, so a worked example pays off most here. (Cross-*profile* / federation seeds are out of scope — those need DuckDB ATTACH; this is cross-*schema* within one DB.)
+- **Count scales with the model:** a single-schema DB is fine at ~10–12; a multi-schema one wants ~2–3 per subject area **plus** the 2–4 cross-schema seeds — don't undersample a 5-schema DB at a flat 12.
+
+Tag each with its `tables` (list **all** tables it touches — both schemas for a cross-area one), `columns`, and `metric`. **Store a cross-area seed under its primary/driving table's area** (tagged with both schemas' tables, so the ranker can surface it from either side). Write the candidates as a JSON array to `/tmp/agami-seeds.json` — each: **required** `question`, `sql`; optional `tables`, `columns`, `metric`.
 
 **5b+5c — validate + write in ONE packaged call.** **Do NOT write a script to loop EXPLAIN over the seeds and don't hand-write the YAML.** `seed-examples` validates every candidate against the live DB (wraps each as a zero-row query — dialect-agnostic, scans nothing), writes the passing ones (appends, dedups by `question`, commits), and returns the rejects with their DB error:
 ```bash
@@ -705,6 +740,38 @@ The model keeps improving as you use it:
   exclude tables/columns you don't want queried, add metrics, and edit descriptions.
 ```
 End the turn. Picking a number routes the question into query-database. Keep each suggestion under 80 chars and grounded in real tables.
+
+---
+
+## Phase 8.5: Cross-profile link offer (ONLY when ≥2 profiles now exist)
+
+**Gate:** run this **only** when, after this onboarding, the user has **two or more** onboarded profiles (count distinct onboarded profiles — `<artifacts_dir>/*/org.yaml`, or `[section]`s in `~/.agami/credentials`). Skip entirely for the first/only profile, and skip on a plain `reintrospect` of a single-profile setup. This is the **cross-datasource** case — different databases, joined at query time via federation (Phase 2b.federation in agami-query), declared in `~/.agami/cross_profile_relationships.yaml`. Unlike cross-*schema* joins (same DB, auto-detected — Case 1), cross-*profile* links are **never** auto-detected at introspection: each profile is a separate connection, so there's nothing to confirm by overlap.
+
+**Ask (opt-in, AskUserQuestion):**
+> You now have <N> databases connected (`<profileA>`, `<profileB>`, …). Want me to look for likely links between them — so you can ask questions that span both (e.g. join `<profileA>`'s data to `<profileB>`'s)?
+
+Options (no `(Recommended)` — it's the user's call): `Yes — look for links` / `Not now` (default).
+
+**On "Not now":** one line — *"No problem. Say 'link my databases' anytime, or hand-edit `~/.agami/cross_profile_relationships.yaml`."* End.
+
+**On "Yes":**
+1. **Propose candidates by name+type** — compare the just-onboarded profile's columns against the other profile(s)' columns (read each model's tables/columns; no DB access needed). A candidate is a column pair with the **same or obviously-equivalent name** (`dept_id` ↔ `department_id`, `customer_id` ↔ `cust_id`) **and a compatible type**, where one side is a key/grain column. Rank by name closeness.
+2. **Be honest about confidence.** Say plainly: *"These are name/type guesses — I can't sample-join across two separate databases to confirm them, so they're lower-confidence than the joins inside one DB. They'll prove out the first time a federated query uses them."* Never present them as confirmed.
+3. **Confirm each, never auto-write.** Show the candidates (`<profileA>.<schema>.<table>.<col>  →  <profileB>.<schema>.<table>.<col>`) and let the user pick which to keep (multi-select) or skip all.
+4. **Write the confirmed ones** to `~/.agami/cross_profile_relationships.yaml` in the format [agami-query expects](../agami-query/SKILL.md) — **merge**, never clobber an existing file (load it, append new entries, dedup by the `from_profile/from_dataset/to_profile/to_dataset` tuple), `chmod 600`:
+   ```yaml
+   version: "0.1.1"
+   relationships:
+     - name: <profileA>_<tableA>_to_<profileB>_<tableB>
+       from_profile: <profileA>
+       from_dataset: <schema>.<table>
+       from_columns: [<col>]
+       to_profile: <profileB>
+       to_dataset: <schema>.<table>
+       to_columns: [<col>]
+       description: <one line — what the link means, in the user's terms>
+   ```
+5. **Confirm where it landed** — *"Saved <K> cross-database link(s) to `~/.agami/cross_profile_relationships.yaml`. A question that spans both DBs will now use them (federated via DuckDB). I'll flag low confidence on the first answer that does."* Don't block; this is additive.
 
 ---
 

--- a/plugins/agami/skills/agami-query/SKILL.md
+++ b/plugins/agami/skills/agami-query/SKILL.md
@@ -15,7 +15,7 @@ This skill orchestrates:
 2. **Generate SQL** — examples-first traversal: pick the subject area → match curated examples → (cold start) resolve entities/metrics + identify opaque literals → compound `get_table_context` → produce one SQL statement → safety checks.
 3. **Execute** — run via the chosen tool; the Python tier runs the fan/chasm pre-flight + applies default_filters; auto-retry on classified errors; risk-assess large-table queries.
 4. **Present** — markdown table; CSV via `--csv` or "export this"; Chart.js HTML via `--chart` or "make that a chart".
-5. **Log + post-install GitHub-star ask** — write `~/.agami/query_log.jsonl` and ask the user (once, after first successful query) to star us on GitHub.
+5. **Log + post-install GitHub-star ask** — write `~/.agami/query_log.jsonl` and ask the user (once, after first successful query) to star us on GitHub; once they answer, point them to `/agami-serve` (wire the model into Claude Desktop — the experience their business users get).
 
 For the model format: [`scripts/semantic_model/__init__.py`](../../scripts/semantic_model/__init__.py) (layout) + `scripts/semantic_model/models.py`.
 For SQL safety: [`shared/sql-generation-rules.md`](../../shared/sql-generation-rules.md).
@@ -326,10 +326,12 @@ Apply [`shared/sql-generation-rules.md`](../../shared/sql-generation-rules.md):
 
 For each dataset touched by the SQL, look up its `agami.performance_hints`:
 
-- `estimated_row_count > 1_000_000` AND no WHERE clause matches a `recommended_filters[].column`:
-  → **HIGH risk**. Surface a banner before executing: "This query scans `<dataset>` (~<row_count>) without a date filter. Estimated time: <est>. Add a date range, or proceed anyway?" AskUserQuestion: `Add a filter` / `Proceed anyway` / `Cancel`.
-- `100k–1M` rows with no recommended filter → **MEDIUM**. Note in response footer; proceed.
-- Otherwise → **LOW**. Proceed silently.
+`recommended_filters` is a **list of column names** (introspection seeds it with a large table's date/time columns — the columns worth filtering on to avoid a full scan). Check whether the generated SQL's WHERE filters on **any** of them.
+
+- `estimated_row_count > 1_000_000` AND the WHERE filters on **none** of the table's `recommended_filters`:
+  → **HIGH risk**. Surface a banner before executing — **name a suggested column** when one exists: "This query scans `<dataset>` (~<row_count>) with no filter on `<recommended_filters[0]>`. Estimated time: <est>. Narrow it — e.g. a date range on `<recommended_filters[0]>` — or proceed anyway?" AskUserQuestion: `Add a filter` / `Proceed anyway` / `Cancel`. If `recommended_filters` is **empty** (no known good filter for this table), use the generic "…without a filter. Add one, or proceed?" wording.
+- `100k–1M` rows with no filter on a `recommended_filters` column → **MEDIUM**. Note in response footer; proceed.
+- A query that **does** filter on a `recommended_filters` column → treat as narrowed: drop a risk tier (don't HIGH-warn just because the table is big). Otherwise → **LOW**. Proceed silently.
 
 **Time estimate (announced BEFORE Phase 3 execution).** Long-running queries kill the user's confidence — they don't know if the skill is hung or actually working. Before running any non-LOW query, surface a one-liner with the rough wall-clock estimate so they can wait without anxiety:
 
@@ -565,9 +567,16 @@ For each section, build an object:
   "datasets":      [{"label": "<header>", "data": [<numeric values>]}],
   "table_headers": ["<col1>", "<col2>", ...],
   "table_rows":    [[<v>, <v>, ...], ...],
-  "sql":           "<SQL that produced this section's data, NOT HTML-escaped — the template handles it>"
+  "sql":           "<the EXACT, COMPLETE SQL that produced this section's data — verbatim>"
 }
 ```
+
+**`sql` is the exact, complete, runnable query — never a paraphrase.** Paste the *verbatim* SQL string you executed for this section (the text you passed to `sm prepare` / the executor — keep each section's query around for this). It must be:
+- **Complete** — every CTE, column, JOIN, WHERE, GROUP BY. The receipt exists so a data engineer can re-run it and defend the number; a partial query defeats that.
+- **Literal SQL, not prose** — no `...`/`…`, no `-- net revenue = (line_total - gst) - ...`, no "ON paid book lines". If you find yourself writing English where SQL goes, you're summarizing — stop and paste the real query.
+- **Never empty when the section has data.** Every section that ran a query has its query. A section with no `sql` only makes sense for a hand-built/derived table with no underlying SQL — and that is rare; double-check before omitting.
+
+Do NOT HTML-escape it — the template handles escaping. Do NOT shorten it to save tokens; the renderer reads it from a file, so length is free.
 
 When `chart_type` is `null`, set `labels` and `datasets` to `null` (or omit). The template skips the chart card cleanly.
 
@@ -600,8 +609,9 @@ Build the receipt as a single JSON object. Schema (see [`shared/chart-template.h
      "signed_off_at": "<ISO>"}
   ],
   "metrics": [
-    {"name": "<metric>", "definition_prose": "<plain English>",
-     "confidence": <float in [0,1]>, "review_state": "approved|unreviewed|...", "origin": "<enum>",
+    {"name": "<metric>", "area": "<subject area>", "definition_prose": "<plain English>",
+     "expression": "<the SQL fragment / binding>",
+     "confidence": <float in [0,1]>, "review_state": "approved|unreviewed|...", "origin": "<enum | ad_hoc>",
      "signed_off_by": "<email>", "signed_off_role": "<enum>", "signed_off_at": "<ISO>"}
   ],
   "named_filters": [
@@ -626,13 +636,15 @@ How to populate each field:
 - **`tables_used`** — every distinct `<schema>.<table>` referenced in the SQL's FROM/JOIN clauses. `rows` is the **table's size** — pass the table's `performance_hints.estimated_row_count` from the model (the *same* value Phase 3 reads for the scan-risk check, e.g. `12000000`). This is "how big is this dataset," not the query's result-row count. Also pass **`rows_as_of`** = the table's `performance_hints.estimated_row_count_at` (when that estimate was last measured at introspection) — the receipt renders "≈N rows (estimated as of <date>)" so the reader knows it's a point-in-time estimate, not a live count. Only pass `null` for `rows` if the table genuinely has no `estimated_row_count` in the model — don't default to `null` out of caution when the model has it.
   **`freshness`** — pass the **raw ISO timestamp** from `agami.introspect_meta.introspected_at` (e.g., `"2026-05-10T11:57:13Z"`). The chart template prettifies it to `"introspected May 10, 2026, 11:57 AM"` automatically. Don't prefix with "introspected" yourself or you'll double-prefix. If the upstream load cadence is known (e.g., daily ETL at 2am UTC), pass a pre-formatted string instead — e.g., `"2026-05-10T02:00:00Z (daily 2am UTC ETL)"` — and the template passes it through unchanged. Pass `null` when freshness is unknowable.
 - **`relationships`** — for every JOIN edge in the SQL, look up the relationship in the model (from `get_table_context`). **Pull EVERY trust field** carried on the relationship: `relationship` (cardinality), `confidence` (`confirmed`/`inferred`/`proposed`), `review_state` (enum), `signed_off_by`, `signed_off_role`, `signed_off_at`, plus `on:` if it's a CAST/compound join. The template's `approvalPhrase` reads all of them to render "confirmed (FK declared)" vs "approved by jane@x.com (cfo), Mar 15" vs "proposed (inferred join — confirm)". For composite or multi-hop joins, list each edge. Also surface any **auto-rewrite** the pre-flight applied (fan/chasm) and the **default_filters** that were applied (from execute_sql's stderr notes).
-- **`metrics`** — every model metric whose `bindings` SQL matches a fragment in the generated SQL. **Pull EVERY trust field:** `calculation` (prose intent), `confidence`, `review_state`, `signed_off_by`, `signed_off_role`, `signed_off_at`, `source`. If a metric is genuinely unreviewed, that's fine — the receipt shows "proposed" honestly. Don't half-populate (it renders a meaningless "unreviewed (?)").
+- **`metrics`** — TWO kinds of entry, both go here:
+  1. **Model metrics** whose `bindings` SQL matches a fragment in the generated SQL. **Pull EVERY trust field:** `calculation` → `definition_prose`, `confidence`, `review_state`, `signed_off_by`, `signed_off_role`, `signed_off_at`, `source`/`origin`, and the metric's `area`. If a metric is genuinely unreviewed, that's fine — the receipt shows it honestly. Don't half-populate (it renders a meaningless "unreviewed (?)").
+  2. **On-the-fly metrics you calculated for this answer** — any non-trivial aggregation/ratio you composed that ISN'T an approved model metric (e.g. you wrote `(SUM(net_revenue) - SUM(cogs)) / SUM(net_revenue)` for "gross margin" because no `gross_margin` metric exists). Emit one entry per such calc with `review_state: "unreviewed"`, **`origin: "ad_hoc"`**, a snake_case `name` (your suggested metric name), the `area` it belongs to, `definition_prose` (the calculation in plain English), and `expression` (the SQL fragment). This is what feeds the **top-of-report "metrics you haven't approved" banner**, where the user can Approve it (→ saved as a real model metric, signed off) or Change the definition — both routed back to you as feedback. **Don't flag trivial primitives** (a bare `COUNT(*)`, `SUM(amount)` with no logic) as ad-hoc metrics — only genuine, reusable definitions. When in doubt, include it; an over-flag is a one-click dismiss, a miss means an unapproved number ships silently.
 - **`named_filters`** — every filter from `agami.named_filters[]` (model-level) whose `expression` appears in the SQL's WHERE / HAVING. **Pull EVERY trust field** from the filter's entry: `expression`, `definition_prose`, `confidence`, `review_state`, `origin`, `signed_off_by`, `signed_off_role`, `signed_off_at`. Same rationale as relationships and metrics.
 - **`assumptions`** — the AI-derived column meanings this answer **leaned on**, so a wrong/unknown one is caught in context instead of via an upfront review of hundreds of descriptions (see [`docs/design/validated-through-use-descriptions.md`](../../../../docs/design/validated-through-use-descriptions.md)). For each column the SQL used in a **load-bearing** way — SELECT / WHERE / GROUP BY / ORDER BY / a metric binding, **not** pure join plumbing — look it up in `get_table_context` and surface two cases:
   - `description_source == "ai_unvalidated"` (a guess) AND `description` non-empty → `{column, meaning: <description>, source: "ai_unvalidated"}`.
   - `description_source == "ai_unknown"` (agami couldn't read it) → `{column, meaning: null, source: "ai_unknown"}` — agami used a column it doesn't understand; flag it loudly.
   Columns with `description_source` of `human`, `ai_validated`, or `null` are NOT surfaced. **Cap at 3**, ranked by load-bearing-ness (filter/group-by > select > order-by) and putting `ai_unknown` first (an unknown the query relied on is the riskiest). Pass `[]` when none qualify. Advisory — never blocks or warns; it's a "here's what I assumed / didn't know" so the user can correct, confirm, or describe.
-- **`warnings`** — for every entry above whose `review_state ≠ approved`, push a one-line warning naming the entry and its confidence. Examples: `"Used 1 unreviewed join (orders → customers, conf 0.62)."`, `"Used metric `revenue` which has not been signed off."`. If the receipt has any warnings, **append a final action line as the last warning**: `"Run /agami-model review to walk these items, or say 'open the review queue'."` This gives the user a clickable next step (the slash command renders as readable text in the warning banner). If the receipt has zero warnings, pass `[]` and the banner suppresses entirely — no need for an action line if everything is approved. (Assumptions are NOT warnings — keep them separate.)
+- **`warnings`** — for every **non-metric** entry above whose `review_state ≠ approved` (joins, rewrites, applied filters), push a one-line warning naming the entry and its confidence. Example: `"Used 1 unreviewed join (orders → customers, conf 0.62)."`. **Do NOT add a warning line for unreviewed/ad-hoc metrics** — they get their own actionable **"metrics you haven't approved" banner** (from `receipt.metrics`) with Approve / Change controls, so a warning line would just duplicate it. If the receipt has any warnings, **append a final action line as the last warning**: `"Run /agami-model review to walk these items, or say 'open the review queue'."` This gives the user a clickable next step (the slash command renders as readable text in the warning banner). If the receipt has zero warnings, pass `[]` and the banner suppresses entirely. (Assumptions and metric-approvals are NOT warnings — keep them separate.)
 
 Build the receipt at `/tmp/agami-receipt-<ts>.json` and pass it to `render_chart.py` via `--receipt-file` (see 4e.iv below). For a 1×1 scalar answer with no chart (Phase 4e skips the report), still construct the receipt mentally so you can surface warnings inline in the chat answer ("Note: this used 1 unreviewed join").
 
@@ -820,7 +832,11 @@ The correction can arrive two ways: the user **types** it, or they paste the blo
 1. **Floor (always):** the corrected SQL for *this question* lands as a prompt example — `sm add-example "$ROOT" --area <area> --file <json>` (dedups by question, so it replaces). Exactly the onboarding seed behavior. A pure note with no SQL change skips this.
 2. **The learning on top**, routed by the tree — a column's meaning/unit/encoding/value-map → `field_metadata` (`unit` / `value_transform` / `choice_field`); a join fix → `relationship`; a whole-table fact → `table_metadata`; a reusable aggregation → `new_metric`; a per-result caveat tied to this one question → the example's `notes[]`; a cross-cutting display convention for this DB → `ORGANIZATION.md`; a personal stylistic tic → `USER_MEMORY.md`. Model edits go through `sm curate`; build the ops JSON with the **Write tool** (never a heredoc / `python3 -c`).
 
-**Make the routing visible** — name where each piece landed: *"Saved the corrected SQL as an example for `sales`, and set `ORDERS.TOTAL` unit → INR."* Never silent. Then set `feedback: "bad"` on the prior `query_log.jsonl` entry (Phase 5). `$ROOT` and `<area>` come from the model already loaded in Phase 1b; the original SQL is in this turn (and `query_log.jsonl`).
+**A shared-model edit needs the user's nod — an example save doesn't.** Saving the corrected SQL as an *example* (the floor) is automatic; it only shapes this question's few-shot. But a **shared-model edit** (a `caveat` / `unit` / `value_transform`, a relationship fix, a description, a new metric) changes how **every** future query reads that column or join — so **state the exact change and get a quick OK before writing it**, e.g. *"I'd add a caveat to `sales.discount_amount`: 'cart-level discount, not pushed to line items — allocate across lines.' Add it?"* This is the same gate `agami-save-correction` enforces ("show a diff before any model mutation") — handling it inline here does **not** drop it.
+
+**This applies doubly when YOU discovered the issue, not the user.** If mid-analysis you find a model-level subtlety (a column that needs a caveat, a metric that's mis-defined), your interpretation can be wrong — so **propose** the edit, never auto-apply it to the shared model, and **never stamp the user's sign-off on their behalf.** Sign-off is the user's explicit act (the Review tab, or saying "approve") — a correction doesn't grant it. Fixing *your own* answer for the current turn is always fine; persisting a change to the shared model is what needs the nod.
+
+**Make the routing visible** — name where each piece landed: *"Saved the corrected SQL as an example for `sales`, and (with your OK) set `ORDERS.TOTAL` unit → INR."* Never silent. Then set `feedback: "bad"` on the prior `query_log.jsonl` entry (Phase 5). `$ROOT` and `<area>` come from the model already loaded in Phase 1b; the original SQL is in this turn (and `query_log.jsonl`).
 
 **Positive confirmation ("This looks good").** The report also has a **👍 This looks good** button (and the user may just say so) — a paste-back beginning *"This agami answer looked correct."* This is the inverse: set `feedback: "good"` on the log entry, and **consider** saving the question + SQL as a **confirmed** prompt example (`sm add-example`, `status: confirmed`) — **your discretion, not reflexively.** Add it when it's a genuinely reusable, non-trivial pattern (a real join, a metric definition exercised, a non-obvious filter); **skip** trivial one-offs (`SELECT COUNT(*)`), near-duplicates of an existing example, or throwaway exploration. Say what you did — *"Good to hear — saved it as an example so the next similar question reuses this SQL"* or *"Glad it's right (didn't add an example — it's close to one already in the library)."* A confirmed-good example is a strong few-shot, but the library's value is precision, not volume — don't dilute it.
 
@@ -884,9 +900,15 @@ Sequence:
    - `Maybe later` — write `.optins` so we don't ask again, surface "No problem. The link is github.com/AgamiAI/LiteBi if you change your mind." (No `(Recommended)` marker — we'd genuinely prefer "Yes" if the user found it useful, but no marker on any of the three options keeps the ask non-pushy.)
    - `Already starred — thank you!` — surface "🙏 thanks for the early support" and write `.optins`.
 3. **Wait for the user to answer the modal.** That's the end of this turn. Do NOT emit the 5 follow-up bullets yet.
-4. Next turn: process the decision (write `~/.agami/.optins`). Then show the 5 follow-up bullets per Phase 4f, with a tiny acknowledgment line ("Now, where next?") before the numbered list.
+4. Next turn: process the decision (write `~/.agami/.optins`). Then — **whatever they answered** — surface the one-time **`/agami-serve` pointer** (below). After it, show the 5 follow-up bullets per Phase 4f, with a tiny acknowledgment line ("Now, where next?") before the numbered list.
 
-If `~/.agami/.optins` already exists, skip the ask entirely and emit the 5 follow-ups in the same turn as the answer (Phase 4f as today).
+**The `/agami-serve` pointer (one-time, right after the star answer).** Plain prose — NOT an `AskUserQuestion`, NOT one of the numbered follow-ups. Surface it once, here, regardless of which of the three star responses they gave:
+
+> One more thing worth trying: **`/agami-serve`** wires this same model into the **Claude Desktop app** as a local MCP server — so you can ask these questions in plain English from Desktop, no Claude Code needed. It's the local mirror of the hosted "Ask Agami" connector, so it's the exact experience your business users would get. Run `/agami-serve` whenever you want to set it up.
+
+Keep it to ~2 sentences; don't oversell, don't repeat it in the follow-up bullets. Because it lives in the same turn that writes `.optins`, it fires exactly once — every later query takes the `.optins`-exists path below and skips both the star ask and this pointer.
+
+If `~/.agami/.optins` already exists, skip the ask **and the `/agami-serve` pointer** entirely, and emit the 5 follow-ups in the same turn as the answer (Phase 4f as today).
 
 `~/.agami/.optins` shape (chmod 600):
 

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -1,0 +1,48 @@
+"""Tests for _interp.py — the directly-invoked-script interpreter self-heal (re-exec under
+agami's configured interpreter when PyYAML / the model deps are missing)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest  # noqa: F401
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "plugins" / "agami" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import _interp  # noqa: E402
+
+
+def test_present_dep_does_not_reexec(monkeypatch):
+    calls = []
+    monkeypatch.setattr(_interp.os, "execv", lambda p, a: calls.append((p, a)))
+    _interp.ensure_deps("json")          # stdlib — always importable
+    assert calls == []
+
+
+def test_already_reexeced_does_not_loop(monkeypatch):
+    calls = []
+    monkeypatch.setattr(_interp.os, "execv", lambda p, a: calls.append((p, a)))
+    monkeypatch.setenv("AGAMI_REEXEC", "1")            # the guard flag is set
+    monkeypatch.setenv("AGAMI_PYTHON", sys.executable)
+    _interp.ensure_deps("a_missing_module_zzz_123")
+    assert calls == []                                 # guarded — no second re-exec
+
+
+def test_reexecs_under_configured_interpreter(tmp_path, monkeypatch):
+    fake = tmp_path / "py"
+    fake.write_text("#!/bin/sh\n")
+    fake.chmod(0o755)
+    calls = []
+    monkeypatch.setattr(_interp.os, "execv", lambda p, a: calls.append((p, a)))
+    monkeypatch.delenv("AGAMI_REEXEC", raising=False)
+    monkeypatch.setenv("AGAMI_PYTHON", str(fake))
+    try:
+        _interp.ensure_deps("a_missing_module_zzz_123")   # dep absent → should re-exec
+        assert len(calls) == 1
+        interp, argv = calls[0]
+        assert interp == str(fake) and argv[0] == str(fake)   # re-exec under the configured interp
+    finally:
+        # ensure_deps sets AGAMI_REEXEC directly (not via monkeypatch) before execv — clean it up
+        import os
+        os.environ.pop("AGAMI_REEXEC", None)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -31,10 +31,12 @@ sys.path.insert(0, str(SCRIPTS))
 
 from mcp_server import (  # noqa: E402
     _classify_exit,
+    _resolve_receipt,
     _resolve_units,
     check_read_only,
     resolve_artifacts_dir,
     resolve_profile,
+    tool_save_correction,
 )
 
 
@@ -197,6 +199,11 @@ def test_initialize_and_tools_list():
     init = by_id[1]["result"]
     assert init["protocolVersion"] == "2025-06-18"  # echoes client's version
     assert init["serverInfo"]["name"] == "agami"
+    # The lean playbook signposts the trust flow so a Desktop client surfaces it (soft layer;
+    # the hard guarantees are enforced in code). Don't let these silently drop out.
+    instr = init["instructions"].lower()
+    for token in ("examples-first", "receipt", "review_state", "save_correction", "confirmed"):
+        assert token in instr, token
 
     tools = {t["name"] for t in by_id[2]["result"]["tools"]}
     assert tools == {
@@ -206,6 +213,8 @@ def test_initialize_and_tools_list():
         # semantic-model traversal tools
         "list_subject_areas", "get_subject_area_bundle", "get_table_context",
         "identify_entity", "pre_flight_check",
+        # write-back: corrections land through the same engine as the skill
+        "save_correction",
     }
 
 
@@ -227,3 +236,137 @@ def test_unknown_method_returns_error():
     ])
     by_id = {m.get("id"): m for m in out}
     assert by_id[9]["error"]["code"] == -32601
+
+
+# ---------------------------------------------------------------------------
+# Trust receipt + corrections through the MCP — the SAME engine the skill uses,
+# so the query→receipt→correct loop is identical in Claude Desktop and Claude Code.
+# ---------------------------------------------------------------------------
+
+
+def _write_rich_model(tmp_path):
+    """A model with an UNREVIEWED metric + an UNREVIEWED join — the trust signals the
+    receipt must surface. Returns (artifacts_dir, profile, root)."""
+    import subprocess
+    yaml = __import__("yaml")
+    p = tmp_path / "p"
+    (p / "datasources" / "c").mkdir(parents=True)
+    (p / "subject_areas" / "s" / "tables").mkdir(parents=True)
+    (p / "subject_areas" / "s" / "metrics").mkdir(parents=True)
+    (p / "org.yaml").write_text(yaml.safe_dump({
+        "organization": "p", "version": 1,
+        "storage_connections": [{"name": "c", "ref": "datasources/c/storage.yaml"}],
+        "subject_areas": ["subject_areas/s"]}))
+    (p / "datasources" / "c" / "storage.yaml").write_text(
+        yaml.safe_dump({"name": "c", "storage_type": "PostgreSQL"}))
+    (p / "subject_areas" / "s" / "subject_area.yaml").write_text(yaml.safe_dump({
+        "name": "s", "tables": [{"storage_connection": "c", "schema": "public", "table": "orders"},
+                                {"storage_connection": "c", "schema": "public", "table": "customers"}]}))
+    (p / "subject_areas" / "s" / "tables" / "orders.yaml").write_text(yaml.safe_dump({
+        "name": "orders", "schema": "public", "storage_connection": "c", "grain": ["id"], "description": "o",
+        "columns": [{"name": "id", "type": "integer", "primary_key": True},
+                    {"name": "customer_id", "type": "integer"},
+                    {"name": "amount", "type": "decimal", "description": "net revenue",
+                     "description_source": "ai_unvalidated"}]}))
+    (p / "subject_areas" / "s" / "tables" / "customers.yaml").write_text(yaml.safe_dump({
+        "name": "customers", "schema": "public", "storage_connection": "c", "grain": ["id"], "description": "c",
+        "columns": [{"name": "id", "type": "integer", "primary_key": True}]}))
+    (p / "subject_areas" / "s" / "metrics" / "revenue.yaml").write_text(yaml.safe_dump({
+        "name": "revenue", "calculation": "sum of order amount", "bindings": {"PostgreSQL": "SUM(amount)"},
+        "source_tables": ["orders"], "confidence": "proposed", "review_state": "unreviewed"}))
+    (p / "subject_areas" / "s" / "relationships.yaml").write_text(yaml.safe_dump({
+        "relationships": [{"from_table": "orders", "from_column": "customer_id",
+                           "to_table": "customers", "to_column": "id", "from_schema": "public",
+                           "to_schema": "public", "relationship": "many_to_one",
+                           "confidence": "inferred", "review_state": "unreviewed"}]}))
+    subprocess.run(["git", "-C", str(p), "init", "-q"])
+    subprocess.run(["git", "-C", str(p), "add", "-A"])
+    subprocess.run(["git", "-C", str(p), "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "-q", "-m", "init"])
+    return tmp_path, "p", p
+
+
+SQL = "SELECT c.id, SUM(amount) AS total FROM orders o JOIN customers c ON o.customer_id = c.id GROUP BY c.id"
+
+
+def test_mcp_receipt_surfaces_unapproved_metric_and_join(monkeypatch, tmp_path):
+    import pytest
+    pytest.importorskip("pydantic"); pytest.importorskip("sqlglot")
+    art, profile, _ = _write_rich_model(tmp_path)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+    r = _resolve_receipt(profile, SQL)
+    assert r is not None
+    # the unapproved metric is surfaced WITH its review_state (drives the approve/change banner)
+    rev = next(m for m in r["metrics"] if m["name"] == "revenue")
+    assert rev["review_state"] == "unreviewed"
+    # the unreviewed join is warned about; the ai-written column is flagged as an assumption
+    assert any("unreviewed join" in w for w in r["warnings"])
+    assert any(a["column"].endswith("orders.amount") for a in r["assumptions"])
+
+
+def test_mcp_receipt_equals_shared_assembler(monkeypatch, tmp_path):
+    """Golden parity: the MCP receipt IS the shared assembler's output — no divergent
+    second implementation. (model_version is the only MCP-added field.)"""
+    import pytest
+    pytest.importorskip("pydantic"); pytest.importorskip("sqlglot")
+    art, profile, root = _write_rich_model(tmp_path)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+    from semantic_model import loader as L, runtime as RT
+    shared = RT.assemble_receipt(L.load_organization(root), SQL)
+    mcp = _resolve_receipt(profile, SQL)
+    for key in ("tables_used", "relationships", "metrics", "assumptions", "warnings"):
+        assert mcp[key] == shared[key], key
+
+
+def test_mcp_save_correction_approves_through_engine(monkeypatch, tmp_path):
+    import pytest
+    pytest.importorskip("pydantic"); pytest.importorskip("sqlglot")
+    art, profile, root = _write_rich_model(tmp_path)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+    out = json.loads(tool_save_correction({
+        "datasource": profile,
+        "ops": [{"op": "approve", "kind": "metric", "area": "s", "name": "revenue",
+                 "at": "2026-06-12T00:00:00Z"}],
+        "confirmed": True,
+        "signer": "reviewer@example.com", "role": "cfo",
+    }))
+    assert out["ops"][0]["validated"] and out["ops"][0]["applied"]
+    # the metric is now approved on disk — corrections land through the curate engine
+    from semantic_model import loader as L
+    org = L.load_organization(root)
+    met = next(m for sa in org.subject_areas for m in sa.metrics if m.name == "revenue")
+    assert met.review_state == "approved" and met.signed_off_by == "reviewer@example.com"
+
+
+def test_mcp_save_correction_gates_unconfirmed_model_edits(monkeypatch, tmp_path):
+    """Enforced (not advisory): ops WITHOUT confirmed:true must NOT mutate the model."""
+    import pytest
+    pytest.importorskip("pydantic"); pytest.importorskip("sqlglot")
+    art, profile, root = _write_rich_model(tmp_path)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+    out = json.loads(tool_save_correction({
+        "datasource": profile,
+        "ops": [{"op": "approve", "kind": "metric", "area": "s", "name": "revenue"}],
+        # no confirmed
+    }))
+    assert out.get("requires_confirmation") is True and out["pending_ops"]
+    assert "ops" not in out  # nothing applied
+    # the metric is UNTOUCHED on disk
+    from semantic_model import loader as L
+    org = L.load_organization(root)
+    met = next(m for sa in org.subject_areas for m in sa.metrics if m.name == "revenue")
+    assert met.review_state == "unreviewed" and met.signed_off_by is None
+
+
+def test_mcp_save_correction_example_is_not_gated(monkeypatch, tmp_path):
+    """The safe floor: saving a corrected example needs no confirmation."""
+    import pytest
+    pytest.importorskip("pydantic"); pytest.importorskip("sqlglot")
+    art, profile, _ = _write_rich_model(tmp_path)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+    out = json.loads(tool_save_correction({
+        "datasource": profile,
+        "example": {"area": "s", "question": "total orders?", "sql": "SELECT COUNT(*) FROM orders"},
+    }))
+    assert out.get("example") and out["example"]["validated"]
+    assert "requires_confirmation" not in out

--- a/tests/test_promote_credentials.py
+++ b/tests/test_promote_credentials.py
@@ -1,0 +1,93 @@
+"""Tests for promote_credentials.py — deterministic credentials.example -> credentials.
+
+The old skill-inline `if [ ! -f credentials ]; then mv` only handled the first profile;
+the Nth profile (file already exists) was left to LLM improvisation, which could duplicate
+a profile or create a [main]/[main] collision. This locks the behavior down.
+"""
+from __future__ import annotations
+
+import stat
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from promote_credentials import promote  # noqa: E402
+
+_FILLED = """\
+# ~/.agami/credentials.example
+[main]
+type     = postgres
+host     = db.example.com
+port     = 5432
+database = shop
+user     = analyst
+password = s3cret
+"""
+
+_TEMPLATE_WITH_PLACEHOLDERS = """\
+[main]
+type     = postgres
+host     = your-host
+port     = 5432
+database = your-database
+user     = your-username
+password = your-password
+"""
+
+
+def _example(d: Path, body: str) -> None:
+    (d / "credentials.example").write_text(body, encoding="utf-8")
+
+
+def test_first_profile_is_moved_and_chmod_600(tmp_path):
+    _example(tmp_path, _FILLED)
+    msg, code = promote(tmp_path)
+    assert code == 0 and msg.startswith("SECURED") and "main" in msg
+    creds = tmp_path / "credentials"
+    assert creds.exists() and not (tmp_path / "credentials.example").exists()  # template consumed
+    assert stat.S_IMODE(creds.stat().st_mode) == 0o600
+    assert "[main]" in creds.read_text()
+
+
+def test_second_profile_is_appended(tmp_path):
+    # an existing credentials file with [main] already present
+    (tmp_path / "credentials").write_text("[main]\ntype = postgres\nhost = a\nuser = u\npassword = p\n")
+    _example(tmp_path, _FILLED.replace("[main]", "[warehouse]"))
+    msg, code = promote(tmp_path)
+    assert code == 0 and msg.startswith("APPENDED") and "warehouse" in msg
+    text = (tmp_path / "credentials").read_text()
+    assert "[main]" in text and "[warehouse]" in text  # both profiles present
+    assert not (tmp_path / "credentials.example").exists()  # template consumed
+    assert stat.S_IMODE((tmp_path / "credentials").stat().st_mode) == 0o600
+
+
+def test_name_collision_refuses_and_touches_nothing(tmp_path):
+    original = "[main]\ntype = postgres\nhost = ORIGINAL\nuser = u\npassword = p\n"
+    (tmp_path / "credentials").write_text(original)
+    _example(tmp_path, _FILLED)  # also [main] -> clash
+    msg, code = promote(tmp_path)
+    assert code == 3 and msg.startswith("COLLISION") and "main" in msg
+    # neither file changed — the user must rename the new profile
+    assert (tmp_path / "credentials").read_text() == original
+    assert (tmp_path / "credentials.example").exists()
+
+
+def test_placeholders_refused(tmp_path):
+    _example(tmp_path, _TEMPLATE_WITH_PLACEHOLDERS)
+    msg, code = promote(tmp_path)
+    assert code == 2 and msg.startswith("PLACEHOLDERS_REMAIN")
+    assert not (tmp_path / "credentials").exists()
+    assert (tmp_path / "credentials.example").exists()  # left for the user to finish
+
+
+def test_no_example_is_noop(tmp_path):
+    msg, code = promote(tmp_path)
+    assert code == 1 and msg == "NOTHING"
+
+
+def test_example_without_section_errors(tmp_path):
+    _example(tmp_path, "# just a comment, no [section]\n")
+    msg, code = promote(tmp_path)
+    assert code == 4 and msg.startswith("ERROR")

--- a/tests/test_semantic_model_cli.py
+++ b/tests/test_semantic_model_cli.py
@@ -417,3 +417,16 @@ def test_remove_example_rejects_for_audit_and_drops_from_runtime(tmp_path):
     # a question that doesn't exist is reported (skipped), not silently swallowed
     rc2, out2 = _run(["remove-example", str(tmp_path), "--area", "s", "--question", "no such q?"])
     assert rc2 == 1 and json.loads(out2)["skipped"]
+
+
+def test_suggest_units_finds_money_columns(tmp_path):
+    """`sm suggest-units` returns the numeric money columns via the tested matcher — so the
+    skill never hand-rolls a regex that drops `discount_amount` by matching `count`."""
+    _model(tmp_path)
+    rc, out = _run(["suggest-units", str(tmp_path)])
+    assert rc == 0
+    cols = json.loads(out)["money_columns"]
+    names = {(c["table"], c["column"]) for c in cols}
+    assert ("orders", "total") in names            # numeric + money-named
+    assert ("order_items", "qty") not in names      # a count, not money
+    assert all(c["column"] != "id" for c in cols)   # ids excluded

--- a/tests/test_semantic_model_curate.py
+++ b/tests/test_semantic_model_curate.py
@@ -153,3 +153,108 @@ def test_edit_relationship_on_clause(tmp_path):
     assert res.validated, res.errors
     rel = loader.load_organization(tmp_path).subject_areas[0].relationships[0]
     assert rel.on and "CAST" in rel.on
+
+
+def test_approve_resolves_slugged_metric_name(tmp_path):
+    """Regression: a multi-word metric name is stored slugged (`total event sales` →
+    total_event_sales.yaml). `apply(approve)` must resolve the slug — looking for a literal
+    `total event sales.yaml` was caught into res.skipped, so the approval silently no-op'd."""
+    _write_model(tmp_path)
+    curate.write_items(tmp_path, "sales", "metric", [
+        {"name": "total event sales", "calculation": "count of event sales",
+         "bindings": {"PostgreSQL": "COUNT(*)"}, "source_tables": ["orders"],
+         "confidence": "inferred", "review_state": "unreviewed"}])
+    assert (tmp_path / "subject_areas" / "sales" / "metrics" / "total_event_sales.yaml").exists()
+
+    res = curate.apply(tmp_path, [{"op": "approve", "kind": "metric", "area": "sales",
+                                   "name": "total event sales", "at": "2026-06-12T00:00:00Z"}],
+                       signer="x@y.com", role="cto")
+    assert res.applied and not res.skipped, res.skipped
+    m2 = next(x for x in loader.load_organization(tmp_path).subject_areas[0].metrics
+              if x.name == "total event sales")
+    assert m2.review_state == "approved"
+
+    # a genuinely-missing metric now fails with a CLEAR reason (not a cryptic FileNotFoundError)
+    res2 = curate.apply(tmp_path, [{"op": "approve", "kind": "metric", "area": "sales",
+                                    "name": "no such metric"}])
+    assert res2.skipped and "no metric named" in res2.skipped[0]["reason"]
+
+
+def test_edit_op_auto_resolves_area_when_omitted(tmp_path):
+    """No `area` on the op -> curate resolves which area owns the table by name (so callers
+    never hand-maintain a table->area map / generator script)."""
+    _write_model(tmp_path)
+    res = curate.apply(tmp_path, [{"op": "edit", "kind": "table", "name": "orders",
+                                   "field": "description", "value": "all orders", "source": "ai"}])
+    assert res.validated and res.applied and not res.skipped, res.skipped
+    orders = loader.load_organization(tmp_path).subject_areas[0].defined_table("orders")
+    assert orders.description == "all orders"
+    assert orders.description_source == "ai_unvalidated"  # source:"ai" stamped
+
+
+def test_edit_op_ambiguous_area_errors_clearly(tmp_path):
+    """A bare table name that exists in two schema areas can't be auto-resolved -> the op is
+    skipped with a clear 'pass an explicit area' reason rather than editing the wrong one."""
+    yaml = __import__("yaml")
+    _write_model(tmp_path)
+    # add a second area 'crm' that ALSO has an `orders` table (the cross-schema collision shape)
+    crm = tmp_path / "subject_areas" / "crm" / "tables"
+    crm.mkdir(parents=True)
+    (tmp_path / "subject_areas" / "crm" / "subject_area.yaml").write_text(yaml.safe_dump({
+        "name": "crm", "tables": [{"storage_connection": "c", "schema": "crm", "table": "orders"}]}))
+    (crm / "orders.yaml").write_text(yaml.safe_dump({
+        "name": "orders", "schema": "crm", "storage_connection": "c", "grain": ["id"],
+        "description": "crm orders", "columns": [{"name": "id", "type": "integer", "primary_key": True}]}))
+    res = curate.apply(tmp_path, [{"op": "edit", "kind": "table", "name": "orders",
+                                   "field": "description", "value": "x", "source": "ai"}])
+    assert res.skipped and "multiple areas" in res.skipped[0]["reason"]
+    # with an explicit area it resolves fine
+    res2 = curate.apply(tmp_path, [{"op": "edit", "kind": "table", "area": "crm", "name": "orders",
+                                    "field": "description", "value": "crm only", "source": "ai"}])
+    assert res2.applied and not res2.skipped, res2.skipped
+
+
+def test_approve_cross_area_relationship_writes_org_yaml(tmp_path):
+    """A cross-schema/cross-area join lives in org.yaml (not an area's relationships.yaml),
+    so approving it must update org.yaml via the org-level fallback."""
+    root = tmp_path
+    (root / "datasources" / "c").mkdir(parents=True)
+    (root / "datasources" / "c" / "storage.yaml").write_text(
+        yaml.safe_dump({"name": "c", "storage_type": "PostgreSQL"}))
+    for area, tbl in [("billing", "invoices"), ("crm", "customers")]:
+        (root / "subject_areas" / area / "tables").mkdir(parents=True)
+        (root / "subject_areas" / area / "subject_area.yaml").write_text(yaml.safe_dump({
+            "name": area, "tables": [{"storage_connection": "c", "schema": area, "table": tbl}]}))
+        (root / "subject_areas" / area / "tables" / f"{tbl}.yaml").write_text(yaml.safe_dump({
+            "name": tbl, "schema": area, "storage_connection": "c", "grain": ["id"], "description": tbl,
+            "columns": [{"name": "id", "type": "integer", "primary_key": True},
+                        {"name": "customer_id", "type": "integer"}]}))
+    (root / "org.yaml").write_text(yaml.safe_dump({
+        "organization": "shop", "version": 1,
+        "storage_connections": [{"name": "c", "ref": "datasources/c/storage.yaml"}],
+        "subject_areas": ["subject_areas/billing", "subject_areas/crm"],
+        "cross_subject_area_relationships": [{
+            "from_table": "invoices", "from_column": "customer_id", "to_table": "customers", "to_column": "id",
+            "from_subject_area": "billing", "to_subject_area": "crm", "from_schema": "billing", "to_schema": "crm",
+            "relationship": "many_to_one", "confidence": "inferred", "review_state": "unreviewed"}]}))
+    subprocess.run(["git", "-C", str(root), "init", "-q"])
+    subprocess.run(["git", "-C", str(root), "add", "-A"])
+    subprocess.run(["git", "-C", str(root), "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "-q", "-m", "i"])
+
+    res = curate.apply(root, [{"op": "approve", "kind": "relationship", "area": "billing",
+                               "name": "invoices->customers", "at": "2026-06-12T00:00:00Z"}],
+                       signer="reviewer@example.com", role="data_lead")
+    assert res.validated and res.applied and not res.skipped, res.skipped
+    o = yaml.safe_load((root / "org.yaml").read_text())
+    cr = o["cross_subject_area_relationships"][0]
+    assert cr["review_state"] == "approved" and cr["signed_off_by"] == "reviewer@example.com"
+
+    # editing a cross-area join's field also persists to org.yaml (the UI edit path) —
+    # not just approve/reject. So cross joins are as editable as regular joins.
+    res2 = curate.apply(root, [{"op": "edit", "kind": "relationship", "area": "billing",
+                                "name": "invoices->customers", "field": "description",
+                                "value": "invoice to its CRM account"}])
+    assert res2.validated and res2.applied and not res2.skipped, res2.skipped
+    cr2 = yaml.safe_load((root / "org.yaml").read_text())["cross_subject_area_relationships"][0]
+    assert cr2["description"] == "invoice to its CRM account"

--- a/tests/test_semantic_model_introspect.py
+++ b/tests/test_semantic_model_introspect.py
@@ -318,6 +318,66 @@ def test_wide_mart_skips_noisy_date_columns(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Grain-probe size guard: a giant fact table with no catalog PK must NOT be
+# COUNT(DISTINCT)-full-scanned once per id column to guess a grain it doesn't have.
+# ---------------------------------------------------------------------------
+
+
+def _no_pk_runner(table, est_rows, *, seen):
+    """Catalog-mode runner for ONE table with no PK/FK; `est_rows` row estimate.
+    Records every SQL it sees in `seen` so a test can assert the probe ran or not."""
+    cols = [
+        {"column_name": "event_id", "data_type": "integer", "is_nullable": "YES", "ordinal_position": "1", "numeric_scale": ""},
+        {"column_name": "asset_id", "data_type": "integer", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""},
+        {"column_name": "ts", "data_type": "timestamp", "is_nullable": "YES", "ordinal_position": "3", "numeric_scale": ""},
+    ]
+
+    def run(sql):
+        s = " ".join(sql.split())
+        seen.append(s)
+        if "information_schema.schemata" in s:
+            return [{"schema_name": "public"}]
+        if "information_schema.tables" in s and "table_type" in s:
+            return [{"schema_name": "public", "table_name": table, "table_type": "BASE TABLE"}]
+        if "information_schema.columns" in s:
+            return cols
+        if "PRIMARY KEY" in s:
+            return []  # no catalog PK → without the guard this would fall into the scan probe
+        if "FOREIGN KEY" in s:
+            return []
+        if "reltuples" in s:
+            return [{"estimated_rows": str(est_rows)}]
+        if "COUNT(DISTINCT" in s:           # the expensive uniqueness probe — unique id
+            return [{"total": "1000", "distinct_count": "1000", "null_count": "0"}]
+        return []
+
+    return run
+
+
+def test_giant_table_skips_grain_probe(tmp_path):
+    seen: list[str] = []
+    run = _no_pk_runner("sm_asset_mgmt", 40_000_000, seen=seen)  # 40M rows, no PK
+    org, rep = I.introspect("ops", "postgres", runner=run, artifacts_dir=tmp_path, dry_run=True)
+    fact = org.subject_areas[0].defined_table("sm_asset_mgmt")
+    assert fact.grain == []                                   # left empty, not guessed
+    assert rep.mode_per_capability["grain"] == "probe_skipped_large"
+    assert not any("COUNT(DISTINCT" in s for s in seen)       # the full scans never ran
+    assert any("skipped grain probe" in n for n in rep.notes)  # and the skip is surfaced
+    # the catalog row estimate is still recorded (it's a cheap stat, fetched once)
+    assert fact.performance_hints.estimated_row_count == 40_000_000
+
+
+def test_small_table_without_pk_still_probes_grain(tmp_path):
+    seen: list[str] = []
+    run = _no_pk_runner("dim_small", 1000, seen=seen)  # well under the guard
+    org, rep = I.introspect("ops", "postgres", runner=run, artifacts_dir=tmp_path, dry_run=True)
+    fact = org.subject_areas[0].defined_table("dim_small")
+    assert fact.grain == ["event_id"]                        # probe found the unique id
+    assert rep.mode_per_capability["grain"] == "probe"
+    assert any("COUNT(DISTINCT" in s for s in seen)          # the guard did NOT over-trigger
+
+
+# ---------------------------------------------------------------------------
 # Supabase: drop system schemas (auth/storage/vault/…), keep the app schemas
 # ---------------------------------------------------------------------------
 

--- a/tests/test_semantic_model_introspect.py
+++ b/tests/test_semantic_model_introspect.py
@@ -269,3 +269,244 @@ def test_sniff_date_detects_epoch_yyyymmdd_iso_and_rejects_ids():
     # native timestamp: no re-encoding; tz only when the sample carries an offset
     assert I._sniff_date("updated_at", "timestamp", ["2024-01-01 10:00:00+05:30"]) == (None, "offset-aware")
     assert I._sniff_date("updated_at", "timestamp", ["2024-01-01 10:00:00"]) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Large-table scan hints: recommended_filters seeded from date columns
+# ---------------------------------------------------------------------------
+
+
+def _large_runner(sql):
+    """Two large tables: `events` (one clear date column) and `wide_mart` (7 date columns)."""
+    s = " ".join(sql.split())
+    if "information_schema.schemata" in s:
+        return [{"schema_name": "public"}]
+    if "information_schema.tables" in s and "table_type" in s:
+        return [{"schema_name": "public", "table_name": "events", "table_type": "BASE TABLE"},
+                {"schema_name": "public", "table_name": "wide_mart", "table_type": "BASE TABLE"}]
+    if "information_schema.columns" in s:
+        if "'events'" in s:
+            return [{"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""},
+                    {"column_name": "created_at", "data_type": "timestamp", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""},
+                    {"column_name": "label", "data_type": "varchar", "is_nullable": "YES", "ordinal_position": "3", "numeric_scale": ""}]
+        cols = [{"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""}]
+        for i in range(7):  # 7 date columns → too many to be a clear scan key
+            cols.append({"column_name": f"d{i}_date", "data_type": "date", "is_nullable": "YES", "ordinal_position": str(i + 2), "numeric_scale": ""})
+        return cols
+    if "PRIMARY KEY" in s:
+        return [{"column_name": "id"}]
+    if "FOREIGN KEY" in s:
+        return []
+    if "reltuples" in s:
+        return [{"estimated_rows": "5000000"}]   # 5M → large
+    return []
+
+
+def test_large_table_recommends_its_date_columns(tmp_path):
+    org, _ = I.introspect("shop", "postgres", runner=_large_runner, artifacts_dir=tmp_path, dry_run=True)
+    events = org.subject_areas[0].defined_table("events")
+    assert events.performance_hints.estimated_row_count == 5_000_000
+    # a clear single date column → the narrow-by-date hint, so the scan warning can name it
+    assert events.performance_hints.recommended_filters == ["created_at"]
+
+
+def test_wide_mart_skips_noisy_date_columns(tmp_path):
+    org, _ = I.introspect("shop", "postgres", runner=_large_runner, artifacts_dir=tmp_path, dry_run=True)
+    wide = org.subject_areas[0].defined_table("wide_mart")
+    # 7 date columns is too many to be a clear scan key — left empty for the index/partition pass
+    assert wide.performance_hints.recommended_filters == []
+
+
+# ---------------------------------------------------------------------------
+# Supabase: drop system schemas (auth/storage/vault/…), keep the app schemas
+# ---------------------------------------------------------------------------
+
+
+def test_supabase_system_schemas_are_dropped():
+    rep = I.IntrospectReport(profile="p", db_type="postgres", out_dir=None, dry_run=True)
+    schemas = ["auth", "storage", "vault", "realtime", "extensions", "public", "analytics"]
+    kept = I._filter_supabase_system_schemas(schemas, rep)
+    assert kept == ["public", "analytics"]                       # only the user's app schemas
+    assert any("Supabase detected" in n for n in rep.notes)      # and it's surfaced, not silent
+
+
+def test_plain_postgres_auth_schema_is_not_filtered():
+    # A plain Postgres DB with its OWN `auth` schema (no other Supabase signature) is left alone —
+    # the filter only triggers on the full Supabase signature, so it never eats real app schemas.
+    rep = I.IntrospectReport(profile="p", db_type="postgres", out_dir=None, dry_run=True)
+    assert I._filter_supabase_system_schemas(["public", "auth"], rep) == ["public", "auth"]
+    assert rep.notes == []
+
+
+# ---------------------------------------------------------------------------
+# Money-column detection (word boundaries — `count` must not match `discount`)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_money_column_handles_word_boundaries():
+    money = ["amount", "price", "total_revenue", "discount_amount", "member_discount",
+             "tax_amount", "account_balance", "salary", "refund_amt", "subtotal"]
+    not_money = ["order_count", "discount_rate", "total_count", "num_payments",
+                 "credit_score", "customer_id", "created_at", "status", "quantity"]
+    for c in money:
+        assert build.detect_money_column(c), f"{c} should be money"
+    for c in not_money:
+        assert not build.detect_money_column(c), f"{c} should NOT be money"
+
+
+# ---------------------------------------------------------------------------
+# Cross-schema relationships (Case 1): schema is stamped on every edge, declared
+# cross-schema FKs are surfaced for review (not auto-approved), and the inferred
+# probe binds to the same-schema target instead of a same-named decoy in another schema.
+# ---------------------------------------------------------------------------
+
+
+def _xschema_fk_runner(sql):
+    """Two schemas; a FK declared in `sales` that REFERENCES `billing` (cross-schema)."""
+    s = " ".join(sql.split())
+    if "information_schema.schemata" in s:
+        return [{"schema_name": "sales"}, {"schema_name": "billing"}]
+    if "information_schema.tables" in s and "table_type" in s:
+        if "'sales'" in s:
+            return [{"schema_name": "sales", "table_name": "invoices", "table_type": "BASE TABLE"}]
+        return [{"schema_name": "billing", "table_name": "customers", "table_type": "BASE TABLE"}]
+    if "information_schema.columns" in s:
+        if "'invoices'" in s:
+            return [{"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""},
+                    {"column_name": "customer_id", "data_type": "integer", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""}]
+        return [{"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""},
+                {"column_name": "email", "data_type": "varchar", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""}]
+    if "PRIMARY KEY" in s:
+        return [{"column_name": "id"}]
+    if "FOREIGN KEY" in s:
+        if "'sales'" in s:
+            return [{"from_table": "invoices", "from_column": "customer_id", "from_schema": "sales",
+                     "to_table": "customers", "to_column": "id", "to_schema": "billing"}]
+        return []
+    if "reltuples" in s:
+        return [{"estimated_rows": "1000"}]
+    return []
+
+
+def test_cross_schema_fk_is_flagged_and_not_auto_approved(tmp_path):
+    org, rep = I.introspect("shop", "postgres", runner=_xschema_fk_runner,
+                            artifacts_dir=tmp_path, dry_run=True)
+    # two schemas -> two areas; the join spans them, so it's a cross-AREA relationship.
+    assert {sa.name for sa in org.subject_areas} == {"sales", "billing"}
+    assert not [r for sa in org.subject_areas for r in sa.relationships]  # none intra-area
+    cross = org.cross_subject_area_relationships
+    assert len(cross) == 1, cross
+    r = cross[0]
+    assert (r.from_table, r.to_table) == ("invoices", "customers")
+    assert r.from_schema == "sales" and r.to_schema == "billing" and r.cross_schema is True
+    assert (r.from_subject_area, r.to_subject_area) == ("sales", "billing")
+    # enforced Postgres FK, but it spans schemas -> surfaced for review, NOT auto-signed-off
+    assert r.review_state == "unreviewed" and r.signed_off_by is None
+    assert any("cross-schema" in n for n in rep.notes), rep.notes
+
+
+def _collision_probe_runner(sql):
+    """`customers` exists in BOTH s1 and s2. `s1.orders.customer_id` must bind to
+    s1.customers (same schema), not the s2 decoy. Empty FK catalog -> probe path."""
+    s = " ".join(sql.split())
+    if "information_schema.schemata" in s:
+        return [{"schema_name": "s1"}, {"schema_name": "s2"}]
+    if "information_schema.tables" in s and "table_type" in s:
+        if "'s1'" in s:
+            return [{"schema_name": "s1", "table_name": "orders", "table_type": "BASE TABLE"},
+                    {"schema_name": "s1", "table_name": "customers", "table_type": "BASE TABLE"}]
+        return [{"schema_name": "s2", "table_name": "customers", "table_type": "BASE TABLE"}]
+    if "information_schema.columns" in s:
+        if "'orders'" in s:
+            return [{"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""},
+                    {"column_name": "customer_id", "data_type": "integer", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""}]
+        return [{"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""},
+                {"column_name": "email", "data_type": "varchar", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""}]
+    if "PRIMARY KEY" in s:
+        return [{"column_name": "id"}]
+    if "FOREIGN KEY" in s:
+        return []                      # no catalog FKs -> force the probe
+    if "matched" in s:                 # _overlaps EXISTS probe -> overlap confirmed
+        return [{"matched": "2"}]
+    if "reltuples" in s:
+        return [{"estimated_rows": "1000"}]
+    return []
+
+
+def test_probe_binds_same_schema_target_on_name_collision(tmp_path):
+    org, _ = I.introspect("shop", "postgres", runner=_collision_probe_runner,
+                          artifacts_dir=tmp_path, dry_run=True)
+    rels = [r for sa in org.subject_areas for r in sa.relationships]
+    match = [r for r in rels if r.from_table == "orders" and r.to_table == "customers"]
+    assert len(match) == 1, rels
+    r = match[0]
+    # the fix: resolve the target schema-aware (same schema first), not the last bare-name write
+    assert r.from_schema == "s1" and r.to_schema == "s1"
+    assert r.cross_schema is False
+
+
+def test_relationship_cross_schema_property():
+    same = m.Relationship(from_table="a", to_table="b", from_column="b_id", to_column="id",
+                          from_schema="x", to_schema="x", relationship="many_to_one")
+    assert same.cross_schema is False
+    diff = m.Relationship(from_table="a", to_table="b", from_column="b_id", to_column="id",
+                          from_schema="x", to_schema="y", relationship="many_to_one")
+    assert diff.cross_schema is True
+    # schema-less (SQLite / legacy) -> never flagged
+    none = m.Relationship(from_table="a", to_table="b", from_column="b_id", to_column="id",
+                          relationship="many_to_one")
+    assert none.cross_schema is False
+
+
+def _collision_schemas_runner(sql):
+    """billing + crm both contain a `products` table — the bare-name collision that used to
+    drop billing.products on write. Plus billing.invoices.product_id (probe join)."""
+    s = " ".join(sql.split())
+    if "information_schema.schemata" in s:
+        return [{"schema_name": "billing"}, {"schema_name": "crm"}]
+    if "information_schema.tables" in s and "table_type" in s:
+        if "'billing'" in s:
+            return [{"schema_name": "billing", "table_name": "products", "table_type": "BASE TABLE"},
+                    {"schema_name": "billing", "table_name": "invoices", "table_type": "BASE TABLE"}]
+        return [{"schema_name": "crm", "table_name": "products", "table_type": "BASE TABLE"},
+                {"schema_name": "crm", "table_name": "accounts", "table_type": "BASE TABLE"}]
+    if "information_schema.columns" in s:
+        if "'invoices'" in s:
+            return [{"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""},
+                    {"column_name": "product_id", "data_type": "integer", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""}]
+        return [{"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""},
+                {"column_name": "name", "data_type": "varchar", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""}]
+    if "PRIMARY KEY" in s:
+        return [{"column_name": "id"}]
+    if "FOREIGN KEY" in s:
+        return []
+    if "matched" in s:
+        return [{"matched": "2"}]
+    if "reltuples" in s:
+        return [{"estimated_rows": "100"}]
+    return []
+
+
+def test_same_named_tables_in_two_schemas_both_survive(tmp_path):
+    """Regression: `billing.products` and `crm.products` must BOTH be modeled (the old engine
+    keyed tables by bare name and dropped one on write). One area per schema keeps them apart."""
+    org, rep = I.introspect("meridian", "postgres", runner=_collision_schemas_runner,
+                            artifacts_dir=tmp_path, dry_run=False)
+    # one area per schema, not per-table fragmentation
+    assert {sa.name for sa in org.subject_areas} == {"billing", "crm"}
+    # all 4 tables survive — neither products dropped
+    tabs = {(t.schema_name, t.name) for sa in org.subject_areas for t in sa.tables_defined}
+    assert tabs == {("billing", "products"), ("billing", "invoices"),
+                    ("crm", "products"), ("crm", "accounts")}
+    # both products.yaml files exist on disk (the collision used to overwrite one)
+    root = tmp_path / "meridian"
+    assert (root / "subject_areas" / "billing" / "tables" / "products.yaml").exists()
+    assert (root / "subject_areas" / "crm" / "tables" / "products.yaml").exists()
+    # reload from disk -> still 4 tables (write+read round-trips without loss)
+    from semantic_model import loader as L
+    reloaded = L.load_organization(root)
+    assert sum(len(sa.tables_defined) for sa in reloaded.subject_areas) == 4
+    # the probed join binds within billing (same-schema), not across to crm.products
+    bil = next(sa for sa in reloaded.subject_areas if sa.name == "billing")
+    inv_join = [r for r in bil.relationships if r.from_table == "invoices"]
+    assert inv_join and inv_join[0].to_table == "products" and inv_join[0].cross_schema is False


### PR DESCRIPTION
## Summary

Two commits landing the cross-schema/MCP/explorer batch plus an engine perf fix surfaced while onboarding a large customer DB.

### `feat(model)` — cross-schema relationships, MCP trust parity, explorer review UX
- **Cross-schema relationships + schema-based subject areas**: one area per schema for multi-schema DBs; cross-area joins become `cross_subject_area_relationships`, schema-qualified to avoid bare-name collisions. Fixes both the 46-area fragmentation and the same-named-table drop (e.g. `products` in two schemas).
- **MCP trust parity**: shared `assemble_receipt`, receipt on `execute_sql`, and a `save_correction` tool with an enforced `confirmed` gate (no silent model writes).
- **Curate**: area auto-resolution, cross-area approve/edit, and the `description_source`-on-Relationship validation fix (which also unblocked editing ordinary joins).
- **Explorer review UX**: kind grouping (Metrics / In-schema joins / Cross-schema joins / Entities), per-kind approve, "Looks right" guidance, cross-area joins first-class.
- **`promote_credentials.py`**, chart inline-edit + unapproved-metric banner, examples-page button styling.
- Skill updates (connect: add-schema/cross-profile/seed-coverage/review-gate; agami-query: exact-SQL receipt + gates) and a leak/bloat sweep.

### `fix(introspect)` — grain-probe size guard on giant tables
With no catalog PK, `_grain()` full-scanned a table once per `*_id` candidate to guess a single-column grain. On a 40M-row / 41GB fact table with a composite grain that's tens of minutes of fruitless scans. Now skipped above 5M rows (catalog PKs always honored), row count estimated once from catalog stats, and the skip surfaced as a report note.

## Tests
406 passing (introspect, curate, MCP, promote-credentials, renderers).