### PR TITLE
feat(model): metric semantics — aggregation class, additivity, derived & second-order metrics (#1–#4)

### DIFF
--- a/plugins/agami/scripts/render_model_explorer.py
+++ b/plugins/agami/scripts/render_model_explorer.py
@@ -142,6 +142,8 @@ def build_manifest(profile_dir: Path, profile: str) -> dict:
             metrics_out.append({
                 "name": mm.name, "qname": f"{sa.name}.{mm.name}", "calculation": mm.calculation,
                 "bindings": mm.bindings, "unit": mm.unit, "other_names": mm.other_names,
+                "non_additive_dimensions": mm.non_additive_dimensions,
+                "semi_additive_agg": mm.semi_additive_agg,
                 "source_tables": mm.source_tables, "description": mm.description,
                 "review_state": mm.review_state, "confidence": mm.confidence,
                 "excluded": mm.review_state == "rejected",

--- a/plugins/agami/scripts/render_model_explorer.py
+++ b/plugins/agami/scripts/render_model_explorer.py
@@ -105,6 +105,7 @@ def build_manifest(profile_dir: Path, profile: str) -> dict:
                 fields_out.append({
                     "name": c.name, "qname": f"{qname}.{c.name}", "type": c.type,
                     "description": c.description, "description_source": c.description_source,
+                    "aggregation": c.aggregation,
                     "review_state": c.review_state,
                     "origin": "", "confidence": c.confidence, "excluded": f_excluded,
                     "sensitive": c.sensitive, "unit": c.unit, "caveats": c.caveats,

--- a/plugins/agami/scripts/semantic_model/build.py
+++ b/plugins/agami/scripts/semantic_model/build.py
@@ -69,6 +69,59 @@ def detect_money_column(column_name: str) -> bool:
     return bool(_MONEY_RE.search(column_name)) and not _MONEY_NEGATIVE_RE.search(column_name)
 
 
+# --- aggregation class (the Phase-1 column-intrinsic measure semantics) ------
+
+# Only these column types can be MEASURES at all; everything else (string, date,
+# timestamp, boolean, json, …) is a grouping dimension.
+_NUMERIC_TYPES = frozenset({"integer", "decimal", "float"})
+
+# Identifier / code / calendar / flag tokens → the column is a DIMENSION, never a measure.
+# Deliberately conservative (omit ambiguous num/number/day/week/month) — a miss falls to a
+# safe class downstream, a false dimension would wrongly block a real measure.
+_DIMENSION_RE = re.compile(
+    r"(^|_)(id|guid|uuid|key|code|cd|no|zip|zipcode|pincode|pin|year|fiscal|quarter|"
+    r"status|state|type|category|flag|version|is|has)s?(_|$)",
+    re.IGNORECASE,
+)
+# Rate / ratio / per-unit / index tokens → AVERAGEABLE (AVG/MIN/MAX ok, SUM is meaningless).
+# Checked BEFORE additive so `avg_balance`, `discount_rate`, `cost_per_unit`, `unit_price`
+# resolve to averageable rather than being summed.
+_AVERAGEABLE_RE = re.compile(
+    r"(^|_)(rate|ratio|pct|percent|percentage|avg|average|mean|median|per|price|"
+    r"score|rating|temperature|temp|index|margin|share|utilization|util|occupancy)s?(_|$)",
+    re.IGNORECASE,
+)
+# Quantity / money / volume tokens → ADDITIVE (SUM is meaningful). Includes semi-additive
+# STOCKS (balance, inventory, headcount) — they ARE summable; the time exception is declared
+# on the metric as `non_additive_dimensions` (Phase 2 / #3), not here.
+_ADDITIVE_RE = re.compile(
+    r"(^|_)(amount|amt|total|subtotal|sum|qty|quantity|count|cnt|revenue|sales|cost|"
+    r"spend|spent|value|volume|units|gmv|charge|fee|tax|discount|paid|due|gross|net|"
+    r"profit|income|expense|balance|deposit|withdrawal|refund|credit|debit|payment|"
+    r"inventory|stock|headcount|distance|weight|duration|bytes|size)s?(_|$)",
+    re.IGNORECASE,
+)
+
+
+def classify_aggregation(column_name: str, column_type: str, is_key: bool = False) -> str:
+    """Heuristic column-intrinsic aggregation class — one of additive / averageable /
+    dimension / unknown (see models.Aggregation). Name + type only; advisory, refined by
+    the curator, and `unknown` is never enforced against. Order matters: keys and
+    non-numeric types are dimensions; rate-ish names are averageable; money/quantity names
+    are additive; anything else stays `unknown` (safe — no enforcement)."""
+    if is_key:
+        return "dimension"
+    if column_type not in _NUMERIC_TYPES:
+        return "dimension"
+    if _DIMENSION_RE.search(column_name):
+        return "dimension"
+    if _AVERAGEABLE_RE.search(column_name):
+        return "averageable"
+    if detect_money_column(column_name) or _ADDITIVE_RE.search(column_name):
+        return "additive"
+    return "unknown"
+
+
 def detect_sensitive(table_name: str, column_name: str) -> bool:
     """Strongly-PII column names (email/phone/dob/ssn/address/…) are sensitive
     regardless of table. Weakly-PII names (name/first_name/…) are sensitive only

--- a/plugins/agami/scripts/semantic_model/derived.py
+++ b/plugins/agami/scripts/semantic_model/derived.py
@@ -114,11 +114,85 @@ def _has_nested_aggregate(sql_fragment: str) -> bool:
     return False
 
 
+# A second-order metric's binding is exactly OUTERAGG({base metric}) — e.g. "AVG({daily_revenue})".
+SECOND_ORDER_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\{([^{}]+)\}\s*\)\s*$")
+
+
+def is_second_order(metric) -> bool:
+    """A declared second-order statistic — has `inner_grain` set (the dimension(s) its
+    base aggregate is grouped by before the outer aggregate)."""
+    return bool(getattr(metric, "inner_grain", None))
+
+
+def _slug(name: str) -> str:
+    s = re.sub(r"[^A-Za-z0-9]+", "_", name.lower()).strip("_")
+    return s or "inner_value"
+
+
+def synthesize_second_order(metric, storage_type: str, idx: dict) -> str:
+    """Deterministically build the CTE for a second-order statistic — compute the base
+    aggregate at `inner_grain`, then apply the outer aggregate across it. Emitted as a
+    scalar subquery so it slots in wherever a metric expression goes:
+
+        (SELECT AVG(daily_revenue) FROM (
+           SELECT order_date, SUM(amount) AS daily_revenue
+           FROM orders GROUP BY order_date) _inner)
+
+    Raises DerivedError if the shape isn't `OUTERAGG({base})`, the base is unknown / not a
+    plain aggregate, `inner_grain` is empty, or the base spans more than one source table
+    (multi-table inner joins aren't synthesized yet)."""
+    binding = (getattr(metric, "bindings", None) or {}).get(storage_type)
+    if binding is None:
+        raise DerivedError(f"metric {metric.name!r} has no {storage_type} binding")
+    mt = SECOND_ORDER_RE.match(binding)
+    if not mt:
+        raise DerivedError(
+            f"second-order metric {metric.name!r} must bind as OUTERAGG({{base_metric}}) "
+            f"(e.g. \"AVG({{daily_revenue}})\"); got {binding!r}"
+        )
+    outer_func, base_name = mt.group(1).upper(), mt.group(2).strip()
+    if not metric.inner_grain:
+        raise DerivedError(f"second-order metric {metric.name!r} needs inner_grain set")
+    base = idx.get(base_name)
+    if base is None:
+        raise DerivedError(f"metric {metric.name!r} references unknown base metric {base_name!r}")
+    # The inner aggregate is the base's own (first-order) binding — expand_binding refuses a
+    # base that is itself nested, so we never double-nest.
+    inner_sql = expand_binding(base, storage_type, idx)
+    if _has_nested_aggregate(inner_sql):
+        raise DerivedError(
+            f"second-order metric {metric.name!r}: base {base_name!r} is itself a "
+            "second-order statistic — only one level of nesting is synthesized"
+        )
+    froms = list(base.source_tables) or list(metric.source_tables)
+    if len(froms) != 1:
+        raise DerivedError(
+            f"second-order metric {metric.name!r}: synthesis needs exactly one source table "
+            f"(got {froms or 'none'}); multi-table inner joins aren't synthesized yet"
+        )
+    table = froms[0]
+    grain = ", ".join(metric.inner_grain)
+    alias = _slug(base_name)
+    return (
+        f"(SELECT {outer_func}({alias}) FROM ("
+        f"SELECT {grain}, {inner_sql} AS {alias} "
+        f"FROM {table} GROUP BY {grain}) _inner)"
+    )
+
+
+def resolve_metric_sql(metric, storage_type: str, idx: dict) -> str:
+    """The one entry point: standalone SQL for a metric's binding in `storage_type`.
+    Second-order (case b) → synthesized CTE; otherwise placeholder expansion (case a /
+    first-order). Raises DerivedError on any composition problem."""
+    if is_second_order(metric):
+        return synthesize_second_order(metric, storage_type, idx)
+    return expand_binding(metric, storage_type, idx)
+
+
 def expanded_bindings(metric, idx: dict) -> dict:
-    """All of a metric's bindings with placeholders resolved. For a non-derived
-    metric this is just its bindings; for a derived one, each dialect is composed.
-    Raises DerivedError if any dialect can't be expanded."""
+    """All of a metric's bindings resolved to standalone SQL (placeholder expansion for
+    first-order, CTE synthesis for second-order). Raises DerivedError on failure."""
     out: dict = {}
     for stype in (getattr(metric, "bindings", None) or {}):
-        out[stype] = expand_binding(metric, stype, idx)
+        out[stype] = resolve_metric_sql(metric, stype, idx)
     return out

--- a/plugins/agami/scripts/semantic_model/derived.py
+++ b/plugins/agami/scripts/semantic_model/derived.py
@@ -11,11 +11,13 @@ placeholders in its binding — so the definition lives in ONE place and never d
 `expand_binding` resolves those placeholders recursively into standalone SQL
 (`SUM(amount) / COUNT(DISTINCT order_id)`), with cycle / missing-reference guards.
 
-SCOPE: this handles case (a) — composition of metrics over the same grain (ratios,
-rates, arithmetic). Case (b) — a SECOND-ORDER statistic, an aggregate OF an aggregate
-at a finer grain (`AVG` of a daily `SUM`) — needs nested CTE composition and is
-deferred to the grain-attributed planner (#4); it's detected here and refused with a
-clear message rather than emitting illegal `AVG(SUM(...))`.
+SCOPE: case (a) — composition of metrics over the same grain (ratios, rates, arithmetic)
+— is handled by `expand_binding` (inline placeholder substitution). Case (b) — a
+SECOND-ORDER statistic, an aggregate OF an aggregate at a finer grain (`AVG` of a daily
+`SUM`) — IS supported, via `synthesize_second_order`: declare it with an `inner_grain` and
+bind it as `OUTERAGG({base})`, and the CTE is built deterministically (see
+`resolve_metric_sql`, the single entry point). A nested aggregate with NO `inner_grain`
+declared is still refused — illegal `AVG(SUM(...))` is never emitted.
 """
 
 from __future__ import annotations
@@ -86,8 +88,9 @@ def expand_binding(metric, storage_type: str, idx: dict, *, _stack: Optional[lis
     if _has_nested_aggregate(expanded):
         raise DerivedError(
             f"metric {metric.name!r} composes an aggregate of an aggregate "
-            "(second-order statistic) — that needs CTE composition and is deferred to "
-            "the grain-attributed planner (#4). Express it with a direct binding for now."
+            "(second-order statistic) but has no `inner_grain` declared. To support it, set "
+            "`inner_grain` (the dimension the base is grouped by) and bind it as "
+            "OUTERAGG({base}) — the CTE is then synthesized (see synthesize_second_order)."
         )
     return expanded
 

--- a/plugins/agami/scripts/semantic_model/derived.py
+++ b/plugins/agami/scripts/semantic_model/derived.py
@@ -1,0 +1,124 @@
+"""Composable derived metrics (scorecard #1).
+
+A *derived* metric defines its SQL in terms of OTHER metrics, via `{metric name}`
+placeholders in its binding — so the definition lives in ONE place and never drifts:
+
+    revenue        bindings.PostgreSQL = "SUM(amount)"
+    order_count    bindings.PostgreSQL = "COUNT(DISTINCT order_id)"
+    avg_order_value  base_metrics=[revenue, order_count]
+                     bindings.PostgreSQL = "{revenue} / {order_count}"
+
+`expand_binding` resolves those placeholders recursively into standalone SQL
+(`SUM(amount) / COUNT(DISTINCT order_id)`), with cycle / missing-reference guards.
+
+SCOPE: this handles case (a) — composition of metrics over the same grain (ratios,
+rates, arithmetic). Case (b) — a SECOND-ORDER statistic, an aggregate OF an aggregate
+at a finer grain (`AVG` of a daily `SUM`) — needs nested CTE composition and is
+deferred to the grain-attributed planner (#4); it's detected here and refused with a
+clear message rather than emitting illegal `AVG(SUM(...))`.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# {metric name} — names may contain spaces/underscores/digits (agami metric names do).
+PLACEHOLDER_RE = re.compile(r"\{\s*([^{}]+?)\s*\}")
+
+
+class DerivedError(ValueError):
+    """A derived metric can't be composed (cycle, missing base, or a case-(b) nesting)."""
+
+
+def metric_index(org) -> dict:
+    """name -> Metric across every subject area + org-level cross metrics."""
+    idx: dict = {}
+    for sa in org.subject_areas:
+        for mm in sa.metrics:
+            idx[mm.name] = mm
+    for mm in getattr(org, "cross_subject_area_metrics", []) or []:
+        idx[mm.name] = mm
+    return idx
+
+
+def binding_refs(binding_sql: Optional[str]) -> list[str]:
+    """The metric names a single binding references via {…} placeholders."""
+    if not binding_sql:
+        return []
+    return [m.strip() for m in PLACEHOLDER_RE.findall(binding_sql)]
+
+
+def is_derived(metric) -> bool:
+    """True if the metric composes other metrics — declared via base_metrics or
+    detected from {…} placeholders in any binding."""
+    if getattr(metric, "base_metrics", None):
+        return True
+    return any(binding_refs(b) for b in (getattr(metric, "bindings", None) or {}).values())
+
+
+def expand_binding(metric, storage_type: str, idx: dict, *, _stack: Optional[list] = None) -> str:
+    """Recursively expand a metric's `{base}` placeholders for `storage_type` into
+    standalone SQL. Raises DerivedError on a cycle, an unknown base, a base that
+    lacks a binding for this dialect, or a second-order (case-b) nesting."""
+    _stack = list(_stack or [])
+    if metric.name in _stack:
+        raise DerivedError(
+            "derived metric cycle: " + " -> ".join(_stack + [metric.name])
+        )
+    binding = (getattr(metric, "bindings", None) or {}).get(storage_type)
+    if binding is None:
+        raise DerivedError(
+            f"metric {metric.name!r} has no {storage_type} binding to expand"
+        )
+
+    def _sub(mo: "re.Match") -> str:
+        ref = mo.group(1).strip()
+        base = idx.get(ref)
+        if base is None:
+            raise DerivedError(
+                f"metric {metric.name!r} references unknown base metric {ref!r}"
+            )
+        inner = expand_binding(base, storage_type, idx, _stack=_stack + [metric.name])
+        return "(" + inner + ")"
+
+    expanded = PLACEHOLDER_RE.sub(_sub, binding)
+    if _has_nested_aggregate(expanded):
+        raise DerivedError(
+            f"metric {metric.name!r} composes an aggregate of an aggregate "
+            "(second-order statistic) — that needs CTE composition and is deferred to "
+            "the grain-attributed planner (#4). Express it with a direct binding for now."
+        )
+    return expanded
+
+
+def _has_nested_aggregate(sql_fragment: str) -> bool:
+    """True if `sql_fragment` contains an aggregate inside another aggregate
+    (e.g. AVG(SUM(x))) — illegal SQL and the signature of a case-(b) second-order
+    statistic. Best-effort via sqlglot; if it can't parse, don't block."""
+    try:
+        import sqlglot
+        from sqlglot import expressions as exp
+    except Exception:
+        return False
+    try:
+        tree = sqlglot.parse_one(sql_fragment, error_level="ignore")
+    except Exception:
+        return False
+    if tree is None:
+        return False
+    for agg in tree.find_all(exp.AggFunc):
+        for inner in agg.find_all(exp.AggFunc):
+            if inner is not agg:
+                return True
+    return False
+
+
+def expanded_bindings(metric, idx: dict) -> dict:
+    """All of a metric's bindings with placeholders resolved. For a non-derived
+    metric this is just its bindings; for a derived one, each dialect is composed.
+    Raises DerivedError if any dialect can't be expanded."""
+    out: dict = {}
+    for stype in (getattr(metric, "bindings", None) or {}):
+        out[stype] = expand_binding(metric, stype, idx)
+    return out

--- a/plugins/agami/scripts/semantic_model/introspect.py
+++ b/plugins/agami/scripts/semantic_model/introspect.py
@@ -423,6 +423,9 @@ def _build_table(
     pk_set = set(grain)
     for c in cols:
         c.primary_key = c.name in pk_set
+        # column-intrinsic aggregation class (additive / averageable / dimension / unknown).
+        # Keys are dimensions; the rest is a name+type heuristic the curator can refine.
+        c.aggregation = build.classify_aggregation(c.name, c.type, is_key=c.primary_key)
         if build.detect_sensitive(table, c.name):
             c.sensitive = True
             report.sensitive_columns += 1

--- a/plugins/agami/scripts/semantic_model/models.py
+++ b/plugins/agami/scripts/semantic_model/models.py
@@ -456,6 +456,13 @@ class Metric(_Base):
     # fully-additive metric leaves both empty.
     non_additive_dimensions: list[str] = Field(default_factory=list)
     semi_additive_agg: Optional[SemiAdditiveAgg] = None
+    # Second-order statistic (scorecard #1, case b): an aggregate OF an aggregate at a finer
+    # grain — AVG of a daily SUM, MAX of a monthly COUNT. The binding is `OUTERAGG({base})`
+    # (e.g. "AVG({daily_revenue})") and `inner_grain` names the dimension(s) the BASE metric is
+    # grouped by first. The engine deterministically synthesizes the CTE (compute the base at
+    # `inner_grain`, then apply the outer aggregate) — illegal AVG(SUM(...)) is never emitted.
+    # Empty for first-order / case-(a) metrics.
+    inner_grain: list[str] = Field(default_factory=list)
     business_question: Optional[str] = None
     confidence: Confidence = "proposed"
     source: Optional[str] = None

--- a/plugins/agami/scripts/semantic_model/models.py
+++ b/plugins/agami/scripts/semantic_model/models.py
@@ -67,6 +67,17 @@ ColumnType = Literal[
 
 Confidence = Literal["confirmed", "inferred", "proposed"]
 ReviewState = Literal["unreviewed", "approved", "rejected", "stale", "not_applicable"]
+# How a column may be aggregated when used as a MEASURE. Column-INTRINSIC only:
+# semi-additivity (additive over some dimensions but not others — e.g. an account
+# balance is summable across accounts but NOT across time) is a column×dimension
+# property and lives on the metric as `non_additive_dimensions`, NOT here.
+#   additive     → SUM is meaningful (amount, quantity, revenue). Semi-additive measures
+#                  are ALSO `additive` here — the time exception is declared on the metric.
+#   averageable  → AVG/MIN/MAX meaningful, SUM is NOT (unit_price, rate, ratio, score).
+#   dimension    → not a measure; a grouping key (ids, codes, year, zip) — never aggregated.
+#   unknown      → not yet classified (legacy models, or the heuristic was unsure). Never
+#                  enforced against — the enforcement layer only acts on a definite class.
+Aggregation = Literal["additive", "averageable", "dimension", "unknown"]
 # Provenance of a table/column `description` (NOT a sign-off gate — advisory only).
 #   None    → unknown / legacy; treated as trusted, never surfaced for confirmation
 #   human   → written or edited by a person; trusted
@@ -206,6 +217,11 @@ class Column(_Base):
     foreign_key: Optional[ForeignKey] = None
     # enum semantics: maps stored value -> human meaning
     choice_field: Optional[dict[str, str]] = None
+    # How this column may be aggregated as a measure (additive / averageable / dimension).
+    # Set by an introspection heuristic, refined by the curator. Consumed by the query-time
+    # enforcement layer (e.g. refuse SUM of an `averageable` price, or AVG of a `dimension`
+    # id). `unknown` is never enforced against. See the `Aggregation` literal above.
+    aggregation: Aggregation = "unknown"
     sensitive: bool = False
     # declarative cleaning/transform SQL (regexp_replace, TO_TIMESTAMP, …)
     value_transform: Optional[str] = None

--- a/plugins/agami/scripts/semantic_model/models.py
+++ b/plugins/agami/scripts/semantic_model/models.py
@@ -78,6 +78,11 @@ ReviewState = Literal["unreviewed", "approved", "rejected", "stale", "not_applic
 #   unknown      → not yet classified (legacy models, or the heuristic was unsure). Never
 #                  enforced against — the enforcement layer only acts on a definite class.
 Aggregation = Literal["additive", "averageable", "dimension", "unknown"]
+# How a SEMI-ADDITIVE metric is collapsed over a dimension it can't be summed across
+# (almost always time): take the period-end (`last`) / period-start (`first`) value, or an
+# `average`/`min`/`max`. None on a metric with `non_additive_dimensions` means "don't sum
+# over them — refuse/warn rather than auto-collapse."
+SemiAdditiveAgg = Literal["last", "first", "average", "min", "max"]
 # Provenance of a table/column `description` (NOT a sign-off gate — advisory only).
 #   None    → unknown / legacy; treated as trusted, never surfaced for confirmation
 #   human   → written or edited by a person; trusted
@@ -442,6 +447,15 @@ class Metric(_Base):
     source_tables: list[str] = Field(default_factory=list)
     base_metrics: list[str] = Field(default_factory=list)
     subject_areas: list[str] = Field(default_factory=list)
+    # Additivity (scorecard #3). A SEMI-ADDITIVE measure (account balance, inventory,
+    # headcount, point-in-time subscribers) is summable across some dimensions but NOT
+    # across others — almost always time. `non_additive_dimensions` names those (a column
+    # name, or the shorthand "time" = any date/time grain in the query); `semi_additive_agg`
+    # says how to collapse over them (period-end `last`, `average`, …). With dims set but no
+    # agg, the enforcement layer (#4) refuses/warns instead of auto-collapsing. A
+    # fully-additive metric leaves both empty.
+    non_additive_dimensions: list[str] = Field(default_factory=list)
+    semi_additive_agg: Optional[SemiAdditiveAgg] = None
     business_question: Optional[str] = None
     confidence: Confidence = "proposed"
     source: Optional[str] = None
@@ -457,6 +471,17 @@ class Metric(_Base):
         if not v or not v.strip():
             raise ValueError("metric calculation (prose intent) must be non-empty")
         return v
+
+    @model_validator(mode="after")
+    def _semi_additive_coherent(self) -> "Metric":
+        # "how to collapse over a non-additive dimension" is meaningless without naming
+        # the dimension(s). (The reverse is fine: dims without an agg = refuse to sum.)
+        if self.semi_additive_agg and not self.non_additive_dimensions:
+            raise ValueError(
+                "semi_additive_agg is set but non_additive_dimensions is empty — name the "
+                "dimension(s) the metric can't be summed over (e.g. [\"time\"])"
+            )
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/agami/scripts/semantic_model/runtime.py
+++ b/plugins/agami/scripts/semantic_model/runtime.py
@@ -168,6 +168,8 @@ def resolve_entities(
 def resolve_metrics(
     query: str, org: Organization, *, area: Optional[str] = None, top_k: int = 5
 ) -> list[dict[str, Any]]:
+    from . import derived as _D
+
     q = query.lower()
     ranked: list[tuple[float, dict[str, Any]]] = []
     metrics: list[tuple[Optional[str], Metric]] = []
@@ -178,10 +180,20 @@ def resolve_metrics(
             metrics.append((sa.name, mm))
     for mm in org.cross_subject_area_metrics:
         metrics.append((None, mm))
+    idx = _D.metric_index(org)
     for area_name, mm in metrics:
         names = [mm.name] + list(mm.other_names)
         score = max((_term_score(q, n) for n in names if n), default=0.0)
         if score > 0:
+            # A derived metric surfaces its COMPOSED SQL (base placeholders resolved) so
+            # the generator gets ready-to-run SQL and the single-source-of-truth holds.
+            # Fall back to the raw binding if expansion fails (validator gates the model).
+            bindings = mm.bindings
+            if _D.is_derived(mm):
+                try:
+                    bindings = _D.expanded_bindings(mm, idx)
+                except _D.DerivedError:
+                    bindings = mm.bindings
             ranked.append(
                 (
                     score,
@@ -190,7 +202,7 @@ def resolve_metrics(
                         "subject_area": area_name,
                         "score": round(score, 3),
                         "calculation": mm.calculation,
-                        "bindings": mm.bindings,
+                        "bindings": bindings,
                         "confidence": mm.confidence,
                     },
                 )

--- a/plugins/agami/scripts/semantic_model/runtime.py
+++ b/plugins/agami/scripts/semantic_model/runtime.py
@@ -530,26 +530,37 @@ def _bare_aggregate_column(agg: "exp.AggFunc") -> Optional["exp.Column"]:
     return None
 
 
-def _semi_additive_columns(org: Organization) -> dict[str, "Metric"]:
-    """Column name -> the semi-additive Metric that SUMs it (declares non_additive_dimensions).
-    Parsed from each such metric's bindings (the column inside its SUM)."""
-    out: dict[str, "Metric"] = {}
+def _semi_additive_columns(org: Organization) -> dict[tuple[str, str], "Metric"]:
+    """(table, column) -> the semi-additive Metric that SUMs it (declares
+    non_additive_dimensions). Keyed by (table, column) — NOT bare column name — so two
+    tables that both have a `balance` don't cross-contaminate. The table is the binding's
+    own qualifier when present, else the metric's source_tables. Includes org-level
+    cross-subject-area metrics."""
+    all_metrics: list["Metric"] = list(getattr(org, "cross_subject_area_metrics", []) or [])
     for sa in org.subject_areas:
-        metrics = list(sa.metrics)
-        for mm in metrics:
-            if not mm.non_additive_dimensions:
+        all_metrics.extend(sa.metrics)
+    out: dict[tuple[str, str], "Metric"] = {}
+    for mm in all_metrics:
+        if not mm.non_additive_dimensions:
+            continue
+        srcs = list(mm.source_tables or [])
+        for binding in (mm.bindings or {}).values():
+            try:
+                frag = sqlglot.parse_one(binding, error_level="ignore")
+            except Exception:
                 continue
-            for binding in (mm.bindings or {}).values():
-                try:
-                    frag = sqlglot.parse_one(binding, error_level="ignore")
-                except Exception:
+            if frag is None:
+                continue
+            for agg in frag.find_all(exp.Sum):
+                col = _bare_aggregate_column(agg)
+                if col is None:
                     continue
-                if frag is None:
-                    continue
-                for agg in frag.find_all(exp.Sum):
-                    col = _bare_aggregate_column(agg)
-                    if col is not None:
-                        out.setdefault(col.name, mm)
+                # the table the summed column belongs to: the binding's qualifier if it has
+                # one, else the metric's source table(s) (attribute to each when >1).
+                tables = [col.table] if col.table else srcs
+                for tname in tables:
+                    if tname:
+                        out.setdefault((tname, col.name), mm)
     return out
 
 
@@ -611,8 +622,14 @@ def _check_aggregation_semantics(
         for select_expr in tree.expressions:
             for agg in select_expr.find_all(exp.Sum):
                 col = _bare_aggregate_column(agg)
-                if col is not None and col.name in semi:
-                    mm = semi[col.name]
+                if col is None:
+                    continue
+                # match on (table, column) — resolve the summed column's table from the
+                # query; skip when it can't be pinned down (don't mis-fire on a bare column
+                # that happens to share a name with a semi-additive measure elsewhere).
+                ctable = _resolve_col_table(col, scope)
+                mm = semi.get((ctable, col.name)) if ctable else None
+                if mm is not None:
                     how = mm.semi_additive_agg or "last"
                     return PreFlightResult(
                         "semi_additive", "refuse", sql,

--- a/plugins/agami/scripts/semantic_model/runtime.py
+++ b/plugins/agami/scripts/semantic_model/runtime.py
@@ -189,7 +189,7 @@ def resolve_metrics(
             # the generator gets ready-to-run SQL and the single-source-of-truth holds.
             # Fall back to the raw binding if expansion fails (validator gates the model).
             bindings = mm.bindings
-            if _D.is_derived(mm):
+            if _D.is_derived(mm) or _D.is_second_order(mm):
                 try:
                     bindings = _D.expanded_bindings(mm, idx)
                 except _D.DerivedError:

--- a/plugins/agami/scripts/semantic_model/runtime.py
+++ b/plugins/agami/scripts/semantic_model/runtime.py
@@ -43,7 +43,7 @@ try:
 except ImportError:  # pragma: no cover
     _HAVE_SQLGLOT = False
 
-from .models import Entity, Metric, Organization, Relationship, SubjectArea
+from .models import Column, Entity, Metric, Organization, Relationship, SubjectArea
 
 # A prober resolves a literal/value against the DB. Returns True if the value
 # exists in <table>.<column>. Injected so runtime stays DB-agnostic.
@@ -482,7 +482,151 @@ def pre_flight_check(sql: str, org: Organization) -> PreFlightResult:
             triggering_joins=[f"{measure_table} (1) <- {mt} (N)" for mt in sorted(many_tables)],
         )
 
-    return PreFlightResult(None, "allow", sql, reason="no fan/chasm trap detected")
+    # No structural (join) trap. Now the SEMANTIC checks the fan/chasm detector is
+    # blind to (scorecard #4): aggregation-class violations (#2) and semi-additive
+    # rollups over time (#3) — these need NO join, so cardinality analysis can't see them.
+    semantic = _check_aggregation_semantics(tree, org, tables_in_scope, sql)
+    if semantic is not None:
+        return semantic
+
+    return PreFlightResult(None, "allow", sql, reason="no fan/chasm or aggregation issue")
+
+
+# ---------------------------------------------------------------------------
+# Aggregation-semantics enforcement (#4 teeth for #2 and #3)
+# ---------------------------------------------------------------------------
+
+
+def _column_index(org: Organization) -> dict[str, dict[str, Column]]:
+    """bare table name -> {column name -> Column}."""
+    idx: dict[str, dict[str, Column]] = {}
+    for sa in org.subject_areas:
+        for t in sa.tables_defined:
+            idx.setdefault(t.name, {}).update({c.name: c for c in t.columns})
+    return idx
+
+
+def _lookup_column(col: "exp.Column", scope: dict[str, str],
+                   colidx: dict[str, dict[str, Column]]) -> Optional[Column]:
+    t = _resolve_col_table(col, scope)
+    if t and col.name in colidx.get(t, {}):
+        return colidx[t][col.name]
+    # bare column, ambiguous table: only safe if exactly one in-scope table defines it
+    if not t:
+        owners = [tt for tt, cols in colidx.items()
+                  if tt in set(scope.values()) and col.name in cols]
+        if len(owners) == 1:
+            return colidx[owners[0]][col.name]
+    return None
+
+
+def _bare_aggregate_column(agg: "exp.AggFunc") -> Optional["exp.Column"]:
+    """The single column an aggregate is applied to, ONLY when the argument is that
+    bare column (optionally DISTINCT). Returns None for composite args like
+    SUM(price * qty) — those can be legitimately additive even if a part isn't."""
+    cols = list(agg.find_all(exp.Column))
+    if len(cols) == 1 and agg.find(exp.Binary) is None:
+        return cols[0]
+    return None
+
+
+def _semi_additive_columns(org: Organization) -> dict[str, "Metric"]:
+    """Column name -> the semi-additive Metric that SUMs it (declares non_additive_dimensions).
+    Parsed from each such metric's bindings (the column inside its SUM)."""
+    out: dict[str, "Metric"] = {}
+    for sa in org.subject_areas:
+        metrics = list(sa.metrics)
+        for mm in metrics:
+            if not mm.non_additive_dimensions:
+                continue
+            for binding in (mm.bindings or {}).values():
+                try:
+                    frag = sqlglot.parse_one(binding, error_level="ignore")
+                except Exception:
+                    continue
+                if frag is None:
+                    continue
+                for agg in frag.find_all(exp.Sum):
+                    col = _bare_aggregate_column(agg)
+                    if col is not None:
+                        out.setdefault(col.name, mm)
+    return out
+
+
+def _groups_by_time(tree: "exp.Select", scope: dict[str, str],
+                    colidx: dict[str, dict[str, Column]]) -> bool:
+    """Does the query GROUP BY a time grain — a date/timestamp column, or a
+    DATE_TRUNC/EXTRACT/TO_CHAR/DATE_PART over one?"""
+    grp = tree.args.get("group")
+    if not grp:
+        return False
+    for col in grp.find_all(exp.Column):
+        c = _lookup_column(col, scope, colidx)
+        if c and (c.type in ("date", "timestamp", "time") or c.date_format):
+            return True
+    return False
+
+
+def _check_aggregation_semantics(
+    tree: "exp.Select", org: Organization, scope: dict[str, str], sql: str
+) -> Optional[PreFlightResult]:
+    colidx = _column_index(org)
+
+    # --- #2: aggregation-class violations (SUM of a rate/id, AVG of an id) ---
+    for select_expr in tree.expressions:
+        for agg in select_expr.find_all(exp.AggFunc):
+            is_sum, is_avg = isinstance(agg, exp.Sum), isinstance(agg, exp.Avg)
+            if not (is_sum or is_avg):
+                continue  # COUNT / MIN / MAX are fine even on dimensions
+            col = _bare_aggregate_column(agg)
+            if col is None:
+                continue
+            c = _lookup_column(col, scope, colidx)
+            if c is None:
+                continue
+            cls = getattr(c, "aggregation", "unknown")
+            bad = (is_sum and cls in ("averageable", "dimension")) or (is_avg and cls == "dimension")
+            if bad:
+                verb = "SUM" if is_sum else "AVG"
+                return PreFlightResult(
+                    "bad_aggregation", "refuse", sql,
+                    reason=(
+                        f"{verb}({col.name}) is meaningless: {col.name!r} is classified "
+                        f"`{cls}` ("
+                        + ("a rate/ratio/price — summing it has no meaning"
+                           if cls == "averageable"
+                           else "an identifier/code, not a measure")
+                        + ")."
+                    ),
+                    suggestion=(
+                        "Average it instead of summing"
+                        if cls == "averageable"
+                        else f"{col.name!r} is a dimension — GROUP BY it or COUNT it, don't aggregate its value"
+                    ),
+                )
+
+    # --- #3: semi-additive measure summed over time ---
+    semi = _semi_additive_columns(org)
+    if semi and _groups_by_time(tree, scope, colidx):
+        for select_expr in tree.expressions:
+            for agg in select_expr.find_all(exp.Sum):
+                col = _bare_aggregate_column(agg)
+                if col is not None and col.name in semi:
+                    mm = semi[col.name]
+                    how = mm.semi_additive_agg or "last"
+                    return PreFlightResult(
+                        "semi_additive", "refuse", sql,
+                        reason=(
+                            f"SUM({col.name}) across time is wrong: {col.name!r} backs the "
+                            f"semi-additive metric {mm.name!r} ({mm.non_additive_dimensions}) — "
+                            "summing a stock over a date grain multiplies it."
+                        ),
+                        suggestion=(
+                            f"Take the period-end value ({how}) per entity over time "
+                            f"(e.g. window function), then sum across entities — or drop the time grouping."
+                        ),
+                    )
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/agami/scripts/semantic_model/validator.py
+++ b/plugins/agami/scripts/semantic_model/validator.py
@@ -141,6 +141,7 @@ def validate(org: Organization) -> ValidationResult:
 
     _check_cross_area_entity_collisions(org, res)
     _check_metric_backend_neutrality(org, res)
+    _check_derived_metrics(org, res)
 
     return res
 
@@ -483,6 +484,40 @@ def _check_metric_backend_neutrality(org: Organization, res: ValidationResult) -
                 f"metric {met.name!r} has SQL bindings but no prose calculation "
                 "(backend-neutrality violation)",
             )
+
+
+def _check_derived_metrics(org: Organization, res: ValidationResult) -> None:
+    """Scorecard #1: a derived metric (one composing others via {base} placeholders)
+    must resolve — no cycles, no unknown bases, no illegal second-order nesting. A
+    base over a disjoint grain is a warning (inline composition may be wrong; full
+    grain attribution is #4)."""
+    from . import derived as D
+
+    idx = D.metric_index(org)
+    all_metrics = list(org.cross_subject_area_metrics)
+    for sa in org.subject_areas:
+        all_metrics.extend(sa.metrics)
+    for met in all_metrics:
+        if not D.is_derived(met):
+            continue
+        for stype in (met.bindings or {}):
+            try:
+                D.expand_binding(met, stype, idx)
+            except D.DerivedError as e:
+                res.error("derived_metric", str(e))
+        # grain sanity: a base sharing no source_table with this metric may be a
+        # cross-grain ratio that inline composition can't get right (deferred to #4).
+        for stype in (met.bindings or {}):
+            for ref in D.binding_refs(met.bindings.get(stype)):
+                base = idx.get(ref)
+                if (base and met.source_tables and base.source_tables
+                        and not (set(met.source_tables) & set(base.source_tables))):
+                    res.warn(
+                        "derived_metric_grain",
+                        f"metric {met.name!r} composes {ref!r} but they share no source "
+                        "table — verify they're at the same grain (cross-grain composition "
+                        "needs the grain-attributed planner, #4)",
+                    )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/agami/scripts/semantic_model/validator.py
+++ b/plugins/agami/scripts/semantic_model/validator.py
@@ -498,15 +498,21 @@ def _check_derived_metrics(org: Organization, res: ValidationResult) -> None:
     for sa in org.subject_areas:
         all_metrics.extend(sa.metrics)
     for met in all_metrics:
-        if not D.is_derived(met):
+        if not (D.is_derived(met) or D.is_second_order(met)):
             continue
+        # resolve_metric_sql dispatches: second-order → CTE synthesis, else placeholder
+        # expansion. Either failure mode (cycle, unknown base, bad shape, multi-table inner
+        # synth, missing inner_grain) is deploy-blocking.
         for stype in (met.bindings or {}):
             try:
-                D.expand_binding(met, stype, idx)
+                D.resolve_metric_sql(met, stype, idx)
             except D.DerivedError as e:
                 res.error("derived_metric", str(e))
-        # grain sanity: a base sharing no source_table with this metric may be a
-        # cross-grain ratio that inline composition can't get right (deferred to #4).
+        # grain sanity (first-order case-a only): a base sharing no source_table may be a
+        # cross-grain ratio inline composition can't get right (the synthesizer handles the
+        # second-order case explicitly, so skip the warning there).
+        if D.is_second_order(met):
+            continue
         for stype in (met.bindings or {}):
             for ref in D.binding_refs(met.bindings.get(stype)):
                 base = idx.get(ref)

--- a/plugins/agami/shared/metric-entity-shape.md
+++ b/plugins/agami/shared/metric-entity-shape.md
@@ -59,6 +59,31 @@ confidence: inferred
 review_state: unreviewed
 ```
 
+**Semi-additive metrics (`non_additive_dimensions` + `semi_additive_agg`) — set these whenever
+the measure is a STOCK, not a flow.** A balance, inventory level, headcount, or point-in-time
+subscriber count is summable across *entities* (accounts, warehouses, regions) but **NOT across
+time** — summing an account balance over 90 days multiplies it ~90×. Name the dimension(s) it
+can't be summed over (`time` is the usual shorthand for any date/time grain) and how to collapse
+over them (`last` = period-end value, `average`, `min`, `max`). Flow metrics (revenue, counts,
+quantities) leave both empty. Tell-tale: the metric's source column has `aggregation: additive`
+but is a *level/balance/on-hand* (a stock), or its name is balance/inventory/headcount/AUM/etc.
+
+```yaml
+name: total balance
+description: End-of-period balance summed across accounts.
+calculation: Sum of account balances at the period end (NOT across days within the period).
+bindings:
+  PostgreSQL: "SUM(balance)"
+unit: USD
+source_tables:
+  - daily_balances
+non_additive_dimensions:
+  - time
+semi_additive_agg: last     # over time take the period-end balance, then sum across accounts
+confidence: inferred
+review_state: unreviewed
+```
+
 ## Entity
 
 Fields: `name`, `plural`, `other_names`, `description`, `maps_to` (one entry per

--- a/plugins/agami/shared/metric-entity-shape.md
+++ b/plugins/agami/shared/metric-entity-shape.md
@@ -84,6 +84,39 @@ confidence: inferred
 review_state: unreviewed
 ```
 
+**Derived metrics (compose other metrics — don't re-derive).** When a metric is a function of
+OTHER metrics, reference them by name with `{…}` placeholders and list them in `base_metrics`.
+Define `revenue` once; everything downstream tracks it (no drift).
+
+```yaml
+name: average order value
+description: Revenue per order.
+calculation: Total revenue divided by order count.
+base_metrics: [revenue, order count]
+bindings:
+  PostgreSQL: "{revenue} / {order count}"   # expands to (SUM(amount)) / (COUNT(DISTINCT order_id))
+source_tables:
+  - orders
+```
+
+**Second-order statistics (an aggregate OF an aggregate).** A metric like *average daily revenue*
+or *peak monthly orders* aggregates a finer-grain aggregate — `AVG` of a daily `SUM`. Don't write
+`AVG(SUM(...))` (illegal SQL). Declare it: bind as `OUTERAGG({base_metric})` and set `inner_grain`
+to the dimension(s) the base is grouped by first. The engine synthesizes the CTE deterministically.
+
+```yaml
+name: average daily revenue
+description: Mean of each day's total revenue.
+calculation: Average over days of the daily revenue total.
+base_metrics: [daily revenue]
+bindings:
+  PostgreSQL: "AVG({daily revenue})"   # → (SELECT AVG(v) FROM (SELECT order_date, SUM(amount) AS v FROM orders GROUP BY order_date) _i)
+inner_grain:
+  - order_date
+source_tables:
+  - orders
+```
+
 ## Entity
 
 Fields: `name`, `plural`, `other_names`, `description`, `maps_to` (one entry per

--- a/tests/test_additivity.py
+++ b/tests/test_additivity.py
@@ -1,0 +1,66 @@
+"""Phase 2 (scorecard #3): additivity constraints on metrics.
+
+A semi-additive metric declares `non_additive_dimensions` (the dimensions it can't
+be summed over — usually time) and optionally `semi_additive_agg` (how to collapse
+over them). The declaration lands + validates here; enforcement is Phase 4 (#4).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import models as m  # noqa: E402
+
+
+def _metric(**kw):
+    base = dict(name="total balance", calculation="sum of balances at period end",
+                bindings={"PostgreSQL": "SUM(balance)"}, source_tables=["daily_balances"])
+    base.update(kw)
+    return m.Metric(**base)
+
+
+def test_fully_additive_metric_leaves_fields_empty():
+    mm = _metric(name="revenue", calculation="sum of line totals")
+    assert mm.non_additive_dimensions == []
+    assert mm.semi_additive_agg is None
+
+
+def test_semi_additive_metric_declares_dims_and_agg():
+    mm = _metric(non_additive_dimensions=["time"], semi_additive_agg="last")
+    assert mm.non_additive_dimensions == ["time"]
+    assert mm.semi_additive_agg == "last"
+
+
+def test_non_additive_dims_without_agg_is_allowed():
+    # dims-only = "refuse to sum over these" (Phase 4 blocks rather than auto-collapses)
+    mm = _metric(non_additive_dimensions=["time"])
+    assert mm.semi_additive_agg is None
+
+
+def test_agg_without_dims_is_rejected():
+    # "how to collapse" is meaningless without naming what to collapse over
+    with pytest.raises(Exception):
+        _metric(semi_additive_agg="last")
+
+
+def test_bad_semi_additive_agg_value_rejected():
+    with pytest.raises(Exception):
+        _metric(non_additive_dimensions=["time"], semi_additive_agg="sum")
+
+
+def test_round_trip_through_dump_and_load():
+    mm = _metric(non_additive_dimensions=["snapshot_date"], semi_additive_agg="average")
+    dumped = mm.model_dump()
+    assert dumped["non_additive_dimensions"] == ["snapshot_date"]
+    assert dumped["semi_additive_agg"] == "average"
+    again = m.Metric(**dumped)
+    assert again.non_additive_dimensions == ["snapshot_date"]
+    assert again.semi_additive_agg == "average"

--- a/tests/test_aggregation_class.py
+++ b/tests/test_aggregation_class.py
@@ -1,0 +1,130 @@
+"""Phase 1 (scorecard #2): column-intrinsic aggregation semantics.
+
+`Column.aggregation` classifies how a column may be aggregated as a measure
+(additive / averageable / dimension / unknown). Set by a name+type heuristic at
+introspection, refined by the curator, never enforced against when `unknown`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import build  # noqa: E402
+from semantic_model import curate as C  # noqa: E402
+from semantic_model import introspect as I  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+from semantic_model import validator as V  # noqa: E402
+
+
+# --- classify_aggregation heuristic ----------------------------------------
+
+@pytest.mark.parametrize("name,ctype,is_key,expected", [
+    # keys / non-numeric → dimension
+    ("id", "integer", True, "dimension"),
+    ("customer_id", "integer", False, "dimension"),
+    ("order_no", "integer", False, "dimension"),
+    ("zip_code", "integer", False, "dimension"),
+    ("fiscal_year", "integer", False, "dimension"),
+    ("status", "string", False, "dimension"),         # non-numeric
+    ("created_at", "timestamp", False, "dimension"),   # non-numeric
+    ("is_active", "boolean", False, "dimension"),      # non-numeric
+    # averageable (rates/prices/ratios) — even when numeric & money-ish
+    ("unit_price", "decimal", False, "averageable"),
+    ("discount_rate", "decimal", False, "averageable"),
+    ("conversion_pct", "float", False, "averageable"),
+    ("avg_balance", "decimal", False, "averageable"),  # 'avg' beats 'balance'
+    ("cost_per_unit", "decimal", False, "averageable"),  # 'per' beats 'cost'
+    ("credit_score", "integer", False, "averageable"),
+    # additive (money / quantity / stocks)
+    ("order_amount", "decimal", False, "additive"),
+    ("quantity", "integer", False, "additive"),
+    ("revenue", "decimal", False, "additive"),
+    ("total_cost", "decimal", False, "additive"),
+    ("account_balance", "decimal", False, "additive"),   # stock: summable across accounts
+    ("inventory_on_hand", "integer", False, "additive"),
+    # unrecognized numeric → unknown (safe; never enforced)
+    ("xyz", "decimal", False, "unknown"),
+    ("v_1", "float", False, "unknown"),
+])
+def test_classify_aggregation(name, ctype, is_key, expected):
+    assert build.classify_aggregation(name, ctype, is_key=is_key) == expected
+
+
+def test_default_is_unknown_on_model():
+    col = m.Column(name="foo", type="decimal")
+    assert col.aggregation == "unknown"  # back-compat: legacy models never falsely enforced
+
+
+def test_invalid_aggregation_value_rejected():
+    with pytest.raises(Exception):
+        m.Column(name="foo", type="decimal", aggregation="summable")  # not in the Literal
+
+
+# --- introspection stamps the class ----------------------------------------
+
+def _catalog_runner(sql):
+    s = " ".join(sql.split())
+    if "information_schema.schemata" in s:
+        return [{"schema_name": "public"}]
+    if "information_schema.tables" in s and "table_type" in s:
+        return [{"schema_name": "public", "table_name": "orders", "table_type": "BASE TABLE"}]
+    if "information_schema.columns" in s:
+        return [
+            {"column_name": "id", "data_type": "integer", "is_nullable": "NO", "ordinal_position": "1", "numeric_scale": ""},
+            {"column_name": "customer_id", "data_type": "integer", "is_nullable": "YES", "ordinal_position": "2", "numeric_scale": ""},
+            {"column_name": "amount", "data_type": "numeric", "is_nullable": "YES", "ordinal_position": "3", "numeric_scale": "2"},
+            {"column_name": "discount_rate", "data_type": "numeric", "is_nullable": "YES", "ordinal_position": "4", "numeric_scale": "4"},
+        ]
+    if "PRIMARY KEY" in s:
+        return [{"column_name": "id"}]
+    return []
+
+
+def test_introspect_stamps_aggregation(tmp_path):
+    org, _ = I.introspect("shop", "postgres", runner=_catalog_runner,
+                          artifacts_dir=tmp_path, dry_run=True)
+    assert V.validate(org).ok
+    t = org.subject_areas[0].defined_table("orders")
+    cls = {c.name: c.aggregation for c in t.columns}
+    assert cls["id"] == "dimension"            # primary key
+    assert cls["customer_id"] == "dimension"   # *_id
+    assert cls["amount"] == "additive"
+    assert cls["discount_rate"] == "averageable"
+
+
+# --- curator can correct it (and the strict schema guards the value) --------
+
+def test_curator_can_edit_aggregation(tmp_path):
+    org, _ = I.introspect("shop", "postgres", runner=_catalog_runner,
+                          artifacts_dir=tmp_path)  # writes the tree
+    root = tmp_path / "shop"
+    area = org.subject_areas[0].name
+    res = C.apply(root, [{
+        "op": "edit", "kind": "table", "area": area, "name": "orders",
+        "column": "amount", "field": "aggregation", "value": "averageable",
+    }])
+    assert not res.errors, res.errors
+    reloaded = __import__("semantic_model.loader", fromlist=["load_organization"]).load_organization(root)
+    t = reloaded.subject_areas[0].defined_table("orders")
+    assert t.get_column("amount").aggregation == "averageable"
+
+
+def test_curator_edit_rejects_bad_value(tmp_path):
+    org, _ = I.introspect("shop", "postgres", runner=_catalog_runner, artifacts_dir=tmp_path)
+    root = tmp_path / "shop"
+    area = org.subject_areas[0].name
+    res = C.apply(root, [{
+        "op": "edit", "kind": "table", "area": area, "name": "orders",
+        "column": "amount", "field": "aggregation", "value": "bogus",
+    }])
+    # strict schema rejects the batch (reverted); the model on disk is unchanged
+    assert res.errors

--- a/tests/test_aggregation_enforcement.py
+++ b/tests/test_aggregation_enforcement.py
@@ -111,3 +111,23 @@ def test_semi_additive_sum_without_time_group_is_allowed():
     org = _balance_org()
     r = RT.pre_flight_check("SELECT account_id, SUM(balance) FROM facts GROUP BY account_id", org)
     assert r.action == "allow"
+
+
+def test_semi_additive_is_table_scoped_no_cross_table_misfire():
+    # a SECOND table also has a `balance` column but its metric is fully additive — summing
+    # THAT balance over time must NOT be refused (keyed by (table, column), not bare name).
+    facts = m.Table(name="facts", schema="public", storage_connection="c", grain=["id"],
+                    columns=[_col("balance", "decimal", "additive"), _col("snapshot_date", "date", "dimension")])
+    ledger = m.Table(name="ledger", schema="public", storage_connection="c", grain=["id"],
+                     columns=[_col("balance", "decimal", "additive"), _col("entry_date", "date", "dimension")])
+    semi = m.Metric(name="account balance", calculation="period-end balance",
+                    bindings={"PostgreSQL": "SUM(balance)"}, source_tables=["facts"],
+                    non_additive_dimensions=["time"], semi_additive_agg="last")
+    sa = m.SubjectArea(name="area", description="d", tables_defined=[facts, ledger], metrics=[semi])
+    org = m.Organization(organization="o", version=1, subject_areas=[sa])
+    # ledger.balance is NOT the semi-additive one → allowed
+    r = RT.pre_flight_check("SELECT entry_date, SUM(balance) FROM ledger GROUP BY entry_date", org)
+    assert r.action == "allow"
+    # facts.balance IS → refused
+    r2 = RT.pre_flight_check("SELECT snapshot_date, SUM(balance) FROM facts GROUP BY snapshot_date", org)
+    assert r2.action == "refuse" and r2.risk == "semi_additive"

--- a/tests/test_aggregation_enforcement.py
+++ b/tests/test_aggregation_enforcement.py
@@ -1,0 +1,113 @@
+"""Phase 4 (scorecard #4): query-time enforcement of #2 (aggregation class) and
+#3 (additivity) — the SEMANTIC checks the join-based fan/chasm detector is blind to
+(they need no join). pre_flight_check refuses SUM(rate)/SUM(id)/AVG(id) and a
+semi-additive SUM over a time grain.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as RT  # noqa: E402
+
+
+def _col(name, type_, agg):
+    return m.Column(name=name, type=type_, aggregation=agg)
+
+
+def _org(columns, metrics=None, table="facts"):
+    t = m.Table(name=table, schema="public", storage_connection="c", grain=["id"],
+                columns=columns)
+    sa = m.SubjectArea(name="area", description="d", tables_defined=[t],
+                       metrics=metrics or [])
+    return m.Organization(organization="o", version=1, subject_areas=[sa])
+
+
+# --- #2 aggregation-class enforcement --------------------------------------
+
+def test_sum_of_averageable_is_refused():
+    org = _org([_col("id", "integer", "dimension"), _col("unit_price", "decimal", "averageable")])
+    r = RT.pre_flight_check("SELECT SUM(unit_price) FROM facts", org)
+    assert r.action == "refuse" and r.risk == "bad_aggregation"
+    assert "unit_price" in r.reason
+
+
+def test_sum_of_dimension_id_is_refused():
+    org = _org([_col("customer_id", "integer", "dimension"), _col("amount", "decimal", "additive")])
+    r = RT.pre_flight_check("SELECT SUM(customer_id) FROM facts", org)
+    assert r.action == "refuse" and r.risk == "bad_aggregation"
+
+
+def test_avg_of_dimension_is_refused():
+    org = _org([_col("zip_code", "integer", "dimension")])
+    r = RT.pre_flight_check("SELECT AVG(zip_code) FROM facts", org)
+    assert r.action == "refuse"
+
+
+def test_sum_of_additive_is_allowed():
+    org = _org([_col("amount", "decimal", "additive")])
+    r = RT.pre_flight_check("SELECT SUM(amount) FROM facts", org)
+    assert r.action == "allow"
+
+
+def test_avg_of_averageable_is_allowed():
+    org = _org([_col("unit_price", "decimal", "averageable")])
+    r = RT.pre_flight_check("SELECT AVG(unit_price) FROM facts", org)
+    assert r.action == "allow"
+
+
+def test_unknown_class_is_never_enforced():
+    # back-compat: legacy columns default to unknown and must not be flagged
+    org = _org([_col("mystery", "decimal", "unknown")])
+    r = RT.pre_flight_check("SELECT SUM(mystery) FROM facts", org)
+    assert r.action == "allow"
+
+
+def test_composite_sum_not_falsely_flagged():
+    # SUM(price * qty) is additive revenue even though price alone is averageable
+    org = _org([_col("unit_price", "decimal", "averageable"), _col("qty", "integer", "additive")])
+    r = RT.pre_flight_check("SELECT SUM(unit_price * qty) FROM facts", org)
+    assert r.action == "allow"
+
+
+def test_count_of_id_is_allowed():
+    org = _org([_col("customer_id", "integer", "dimension")])
+    r = RT.pre_flight_check("SELECT COUNT(DISTINCT customer_id) FROM facts", org)
+    assert r.action == "allow"
+
+
+# --- #3 semi-additive enforcement ------------------------------------------
+
+def _balance_org():
+    cols = [_col("account_id", "integer", "dimension"),
+            _col("balance", "decimal", "additive"),
+            _col("snapshot_date", "date", "dimension")]
+    metric = m.Metric(name="total balance", calculation="sum of balances at period end",
+                      bindings={"PostgreSQL": "SUM(balance)"}, source_tables=["facts"],
+                      non_additive_dimensions=["time"], semi_additive_agg="last")
+    return _org(cols, metrics=[metric])
+
+
+def test_semi_additive_sum_over_time_is_refused():
+    org = _balance_org()
+    sql = "SELECT snapshot_date, SUM(balance) FROM facts GROUP BY snapshot_date"
+    r = RT.pre_flight_check(sql, org)
+    assert r.action == "refuse" and r.risk == "semi_additive"
+    assert "balance" in r.reason and "last" in (r.suggestion or "")
+
+
+def test_semi_additive_sum_without_time_group_is_allowed():
+    # summing balance across accounts (no time grain) is valid
+    org = _balance_org()
+    r = RT.pre_flight_check("SELECT account_id, SUM(balance) FROM facts GROUP BY account_id", org)
+    assert r.action == "allow"

--- a/tests/test_derived_metrics.py
+++ b/tests/test_derived_metrics.py
@@ -1,0 +1,125 @@
+"""Phase 3 (scorecard #1): composable derived metrics.
+
+A derived metric defines its binding via {base metric} placeholders; the resolver
+expands them into standalone SQL (single source of truth, no drift). Cycles,
+unknown bases, and second-order (aggregate-of-aggregate) nestings are refused.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import derived as D  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as RT  # noqa: E402
+from semantic_model import validator as V  # noqa: E402
+
+
+def _metric(name, binding, *, base=None, calc="x", tables=("orders",)):
+    return m.Metric(name=name, calculation=calc, bindings={"PostgreSQL": binding},
+                    base_metrics=list(base or []), source_tables=list(tables))
+
+
+def _org(metrics):
+    sa = m.SubjectArea(name="sales", description="d", metrics=metrics)
+    return m.Organization(organization="o", version=1, subject_areas=[sa])
+
+
+# --- resolver ---------------------------------------------------------------
+
+def test_expand_simple_ratio():
+    rev = _metric("revenue", "SUM(amount)")
+    cnt = _metric("order_count", "COUNT(DISTINCT order_id)")
+    aov = _metric("avg_order_value", "{revenue} / {order_count}",
+                  base=["revenue", "order_count"])
+    idx = D.metric_index(_org([rev, cnt, aov]))
+    assert D.expand_binding(aov, "PostgreSQL", idx) == "(SUM(amount)) / (COUNT(DISTINCT order_id))"
+
+
+def test_expand_is_recursive():
+    rev = _metric("revenue", "SUM(amount)")
+    cnt = _metric("order_count", "COUNT(*)")
+    aov = _metric("aov", "{revenue} / {order_count}", base=["revenue", "order_count"])
+    margin = _metric("aov_x2", "{aov} * 2", base=["aov"])
+    idx = D.metric_index(_org([rev, cnt, aov, margin]))
+    assert D.expand_binding(margin, "PostgreSQL", idx) == "((SUM(amount)) / (COUNT(*))) * 2"
+
+
+def test_unknown_base_raises():
+    bad = _metric("x", "{nonexistent} + 1", base=["nonexistent"])
+    idx = D.metric_index(_org([bad]))
+    with pytest.raises(D.DerivedError):
+        D.expand_binding(bad, "PostgreSQL", idx)
+
+
+def test_cycle_raises():
+    a = _metric("a", "{b} + 1", base=["b"])
+    b = _metric("b", "{a} + 1", base=["a"])
+    idx = D.metric_index(_org([a, b]))
+    with pytest.raises(D.DerivedError):
+        D.expand_binding(a, "PostgreSQL", idx)
+
+
+def test_second_order_nesting_refused():
+    # AVG of a daily SUM = aggregate of an aggregate → needs CTE (deferred to #4)
+    daily = _metric("daily_revenue", "SUM(amount)")
+    avg = _metric("avg_daily_revenue", "AVG({daily_revenue})", base=["daily_revenue"])
+    idx = D.metric_index(_org([daily, avg]))
+    with pytest.raises(D.DerivedError) as e:
+        D.expand_binding(avg, "PostgreSQL", idx)
+    assert "second-order" in str(e.value) or "#4" in str(e.value)
+
+
+def test_is_derived_detection():
+    assert D.is_derived(_metric("x", "{revenue} / 2", base=["revenue"]))
+    assert D.is_derived(_metric("y", "{revenue} / 2"))      # placeholder, no base_metrics
+    assert not D.is_derived(_metric("z", "SUM(amount)"))
+
+
+# --- validator gate ---------------------------------------------------------
+
+def test_validator_blocks_cycle():
+    a = _metric("a", "{b} + 1", base=["b"])
+    b = _metric("b", "{a} + 1", base=["a"])
+    res = V.validate(_org([a, b]))
+    assert not res.ok
+    assert any("cycle" in e for e in res.errors)
+
+
+def test_validator_passes_clean_derived():
+    rev = _metric("revenue", "SUM(amount)")
+    cnt = _metric("order_count", "COUNT(*)")
+    aov = _metric("aov", "{revenue} / {order_count}", base=["revenue", "order_count"])
+    res = V.validate(_org([rev, cnt, aov]))
+    assert res.ok, res.errors
+
+
+def test_validator_warns_cross_grain():
+    rev = _metric("revenue", "SUM(amount)", tables=("orders",))
+    cust = _metric("customer_count", "COUNT(*)", tables=("customers",))
+    rpc = _metric("revenue_per_customer", "{revenue} / {customer_count}",
+                  base=["revenue", "customer_count"], tables=("orders",))
+    res = V.validate(_org([rev, cust, rpc]))
+    assert res.ok  # warning, not error
+    assert any("grain" in w for w in res.warnings)
+
+
+# --- runtime surfacing -------------------------------------------------------
+
+def test_resolve_metrics_surfaces_composed_sql():
+    rev = _metric("revenue", "SUM(amount)")
+    cnt = _metric("order_count", "COUNT(DISTINCT order_id)")
+    aov = _metric("average order value", "{revenue} / {order_count}",
+                  base=["revenue", "order_count"])
+    hits = RT.resolve_metrics("average order value", _org([rev, cnt, aov]))
+    top = next(h for h in hits if h["metric"] == "average order value")
+    assert top["bindings"]["PostgreSQL"] == "(SUM(amount)) / (COUNT(DISTINCT order_id))"

--- a/tests/test_second_order_metrics.py
+++ b/tests/test_second_order_metrics.py
@@ -1,0 +1,117 @@
+"""Case (b): second-order statistics — an aggregate OF an aggregate at a finer grain
+(AVG of a daily SUM). The engine deterministically synthesizes the CTE from the
+declaration (base metric + inner_grain + outer agg); illegal AVG(SUM(...)) is never
+emitted, and the same question yields the same defensible SQL every time.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import derived as D  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as RT  # noqa: E402
+from semantic_model import validator as V  # noqa: E402
+
+
+def _metric(name, binding, *, base=None, inner_grain=None, tables=("orders",)):
+    return m.Metric(name=name, calculation="c", bindings={"PostgreSQL": binding},
+                    base_metrics=list(base or []), inner_grain=list(inner_grain or []),
+                    source_tables=list(tables))
+
+
+def _org(metrics):
+    sa = m.SubjectArea(name="sales", description="d", metrics=metrics)
+    return m.Organization(organization="o", version=1, subject_areas=[sa])
+
+
+def test_synthesizes_avg_daily_revenue_cte():
+    rev = _metric("daily_revenue", "SUM(amount)")
+    avg = _metric("avg_daily_revenue", "AVG({daily_revenue})",
+                  base=["daily_revenue"], inner_grain=["order_date"])
+    idx = D.metric_index(_org([rev, avg]))
+    sql = D.resolve_metric_sql(avg, "PostgreSQL", idx)
+    assert sql == (
+        "(SELECT AVG(daily_revenue) FROM ("
+        "SELECT order_date, SUM(amount) AS daily_revenue "
+        "FROM orders GROUP BY order_date) _inner)"
+    )
+
+
+def test_synthesized_sql_is_valid_and_not_nested():
+    import sqlglot
+    rev = _metric("monthly_orders", "COUNT(*)")
+    peak = _metric("peak_monthly_orders", "MAX({monthly_orders})",
+                   base=["monthly_orders"], inner_grain=["order_month"])
+    idx = D.metric_index(_org([rev, peak]))
+    sql = D.resolve_metric_sql(peak, "PostgreSQL", idx)
+    # parses cleanly and contains NO aggregate-inside-aggregate
+    tree = sqlglot.parse_one(sql)
+    assert tree is not None
+    assert not D._has_nested_aggregate(sql.replace("(SELECT", "").replace(")", ""))
+
+
+def test_is_second_order_detection():
+    assert D.is_second_order(_metric("x", "AVG({y})", base=["y"], inner_grain=["d"]))
+    assert not D.is_second_order(_metric("z", "SUM(amount)"))
+
+
+def test_missing_inner_grain_refuses_nested():
+    # nested aggregate WITHOUT inner_grain stays an error (we can't guess the grain)
+    rev = _metric("daily_revenue", "SUM(amount)")
+    avg = _metric("avg_daily_revenue", "AVG({daily_revenue})", base=["daily_revenue"])
+    idx = D.metric_index(_org([rev, avg]))
+    with pytest.raises(D.DerivedError):
+        D.resolve_metric_sql(avg, "PostgreSQL", idx)
+
+
+def test_bad_shape_refused():
+    # second-order binding must be exactly OUTERAGG({base})
+    rev = _metric("daily_revenue", "SUM(amount)")
+    bad = _metric("x", "AVG({daily_revenue}) + 1", base=["daily_revenue"], inner_grain=["d"])
+    idx = D.metric_index(_org([rev, bad]))
+    with pytest.raises(D.DerivedError):
+        D.resolve_metric_sql(bad, "PostgreSQL", idx)
+
+
+def test_multi_table_inner_refused():
+    rev = _metric("daily_revenue", "SUM(amount)", tables=("orders", "refunds"))
+    avg = _metric("avg_daily_revenue", "AVG({daily_revenue})",
+                  base=["daily_revenue"], inner_grain=["order_date"])
+    idx = D.metric_index(_org([rev, avg]))
+    with pytest.raises(D.DerivedError):
+        D.resolve_metric_sql(avg, "PostgreSQL", idx)
+
+
+def test_validator_accepts_well_formed_second_order():
+    rev = _metric("daily_revenue", "SUM(amount)")
+    avg = _metric("avg_daily_revenue", "AVG({daily_revenue})",
+                  base=["daily_revenue"], inner_grain=["order_date"])
+    res = V.validate(_org([rev, avg]))
+    assert res.ok, res.errors
+
+
+def test_validator_blocks_second_order_missing_grain_via_bad_binding():
+    # inner_grain set but binding isn't OUTERAGG({base}) → deploy-blocking error
+    rev = _metric("daily_revenue", "SUM(amount)")
+    bad = _metric("x", "SUM(amount) / 2", inner_grain=["order_date"])
+    res = V.validate(_org([rev, bad]))
+    assert not res.ok
+
+
+def test_resolve_metrics_surfaces_synthesized_cte():
+    rev = _metric("daily_revenue", "SUM(amount)")
+    avg = _metric("average daily revenue", "AVG({daily_revenue})",
+                  base=["daily_revenue"], inner_grain=["order_date"])
+    hits = RT.resolve_metrics("average daily revenue", _org([rev, avg]))
+    top = next(h for h in hits if h["metric"] == "average daily revenue")
+    assert top["bindings"]["PostgreSQL"].startswith("(SELECT AVG(daily_revenue) FROM (")


### PR DESCRIPTION
Implements the four open items from Sandeep's OSI-model scorecard.

- **#2 Column aggregation class** — `Column.aggregation` (additive / averageable / dimension / unknown), introspection heuristic, curator-editable.
- **#3 Additivity constraints** — `Metric.non_additive_dimensions` + `semi_additive_agg` for semi-additive measures (a balance summed over time).
- **#1 Composable metrics** — `base_metrics` placeholders compose into standalone SQL (case a); second-order statistics (AVG of a daily SUM) synthesize a CTE deterministically (case b) via `inner_grain`.
- **#4 Enforcement** — `pre_flight_check` refuses `SUM(rate)`/`SUM(id)`/`AVG(id)` and a semi-additive `SUM` over a time grain — the semantic violations the join-based fan/chasm detector is blind to.

The spine: #2 classifies → #3 constrains → #1 composes → #4 enforces. +56 tests, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)