### PR TITLE
fix(coverage): catch under-enriched tables, not just fully-blank ones

### DIFF
--- a/plugins/agami/scripts/semantic_model/cli.py
+++ b/plugins/agami/scripts/semantic_model/cli.py
@@ -331,8 +331,9 @@ def _coverage_gate(org) -> Optional[dict]:
             ),
         }
     under = cov["under_enriched_tables"]
+    under_set = set(under)   # compute once, not per row
     skipped = {r["table"]: r["blank_meaningful_columns"]
-               for r in cov["tables"] if r["table"] in set(under)}
+               for r in cov["tables"] if r["table"] in under_set}
     return {
         "refused": "columns_underenriched",
         "table_count": len(under),

--- a/plugins/agami/scripts/semantic_model/cli.py
+++ b/plugins/agami/scripts/semantic_model/cli.py
@@ -304,28 +304,48 @@ def _preseed_gate(org) -> Optional[dict]:
 
 
 def _coverage_gate(org) -> Optional[dict]:
-    """Enrichment-completeness gate: refuse to seed (or finish) a model that has tables
-    whose columns enrichment never described at all (0 described + 0 ai_unknown). Naked
-    columns degrade the explorer AND every NL→SQL answer (column descriptions are the
-    generator's context). Table-level so it never collides with the deliberate
-    self-evident-blank rule. NOT bypassable: the fix is to run the column pass."""
+    """Enrichment-completeness gate: refuse to seed (or finish) a model whose column pass
+    didn't finish. Two failure modes (see curate.column_coverage):
+      - `columns_unenriched` — a table with NO column descriptions at all (the pass never ran).
+      - `columns_underenriched` — a table the pass touched but which still has a wall of blank
+        columns with non-self-evident names (skipped meaningful columns like `bptype`).
+    Naked columns degrade the explorer AND every NL→SQL answer (descriptions are the
+    generator's context). NOT bypassable: the fix is to finish the column pass."""
     from . import curate
     cov = curate.column_coverage(org)
     if cov["ok"]:
         return None
-    tbls = cov["unenriched_tables"]
+    unenr = cov["unenriched_tables"]
+    if unenr:
+        return {
+            "refused": "columns_unenriched",
+            "table_count": len(unenr),
+            "unenriched_tables": unenr,
+            "coverage_pct": cov["totals"]["coverage_pct"],
+            "message": (
+                f"{len(unenr)} table(s) have NO column descriptions at all — enrichment wrote the "
+                f"table descriptions but skipped the column pass. Run Phase 2's column pass: "
+                f"describe each meaningful column from sampled values, mark genuinely-opaque ones "
+                f"description_source=ai_unknown (self-evident id/timestamps may stay blank), then "
+                f"re-run. Tables: {', '.join(unenr[:10])}" + ("…" if len(unenr) > 10 else "")
+            ),
+        }
+    under = cov["under_enriched_tables"]
+    skipped = {r["table"]: r["blank_meaningful_columns"]
+               for r in cov["tables"] if r["table"] in set(under)}
     return {
-        "refused": "columns_unenriched",
-        "table_count": len(tbls),
-        "unenriched_tables": tbls,
+        "refused": "columns_underenriched",
+        "table_count": len(under),
+        "under_enriched_tables": under,
+        "meaningful_blank": cov["totals"]["meaningful_blank"],
         "coverage_pct": cov["totals"]["coverage_pct"],
+        "skipped_columns": skipped,
         "message": (
-            f"{len(tbls)} table(s) have NO column descriptions at all — enrichment wrote the "
-            f"table descriptions but skipped the column pass. Run Phase 2's column pass: "
-            f"describe each meaningful column from sampled values, mark genuinely-opaque ones "
-            f"description_source=ai_unknown (self-evident id/timestamps may stay blank), then "
-            f"re-run. Column descriptions are what the explorer shows and what NL→SQL reads. "
-            f"Tables: {', '.join(tbls[:10])}" + ("…" if len(tbls) > 10 else "")
+            f"{len(under)} table(s) have many MEANINGFUL columns left blank — the column pass "
+            f"described the easy ones and stopped ({cov['totals']['meaningful_blank']} non-self-evident "
+            f"blanks total). Describe them from sampled values (or mark genuinely-opaque ones "
+            f"description_source=ai_unknown), then re-run. e.g. "
+            + "; ".join(f"{t}: {', '.join(cols[:5])}" for t, cols in list(skipped.items())[:3])
         ),
     }
 

--- a/plugins/agami/scripts/semantic_model/curate.py
+++ b/plugins/agami/scripts/semantic_model/curate.py
@@ -140,6 +140,19 @@ def all_items(org: Organization, *, scope: str = "all") -> list[dict]:
 
 _MIN_GATE_COLS = 2  # below this a table is too small to confidently call "skipped"
 
+# A blank column whose NAME makes its meaning self-evident (keys, audit cols, flags) may
+# stay blank by design. A blank column whose name is NOT self-evident is a SKIPPED
+# meaningful column — enrichment should have described it or marked it `ai_unknown`. This
+# is what makes the gate able to tell "intentionally blank" from "the pass didn't finish".
+_SELF_EVIDENT_NAME_RE = re.compile(
+    r"^(id|.*_id|.*_no|.*_uuid|.*_guid|.*_key|created.*|modified.*|updated.*|deleted.*|"
+    r".*_at|.*_by|.*_date|.*_ts|.*_time|.*timestamp|is_.*|has_.*|.*_flag)$",
+    re.IGNORECASE,
+)
+# More than this many skipped-meaningful columns in one table ⇒ under-enriched. A couple of
+# genuinely-ambiguous columns are tolerated; a wall of them means the column pass stopped early.
+_MEANINGFUL_BLANK_TOLERANCE = 2
+
 
 def column_coverage(org: Organization) -> dict:
     """Per-table column-description coverage — the enrichment-completeness check.
@@ -152,19 +165,25 @@ def column_coverage(org: Organization) -> dict:
     columns worth a line). A table enrichment **never ran on** has ZERO — that's the
     failure mode where the model got table descriptions but no column pass.
 
-    A table is `unenriched` when `described == 0 AND ai_unknown == 0` and it has at
-    least `_MIN_GATE_COLS` columns. `ok` is true when no kept table is unenriched.
-    Rejected tables/columns are excluded. `coverage_pct` (described / columns) is
-    informational — self-evident blanks legitimately hold it below 100%, so it is
-    surfaced for the eye, not gated on."""
+    Two failure modes gate `ok`:
+      - `unenriched` — a table with `described == 0 AND ai_unknown == 0` (≥ `_MIN_GATE_COLS`
+        columns): the column pass never ran on it.
+      - `under_enriched` — a table the pass touched but which still has more than
+        `_MEANINGFUL_BLANK_TOLERANCE` blank columns whose NAMES aren't self-evident (not
+        `*_id`/`*_date`/`created_*`/…). Those are SKIPPED meaningful columns — the pass should
+        have described them or marked them `ai_unknown`. `blank_meaningful_columns` names them.
+    `ok` is true only when neither list has entries. Rejected tables/columns are excluded.
+    `coverage_pct` stays informational — self-evident blanks legitimately hold it below 100%."""
     tables: list[dict] = []
-    tot = {"columns": 0, "described": 0, "ai_unknown": 0, "blank": 0}
+    tot = {"columns": 0, "described": 0, "ai_unknown": 0, "blank": 0, "meaningful_blank": 0}
     unenriched: list[str] = []
+    under_enriched: list[str] = []
     for sa in org.subject_areas:
         for t in sa.tables_defined:
             if getattr(t, "review_state", "approved") == "rejected":
                 continue
-            described = ai_unknown = blank = 0
+            described = ai_unknown = blank = meaningful_blank = 0
+            blank_meaningful_names: list[str] = []
             for c in t.columns:
                 if getattr(c, "review_state", "approved") == "rejected":
                     continue
@@ -176,27 +195,39 @@ def column_coverage(org: Organization) -> dict:
                     ai_unknown += 1
                 else:                                  # blank + no source: self-evident OR skipped
                     blank += 1
+                    if not _SELF_EVIDENT_NAME_RE.match(c.name):
+                        meaningful_blank += 1
+                        blank_meaningful_names.append(c.name)
             n = described + ai_unknown + blank
             enriched = (described + ai_unknown) > 0
+            # under-enriched: the pass touched the table but left a wall of meaningful columns blank
+            is_under = enriched and meaningful_blank > _MEANINGFUL_BLANK_TOLERANCE
             tables.append({
                 "area": sa.name, "table": t.name, "columns": n,
                 "described": described, "ai_unknown": ai_unknown, "blank": blank,
+                "meaningful_blank": meaningful_blank,
+                "blank_meaningful_columns": blank_meaningful_names,
                 "coverage_pct": round(100 * described / n) if n else 100,
-                "enriched": enriched,
+                "enriched": enriched, "under_enriched": is_under,
             })
             if not enriched and n >= _MIN_GATE_COLS:
                 unenriched.append(t.name)
+            elif is_under:
+                under_enriched.append(t.name)
             tot["columns"] += n
             tot["described"] += described
             tot["ai_unknown"] += ai_unknown
             tot["blank"] += blank
-    tables.sort(key=lambda x: (x["enriched"], x["table"]))   # unenriched tables first
+            tot["meaningful_blank"] += meaningful_blank
+    # worst first: unenriched, then under-enriched, then by table
+    tables.sort(key=lambda x: (x["enriched"], not x["under_enriched"], x["table"]))
     tot["coverage_pct"] = round(100 * tot["described"] / tot["columns"]) if tot["columns"] else 100
     return {
         "tables": tables,
         "totals": tot,
         "unenriched_tables": unenriched,
-        "ok": not unenriched,
+        "under_enriched_tables": under_enriched,
+        "ok": not unenriched and not under_enriched,
     }
 
 

--- a/tests/test_coverage_underenriched.py
+++ b/tests/test_coverage_underenriched.py
@@ -1,0 +1,69 @@
+"""The coverage gate now also catches UNDER-enrichment: a table the column pass
+touched but which still has a wall of blank columns with non-self-evident names
+(skipped meaningful columns like `bptype`), not just fully-blank tables."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import curate as C  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+
+
+def _t(name, cols):
+    return m.Table(name=name, schema="public", storage_connection="c", grain=["id"], columns=cols)
+
+
+def _col(name, desc=""):
+    return m.Column(name=name, type="string", description=desc)
+
+
+def _org(tables):
+    sa = m.SubjectArea(name="a", description="d", tables_defined=tables)
+    return m.Organization(organization="o", version=1, subject_areas=[sa])
+
+
+def test_self_evident_blanks_are_fine():
+    # id / *_id / *_date / created_* / *_by left blank is allowed; one described col → enriched
+    t = _t("vehicles", [_col("id"), _col("dealer_id"), _col("created_date"),
+                        _col("modified_by"), _col("make", "manufacturer of the vehicle")])
+    cov = C.column_coverage(_org([t]))
+    assert cov["ok"] is True
+    assert cov["under_enriched_tables"] == []
+
+
+def test_skipped_meaningful_columns_flag_under_enriched():
+    # many non-self-evident blanks (bptype, vehicle_phase, …) → under-enriched, ok False
+    t = _t("vehicles", [_col("id"), _col("make", "manufacturer"),
+                        _col("bptype"), _col("dispensingunittype"), _col("vehicle_phase"),
+                        _col("payment_status"), _col("supported_partners")])
+    cov = C.column_coverage(_org([t]))
+    assert cov["ok"] is False
+    assert "vehicles" in cov["under_enriched_tables"]
+    row = next(r for r in cov["tables"] if r["table"] == "vehicles")
+    assert row["meaningful_blank"] == 5
+    assert "bptype" in row["blank_meaningful_columns"]
+
+
+def test_a_couple_meaningful_blanks_tolerated():
+    t = _t("vehicles", [_col("id"), _col("make", "mfr"), _col("color", "paint color"),
+                        _col("bptype"), _col("vehicle_phase")])   # only 2 meaningful blanks
+    cov = C.column_coverage(_org([t]))
+    assert cov["ok"] is True   # within tolerance
+
+
+def test_ai_unknown_counts_as_handled_not_blank():
+    t = _t("vehicles", [_col("id"), _col("make", "mfr"),
+                        m.Column(name="bptype", type="string", description="", description_source="ai_unknown"),
+                        m.Column(name="xfield", type="string", description="", description_source="ai_unknown"),
+                        m.Column(name="yfield", type="string", description="", description_source="ai_unknown")])
+    cov = C.column_coverage(_org([t]))
+    assert cov["ok"] is True   # ai_unknown is a handled state, not a skipped blank


### PR DESCRIPTION
The coverage gate was table-level: it only failed when a table had ZERO column descriptions. A table the column pass touched but left half-blank (described the easy columns, skipped meaningful ones like `bptype`) sailed through.

Distinguish skipped-meaningful from intentionally-blank by NAME: a blank column whose name isn't self-evident (`*_id` / `*_date` / `created_*` / …) is a skipped meaningful column. A table with more than a tolerance of those is `under_enriched` → `ok: false`, and the seed gate refuses with `columns_underenriched` naming them. +4 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)