### PR TITLE
feat(model): write model-version snapshots (fix model_version: null everywhere)

### DIFF
--- a/plugins/agami/scripts/semantic_model/build.py
+++ b/plugins/agami/scripts/semantic_model/build.py
@@ -534,6 +534,10 @@ def write_tree(
         if sa.name in examples_by_area:
             write(f"prompt_examples/{sa.name}/examples.yaml",
                   _dump({"examples": examples_by_area[sa.name]}))
+    if not dry_run:
+        # Stamp the model_version pin for the freshly-written model (best-effort).
+        from . import snapshot
+        snapshot.write_snapshot(out)
     return rep
 
 

--- a/plugins/agami/scripts/semantic_model/cli.py
+++ b/plugins/agami/scripts/semantic_model/cli.py
@@ -56,6 +56,17 @@ def cmd_validate(args) -> int:
     return 0 if res.ok else 1
 
 
+def cmd_snapshot(args) -> int:
+    """Stamp the model_version snapshot for a profile tree. Introspect/curate do this
+    automatically; this command is for paths that write a model WITHOUT going through
+    them — e.g. agami-connect's sample copy (6A) drops the prebuilt model into place,
+    then calls this so the answer receipt has a real model_version."""
+    from . import snapshot as SN
+    h = SN.write_snapshot(args.root)
+    print(h or "(no model to snapshot)")
+    return 0 if h else 1
+
+
 def cmd_context(args) -> int:
     org = L.load_organization(args.root)
     out = L.get_table_context(
@@ -933,6 +944,10 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("validate", help="validate a profile tree")
     sp.add_argument("root")
     sp.set_defaults(func=cmd_validate)
+
+    sp = sub.add_parser("snapshot", help="stamp the model_version snapshot for a profile (e.g. after copying a model)")
+    sp.add_argument("root")
+    sp.set_defaults(func=cmd_snapshot)
 
     sp = sub.add_parser("context", help="assemble get_table_context")
     sp.add_argument("root")

--- a/plugins/agami/scripts/semantic_model/curate.py
+++ b/plugins/agami/scripts/semantic_model/curate.py
@@ -975,6 +975,12 @@ def _restore(backups: list[tuple[Path, Optional[str]]]) -> None:
 
 
 def _git_commit(root: Path, msg: str) -> bool:
+    # Model-write finalization point for every curation path (apply / write_items /
+    # terminology / examples / metadata relationships). Stamp the model_version
+    # snapshot here FIRST — unconditionally, before the git check — so it happens
+    # whether or not the artifacts dir is a git repo (it usually isn't).
+    from . import snapshot
+    snapshot.write_snapshot(root)
     if not (root / ".git").exists():
         return False
     try:

--- a/plugins/agami/scripts/semantic_model/snapshot.py
+++ b/plugins/agami/scripts/semantic_model/snapshot.py
@@ -1,0 +1,107 @@
+"""Model snapshots — the source of an answer's `model_version` pin.
+
+An answer's trust receipt reports `model_version` = the newest directory name
+under `<profile>/.snapshots/`, where the directory name IS a content hash of the
+model (read by `mcp_server._model_version` and the agami-query skill's
+`ls -t .snapshots/ | head -1`). Nothing used to WRITE that directory, so
+`model_version` was `null` for every profile. This module is the writer: it is
+called from the deterministic model-write chokepoints (introspect's
+`build.write_tree` and every curation commit via `curate._git_commit`) so a
+snapshot is stamped whenever the model changes — independent of git, identical
+across the skill / MCP server / cron.
+
+Design:
+  * The directory NAME is a 12-char SHA-256 over the model's content (every file
+    under the profile root except machine-state: .snapshots/, .introspect/,
+    .legacy_backup/, .git/, curation_log.jsonl). So the hash changes iff the
+    model changes, and writing is idempotent — an unchanged model re-uses its
+    existing directory (we just refresh its mtime so it stays "newest").
+  * Each snapshot dir holds a deterministic `manifest.json` (model hash + per-file
+    hashes) — no timestamp in the content, so a committed snapshot never churns;
+    recency comes from the directory mtime, which is what the readers use.
+  * Best-effort: never raises into the write path; a snapshot failure must not
+    break introspection or curation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+
+SNAPSHOT_DIR = ".snapshots"
+KEEP = 20  # cap retained snapshots; prune oldest beyond this
+
+# Machine-state that is NOT part of the model's identity.
+_EXCLUDE_TOP = {SNAPSHOT_DIR, ".introspect", ".legacy_backup", ".git"}
+_EXCLUDE_NAMES = {"curation_log.jsonl"}
+
+
+def _model_files(root: Path) -> list[Path]:
+    """Every model file under root (sorted), excluding machine-state."""
+    out: list[Path] = []
+    for p in sorted(root.rglob("*")):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(root)
+        if rel.parts and rel.parts[0] in _EXCLUDE_TOP:
+            continue
+        if p.name in _EXCLUDE_NAMES:
+            continue
+        out.append(p)
+    return out
+
+
+def _file_sha(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def compute_model_hash(root: str | os.PathLike) -> str:
+    """12-char content hash over the model tree (path + bytes of each file)."""
+    root = Path(root)
+    h = hashlib.sha256()
+    for p in _model_files(root):
+        rel = str(p.relative_to(root)).replace(os.sep, "/")
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()[:12]
+
+
+def _prune(snaps: Path, keep: int) -> None:
+    dirs = sorted((p for p in snaps.iterdir() if p.is_dir()),
+                  key=lambda p: p.stat().st_mtime, reverse=True)
+    for old in dirs[keep:]:
+        shutil.rmtree(old, ignore_errors=True)
+
+
+def write_snapshot(root: str | os.PathLike) -> str | None:
+    """Stamp a snapshot of the current model state. Returns the hash (the
+    `model_version`), or None if there's no model / on any error (best-effort)."""
+    try:
+        root = Path(root)
+        if not (root / "org.yaml").exists():
+            return None  # not a model root — nothing to snapshot
+        digest = compute_model_hash(root)
+        snaps = root / SNAPSHOT_DIR
+        snaps.mkdir(exist_ok=True)
+        d = snaps / digest
+        if d.exists():
+            os.utime(d, None)  # unchanged model → keep its dir, mark it newest
+        else:
+            d.mkdir()
+            manifest = {
+                "schema_version": 1,
+                "model_hash": digest,
+                "files": {str(p.relative_to(root)).replace(os.sep, "/"): _file_sha(p)
+                          for p in _model_files(root)},
+            }
+            (d / "manifest.json").write_text(
+                json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+        _prune(snaps, KEEP)
+        return digest
+    except Exception:
+        return None

--- a/tests/test_model_snapshots.py
+++ b/tests/test_model_snapshots.py
@@ -1,0 +1,114 @@
+"""Model-version snapshots (semantic_model/snapshot.py).
+
+The answer receipt's `model_version` = the newest dir name under
+`<profile>/.snapshots/`. Nothing wrote that dir, so model_version was null for
+every profile. These tests cover the writer: a content hash that's stable +
+change-sensitive, idempotent dir creation, pruning, the reader contract
+(mcp_server._model_version), and that introspect actually stamps one.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from catalog_helpers import col, make_catalog_runner  # noqa: E402
+from semantic_model import introspect as I  # noqa: E402
+from semantic_model import snapshot as S  # noqa: E402
+
+
+def _mini_model(root: Path) -> None:
+    (root / "subject_areas" / "a").mkdir(parents=True, exist_ok=True)
+    (root / "org.yaml").write_text("organization: t\nversion: 1\n", encoding="utf-8")
+    (root / "subject_areas" / "a" / "subject_area.yaml").write_text("name: a\n", encoding="utf-8")
+
+
+def test_hash_is_stable_and_change_sensitive(tmp_path):
+    r = tmp_path / "m"
+    _mini_model(r)
+    h1 = S.compute_model_hash(r)
+    assert len(h1) == 12
+    assert S.compute_model_hash(r) == h1  # stable for identical content
+    (r / "org.yaml").write_text("organization: t\nversion: 2\n", encoding="utf-8")
+    assert S.compute_model_hash(r) != h1  # changes when the model changes
+
+
+def test_hash_ignores_machine_state(tmp_path):
+    r = tmp_path / "m"
+    _mini_model(r)
+    h1 = S.compute_model_hash(r)
+    S.write_snapshot(r)  # creates .snapshots/
+    (r / ".introspect").mkdir()
+    (r / ".introspect" / "progress.log").write_text("noise", encoding="utf-8")
+    (r / "curation_log.jsonl").write_text('{"op":"x"}\n', encoding="utf-8")
+    assert S.compute_model_hash(r) == h1  # .snapshots/.introspect/curation_log excluded
+
+
+def test_write_snapshot_idempotent(tmp_path):
+    r = tmp_path / "prof"
+    _mini_model(r)
+    h = S.write_snapshot(r)
+    assert h and (r / ".snapshots" / h / "manifest.json").exists()
+    assert S.write_snapshot(r) == h  # unchanged model → same hash
+    dirs = [p for p in (r / ".snapshots").iterdir() if p.is_dir()]
+    assert len(dirs) == 1  # no duplicate dir
+
+
+def test_write_snapshot_noop_without_model(tmp_path):
+    assert S.write_snapshot(tmp_path / "empty") is None  # no org.yaml → no snapshot
+
+
+def test_prune_keeps_last_N(tmp_path):
+    r = tmp_path / "prof"
+    _mini_model(r)
+    for i in range(S.KEEP + 5):
+        (r / "org.yaml").write_text(f"organization: t\nversion: {i}\n", encoding="utf-8")
+        S.write_snapshot(r)
+        time.sleep(0.005)  # distinct mtimes so prune order is well-defined
+    dirs = [p for p in (r / ".snapshots").iterdir() if p.is_dir()]
+    assert len(dirs) == S.KEEP
+
+
+def test_model_version_reader_contract(tmp_path, monkeypatch):
+    """mcp_server._model_version returns the newest snapshot hash — and after a
+    model change, the NEW hash (newest-by-mtime wins)."""
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    r = tmp_path / "prof"
+    _mini_model(r)
+    h1 = S.write_snapshot(r)
+    import mcp_server
+    assert mcp_server._model_version("prof") == h1
+    time.sleep(0.02)
+    (r / "org.yaml").write_text("organization: t\nversion: 99\n", encoding="utf-8")
+    h2 = S.write_snapshot(r)
+    assert h2 != h1
+    assert mcp_server._model_version("prof") == h2
+
+
+def test_introspect_stamps_a_snapshot(tmp_path):
+    """The real introspect path (build.write_tree) stamps a model_version, so a
+    freshly-introspected profile is never model_version: null."""
+    runner = make_catalog_runner(
+        tables=["customers", "orders"],
+        columns={
+            "customers": [col("id", "integer", nullable=False), col("email", "varchar")],
+            "orders": [col("id", "integer", nullable=False), col("customer_id", "integer")],
+        },
+        fks=[{"from_table": "orders", "from_column": "customer_id",
+              "to_table": "customers", "to_column": "id"}],
+    )
+    I.introspect("shop", "postgres", runner=runner, artifacts_dir=tmp_path)  # dry_run=False → writes
+    snaps = tmp_path / "shop" / ".snapshots"
+    dirs = [p for p in snaps.iterdir() if p.is_dir()] if snaps.exists() else []
+    assert len(dirs) == 1
+    assert (dirs[0] / "manifest.json").exists()
+    assert dirs[0].name == S.compute_model_hash(tmp_path / "shop")


### PR DESCRIPTION
## Problem

`<profile>/.snapshots/<hash>/` is read by `mcp_server._model_version` and the agami-query skill (newest dir name = the model version reported in every answer's trust receipt), and it's documented in `file-layout.md` and the chart template — but **nothing ever wrote it**. So `model_version` was `null` for **every** profile, on every answer. The trust-receipt's version pin was silently inert.

## Fix

New `semantic_model/snapshot.py`:
- **`compute_model_hash(root)`** — 12-char SHA-256 over the model's content: every file under the profile root *except* machine-state (`.snapshots/`, `.introspect/`, `.legacy_backup/`, `.git/`, `curation_log.jsonl`). Hash changes iff the model changes.
- **`write_snapshot(root)`** — creates `.snapshots/<hash>/` with a **deterministic** `manifest.json` (model hash + per-file hashes; no timestamp, so a committed snapshot never churns — recency comes from the dir mtime, which is exactly what the readers use). **Idempotent** (an unchanged model re-uses its dir, mtime-refreshed so it stays "newest"); **prunes** to the last 20. Best-effort — never raises into the write path.

Stamped at the **two deterministic model-write chokepoints**, so the skill, the local MCP server, and cron all get a version identically:
- `build.write_tree` (introspect)
- `curate._git_commit` (every curation / enrichment / example write) — placed **before** the git check so it runs whether or not the artifacts dir is a git repo (it usually isn't).

## Tests

`tests/test_model_snapshots.py` — hash stability + change-sensitivity, machine-state exclusion, idempotent dir, prune cap, the `mcp_server._model_version` reader contract (newest-by-mtime wins after a change), and the **real introspect path** stamping a snapshot. **578 unit tests pass.**

## Scope note

This makes `model_version` **resolve**. Full content-reproduction "against the hash it ran on" (storing the model state to roll back to) remains a future enhancement — the manifest records per-file hashes for *verification*, not the content to reconstruct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)