### PR TITLE
feat(query): deterministic render piping — numbers from the CSV, not the LLM (Phase A)

### DIFF
--- a/docs/design/determinism-refactor.md
+++ b/docs/design/determinism-refactor.md
@@ -1,0 +1,127 @@
+# Determinism refactor — move mechanical orchestration out of LLM prose
+
+**Status:** in progress · **Owner:** agami core · anchor doc for a multi-PR effort.
+
+## Why
+
+agami's skills are LLM prose that interleaves *judgment* (what does the user
+mean? what does this column mean? is this number real?) with *mechanical
+plumbing* (resolve a path, parse a pasted block, format a number, write a
+config). When the LLM has to faithfully execute the plumbing, it sometimes
+doesn't — the fidelity failures we keep hitting are almost all in the plumbing,
+not the judgment: a wrong interpreter written to `.config`, a `/sample` vs
+`/agami-example` mis-wire, a `sqlite3` query missing `-header`, the model
+**re-typing result numbers** into a chart (a silent wrong-number risk).
+
+The deterministic *core* is already heavily scripted (13 scripts + ~30 `sm`
+subcommands). The gap is the **orchestration** around it, still in prose.
+
+## Principle — thick deterministic core, thin LLM orchestration, judgment escape hatch
+
+1. **Every deterministic step is a script that emits structured JSON** —
+   `{status, data, anomalies: [...], needs_judgment?: {...}}`. The skill prose
+   shrinks to: *call script → read JSON → branch* (continue / ask the user at a
+   seam / hand an anomaly to the LLM).
+2. **The LLM is reserved for exactly four things:**
+   - **Seams** — interactive choices (`AskUserQuestion`): which DB, profile name,
+     which schemas, copy-vs-rebuild, etc. These are the natural boundaries
+     between deterministic script segments. *The flow is `script → ask → script`,
+     never one monolith.*
+   - **Authoring** — prose and SQL: table/column descriptions, entity names,
+     metric definitions, NL→SQL, the answer insight. Genuine creativity.
+   - **Decide-what, script-does** (the **Hybrid** pattern, already used by
+     `sm curate` / `sm add` / `sm seed-examples`): the LLM emits a structured
+     decision (ops JSON, a presentation spec) and a *tested* command applies it.
+   - **Anomalies / unforeseen errors** — the case that justifies an agent at all:
+     it samples data, finds a sentinel value, and figures out what to do.
+
+3. **Scripts must surface anomalies, never swallow them.** A deterministic script
+   that hits something ambiguous (a column it can't classify, a result that
+   can't be parsed, an unexpected DB error) returns `needs_judgment` with
+   context — it does **not** guess and does **not** hard-fail silently. That is
+   the mechanism that keeps the LLM in the loop *exactly* where it adds value.
+
+## The lens — classify every step
+
+- **D (Deterministic)** — pure I/O / mechanical → script.
+- **J (Judgment)** — genuine LLM call → keep.
+- **H (Hybrid)** — LLM emits a spec, a script executes it → keep both, with a
+  tested apply-command.
+- **Seam** — an `AskUserQuestion` decision point → segment boundary.
+
+### What stays LLM (do NOT script)
+Pick DB type / name profile / choose schemas (seams); subject-area boundaries;
+**all enrichment authoring** (descriptions, entity names, metric definitions);
+NL→SQL; insight/approach prose; chart-type choice; the bad-number / anomaly
+diagnosis. These are judgment.
+
+## The three gaps (everything else is already scripted)
+
+### Gap 1 — Render pipeline (highest value; correctness/trust)
+`agami-query` Phase 4e.iii: the LLM hand-builds `agami-sections.json`,
+**transcribing result numbers** into `table_rows` *and* `datasets[].data`.
+`render_chart.py` never reads the result CSV — it renders whatever the model
+typed. A miscopy shows a wrong number in the chart while the table is right;
+nothing catches it. Phase 4e.iii.5 similarly hand-builds the trust receipt.
+- **Fix:** `csv_to_sections.py` reads the result CSV + the units map (reusing the
+  same `units.py` logic `sm format-table` uses) and emits
+  `labels` / `table_rows` / `datasets[].data`. The LLM supplies only the
+  **presentation spec** (title, insight, chart_type, label column, SQL verbatim).
+  `build_receipt.py` parses the executed SQL (sqlglot) to populate `tables_used`
+  + the relationships/metrics it touches + `model_version` + warnings (from
+  `review_state`), instead of the LLM hand-extracting them. Numbers and
+  provenance leave the model's hands.
+
+### Gap 2 — agami-connect bootstrap spine (the fidelity bugs)
+Phase 0/0a is ~48 deterministic steps in prose; the bug-prone ones cluster here:
+interpreter resolution (the "wrong Python in `.config`" trap), path / credential
+/ config wiring, the zsh word-split in prune handling, gate re-counting.
+- **Fix:** small **segment** scripts between the seams —
+  `connect_resolve.py` (profile + artifacts_dir + credentials + interpreter → one
+  JSON state, with **scored** interpreter selection so it can't pick a Python
+  missing a dep), `parse_prune_block.py`, `parse_validation_batch.py`,
+  `check_curate_gate.py`. The 16 `AskUserQuestion` seams stay as boundaries.
+
+### Gap 3 — near-deterministic skills still prose-driven
+- **agami-serve** (~95% mechanical) — collapse to a thin wrapper over
+  `setup_desktop_mcp.py`.
+- **agami-save-correction** — extract its **rules-based** classification tree to
+  `classify_correction.py` (it's a decision tree, not an opinion).
+- **agami-model** — back-channel block parsing → a parser script (render + apply
+  are already scripts).
+
+## Phasing (each its own PR off `main`)
+
+| Phase | Scope | Risk |
+|---|---|---|
+| **A — Render piping** (Gap 1) | `csv_to_sections.py` + `build_receipt.py`; rewrite query Phase 4d/4e.iii/iii.5 | Touches every render → golden-fixture tests |
+| **B — Connect spine** (Gap 2) | `connect_resolve.py` + 3 parsers; rewrite Phase 0/0a/0s prose to call them | Medium — interactive, segment-by-segment |
+| **C — Collapse skills** (Gap 3) | serve wrapper, `classify_correction.py`, `parse_model_feedback.py` | Low — mechanical |
+
+**Cross-cutting (settled in A):** the JSON contract + the `needs_judgment`
+channel convention, which B and C then follow.
+
+## The JSON contract (settled in Phase A)
+
+Every refactor script prints one JSON object on stdout:
+
+```json
+{
+  "ok": true,
+  "data": { "...": "step-specific result" },
+  "anomalies": [ { "kind": "...", "detail": "...", "where": "..." } ],
+  "needs_judgment": null
+}
+```
+
+- `ok: false` → a hard error the caller surfaces (with `error`).
+- `anomalies` → non-fatal things the LLM *may* want to mention/act on.
+- `needs_judgment` → the script deliberately stopped short of guessing; the LLM
+  must decide (with the provided context) and usually re-invoke with a choice.
+
+Exit code mirrors `ok` (0/non-0) so a bash caller can branch without parsing.
+
+## Non-goals
+- Not scripting judgment (enrichment authoring, NL→SQL, anomaly diagnosis).
+- Not one monolithic orchestrator — segmentation at the seams is mandatory.
+- Not removing the LLM from the loop — moving it to where it's load-bearing.

--- a/plugins/agami/scripts/csv_to_sections.py
+++ b/plugins/agami/scripts/csv_to_sections.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Build a chart/report SECTIONS file from result CSVs — deterministically.
+
+The agami-query render path used to have the LLM hand-write the sections JSON
+that render_chart.py consumes, TRANSCRIBING result numbers into `table_rows` and
+`datasets[].data`. A miscopy shows a wrong number in the chart while the table is
+right, and nothing catches it. This script takes the numbers out of the model's
+hands: it reads the actual result CSV(s) and emits the sections JSON. The LLM
+supplies only the *presentation spec* — title, insight prose, chart type, which
+column is the label, and the verbatim SQL — never the numbers.
+
+Reuses `semantic_model.units` (the exact formatter `sm format-table` uses) so the
+formatted cells are identical across the chat table, the HTML table, and the CSV.
+
+Input — a SPEC file (JSON list of section objects; one per chart/section):
+  {
+    "title":        "Top customers by spend",       # LLM
+    "insights":     "Avery Adams leads at $121,561…",# LLM prose
+    "chart_type":   "bar" | "line" | "pie" | "doughnut" | "scatter" | null,
+    "csv_file":     "/tmp/agami-result-1.csv",       # the executed query's result
+    "units":        {"total_spend": "USD"},          # from `sm prepare`
+    "sql_file":     "/tmp/agami-q-1.sql",            # verbatim SQL (preferred)
+    "sql":          "SELECT …",                       # or inline (sql_file wins)
+    "label_col":    0,                                # optional, default 0
+    "value_cols":   [1],                              # optional, default: non-label cols
+    "header_relabels": {"total_amount": "Total Spend"}# optional cosmetic
+  }
+
+Output — writes the bare sections array (what render_chart.py reads via
+--sections-file) to --out, and prints a status object to stdout:
+  {"ok": true, "data": {"section_count": N, "out": "<path>"}, "anomalies": [...]}
+
+Anomalies (non-fatal, surfaced for the LLM): a value column with non-numeric
+cells (not chartable), a missing label/value column, an empty result. The script
+still produces best-effort sections; the LLM decides whether to mention them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from semantic_model import units  # noqa: E402  (stdlib-only module)
+
+
+def _unit_for(unit_map: dict, headers: list[str], i: int):
+    """Unit for column i: by output name, then by positional key `#i` (carries the
+    unit for DB-auto-named columns) — same lookup as units.format_table."""
+    h = headers[i] if i < len(headers) else ""
+    return unit_map.get(h) or unit_map.get(f"#{i}")
+
+
+def _raw_number(cell: str):
+    """Parse a raw CSV cell to a float for chart data, or None if not numeric."""
+    s = (cell or "").strip().replace(",", "")
+    if s in ("", "-", "+"):
+        return None
+    try:
+        f = float(s)
+        return int(f) if f == int(f) else f
+    except ValueError:
+        return None
+
+
+def _build_section(spec: dict, idx: int, anomalies: list) -> dict:
+    csv_path = spec.get("csv_file")
+    if not csv_path:
+        raise ValueError(f"section {idx}: 'csv_file' is required")
+    text = Path(csv_path).expanduser().read_text(encoding="utf-8")
+    reader = list(csv.reader(io.StringIO(text)))
+    headers = reader[0] if reader else []
+    rows = reader[1:] if len(reader) > 1 else []
+    if not headers:
+        anomalies.append({"kind": "empty_result", "where": f"section {idx}",
+                          "detail": f"{csv_path} has no header row"})
+    if not rows:
+        anomalies.append({"kind": "no_rows", "where": f"section {idx}",
+                          "detail": f"{csv_path} returned 0 data rows"})
+
+    unit_map = spec.get("units") or {}
+    relabels = spec.get("header_relabels") or {}
+    ncols = len(headers)
+    label_col = spec.get("label_col", 0)
+    if label_col >= ncols and ncols:
+        anomalies.append({"kind": "label_col_oob", "where": f"section {idx}",
+                          "detail": f"label_col {label_col} >= column count {ncols}; using 0"})
+        label_col = 0
+    value_cols = spec.get("value_cols")
+    if value_cols is None:
+        value_cols = [i for i in range(ncols) if i != label_col]
+
+    # table_rows — every cell formatted EXACTLY via units (no LLM, no abbreviation).
+    table_headers = [relabels.get(h, h) for h in headers]
+    table_rows = [[units.format_cell(c, _unit_for(unit_map, headers, i)) for i, c in enumerate(r)]
+                  for r in rows]
+
+    # labels — the label column, formatted (handles date encodings / choice labels).
+    label_unit = _unit_for(unit_map, headers, label_col)
+    labels = [units.format_value(r[label_col], label_unit) if label_col < len(r) else ""
+              for r in rows]
+
+    # datasets — RAW numbers parsed from the CSV (Chart.js needs numbers, not strings).
+    datasets = []
+    for ci in value_cols:
+        if ci >= ncols:
+            continue
+        data = [_raw_number(r[ci]) if ci < len(r) else None for r in rows]
+        if rows and all(v is None for v in data):
+            anomalies.append({"kind": "non_numeric_value_col", "where": f"section {idx}",
+                              "detail": f"column '{headers[ci]}' has no numeric values; "
+                                        "not chartable (left out of datasets)"})
+            continue
+        datasets.append({"label": relabels.get(headers[ci], headers[ci]), "data": data})
+
+    # section-level unit — the chart's y-axis/tooltip formatting applies to ALL
+    # datasets, so set it ONLY when every plotted value column shares one non-null
+    # unit. Mixing a currency col with a unitless count → no section unit (else the
+    # count bars would be mis-formatted as currency).
+    value_units = {_unit_for(unit_map, headers, ci) for ci in value_cols if ci < ncols}
+    section_unit = next(iter(value_units)) if (len(value_units) == 1 and None not in value_units) else None
+
+    # verbatim SQL — read from a file (no transcription) if given, else inline.
+    sql = None
+    if spec.get("sql_file"):
+        sql = Path(spec["sql_file"]).expanduser().read_text(encoding="utf-8").strip()
+    elif spec.get("sql"):
+        sql = spec["sql"]
+
+    section: dict = {
+        "title": spec.get("title", ""),
+        "insights": spec.get("insights", ""),
+        "chart_type": spec.get("chart_type"),
+        "labels": labels,
+        "datasets": datasets,
+        "table_headers": table_headers,
+        "table_rows": table_rows,
+    }
+    if section_unit:
+        section["unit"] = section_unit
+    if sql:
+        section["sql"] = sql
+    return section
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Build a render sections file from result CSVs.")
+    ap.add_argument("--spec", required=True, help="JSON file: a list of section specs")
+    ap.add_argument("--out", required=True, help="write the sections array here (render_chart --sections-file)")
+    args = ap.parse_args(argv)
+
+    try:
+        spec = json.loads(Path(args.spec).expanduser().read_text(encoding="utf-8"))
+    except Exception as e:
+        print(json.dumps({"ok": False, "error": f"could not read spec: {e}"}))
+        return 1
+    if isinstance(spec, dict):
+        spec = [spec]  # tolerate a single-section object
+    if not isinstance(spec, list) or not spec:
+        print(json.dumps({"ok": False, "error": "spec must be a non-empty list of section objects"}))
+        return 1
+
+    anomalies: list = []
+    try:
+        sections = [_build_section(s, i, anomalies) for i, s in enumerate(spec)]
+    except Exception as e:
+        print(json.dumps({"ok": False, "error": str(e)}))
+        return 1
+
+    Path(args.out).expanduser().write_text(json.dumps(sections, indent=2), encoding="utf-8")
+    print(json.dumps({"ok": True, "data": {"section_count": len(sections), "out": args.out},
+                      "anomalies": anomalies, "needs_judgment": None}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/agami/scripts/semantic_model/cli.py
+++ b/plugins/agami/scripts/semantic_model/cli.py
@@ -152,6 +152,41 @@ def cmd_prepare(args) -> int:
     return 0
 
 
+def _newest_model_version(root) -> Optional[str]:
+    """model_version pin = newest dir name under <root>/.snapshots (same reader as
+    mcp_server._model_version + the skill). None if no snapshots yet."""
+    try:
+        snaps = Path(root) / ".snapshots"
+        dirs = sorted((p for p in snaps.iterdir() if p.is_dir()),
+                      key=lambda p: p.stat().st_mtime, reverse=True)
+        return dirs[0].name if dirs else None
+    except Exception:
+        return None
+
+
+def cmd_receipt(args) -> int:
+    """Assemble the trust receipt for an executed query — deterministically, from the
+    SQL + the model. Replaces the LLM hand-building the receipt JSON in prose: tables,
+    relationships, metrics, unreviewed-warnings, and model_version all come from
+    parsing the SQL against the model (the SAME `runtime.assemble_receipt` the MCP
+    server uses). The LLM may still append ad-hoc metrics + assumptions afterward."""
+    sql = args.sql
+    if args.sql_file:
+        sql = Path(args.sql_file).read_text()
+    org = L.load_organization(args.root)
+    pf = RT.pre_flight_check(sql, org)
+    applied = json.loads(args.applied_filters) if args.applied_filters else None
+    receipt = RT.assemble_receipt(
+        org, sql,
+        model_version=_newest_model_version(args.root),
+        applied_filters=applied,
+        pre_flight=pf,
+        freshness=args.freshness,
+    )
+    _print_json(receipt)
+    return 0
+
+
 def cmd_review_queue(args) -> int:
     from . import curate
     org = L.load_organization(args.root)
@@ -981,6 +1016,15 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--sql", default=None)
     sp.add_argument("--sql-file", default=None, dest="sql_file")
     sp.set_defaults(func=cmd_prepare)
+
+    sp = sub.add_parser("receipt", help="assemble the trust receipt for a query (deterministic, from SQL + model) — replaces hand-building it")
+    sp.add_argument("root")
+    sp.add_argument("--sql", default=None)
+    sp.add_argument("--sql-file", default=None, dest="sql_file")
+    sp.add_argument("--applied-filters", default=None, dest="applied_filters",
+                    help="JSON list of default_filters applied (from `sm prepare`)")
+    sp.add_argument("--freshness", default=None, help="optional freshness timestamp for tables_used")
+    sp.set_defaults(func=cmd_receipt)
 
     sp = sub.add_parser("review-queue", help="trust-review items needing sign-off (Rule 1/2)")
     sp.add_argument("root")

--- a/plugins/agami/skills/agami-query/SKILL.md
+++ b/plugins/agami/skills/agami-query/SKILL.md
@@ -554,99 +554,53 @@ For each section's SQL result, read `agami.type` for each result column and pick
 
 If the user override-says `--chart pie|line|...` for the **whole** report, apply it to every section that supports a chart.
 
-#### 4e.iii — build the SECTIONS_JSON
+#### 4e.iii — build the SECTIONS file via `csv_to_sections.py` (do NOT hand-write the numbers)
 
-For each section, build an object:
+**You do NOT transcribe result numbers into JSON.** `csv_to_sections.py` reads each section's result CSV + the `units` map (from `sm prepare`) and builds the section's `labels`, `table_rows` (formatted exactly via `units.py`), and `datasets[].data` (raw numbers) — so the chart can never disagree with the table, and a miscopy is impossible. You supply only the **presentation spec**.
 
-```json
-{
-  "title":         "<sub-question or short heading>",
-  "insights":      "<1-3 sentence plain-English insight for this section>",
-  "chart_type":    "bar | line | pie | doughnut | scatter | null",
-  "labels":        ["<x-axis or pie labels>"],
-  "datasets":      [{"label": "<header>", "data": [<numeric values>]}],
-  "table_headers": ["<col1>", "<col2>", ...],
-  "table_rows":    [[<v>, <v>, ...], ...],
-  "sql":           "<the EXACT, COMPLETE SQL that produced this section's data — verbatim>"
-}
-```
-
-**`sql` is the exact, complete, runnable query — never a paraphrase.** Paste the *verbatim* SQL string you executed for this section (the text you passed to `sm prepare` / the executor — keep each section's query around for this). It must be:
-- **Complete** — every CTE, column, JOIN, WHERE, GROUP BY. The receipt exists so a data engineer can re-run it and defend the number; a partial query defeats that.
-- **Literal SQL, not prose** — no `...`/`…`, no `-- net revenue = (line_total - gst) - ...`, no "ON paid book lines". If you find yourself writing English where SQL goes, you're summarizing — stop and paste the real query.
-- **Never empty when the section has data.** Every section that ran a query has its query. A section with no `sql` only makes sense for a hand-built/derived table with no underlying SQL — and that is rare; double-check before omitting.
-
-Do NOT HTML-escape it — the template handles escaping. Do NOT shorten it to save tokens; the renderer reads it from a file, so length is free.
-
-When `chart_type` is `null`, set `labels` and `datasets` to `null` (or omit). The template skips the chart card cleanly.
-
-**Use the formatted values from Phase 3c — not the raw CSV strings.** Specifically:
-
-- `labels` for time-series line charts must be human-readable date labels (`May 2026`, `Q2 2026`, `May 7`, `May 7, 2026`) — NOT raw ISO timestamps like `2026-05-07T15:14:00.000Z` and NOT epoch numbers. The granularity follows the SQL grouping (monthly bucket → `MMM YYYY`, daily → `MMM D` or `MMM D, YYYY`).
-- `labels` for categorical charts use the choice-field display label (e.g. `Closed Won`, not the stored value `closed_won`).
-- `table_rows` cells use the formatted values across the board: `$148.95` not `148.95`, `May 7, 2026 3:14 PM` not `2026-05-07T15:14:00Z`, `Yes` not `true`.
-
-`datasets[].data` is the **only** place raw numeric values belong (Chart.js needs numbers, not formatted strings, to draw the chart). Currency / percent formatting on the chart itself happens via the template's tooltip callbacks, not by passing pre-formatted strings.
-
-The whole report's `SECTIONS_JSON` is a JSON array of these objects.
-
-#### 4e.iii.5 — build the trust receipt
-
-Every answer ships with a **trust receipt** that documents provenance: tables touched, relationships used, metric definitions invoked, named filters applied, source-data freshness, and the model version pin. This is the single most important UX element for a data engineer — it lets them defend any number to a CxO with one click.
-
-Build the receipt as a single JSON object. Schema (see [`shared/chart-template.html` → `RECEIPT_JSON`](../../shared/chart-template.html) for the canonical version):
+Write a spec file `/tmp/agami-spec-<ts>.json` — a JSON array, one object per section:
 
 ```json
-{
-  "model_version": "<short hash — the .snapshots/<hash>/ dir the answer pinned>",
-  "tables_used": [
-    {"qname": "public.orders", "rows": <integer or null>, "freshness": "<ISO8601 + cadence note, or null>"}
-  ],
-  "relationships": [
-    {"name": "<rel name>", "from_to": "<from> → <to>",
-     "confidence": <float in [0,1]>, "review_state": "approved|unreviewed|...", "origin": "fk|...",
-     "signed_off_by": "<email or 'agami_introspect_v1'>", "signed_off_role": "<enum>",
-     "signed_off_at": "<ISO>"}
-  ],
-  "metrics": [
-    {"name": "<metric>", "area": "<subject area>", "definition_prose": "<plain English>",
-     "expression": "<the SQL fragment / binding>",
-     "confidence": <float in [0,1]>, "review_state": "approved|unreviewed|...", "origin": "<enum | ad_hoc>",
-     "signed_off_by": "<email>", "signed_off_role": "<enum>", "signed_off_at": "<ISO>"}
-  ],
-  "named_filters": [
-    {"name": "<filter>", "expression": "<predicate>", "definition_prose": "<plain English>",
-     "confidence": <float in [0,1]>, "review_state": "approved|unreviewed|...", "origin": "<enum>",
-     "signed_off_by": "<email>", "signed_off_role": "<enum>", "signed_off_at": "<ISO>"}
-  ],
-  "assumptions": [
-    {"column": "<schema>.<table>.<column>", "meaning": "<the AI-written description>", "source": "ai_unvalidated"}
-  ],
-  "warnings": ["<one-liner per unreviewed entry that the answer used>"]
-}
+[{
+  "title":       "<sub-question / heading>",
+  "insights":    "<1-3 sentence plain-English insight>",
+  "chart_type":  "bar|line|pie|doughnut|scatter|null",
+  "csv_file":    "/tmp/agami-result-<n>.csv",
+  "units":       { },
+  "sql_file":    "/tmp/agami-q-<n>.sql",
+  "label_col":   0,
+  "value_cols":  [1],
+  "header_relabels": {"total_amount": "Total Spend"}
+}]
 ```
 
-How to populate each field:
+Your fields: `title` + `insights` (prose), `chart_type`, `label_col` (which column is the x-axis/label, default 0), `value_cols` (chart value columns, default: all non-label), and optional cosmetic `header_relabels`. Everything numeric is the script's job — keep each section's result CSV (Phase 3) and its `sql_file` so the spec can point at them. `units` is the object `sm prepare` returned. When `chart_type` is `null` the chart card is skipped; `table_rows` still render.
 
-- **`model_version`** — derive from the **newest directory** under `<artifacts_dir>/<profile>/.snapshots/`. The directory name itself IS the version (a 12-char content hash). Lookup:
-  ```bash
-  model_version=$(ls -t "$artifacts_dir/$profile/.snapshots/" 2>/dev/null | head -n1)
-  ```
-  If `.snapshots/` doesn't exist or is empty (legacy v1.2 model that pre-dates trust-layer), pass `null` and surface a one-liner: *"this model pre-dates the trust-layer launch; reintrospect to enable receipts."* **Do not look for `model_version` inside `index.yaml`** — it's not stored there; the snapshot directory is the source of truth.
-- **`tables_used`** — every distinct `<schema>.<table>` referenced in the SQL's FROM/JOIN clauses. `rows` is the **table's size** — pass the table's `performance_hints.estimated_row_count` from the model (the *same* value Phase 3 reads for the scan-risk check, e.g. `12000000`). This is "how big is this dataset," not the query's result-row count. Also pass **`rows_as_of`** = the table's `performance_hints.estimated_row_count_at` (when that estimate was last measured at introspection) — the receipt renders "≈N rows (estimated as of <date>)" so the reader knows it's a point-in-time estimate, not a live count. Only pass `null` for `rows` if the table genuinely has no `estimated_row_count` in the model — don't default to `null` out of caution when the model has it.
-  **`freshness`** — pass the **raw ISO timestamp** from `agami.introspect_meta.introspected_at` (e.g., `"2026-05-10T11:57:13Z"`). The chart template prettifies it to `"introspected May 10, 2026, 11:57 AM"` automatically. Don't prefix with "introspected" yourself or you'll double-prefix. If the upstream load cadence is known (e.g., daily ETL at 2am UTC), pass a pre-formatted string instead — e.g., `"2026-05-10T02:00:00Z (daily 2am UTC ETL)"` — and the template passes it through unchanged. Pass `null` when freshness is unknowable.
-- **`relationships`** — for every JOIN edge in the SQL, look up the relationship in the model (from `get_table_context`). **Pull EVERY trust field** carried on the relationship: `relationship` (cardinality), `confidence` (`confirmed`/`inferred`/`proposed`), `review_state` (enum), `signed_off_by`, `signed_off_role`, `signed_off_at`, plus `on:` if it's a CAST/compound join. The template's `approvalPhrase` reads all of them to render "confirmed (FK declared)" vs "approved by jane@x.com (cfo), Mar 15" vs "proposed (inferred join — confirm)". For composite or multi-hop joins, list each edge. Also surface any **auto-rewrite** the pre-flight applied (fan/chasm) and the **default_filters** that were applied (from execute_sql's stderr notes).
-- **`metrics`** — TWO kinds of entry, both go here:
-  1. **Model metrics** whose `bindings` SQL matches a fragment in the generated SQL. **Pull EVERY trust field:** `calculation` → `definition_prose`, `confidence`, `review_state`, `signed_off_by`, `signed_off_role`, `signed_off_at`, `source`/`origin`, and the metric's `area`. If a metric is genuinely unreviewed, that's fine — the receipt shows it honestly. Don't half-populate (it renders a meaningless "unreviewed (?)").
-  2. **On-the-fly metrics you calculated for this answer** — any non-trivial aggregation/ratio you composed that ISN'T an approved model metric (e.g. you wrote `(SUM(net_revenue) - SUM(cogs)) / SUM(net_revenue)` for "gross margin" because no `gross_margin` metric exists). Emit one entry per such calc with `review_state: "unreviewed"`, **`origin: "ad_hoc"`**, a snake_case `name` (your suggested metric name), the `area` it belongs to, `definition_prose` (the calculation in plain English), and `expression` (the SQL fragment). This is what feeds the **top-of-report "metrics you haven't approved" banner**, where the user can Approve it (→ saved as a real model metric, signed off) or Change the definition — both routed back to you as feedback. **Don't flag trivial primitives** (a bare `COUNT(*)`, `SUM(amount)` with no logic) as ad-hoc metrics — only genuine, reusable definitions. When in doubt, include it; an over-flag is a one-click dismiss, a miss means an unapproved number ships silently.
-- **`named_filters`** — every filter from `agami.named_filters[]` (model-level) whose `expression` appears in the SQL's WHERE / HAVING. **Pull EVERY trust field** from the filter's entry: `expression`, `definition_prose`, `confidence`, `review_state`, `origin`, `signed_off_by`, `signed_off_role`, `signed_off_at`. Same rationale as relationships and metrics.
-- **`assumptions`** — the AI-derived column meanings this answer **leaned on**, so a wrong/unknown one is caught in context instead of via an upfront review of hundreds of descriptions (see [`docs/design/validated-through-use-descriptions.md`](../../../../docs/design/validated-through-use-descriptions.md)). For each column the SQL used in a **load-bearing** way — SELECT / WHERE / GROUP BY / ORDER BY / a metric binding, **not** pure join plumbing — look it up in `get_table_context` and surface two cases:
-  - `description_source == "ai_unvalidated"` (a guess) AND `description` non-empty → `{column, meaning: <description>, source: "ai_unvalidated"}`.
-  - `description_source == "ai_unknown"` (agami couldn't read it) → `{column, meaning: null, source: "ai_unknown"}` — agami used a column it doesn't understand; flag it loudly.
-  Columns with `description_source` of `human`, `ai_validated`, or `null` are NOT surfaced. **Cap at 3**, ranked by load-bearing-ness (filter/group-by > select > order-by) and putting `ai_unknown` first (an unknown the query relied on is the riskiest). Pass `[]` when none qualify. Advisory — never blocks or warns; it's a "here's what I assumed / didn't know" so the user can correct, confirm, or describe.
-- **`warnings`** — for every **non-metric** entry above whose `review_state ≠ approved` (joins, rewrites, applied filters), push a one-line warning naming the entry and its confidence. Example: `"Used 1 unreviewed join (orders → customers, conf inferred)."`. **Do NOT add a warning line for unreviewed/ad-hoc metrics** — they get their own actionable **"metrics you haven't approved" banner** (from `receipt.metrics`) with Approve / Change controls, so a warning line would just duplicate it. If the receipt has any warnings, **append a final action line as the last warning**: `"Run /agami-model review to walk these items, or say 'open the review queue'."` This gives the user a clickable next step (the slash command renders as readable text in the warning banner). If the receipt has zero warnings, pass `[]` and the banner suppresses entirely. (Assumptions and metric-approvals are NOT warnings — keep them separate.)
+```bash
+python3 "$AGAMI_PLUGIN_ROOT/scripts/csv_to_sections.py" \
+  --spec /tmp/agami-spec-<ts>.json --out /tmp/agami-sections-<ts>.json
+```
 
-Build the receipt at `/tmp/agami-receipt-<ts>.json` and pass it to `render_chart.py` via `--receipt-file` (see 4e.iv below). For a 1×1 scalar answer with no chart (Phase 4e skips the report), still construct the receipt mentally so you can surface warnings inline in the chat answer ("Note: this used 1 unreviewed join").
+It prints `{ok, data:{section_count}, anomalies}`. **Read `anomalies`** and mention/act on them if they matter (e.g. a value column that isn't numeric → left out of the chart; a query that returned 0 rows) — they're not fatal. The `--out` sections file is what `render_chart.py` reads (4e.iv).
+
+Notes the script handles for you: a time-bucket `label_col` is formatted from its unit/date encoding; a categorical label uses the value as-is; the section's chart-axis `unit` is set automatically only when **all** value columns share one unit (so a currency col plotted next to a count never mis-formats); the `sql` is read verbatim from `sql_file` (no paraphrase, no `...`).
+
+#### 4e.iii.5 — build the trust receipt via `sm receipt` (do NOT hand-build it)
+
+The receipt documents provenance: tables touched, relationships + metrics used, unreviewed-warnings, assumptions, and the model-version pin. **It is assembled deterministically from the SQL + the model** by `runtime.assemble_receipt` — the SAME builder the MCP server uses — so it never depends on you extracting fields by hand:
+
+```bash
+bash "$AGAMI_PLUGIN_ROOT/scripts/sm" receipt "$ROOT" \
+  --sql-file /tmp/agami-q-<n>.sql \
+  --applied-filters "$APPLIED_FILTERS_JSON" \
+  > /tmp/agami-receipt-<ts>.json
+```
+
+It emits the full receipt object — `model_version`, `tables_used` (with each table's `estimated_row_count` + `rows_as_of`), `relationships` (every trust field), `metrics` (model metrics whose binding appears in the SQL), `named_filters`, `assumptions` (the load-bearing columns whose description is `ai_unvalidated`/`ai_unknown`), and `warnings` (one per unreviewed join/filter the SQL used). It parses the FROM/JOIN scope and matches model entries itself. `--applied-filters` is the `applied_filters` list from `sm prepare` (optional). `model_version` comes from the newest `.snapshots/<hash>/` dir (null on a pre-trust-layer model — renders gracefully).
+
+**The ONE thing you add by hand — an ad-hoc metric.** If you composed a non-trivial metric for THIS answer that isn't a model metric (e.g. `(SUM(net_revenue) - SUM(cogs)) / SUM(net_revenue)` for "gross margin", with no such model metric), the script can't know it. Append one entry to the receipt's `metrics` array: `{name: "<snake_case>", area: "<area>", origin: "ad_hoc", review_state: "unreviewed", definition_prose: "<plain English>", expression: "<SQL fragment>"}`. This feeds the "metrics you haven't approved" banner. **Don't flag trivial primitives** (a bare `COUNT(*)` / `SUM(amount)`). For a multi-section report, run `sm receipt` per section's SQL and merge `tables_used`/`relationships`/`metrics` (dedup by name), or pass the dominant query's SQL.
+
+For a 1×1 scalar answer with no chart (Phase 4e skips the report), still run `sm receipt` so you can surface any `warnings` inline in the chat answer ("Note: this used 1 unreviewed join").
 
 #### 4e.iv — render via `render_chart.py` (do NOT inline-substitute through the Write tool)
 
@@ -654,9 +608,9 @@ The HTML report is produced by a Python helper that reads the template + SVG log
 
 Instead:
 
-1. Build the sections JSON file at `/tmp/agami-sections-<ts>.json`. The shape is the JSON array built in 4e.iii — a list of section objects (`title`, `insights`, `chart_type`, `labels`, `datasets`, `table_headers`, `table_rows`, `sql`).
+1. The sections JSON file `/tmp/agami-sections-<ts>.json` is produced by `csv_to_sections.py` (4e.iii) — you don't hand-build it; you wrote the spec, the script wrote the numbers.
 
-2. Build the receipt JSON file at `/tmp/agami-receipt-<ts>.json` per Phase 4e.iii.5.
+2. The receipt JSON file `/tmp/agami-receipt-<ts>.json` is produced by `sm receipt` (4e.iii.5) — plus any ad-hoc metric you appended.
 
 3. Run the renderer:
 

--- a/tests/test_render_piping.py
+++ b/tests/test_render_piping.py
@@ -1,0 +1,122 @@
+"""Phase A — deterministic render piping (docs/design/determinism-refactor.md).
+
+csv_to_sections.py builds the render sections from the result CSV (numbers piped,
+not LLM-transcribed); `sm receipt` (cli.cmd_receipt) assembles the trust receipt
+from the SQL. These guard that the numbers a chart/table shows come from the data,
+and the provenance comes from parsing the SQL — not from the model re-typing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "tests"))
+
+import csv_to_sections as C  # noqa: E402
+
+
+def _csv(p: Path, text: str) -> Path:
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# csv_to_sections — numbers come from the CSV
+# ---------------------------------------------------------------------------
+
+def test_table_rows_formatted_datasets_raw(tmp_path):
+    csvf = _csv(tmp_path / "r.csv", "customer,total_spend\nAvery,121560.94\nBlake,58425.20\n")
+    sec = C._build_section(
+        {"title": "T", "csv_file": str(csvf), "units": {"total_spend": "USD"}, "value_cols": [1]}, 0, [])
+    # table cells formatted EXACTLY via units (currency + grouping), no abbreviation
+    assert sec["table_rows"] == [["Avery", "$121,560.94"], ["Blake", "$58,425.20"]]
+    # datasets carry RAW numbers parsed from the CSV (not the formatted string)
+    assert sec["datasets"][0]["data"] == [121560.94, 58425.2]
+    assert sec["labels"] == ["Avery", "Blake"]
+    assert sec["unit"] == "USD"
+
+
+def test_raw_numbers_are_exact_no_drift(tmp_path):
+    """The whole point: a big/awkward value reaches datasets EXACTLY (the kind a
+    hand-transcription would drift on)."""
+    csvf = _csv(tmp_path / "r.csv", "name,rev\nA,2162087.5\nB,1490000\n")
+    sec = C._build_section({"title": "T", "csv_file": str(csvf), "units": {"rev": "INR"}, "value_cols": [1]}, 0, [])
+    assert sec["datasets"][0]["data"] == [2162087.5, 1490000]
+    assert sec["table_rows"][0][1].startswith("₹")  # INR symbol, Indian grouping
+
+
+def test_non_numeric_value_col_is_anomaly_not_a_crash(tmp_path):
+    csvf = _csv(tmp_path / "r.csv", "name,status\nA,active\nB,paused\n")
+    anom: list = []
+    sec = C._build_section({"title": "T", "csv_file": str(csvf), "value_cols": [1]}, 0, anom)
+    assert sec["datasets"] == []  # status isn't chartable
+    assert any(a["kind"] == "non_numeric_value_col" for a in anom)
+    assert sec["table_rows"] == [["A", "active"], ["B", "paused"]]  # table still rendered
+
+
+def test_sql_read_verbatim_from_file(tmp_path):
+    csvf = _csv(tmp_path / "r.csv", "a,b\n1,2\n")
+    sqlf = _csv(tmp_path / "q.sql", "SELECT a, b FROM t  -- kept exactly\n")
+    sec = C._build_section({"title": "T", "csv_file": str(csvf), "sql_file": str(sqlf)}, 0, [])
+    assert sec["sql"] == "SELECT a, b FROM t  -- kept exactly"
+
+
+def test_default_value_cols_are_all_non_label(tmp_path):
+    csvf = _csv(tmp_path / "r.csv", "month,orders,revenue\n2026-01,10,100\n2026-02,20,250\n")
+    sec = C._build_section({"title": "T", "csv_file": str(csvf), "label_col": 0,
+                            "units": {"revenue": "USD"}}, 0, [])
+    labels = {d["label"] for d in sec["datasets"]}
+    assert labels == {"orders", "revenue"}
+    assert sec.get("unit") is None  # mixed units across value cols → no section unit key
+
+
+def test_main_multi_section_writes_array(tmp_path):
+    a = _csv(tmp_path / "a.csv", "k,v\nx,1\n")
+    b = _csv(tmp_path / "b.csv", "k,v\ny,2\n")
+    spec = tmp_path / "spec.json"
+    spec.write_text(json.dumps([
+        {"title": "A", "csv_file": str(a), "value_cols": [1]},
+        {"title": "B", "csv_file": str(b), "value_cols": [1]},
+    ]), encoding="utf-8")
+    out = tmp_path / "sections.json"
+    rc = C.main(["--spec", str(spec), "--out", str(out)])
+    assert rc == 0
+    sections = json.loads(out.read_text())
+    assert [s["title"] for s in sections] == ["A", "B"]
+    assert sections[0]["datasets"][0]["data"] == [1]
+
+
+# ---------------------------------------------------------------------------
+# sm receipt — provenance comes from parsing the SQL, not the LLM
+# ---------------------------------------------------------------------------
+
+def test_receipt_from_sql(tmp_path, capsys):
+    from catalog_helpers import col, make_catalog_runner
+    from semantic_model import cli
+    from semantic_model import introspect as I
+
+    runner = make_catalog_runner(
+        tables=["customers", "orders"],
+        columns={"customers": [col("id", "integer", nullable=False), col("email", "varchar")],
+                 "orders": [col("id", "integer", nullable=False), col("customer_id", "integer")]},
+        fks=[{"from_table": "orders", "from_column": "customer_id",
+              "to_table": "customers", "to_column": "id"}])
+    I.introspect("shop", "postgres", runner=runner, artifacts_dir=tmp_path)
+
+    args = types.SimpleNamespace(
+        root=str(tmp_path / "shop"), sql_file=None, applied_filters=None, freshness=None,
+        sql="SELECT c.id, COUNT(*) FROM orders o JOIN customers c ON o.customer_id = c.id GROUP BY c.id")
+    cli.cmd_receipt(args)
+    receipt = json.loads(capsys.readouterr().out)
+    assert {t["qname"] for t in receipt["tables_used"]} == {"public.customers", "public.orders"}
+    assert any("customers" in r["from_to"] for r in receipt["relationships"])


### PR DESCRIPTION
First phase of the determinism refactor (anchor doc: `docs/design/determinism-refactor.md`).

## Problem
The render path had the LLM **hand-build `agami-sections.json`, transcribing result numbers** into both `table_rows` and `datasets[].data`, and hand-build the trust receipt. `render_chart.py` never reads the result CSV — so a miscopy shows a wrong number in the *chart* while the *table* is right, and nothing catches it. For a tool whose pitch is "trust these numbers," that's the wrong place to rely on the model re-typing.

## Fix — take numbers + provenance out of the model's hands
- **`scripts/csv_to_sections.py`** — reads each section's result CSV + the `units` map (from `sm prepare`) and emits `labels` / `table_rows` (formatted *exactly* via the same `units.py` `sm format-table` uses) / `datasets[].data` (raw numbers). The LLM supplies only a **presentation spec**: title, insight, chart_type, which column is the label vs the values, cosmetic relabels, and the `sql_file` (read verbatim — no paraphrase). Surfaces **anomalies** (a non-numeric value column, 0 rows) for the LLM rather than guessing.
- **`sm receipt`** (`cli.cmd_receipt`) — wraps the existing **`runtime.assemble_receipt`** (the *same* builder the MCP server already uses), so the receipt is parsed from the SQL + model (tables, relationships, metrics, warnings, assumptions, `model_version`) instead of hand-extracted. The LLM only appends an *ad-hoc* metric it composed.
- **agami-query Phase 4e.iii / 4e.iii.5** rewritten to call them; the old "transcribe the formatted values… `datasets[].data` is the only place raw numbers belong" prose is removed.

## Contract (settled here for Phases B/C)
Refactor scripts print `{ok, data, anomalies[], needs_judgment?}`. Anomalies are non-fatal signals; `needs_judgment` is the escape hatch where a script deliberately stops short of guessing and hands context to the LLM (e.g. the "samples data, finds an anomaly, figures out what to do" case).

## Tests
`tests/test_render_piping.py` — number fidelity (table formatted `$121,560.94`, datasets raw `121560.94`, exact big values), non-numeric-col anomaly (not a crash), SQL read verbatim from file, mixed-unit section (no false chart unit), multi-section; `sm receipt` from SQL (tables + relationships parsed). **579 unit tests pass.**

## Scope
Phase A only (render). Phase B (connect bootstrap spine) and Phase C (collapse near-deterministic skills) are separate PRs per the design doc. Independent of the open sample (#15) and snapshots (#16) PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)