### PR TITLE
feat(model): deterministic back-channel parser (Phase C of the determinism refactor)

### DIFF
--- a/plugins/agami/scripts/parse_model_feedback.py
+++ b/plugins/agami/scripts/parse_model_feedback.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Parse the agami-model dashboard's back-channel feedback block into a single
+curate-ready ops set — deterministically.
+
+agami-model used to parse this multi-format block in prose: a `profile:` line,
+comma-lists (`exclude/include tables:` + `… columns:`), and three JSON sub-blocks
+(`curate-ops:` array, `new-metrics:` array, `key-terminology:` object). This
+script does the parse + the exclude/include → curate-op translation, so the skill
+just reads structured output and applies it via `sm curate` / `sm add` /
+`sm set-terminology`.
+
+Input (stdin or --block-file):
+
+    profile: <name>
+    exclude tables:  <area>.<table>, <area>.<table>
+    include tables:  <area>.<table>
+    exclude columns: <area>.<table>.<column>, ...
+    curate-ops: [ {"op":"approve","kind":"metric","area":"...","name":"...","at":"..."}, ... ]
+    new-metrics: [ {"area":"...","name":"...","calculation":"...", ...}, ... ]
+    key-terminology: {"gold tier": "lifetime spend > $10k", ...}
+    signed-off-by: jane@x.com (cfo)
+    done
+
+JSON-valued keys may span multiple lines (value = everything up to the next key
+or `done`). Output (the standard contract):
+
+    {"ok": true,
+     "data": {
+       "profile": "<name>"|null,
+       "ops": [ ...curate ops: exclude/include translated + curate-ops merged verbatim... ],
+       "new_metrics_by_area": {"<area>": [ ...metric dicts... ]},
+       "key_terminology": {..}|null,
+       "signer": "jane@x.com"|null, "role": "cfo"|null
+     },
+     "anomalies": [...], "needs_judgment": {...}|null}
+
+A malformed target (a table without its `<area>.` prefix, unparseable JSON) is a
+`needs_judgment` — the skill asks the user to fix it rather than guessing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_LIST_KEYS = {"exclude tables", "include tables", "exclude columns", "include columns"}
+_JSON_KEYS = {"curate-ops", "new-metrics", "key-terminology", "example-edits", "new-examples"}
+_KEYS = _LIST_KEYS | _JSON_KEYS | {"profile", "signed-off-by", "organization-md"}
+_TABLE_QNAME = re.compile(r"^[A-Za-z0-9_]+\.[A-Za-z0-9_]+$")
+_COLUMN_QNAME = re.compile(r"^[A-Za-z0-9_]+\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+$")
+
+
+def _key_of(line: str):
+    low = line.strip().lower()
+    for k in _KEYS:
+        if low.startswith(k + ":") or low == k + ":":
+            return k
+    return None
+
+
+def _sections(text: str) -> dict:
+    """Split the block into {key: raw value text}, value spanning until the next key/done."""
+    out: dict = {}
+    cur_key = None
+    cur_val: list[str] = []
+    for raw in text.splitlines():
+        if raw.strip().lower() == "done":
+            break
+        k = _key_of(raw)
+        if k:
+            if cur_key:
+                out[cur_key] = "\n".join(cur_val).strip()
+            cur_key = k
+            cur_val = [raw.split(":", 1)[1]]
+        elif cur_key:
+            cur_val.append(raw)
+        # lines before the first key (headers) are ignored
+    if cur_key:
+        out[cur_key] = "\n".join(cur_val).strip()
+    return out
+
+
+def parse(text: str) -> tuple[dict, list, dict | None]:
+    sec = _sections(text)
+    anomalies: list = []
+    needs: dict | None = None
+    ops: list = []
+    data: dict = {"profile": None, "ops": ops, "new_metrics_by_area": {},
+                  "examples_by_area": {}, "key_terminology": None, "organization_md": None,
+                  "signer": None, "role": None}
+
+    if "profile" in sec:
+        data["profile"] = sec["profile"].strip() or None
+    if "signed-off-by" in sec:
+        sb = sec["signed-off-by"].strip()
+        if "/" in sb:  # `email / role`
+            email, role = sb.split("/", 1)
+            data["signer"], data["role"] = email.strip(), role.strip() or None
+        elif "(" in sb:  # `email (role)`
+            email, rest = sb.split("(", 1)
+            data["signer"], data["role"] = email.strip(), rest.rstrip(")").strip() or None
+        else:
+            data["signer"] = sb or None
+
+    def _qnames(val: str) -> list[str]:
+        return [t.strip() for t in val.replace("\n", ",").split(",") if t.strip()]
+
+    bad_targets: list[str] = []
+    for key, op, is_col in (("exclude tables", "exclude", False), ("include tables", "include", False),
+                            ("exclude columns", "exclude", True), ("include columns", "include", True)):
+        if key not in sec:
+            continue
+        for q in _qnames(sec[key]):
+            rx = _COLUMN_QNAME if is_col else _TABLE_QNAME
+            if not rx.match(q):
+                bad_targets.append(q)
+                continue
+            parts = q.split(".")
+            entry = {"op": op, "kind": "table", "area": parts[0], "name": parts[1]}
+            if is_col:
+                entry["column"] = parts[2]
+            ops.append(entry)
+
+    for jk in ("curate-ops", "new-metrics", "key-terminology", "example-edits", "new-examples", "organization-md"):
+        if jk not in sec:
+            continue
+        try:
+            parsed = json.loads(sec[jk])
+        except Exception as e:
+            anomalies.append({"kind": "bad_json", "where": jk, "detail": str(e)})
+            needs = {"kind": "unparseable_json", "section": jk,
+                     "ask": f"the `{jk}:` block isn't valid JSON — re-copy it from the dashboard"}
+            continue
+        if jk == "curate-ops":
+            if isinstance(parsed, list):
+                ops.extend(parsed)  # merge verbatim
+            else:
+                anomalies.append({"kind": "curate_ops_not_list", "detail": "expected a JSON array"})
+        elif jk == "new-metrics":
+            for m in (parsed or []):
+                area = m.get("area")
+                if not area:
+                    anomalies.append({"kind": "metric_missing_area", "detail": str(m.get("name"))})
+                    continue
+                data["new_metrics_by_area"].setdefault(area, []).append(m)
+        elif jk in ("example-edits", "new-examples"):  # both apply via sm add-example
+            for ex in (parsed or []):
+                area = ex.get("area")
+                if not area:
+                    anomalies.append({"kind": "example_missing_area", "detail": str(ex.get("question"))})
+                    continue
+                data["examples_by_area"].setdefault(area, []).append(ex)
+        elif jk == "key-terminology":
+            data["key_terminology"] = parsed
+        elif jk == "organization-md":
+            data["organization_md"] = parsed  # JSON-encoded string → the full ORGANIZATION.md text
+
+    if bad_targets:
+        needs = {"kind": "malformed_targets", "targets": bad_targets,
+                 "ask": "these need an <area>. prefix (e.g. `sales.STG_LEADS`, not `STG_LEADS`) — confirm and re-send"}
+    return data, anomalies, needs
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Parse the agami-model back-channel feedback block.")
+    ap.add_argument("--block-file", help="path to the pasted block (else stdin)")
+    args = ap.parse_args(argv)
+    text = Path(args.block_file).read_text(encoding="utf-8") if args.block_file else sys.stdin.read()
+    data, anomalies, needs = parse(text)
+    print(json.dumps({"ok": True, "data": data, "anomalies": anomalies, "needs_judgment": needs}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/agami/skills/agami-model/SKILL.md
+++ b/plugins/agami/skills/agami-model/SKILL.md
@@ -107,64 +107,30 @@ End the turn. Wait for the user.
 
 ## Phase 2: Parse the chat back-channel
 
-The user replies with a block like:
+The user pastes the dashboard's "Generate feedback" block. **Don't hand-parse it** — pipe it to the parser, which handles the whole grammar (the `profile:` line, the `exclude/include tables|columns:` lists, and the `curate-ops` / `new-metrics` / `new-examples` / `example-edits` / `key-terminology` / `organization-md` JSON blocks) and translates the exclude/include lists into curate ops:
 
-```
-exclude tables: sales.STG_LEADS, sales.STG_RAW
-exclude columns: sales.CUSTOMERS.SSN, sales.CUSTOMERS.EMAIL
-include tables: sales.PAYMENTS
-done
+```bash
+parse_model_feedback.py --block-file <pasted>
 ```
 
-Grammar:
+It prints `{data, anomalies, needs_judgment}`:
+- `data.profile` — the dashboard's target model. **Use it, overriding the active-profile default** (a block was rendered for THAT model; never apply it to whatever's active).
+- `data.ops` — the merged curate ops array (exclude/include for tables/columns, translated, **plus** the `curate-ops` approve/reject/edit verbatim). Apply in one `sm curate "$ROOT" --ops-file <json>` call.
+- `data.new_metrics_by_area` — `{area: [metric…]}` → one `sm add "$ROOT" --kind metric --area <area> --file <json>` per area.
+- `data.examples_by_area` — edited + new NL→SQL examples `{area: [example…]}` → one `sm add-example "$ROOT" --area <area> --file <json>` per area (dedups by question).
+- `data.key_terminology` — the complete glossary object → `sm set-terminology "$ROOT" --file <json> --replace`.
+- `data.organization_md` — the full ORGANIZATION.md text (already decoded) → **Write** it to `<artifacts_dir>/<profile>/ORGANIZATION.md` (overwrite; human narrative only).
+- `data.signer` / `data.role` — the curator identity for `--signer`/`--role` on every approve. **Persist** them into `<artifacts_dir>/local/.config` (`reviewer_email`/`reviewer_role`; preserve other keys, `chmod 600`) so future sessions don't re-ask; if absent on an approve-bearing batch, fall back to `.config`, then the Phase 0 ask.
 
-```
-signed-off-by: you@company.com / data_lead
-exclude tables:  <qname-list>
-include tables:  <qname-list>
-exclude columns: <qname-list>
-include columns: <qname-list>
-curate-ops:
-[{"op":"approve","kind":"metric","area":"...","name":"...","at":"<UTC ISO>"}, {"op":"exclude","kind":"metric","area":"...","name":"..."}, {"op":"edit","kind":"table","area":"...","name":"orders","column":"amount","field":"description","value":"..."}, ...]
-example-edits:
-[{"area":"sales","question":"...","sql":"...","source":"correction","status":"confirmed"}]
-new-metrics:
-[{"area":"sales","name":"repeat_rate","description":"...","calculation":"...","bindings":{"Snowflake":"..."},"source_tables":["orders"],"other_names":["repeat purchase rate"],"unit":"percent","confidence":"proposed"}]
-new-examples:
-[{"area":"sales","question":"How many active vehicles by zone?","sql":"SELECT zone, COUNT(*) ...","source":"human","status":"confirmed"}]
-organization-md: "<full new ORGANIZATION.md text, JSON-encoded>"
-key-terminology: {"gold tier": "lifetime spend > $10k", "churned": "no order in 90 days"}
-done
-```
+**If `needs_judgment` is set, stop and ask** — `malformed_targets` (a table without its `<area>.` prefix → *"Tables need a schema prefix — `sales.STG_LEADS`, not `STG_LEADS`. Did you mean that?"*) or `unparseable_json` (re-copy that block from the dashboard). Don't apply a partial block.
 
-Where `<qname-list>` is comma-separated, whitespace-tolerant:
-- Table qname: `<area>.<table>` (e.g., `sales.STG_LEADS`)
-- Column qname: `<area>.<table>.<column>` (e.g., `sales.CUSTOMERS.EMAIL`)
-
-A header line + several optional blocks may follow (the dashboard emits whichever applies — `curate-ops`, `example-edits`, `new-metrics`, `new-examples`, `organization-md`, `key-terminology`):
-- **`signed-off-by: <email> / <role>`** (header, present only when the batch has approvals) — the curator's sign-off identity, entered at the top of the dashboard's Review tab. **Use it for `--signer`/`--role`** when applying, and **persist** `reviewer_email`/`reviewer_role` into `<artifacts_dir>/local/.config` (preserve other keys; `chmod 600`) so future sessions don't re-ask. If a batch contains approvals but this line is **absent**, fall back to `<artifacts_dir>/local/.config` (`reviewer_email`/`reviewer_role`), then to the Phase 0 ask. Validate the email against `\S+@\S+\.\S+`; the role is a short free-text string (the picker offers CFO / CTO / Data Lead / Engineer / Analyst, but "Other" lets the user type their own — accept any non-empty value ≤ 40 chars; don't reject a custom role).
-- **`curate-ops:`** — the unified ops array. Holds **approve / reject(exclude) / include** on metrics/entities/relationships AND field **edits** (`op:"edit"` with `field`/`value`). Already a valid curate ops array; merge it verbatim with the table/column ops below and apply via one `sm curate` call. **`approve` ops carry an `at` timestamp** (the dashboard stamps it) and require the curator's `--signer`/`--role` from the `signed-off-by:` line — the validator rejects an approved entry with no sign-off stamp. **Rule 1 guard:** before applying an `approve` on a metric, confirm its `calculation` is non-empty (the dashboard always has one for user-authored metrics; for an introspected metric with an empty calculation, ask the user to fill it via an `edit` first).
-- **`example-edits:`** — edited prompt examples `[{area, question, sql, source, status}]`. Group by `area` and apply each group with `sm add-example "$ROOT" --area <area> --file <json>` (it dedups by `question`, so an edit replaces the prior example). Write the per-area JSON with the **Write tool**.
-- **`new-metrics:`** — metrics the user authored in the dashboard's "Add metric" form `[{area, name, description, calculation, bindings, source_tables, other_names, unit?, confidence}]`. Group by `area` and create each group with `sm add "$ROOT" --kind metric --area <area> --file <json>` (validates each item, writes `subject_areas/<area>/metrics/<slug>.yaml`, reverts the batch on failure). Write the per-area JSON with the **Write tool** — it's already in the `sm add` shape, so pass it through verbatim. A user-authored metric is `confidence: proposed` and still needs sign-off (approve it on the Review tab).
-- **`new-examples:`** — NL→SQL examples the user authored in the dashboard's "Add an example" form `[{area, question, sql, source, status}]` (`source: human`, `status: confirmed`). Same shape + apply path as `example-edits:` — group by `area` and apply each group with `sm add-example "$ROOT" --area <area> --file <json>` (Write the per-area JSON with the **Write tool**; it dedups by `question`, appending new ones to `prompt_examples/<area>/examples.yaml`). A human-authored example is trusted (`status: confirmed`) — no sign-off needed.
-- **`organization-md:`** — a JSON-encoded string of the full new `ORGANIZATION.md`. JSON-decode it and **Write** it to `<artifacts_dir>/<profile>/ORGANIZATION.md` (overwrite; free-form Markdown, no validator). This is the human **narrative only** — it never carries the glossary or model facts.
-- **`key-terminology:`** — a JSON object `{term: definition, …}`: the curated domain glossary the user edited in the Organization tab. It's the **complete** intended glossary (adds, edits, and removals already applied), so write it to a temp file and apply with **`--replace`** (it's validated + committed, reverts on failure):
-  ```bash
-  bash "$AGAMI_PLUGIN_ROOT/scripts/sm" set-terminology "$ROOT" --file /tmp/agami-terminology.json --replace
-  ```
-  Write the JSON with the **Write tool**. This lands in the structured `key_terminology` field (not ORGANIZATION.md) and surfaces in the derived domain context automatically.
-
-Show the user a one-line summary of what each block changed before applying.
-
-Tolerate trailing commas, mixed-case schema/table/column names (the YAMLs typically preserve the DB's casing — pass them through verbatim).
-
-**Reject malformed targets in chat, not by silently dropping them.** If a user types `exclude tables: STG_LEADS` without the schema prefix, surface: *"Tables need a schema prefix — `sales.STG_LEADS` not just `STG_LEADS`. Did you mean that?"* and stop.
+**Rule 1 guard (judgment):** before applying an `approve` on a metric, confirm its `calculation` is non-empty — for an introspected metric with an empty calculation, ask the user to fill it via an `edit` first (the dashboard always has one for user-authored metrics). Show the user a one-line summary of what each block changed before applying.
 
 ---
 
 ## Phase 3: Apply via the curation engine
 
-Translate the parsed table/column exclude/include commands into curation ops, **then merge in the `curate-ops:` JSON array verbatim** (it already holds the approve / reject / include / edit ops for metrics, entities, and joins). Table targets are `<area>.<table>`, column targets `<area>.<table>.<column>`. `exclude` → `op: exclude` (engine treats it as reject), `include` → `op: include`, `approve` → `op: approve` (+ `at`):
+`data.ops` from the parser is already the merged curation ops array — exclude/include translated + the `curate-ops` approve/reject/edit verbatim. Apply it in one `sm curate` call (shape, for reference):
 
 ```json
 [

--- a/tests/test_model_feedback.py
+++ b/tests/test_model_feedback.py
@@ -1,0 +1,89 @@
+"""Phase C — parse_model_feedback.py (agami-model back-channel parser).
+
+The dashboard's "Generate feedback" block (profile + exclude/include lists +
+curate-ops/new-metrics/key-terminology JSON) used to be parsed in prose. This
+guards the parse + the exclude/include → curate-op translation, and the
+`needs_judgment` escape hatch for malformed input.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import parse_model_feedback as F  # noqa: E402
+
+FULL = """profile: sales_prod
+exclude tables: sales.STG_LEADS, sales.STG_RAW
+exclude columns: sales.CUSTOMERS.SSN
+include tables: sales.PAYMENTS
+curate-ops: [{"op":"approve","kind":"metric","area":"sales","name":"revenue","at":"2026-06-18T00:00:00Z"}]
+new-metrics: [{"area":"sales","name":"aov","calculation":"revenue / orders"}]
+key-terminology: {"gold tier": "lifetime spend > $10k"}
+signed-off-by: jane@x.com (cfo)
+done
+"""
+
+
+def test_full_block_parse_and_translate():
+    data, anomalies, needs = F.parse(FULL)
+    assert data["profile"] == "sales_prod"
+    assert (data["signer"], data["role"]) == ("jane@x.com", "cfo")
+    # exclude/include translated to curate ops + curate-ops merged verbatim
+    ops = data["ops"]
+    assert {"op": "exclude", "kind": "table", "area": "sales", "name": "STG_LEADS"} in ops
+    assert {"op": "exclude", "kind": "table", "area": "sales", "name": "CUSTOMERS", "column": "SSN"} in ops
+    assert {"op": "include", "kind": "table", "area": "sales", "name": "PAYMENTS"} in ops
+    assert any(o.get("op") == "approve" and o.get("name") == "revenue" for o in ops)
+    assert data["new_metrics_by_area"] == {"sales": [{"area": "sales", "name": "aov", "calculation": "revenue / orders"}]}
+    assert data["key_terminology"] == {"gold tier": "lifetime spend > $10k"}
+    assert anomalies == [] and needs is None
+
+
+def test_malformed_target_is_needs_judgment():
+    _, _, needs = F.parse("exclude tables: STG_LEADS\ndone\n")
+    assert needs and needs["kind"] == "malformed_targets"
+    assert "STG_LEADS" in needs["targets"]
+
+
+def test_bad_json_is_needs_judgment_not_crash():
+    data, anomalies, needs = F.parse("curate-ops: [not json]\ndone\n")
+    assert needs and needs["kind"] == "unparseable_json"
+    assert any(a["kind"] == "bad_json" for a in anomalies)
+    assert data["ops"] == []  # nothing applied from the bad block
+
+
+def test_multiline_json_block():
+    block = (
+        "new-metrics: [\n"
+        '  {"area":"a","name":"m1","calculation":"x"},\n'
+        '  {"area":"b","name":"m2","calculation":"y"}\n'
+        "]\n"
+        "done\n"
+    )
+    data, _, needs = F.parse(block)
+    assert needs is None
+    assert set(data["new_metrics_by_area"]) == {"a", "b"}
+
+
+def test_empty_block_is_benign():
+    data, anomalies, needs = F.parse("done\n")
+    assert data["ops"] == [] and not anomalies and needs is None
+
+
+def test_examples_orgmd_and_slash_signer():
+    block = (
+        "signed-off-by: bob@x.com / data_lead\n"
+        'example-edits: [{"area":"sales","question":"q1","sql":"SELECT 1"}]\n'
+        'new-examples: [{"area":"ops","question":"q2","sql":"SELECT 2"}]\n'
+        'organization-md: "About this DB.\\nMRR = monthly recurring revenue."\n'
+        "done\n"
+    )
+    data, _, needs = F.parse(block)
+    assert needs is None
+    assert (data["signer"], data["role"]) == ("bob@x.com", "data_lead")
+    assert set(data["examples_by_area"]) == {"sales", "ops"}
+    assert data["organization_md"].startswith("About this DB.")


### PR DESCRIPTION
Phase C of the determinism refactor (`docs/design/determinism-refactor.md`).

## Problem
agami-model parsed the dashboard's "Generate feedback" block **in prose** — a multi-format grammar (`profile:` line, `exclude/include tables|columns:` comma-lists, and the `curate-ops` / `new-metrics` / `new-examples` / `example-edits` / `key-terminology` / `organization-md` JSON blocks) — and translated the exclude/include lists into curate ops by hand.

## Fix
- **`scripts/parse_model_feedback.py`** — parses the whole block and emits structured JSON: `{profile, ops (exclude/include translated + curate-ops merged verbatim), new_metrics_by_area, examples_by_area, key_terminology, organization_md, signer/role}` + `anomalies`, with a **`needs_judgment`** escape hatch for malformed targets (a table missing its `<area>.` prefix) and unparseable JSON — so the skill *asks the user* instead of guessing or silently dropping.
- agami-model **Phase 2** rewritten to call it; Phase 3's redundant exclude/include→op translation prose trimmed.

## Determinism
The back-channel parse + the exclude/include→op translation are now deterministic; malformed input becomes an explicit `needs_judgment`, not a silent drop. `agami-model/SKILL.md` −34 lines / −3.9KB.

## Tests
`tests/test_model_feedback.py` — full block parse + translate, malformed-target → `needs_judgment`, bad-JSON → `needs_judgment` (not a crash), multi-line JSON, examples/org-md/slash-signer forms. **578 unit tests pass.**

## Note on the rest of Phase C
agami-serve is already script-backed (`setup_desktop_mcp.py`) — little to gain. agami-save-correction's classification is genuinely *judgment* (categorizing a free-text correction needs NL understanding) — deliberately left to the LLM, per the refactor's principle of not scripting judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)