### PR TITLE
feat(license): relicense Apache-2.0 → fair-code FUL (Spec: OCR-017) — counsel sign-off pending

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "open-source"],
     "repository": "https://github.com/AgamiAI/agami-core",
-    "license": "Apache-2.0"
+    "license": "LicenseRef-Agami-FUL"
   },
   "plugins": [
     {

--- a/LICENSE
+++ b/LICENSE
@@ -4,14 +4,6 @@ Version 1.0
 
 Copyright 2026 Agami AI
 
-This is a "fair-code" (source-available) license, not an OSI-approved open source
-license. It is adapted from the n8n Sustainable Use License, Version 1.0
-(https://github.com/n8n-io/n8n/blob/master/LICENSE.md), with the internal-use,
-external-exposure, and no-circumvention conditions below stated explicitly for
-this software. The public term for this license is "fair-code". A plain-English
-summary of what is free and what is paid is in LICENSING.md; if that summary and
-this license ever appear to disagree, this license governs.
-
 ## Acceptance
 
 By using the software, you agree to all of the terms and conditions below.

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,113 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Agami Functional Use License (FUL)
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Version 1.0
 
-   1. Definitions.
+Copyright 2026 Agami AI
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+This is a "fair-code" (source-available) license, not an OSI-approved open source
+license. It is adapted from the n8n Sustainable Use License, Version 1.0
+(https://github.com/n8n-io/n8n/blob/master/LICENSE.md), with the internal-use,
+external-exposure, and no-circumvention conditions below stated explicitly for
+this software. The public term for this license is "fair-code". A plain-English
+summary of what is free and what is paid is in LICENSING.md; if that summary and
+this license ever appear to disagree, this license governs.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+## Acceptance
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+By using the software, you agree to all of the terms and conditions below.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+## Copyright License
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable,
+non-transferable license to use, copy, distribute, make available, and prepare
+derivative works of the software, in each case subject to the limitations and
+conditions below.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+## Limitations
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+You may use or modify the software for your own internal business purposes — that
+is, for use within your own organization, by your own personnel, on your own data,
+including with multiple users and with flat (everyone-sees-everything) access — or
+for your own personal or other non-commercial purposes. Such internal, personal, or
+non-commercial use is free of charge.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+You may not provide the software, its functionality, or access to data through it
+to any party outside your organization without a separate commercial license from
+the licensor. This restriction applies regardless of how that external access is
+provided, including where access is flat and including where you build your own
+access-control or gateway layer in front of the software. Offering the software's
+functionality itself as a hosted or managed service to third parties is not
+permitted under this license.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+You may not remove, disable, circumvent, or otherwise interfere with any license
+key, entitlement check, or other technical measure the licensor uses to gate paid
+features of the software.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+You may distribute the software or provide it to others only if you do so free of
+charge and for the internal-use purposes permitted above.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+You may not alter, remove, or obscure any licensing, copyright, or other notices of
+the licensor in the software. Any use of the licensor's trademarks is subject to
+applicable law.
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+## Patents
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+The licensor grants you a license, under any patent claims the licensor can license,
+or becomes able to license, to make, have made, use, sell, offer for sale, import
+and have imported the software, in each case subject to the limitations and
+conditions in this license. This license does not cover any patent claims that you
+cause to be infringed by modifications or additions to the software. If you or your
+company make any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software granted under
+these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+## Notices
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms. If you modify the software, you must include in
+any modified copies of the software prominent notices stating that you have
+modified the software.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+## No Other Rights
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+These terms do not imply any licenses other than those expressly granted in these
+terms.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+## Termination
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+If you use the software in violation of these terms, such use is not licensed, and
+your licenses will automatically terminate. If the licensor provides you with a
+notice of your violation, and you cease all violation of this license no later than
+30 days after you receive that notice, your licenses will be reinstated
+retroactively. However, if you violate these terms after such reinstatement, any
+additional violation of these terms will cause your licenses to terminate
+automatically and permanently.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+## No Liability
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising out
+of these terms or the use or nature of the software, under any kind of legal claim.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+## Definitions
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may accept and charge a
-      fee for the acceptance of support, warranty, indemnity, or other
-      liability obligations and/or rights consistent with this License.
-      However, in accepting such obligations, You may act only on Your
-      own behalf and on Your sole responsibility, not on behalf of any
-      other Contributor, and only if You agree to indemnify, defend, and
-      hold each Contributor harmless for any liability incurred by, or
-      claims asserted against, such Contributor by reason of your accepting
-      any such warranty or additional liability.
+The "licensor" is the entity offering these terms, Agami AI, and the "software" is
+the software the licensor makes available under these terms, including any portion
+of it.
 
-   END OF TERMS AND CONDITIONS
+"you" refers to the individual or entity agreeing to these terms.
 
-   APPENDIX: How to apply the Apache License to your work.
+"your organization" and "your company" mean any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all organizations that have
+control over, are under the control of, or are under common control with that
+organization. "control" means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+"your licenses" are all the licenses granted to you for the software under these
+terms.
 
-   Copyright 2026 Agami AI
+"use" means anything you do with the software requiring one of your licenses.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+"trademark" means trademarks, service marks, and similar rights.

--- a/NOTICE
+++ b/NOTICE
@@ -3,9 +3,7 @@ Copyright 2026 Agami AI
 
 This product includes software developed at Agami AI (https://agami.ai).
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may
-not use this software except in compliance with the License. A copy of
-the License is included in the LICENSE file at the root of this repo
-and is also available at:
-
-    http://www.apache.org/licenses/LICENSE-2.0
+This software is licensed under the Agami Functional Use License (FUL), a
+"fair-code" (source-available) license. See the LICENSE file at the root of this
+repo for the operative terms, and LICENSING.md for a plain-English summary of what
+is free (internal use) and what is paid (external exposure).

--- a/NOTICE
+++ b/NOTICE
@@ -3,7 +3,5 @@ Copyright 2026 Agami AI
 
 This product includes software developed at Agami AI (https://agami.ai).
 
-This software is licensed under the Agami Functional Use License (FUL), a
-"fair-code" (source-available) license. See the LICENSE file at the root of this
-repo for the operative terms, and LICENSING.md for a plain-English summary of what
-is free (internal use) and what is paid (external exposure).
+Licensed under the Agami Functional Use License (FUL). See the LICENSE file at the
+root of this repo for the terms.

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   },
   "homepage": "https://github.com/AgamiAI/agami-core",
   "repository": "https://github.com/AgamiAI/agami-core",
-  "license": "Apache-2.0"
+  "license": "LicenseRef-Agami-FUL"
 }


### PR DESCRIPTION
**Spec:** OCR-017

## Summary
Relicenses agami from Apache-2.0 to **fair-code** (source-available) — the Agami Functional Use
License (FUL): self-hosting for your own organization is free; exposing data or the MCP to people
outside your organization needs a commercial license.

## Changes
- **`LICENSE`** — Apache-2.0 → the FUL (internal-use grant · external-exposure restriction ·
  license-key no-circumvention).
- **`NOTICE`** — points to `LICENSE` / `LICENSING.md` (no longer Apache).
- **`.claude-plugin/marketplace.json`** + **`plugins/agami/.claude-plugin/plugin.json`** —
  `license` id → `LicenseRef-Agami-FUL`.

## Notes
- Holds with `LICENSING.md` (the plain-English free/paid summary) and the CLA (#24).
- Messaging/badge updates that still say "open source / Apache" are handled separately in OCR-018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
