### PR TITLE
chore(settings): enable Astral + code-review plugins repo-wide (Spec: OCR-026)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,5 +29,16 @@
       "Edit(/Users/*/agami-artifacts/**)"
     ]
   },
-  "enabledPlugins": {}
+  "extraKnownMarketplaces": {
+    "astral": {
+      "source": { "source": "github", "repo": "astral-sh/claude-code-plugins" }
+    },
+    "claude-plugins-official": {
+      "source": { "source": "github", "repo": "anthropics/claude-code" }
+    }
+  },
+  "enabledPlugins": {
+    "astral@astral": true,
+    "code-review@claude-plugins-official": true
+  }
 }


### PR DESCRIPTION
**Spec:** OCR-026 (engineering-standards: repo-wide Claude plugins)

## Summary
Commits the dev-tooling plugin configuration into `.claude/settings.json` so the lint/format and
code-review plugins are enabled **repo-wide** — every contributor, and every Claude Code session
opened on this repo, gets them automatically with no manual setup. This is the standing config we
use for reviewing future edits.

## Changes
- `.claude/settings.json`:
  - `extraKnownMarketplaces` — `astral-sh/claude-code-plugins`, `anthropics/claude-code`
  - `enabledPlugins` — `astral@astral` (ruff lint/format), `code-review@claude-plugins-official`

## Notes
- No change to the existing agami plugin permission allowlist — purely additive (the marketplaces + enablement block).
- Valid JSON; `main` is not branch-protected yet, so this can merge directly when you're ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
