### PR TITLE
docs(messaging): sweep open source / Apache → fair-code (Spec: OCR-018)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
     "version": "0.3.0",
     "pluginRoot": "./plugins",
-    "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "open-source"],
+    "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
     "license": "LicenseRef-Agami-FUL"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ below corresponds to one such version.
   (marketplace `agami`, plugin `agami-core`); the version bump is breaking, so
   existing `agami@litebi` installs must re-add the marketplace to upgrade
   (`/plugin marketplace add AgamiAI/agami-core` → `/plugin install agami-core@agami`).
+- **Relicensed Apache-2.0 → fair-code (the Agami Functional Use License / FUL).**
+  Internal/team use stays free; exposing the data or the MCP to people outside your
+  organization now requires a commercial license. See [LICENSE](LICENSE) and
+  [LICENSING.md](LICENSING.md).
 - **Repositioned around the trust layer.** README, marketplace, and plugin
   metadata now lead with the governance/trust stance ("the trust layer between AI
   and your data") instead of natural-language querying. Dropped the "BI" framing.

--- a/README.md
+++ b/README.md
@@ -167,12 +167,13 @@ connect with your permission). Details: [docs/privacy.md](docs/privacy.md).
 
 ## Fair-code vs hosted
 
-agami is **fair-code** (source-available). The laptop plugin — introspection, the portable
-semantic model, NL→SQL + local execution, the trust layer, corrections, and the
-local MCP server — is **free to self-host for your own team**. Exposing data or the MCP to
-people outside your organization is the paid line — the team cloud (a multi-tenant model
-registry served over a remote MCP endpoint, shared governed context, always-on evals). The
-boundary, stated plainly: [docs/open-vs-hosted.md](docs/open-vs-hosted.md).
+agami is **fair-code** (source-available). Running it on your own machine —
+introspection, the portable semantic model, NL→SQL + local execution, the trust layer,
+corrections, and the local MCP server — is **free to self-host for your own team**.
+Exposing data or the MCP to people outside your organization is the paid line — the team
+cloud (a multi-tenant model registry over a remote MCP endpoint, shared governed context,
+always-on evals). The boundary, stated plainly:
+[docs/open-vs-hosted.md](docs/open-vs-hosted.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 <p align="center"><strong>The trust layer between AI and your data. Local. Private. Yours.</strong></p>
 
-<p align="center"><sub><strong>agami-core</strong> — the open-source core of <a href="https://agami.ai">Agami</a>.</sub></p>
+<p align="center"><sub><strong>agami-core</strong> — the fair-code core of <a href="https://agami.ai">Agami</a>.</sub></p>
 
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License: Apache 2.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-fair--code-blue.svg" alt="License: fair-code"></a>
   <img src="https://img.shields.io/badge/version-0.3.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/status-pre--public-orange" alt="Status">
   <a href="#quickstart-under-5-minutes"><img src="https://img.shields.io/badge/try%20the%20sample-no%20database%20needed-brightgreen" alt="Try the sample"></a>
@@ -165,14 +165,14 @@ exports, and dashboards all live under `~/agami-artifacts/`, and the skill never
 reads files outside those paths (except your DB tool's auth config, set up on first
 connect with your permission). Details: [docs/privacy.md](docs/privacy.md).
 
-## Open source vs hosted
+## Fair-code vs hosted
 
-agami is **open core**, Apache-2.0. The laptop plugin — introspection, the portable
+agami is **fair-code** (source-available). The laptop plugin — introspection, the portable
 semantic model, NL→SQL + local execution, the trust layer, corrections, and the
-local MCP server — is fully open and always will be. The team cloud (a multi-tenant
-model registry served over a remote MCP endpoint, shared governed context, always-on
-evals) is the hosted business. The boundary, stated plainly:
-[docs/open-vs-hosted.md](docs/open-vs-hosted.md).
+local MCP server — is **free to self-host for your own team**. Exposing data or the MCP to
+people outside your organization is the paid line — the team cloud (a multi-tenant model
+registry served over a remote MCP endpoint, shared governed context, always-on evals). The
+boundary, stated plainly: [docs/open-vs-hosted.md](docs/open-vs-hosted.md).
 
 ## Documentation
 
@@ -182,7 +182,7 @@ evals) is the hosted business. The boundary, stated plainly:
 - [Format spec](docs/format-spec.md) — the semantic-model layout + a worked example
 - [MCP server](docs/mcp-server.md) — use agami from Claude Desktop
 - [Troubleshooting & uninstall](docs/troubleshooting.md)
-- [Open vs hosted](docs/open-vs-hosted.md) · [Privacy](docs/privacy.md)
+- [Fair-code vs hosted](docs/open-vs-hosted.md) · [Privacy](docs/privacy.md)
 
 ## Contributing
 
@@ -202,7 +202,7 @@ LLM round-trip).
 
 ## License
 
-Apache License, Version 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
+**fair-code** (source-available) — the Agami Functional Use License. See [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
 What's free vs. paid (internal use vs. external exposure): [LICENSING.md](LICENSING.md).
 

--- a/docs/open-vs-hosted.md
+++ b/docs/open-vs-hosted.md
@@ -1,70 +1,31 @@
-# What's fair-code, what's hosted
+# What's free, what's hosted
 
-agami is **fair-code** (source-available). This page states the boundary plainly:
-what's free to self-host for your own organization, and what's paid. The short
-version of the license is in [LICENSING.md](../LICENSING.md); the binding terms are
-in [LICENSE](../LICENSE).
+agami is **fair-code** (source-available): **free to self-host for your own
+organization**, paid when you expose it to people **outside** it. The short version
+of the license is in [LICENSING.md](../LICENSING.md); the binding terms are in
+[LICENSE](../LICENSE).
 
-## The principle
+## Free — self-host for your own team
 
-> **The laptop plugin is free to self-host for your own organization. Exposing it
-> — the data or the MCP — to people outside your organization is the paid line.**
+Run agami on your own machines, for your own people (multi-user included):
 
-Concretely, the line falls where value stops being single-player and starts
-requiring *more than one person* — which is also where self-hosting stops being
-a weekend project and starts being real infrastructure.
-
-## Free to self-host (this repo, fair-code — your own team, local)
-
-Everything you need to get value as a developer or a team, on your own machines,
-for your own people:
-
-- Schema introspection → a **provider-portable semantic model** (subject areas,
-  tables, entities, metrics, relationships with join cardinality — plain YAML you
-  own, never locked in).
-- NL→SQL generation and **local execution** against your DB (Postgres / Supabase /
-  Redshift / MySQL / Snowflake / BigQuery / SQL Server / Oracle / Databricks /
-  Trino / DuckDB / SQLite).
-- The **trust layer**: confidence scoring, single-reviewer sign-off, receipts,
-  snapshots, git-native model history.
+- Schema introspection → a provider-portable **semantic model** (plain YAML you own).
+- **NL→SQL + local execution** against your DB (Postgres / Supabase / Redshift /
+  MySQL / Snowflake / BigQuery / SQL Server / Oracle / Databricks / Trino / DuckDB /
+  SQLite).
+- The **trust layer**: confidence, sign-off, receipts, snapshots, git-native history.
 - **Corrections** + the `examples.yaml` few-shot library.
-- The **local MCP server** (`agami serve`) — use agami from Claude Code / Claude
-  Desktop. stdio, no auth, no network. See [mcp-server.md](mcp-server.md).
-- You can run your own evals in CI (run `examples.yaml` against the model on a PR)
-  and serve a shared model **to your own team** via git + a server you operate.
-  That's internal use — it's free, and it's a feature.
+- The **local MCP server** (`agami serve`) — stdio, no auth, no network.
+  See [mcp-server.md](mcp-server.md).
 
-## Hosted (the Agami cloud — teams, governed, always-on)
+## Paid — the hosted cloud
 
-The pieces whose value needs a team, and that are a genuine pain to self-host —
-**and serving agami to people outside your own organization**:
+For teams that need it served, and for serving people **outside** your organization:
 
-- A **multi-tenant semantic-model registry** served to many users/agents over a
-  stable remote MCP endpoint (reachable from Claude/Cowork/web/mobile and ChatGPT).
-- **Shared, governed** examples + memory/context across a team.
-- **Continuous / real-time evals**: scheduled runs, regression alerting,
-  dashboards, **golden-dataset management** + the cross-customer golden-set
-  network effect.
-- **CI-gated deploys**: gate a model change on eval-pass, versioned deploy + rollback.
-- **Governance at team scale**: OAuth/SSO, RBAC, per-tool permissions, org-wide audit.
+- A **multi-tenant model registry** over a remote MCP endpoint.
+- **Shared, governed** examples + context across a team.
+- **Continuous evals**: scheduled runs, regression alerting, golden-dataset management.
+- **CI-gated deploys** and org-scale governance (SSO, RBAC, audit).
 
-## Why fair-code (not permissive, not closed)
-
-The one thing the license has to prevent is someone taking the free core and
-re-hosting **agami's own functionality as a managed service to other people** —
-the BSL/SSPL/n8n concern. A permissive license (Apache/MIT) wouldn't stop that;
-a fully closed license would kill the adoption the core is for. **Fair-code is the
-middle path:** the core stays source-available and **free for your own internal
-use** — a developer, a team, your whole org, multi-user, all free — while exposing
-it to outside customers is the paid commercial line. It's the model n8n and the
-Elastic family use, and it's why the boundary above can be a clean, friendly line
-rather than a trap. The reasons are spelled out in [LICENSING.md](../LICENSING.md).
-
-## The upgrade path is a backend swap
-
-Because the local MCP server and the hosted connector expose the **same tool
-surface**, moving a team from local to hosted means pointing at a different
-backend — not learning a new product. You self-host the flat, commoditized part
-for your own team for free; you pay for the part that compounds (evals, the
-golden-set network effect, governance) — and for serving people outside your
-organization — the day it's worth more than running it yourself.
+Moving from local to hosted is a **backend swap** — the local server and the hosted
+connector expose the same tools, so you point at a different backend, not a new product.

--- a/docs/open-vs-hosted.md
+++ b/docs/open-vs-hosted.md
@@ -1,20 +1,23 @@
-# What's open source, what's hosted
+# What's fair-code, what's hosted
 
-agami is **open core**. This page states the boundary plainly so you can build on
-the open pieces without worrying we'll move the line under you.
+agami is **fair-code** (source-available). This page states the boundary plainly:
+what's free to self-host for your own organization, and what's paid. The short
+version of the license is in [LICENSING.md](../LICENSING.md); the binding terms are
+in [LICENSE](../LICENSE).
 
 ## The principle
 
-> **The laptop plugin is fully open (Apache-2.0) and always will be. The team
-> cloud is our business.**
+> **The laptop plugin is free to self-host for your own organization. Exposing it
+> — the data or the MCP — to people outside your organization is the paid line.**
 
 Concretely, the line falls where value stops being single-player and starts
 requiring *more than one person* — which is also where self-hosting stops being
 a weekend project and starts being real infrastructure.
 
-## Open source (this repo, Apache-2.0 — single developer, local)
+## Free to self-host (this repo, fair-code — your own team, local)
 
-Everything you need to get value as one developer, on your own machine:
+Everything you need to get value as a developer or a team, on your own machines,
+for your own people:
 
 - Schema introspection → a **provider-portable semantic model** (subject areas,
   tables, entities, metrics, relationships with join cardinality — plain YAML you
@@ -28,12 +31,13 @@ Everything you need to get value as one developer, on your own machine:
 - The **local MCP server** (`agami serve`) — use agami from Claude Code / Claude
   Desktop. stdio, no auth, no network. See [mcp-server.md](mcp-server.md).
 - You can run your own evals in CI (run `examples.yaml` against the model on a PR)
-  and serve a shared model to your team via git + a server you operate. We won't
-  obstruct that — it's a feature.
+  and serve a shared model **to your own team** via git + a server you operate.
+  That's internal use — it's free, and it's a feature.
 
 ## Hosted (the Agami cloud — teams, governed, always-on)
 
-The pieces whose value needs a team, and that are a genuine pain to self-host:
+The pieces whose value needs a team, and that are a genuine pain to self-host —
+**and serving agami to people outside your own organization**:
 
 - A **multi-tenant semantic-model registry** served to many users/agents over a
   stable remote MCP endpoint (reachable from Claude/Cowork/web/mobile and ChatGPT).
@@ -44,18 +48,23 @@ The pieces whose value needs a team, and that are a genuine pain to self-host:
 - **CI-gated deploys**: gate a model change on eval-pass, versioned deploy + rollback.
 - **Governance at team scale**: OAuth/SSO, RBAC, per-tool permissions, org-wide audit.
 
-## Why this split (and why we won't relicense the core)
+## Why fair-code (not permissive, not closed)
 
-The defensive reason companies adopt source-available licenses (BSL/SSPL) is to
-stop a competitor from re-hosting their open core as a competing SaaS. That threat
-doesn't apply here: the open core is **single-player and file-based** — there's
-nothing to re-SaaS without rebuilding the entire (closed) team backend. So we keep
-the core permissive Apache-2.0, like dbt Core and the LlamaIndex library.
+The one thing the license has to prevent is someone taking the free core and
+re-hosting **agami's own functionality as a managed service to other people** —
+the BSL/SSPL/n8n concern. A permissive license (Apache/MIT) wouldn't stop that;
+a fully closed license would kill the adoption the core is for. **Fair-code is the
+middle path:** the core stays source-available and **free for your own internal
+use** — a developer, a team, your whole org, multi-user, all free — while exposing
+it to outside customers is the paid commercial line. It's the model n8n and the
+Elastic family use, and it's why the boundary above can be a clean, friendly line
+rather than a trap. The reasons are spelled out in [LICENSING.md](../LICENSING.md).
 
 ## The upgrade path is a backend swap
 
 Because the local MCP server and the hosted connector expose the **same tool
 surface**, moving a team from local to hosted means pointing at a different
 backend — not learning a new product. You self-host the flat, commoditized part
-for free; you pay for the part that compounds (evals, the golden-set network
-effect, governance) the day it's worth more than running it yourself.
+for your own team for free; you pay for the part that compounds (evals, the
+golden-set network effect, governance) — and for serving people outside your
+organization — the day it's worth more than running it yourself.


### PR DESCRIPTION
**Spec:** OCR-018 · Requirement: REQ-015

## Summary
Now that the license is the fair-code FUL (OCR-017, merged), this sweeps every "open source /
Apache-2.0" claim about agami to **fair-code**, so the positioning matches the license. This is
the last F12 slice; it resolves the temporary state where `main`'s README said "Apache / open
core" while `LICENSE` was already the FUL.

## Changes
- **README** — license badge → fair-code; "open-source core" → "fair-code core"; "Open source vs
  hosted" heading + prose → "Fair-code vs hosted" (free-to-self-host / external-paid); License
  section → fair-code (the FUL).
- **`.claude-plugin/marketplace.json`** — `"open-source"` tag → `"fair-code"`.
- **`docs/open-vs-hosted.md`** — **full reframe**: dropped "fully open (Apache-2.0) and always
  will be", the "why we won't relicense", and the "permissive like dbt Core / LlamaIndex"
  comparison; replaced with the fair-code rationale (internal free / external paid; n8n/Elastic
  precedent). Also softened a "won't move the line" reassurance that's no longer license-backed
  under the versioned FUL.
- **`CHANGELOG.md`** — relicense entry under 0.3.0.

## Verification
- `git grep -niE 'apache|\bmit\b|open source|open-source'` → only intended hits remain (the
  CHANGELOG relicense entry, the "Indie Open Source CLA" proper noun, the "why not permissive"
  explanation, and file-permission uses of "permissive").
- marketplace.json valid JSON; badge escaping correct; all relative links resolve.
- Self-reviewed via `/code-review` (1 finding — the over-promise above — fixed).

## Notes
- Docs/config only; no code, no version bump needed (the metadata `license` field is already
  `LicenseRef-Agami-FUL` from OCR-017).
- A matching `design.md` tidy was made in the private agami-sdlc repo (internal doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
