### PR TITLE
build(tooling): pyproject.toml — ruff + pytest config (Spec: OCR-022)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ blog/
 
 # curate op-log written when editing the committed sample model in place — never commit
 plugins/agami/samples/store/model/curation_log.jsonl
+
+# Python tooling artifacts
+.coverage
+htmlcov/
+.pytest_cache/
+.ruff_cache/

--- a/plugins/agami/samples/store/build_sample.py
+++ b/plugins/agami/samples/store/build_sample.py
@@ -20,7 +20,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import os
 import shutil
 import sqlite3
 import subprocess

--- a/plugins/agami/scripts/build_duckdb_attach.py
+++ b/plugins/agami/scripts/build_duckdb_attach.py
@@ -26,8 +26,7 @@ Usage:
     python3 build_duckdb_attach.py --profiles itsm finance
     # Writes <artifacts_dir>/local/.duckdb_init_<ts>_<rand>.sql, prints the path on stdout.
 
-The script depends on configparser (stdlib) and reuses `_parse_dsn` /
-`_load_section` from setup_pgauth.py.
+The script reuses `_atomic_write` / `_load_section` from setup_pgauth.py.
 
 Exit codes:
     0  success (init file path printed to stdout)

--- a/plugins/agami/scripts/build_duckdb_attach.py
+++ b/plugins/agami/scripts/build_duckdb_attach.py
@@ -41,13 +41,12 @@ import argparse
 import os
 import secrets
 import sys
-import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
-from setup_pgauth import _atomic_write, _load_section, _resolve_default_profile  # noqa: E402
 import agami_paths  # noqa: E402
+from setup_pgauth import _atomic_write, _load_section  # noqa: E402
 
 AGAMI_HOME = agami_paths.local_dir()
 

--- a/plugins/agami/scripts/reconcile.py
+++ b/plugins/agami/scripts/reconcile.py
@@ -30,7 +30,6 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 # --- Number parsing -------------------------------------------------------
 
 # Currency symbols and their codes that we strip from the front of a number.

--- a/plugins/agami/scripts/render_chart.py
+++ b/plugins/agami/scripts/render_chart.py
@@ -53,7 +53,6 @@ import os
 import sys
 from pathlib import Path
 
-
 VALID_TYPES = {"bar", "line", "pie", "doughnut", "scatter"}
 
 SHARED_DIR = Path(__file__).resolve().parent.parent / "shared"

--- a/plugins/agami/scripts/render_examples_validation.py
+++ b/plugins/agami/scripts/render_examples_validation.py
@@ -27,7 +27,6 @@ import os
 import sys
 from pathlib import Path
 
-
 SHARED_DIR = Path(__file__).resolve().parent.parent / "shared"
 TEMPLATE_PATH = SHARED_DIR / "examples-validation-template.html"
 LOGO_DARK_PATH = SHARED_DIR / "agami-logo-dark.svg"

--- a/plugins/agami/scripts/render_model_explorer.py
+++ b/plugins/agami/scripts/render_model_explorer.py
@@ -32,12 +32,8 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any
 
 import _interp  # noqa: F401 — re-exec under agami's configured interpreter if PyYAML is missing
-
-import yaml
-
 
 SHARED_DIR = Path(__file__).resolve().parent.parent / "shared"
 TEMPLATE_PATH = SHARED_DIR / "model-explorer-template.html"
@@ -72,8 +68,9 @@ def build_manifest(profile_dir: Path, profile: str) -> dict:
 
     org_md_path = profile_dir / "ORGANIZATION.md"
     organization_md = org_md_path.read_text(encoding="utf-8") if org_md_path.exists() else ""
-    from semantic_model import org_draft as _OD
     import re as _re
+
+    from semantic_model import org_draft as _OD
     # `organization_md` is the human's narrative ONLY — this is what the edit box writes back,
     # so model facts must never be folded in here (or saving would persist them). If blank,
     # offer the starter prompt. The model-derived summary (subject areas, conventions, decoded

--- a/plugins/agami/scripts/semantic_model/build.py
+++ b/plugins/agami/scripts/semantic_model/build.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 import yaml
 
 from .models import (
+    DEEP_TABLE_COLUMN_THRESHOLD,
     Column,
     CrossSubjectAreaRelationship,
     Organization,
@@ -27,7 +28,6 @@ from .models import (
     TableRef,
     bare_name,
 )
-from .models import DEEP_TABLE_COLUMN_THRESHOLD
 
 # Strongly-PII column-name patterns — sensitive regardless of table.
 STRONG_PII_RE = re.compile(

--- a/plugins/agami/scripts/semantic_model/cli.py
+++ b/plugins/agami/scripts/semantic_model/cli.py
@@ -468,6 +468,7 @@ def cmd_format_table(args) -> int:
     grouping + currency symbols, never abbreviated. The skill (and later the MCP) emits
     this verbatim so verification numbers don't depend on the LLM's formatting."""
     import csv as _csv
+
     from . import units
     text = Path(args.csv_file).read_text() if args.csv_file else sys.stdin.read()
     reader = list(_csv.reader(io.StringIO(text)))
@@ -590,9 +591,10 @@ def cmd_seed_validate(args) -> int:
     so the fan/chasm pre-flight + default_filters always apply — a raw driver could skip
     that and let a fan-out scan the whole table. A refused/errored seed is surfaced with
     its `error`, not faked. Replaces ad-hoc 'run all the seeds' scripts."""
+    import csv as _csv
     import os
     import subprocess
-    import csv as _csv
+
     from . import units
 
     seeds = L.list_prompt_examples(args.root, args.area)

--- a/plugins/agami/scripts/semantic_model/curate.py
+++ b/plugins/agami/scripts/semantic_model/curate.py
@@ -31,9 +31,9 @@ from typing import Any, Optional
 import yaml
 
 from . import validator as V
-from .loader import load_organization, _read_yaml as _load
+from .loader import _read_yaml as _load
+from .loader import load_organization
 from .models import CrossSubjectAreaRelationship, Entity, Metric, Organization, Relationship
-
 
 # ---------------------------------------------------------------------------
 # Read views

--- a/plugins/agami/scripts/semantic_model/dialects.py
+++ b/plugins/agami/scripts/semantic_model/dialects.py
@@ -32,11 +32,9 @@ NOT live-verified — treat them as such until exercised against a real instance
 
 from __future__ import annotations
 
-import re
 from typing import Callable, Optional
 
 from .models import ColumnType, StorageType
-
 
 # ---------------------------------------------------------------------------
 # Shared native-type → ColumnType normalizer

--- a/plugins/agami/scripts/semantic_model/introspect.py
+++ b/plugins/agami/scripts/semantic_model/introspect.py
@@ -31,7 +31,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 # Introspection-run timestamp for system sign-offs on auto-approved structure.
 _NOW = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -58,7 +58,6 @@ from . import build
 from . import dialects as D
 from .models import (
     Column,
-    ForeignKey,
     Organization,
     PerformanceHints,
     Relationship,

--- a/plugins/agami/scripts/semantic_model/loader.py
+++ b/plugins/agami/scripts/semantic_model/loader.py
@@ -34,7 +34,6 @@ Nothing here imports Pydantic-free; the whole module is v2-only.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -53,7 +52,6 @@ from .models import (
     TableRef,
     bare_name,
 )
-
 
 # The default `include` set for get_table_context / `sm context`. performance_hints
 # is in it so estimated_row_count reaches the answer receipt (the "≈N rows"

--- a/plugins/agami/scripts/semantic_model/models.py
+++ b/plugins/agami/scripts/semantic_model/models.py
@@ -35,7 +35,7 @@ validator gives via `additionalProperties: false`.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Any, Literal, Optional
 
 from pydantic import (
     BaseModel,

--- a/plugins/agami/scripts/semantic_model/runtime.py
+++ b/plugins/agami/scripts/semantic_model/runtime.py
@@ -49,7 +49,8 @@ from .models import (
     Metric,
     Organization,
     Relationship,
-    SubjectArea,
+)
+from .models import (
     bare_name as _bare,
 )
 

--- a/plugins/agami/scripts/semantic_model/validator.py
+++ b/plugins/agami/scripts/semantic_model/validator.py
@@ -38,7 +38,7 @@ list[str] contract while adding structured findings for the review dashboard.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable, Optional
+from typing import Optional
 
 try:
     import sqlglot
@@ -49,14 +49,12 @@ except ImportError:  # pragma: no cover - sqlglot is in requirements
     _HAVE_SQLGLOT = False
 
 from .models import (
-    Column,
     CrossSubjectAreaRelationship,
     Entity,
     Organization,
     Relationship,
     SubjectArea,
     Table,
-    TableRef,
     bare_name,
 )
 

--- a/plugins/agami/scripts/setup_pgauth.py
+++ b/plugins/agami/scripts/setup_pgauth.py
@@ -50,8 +50,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
-from execute_sql import _parse_dsn  # reuse DSN parsing logic  # noqa: E402
 import agami_paths  # noqa: E402
+from execute_sql import _parse_dsn  # reuse DSN parsing logic  # noqa: E402
 
 # NOTE: never bootstrap() at import — this module is imported by build_duckdb_attach and
 # tests. The one-shot legacy migration runs only from main() (and the other entry points).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+# Tooling-only configuration for agami-core.
+#
+# This repo is a Claude Code *plugin* (skills + scripts), not a installable Python
+# package — so there is intentionally NO [build-system] table. This file is the single
+# source of truth for ruff + pytest config; CI (.github/workflows/ci.yml) reads it so
+# the same rules run locally and in the gate, with nothing duplicated.
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+src = ["plugins", "tests"]
+
+[tool.ruff.lint]
+# Calibrated starting set — green day one, ratchet up later (REQ-017). E4/E7/E9 + F are
+# ruff's defaults (real correctness bugs: undefined names, unused imports, bad syntax);
+# I sorts imports. Line-length (E501) and naming (N) are deliberately left out for now —
+# the existing tree has ~1900 long lines; enforce those in a later, dedicated pass.
+select = ["E4", "E7", "E9", "F", "I"]
+# Intentional patterns in existing scripts/tests, left for a later cleanup pass rather than
+# forcing rewrites now: E402 (sys.path tweak before imports), E702 (one-line statements),
+# E731 (lambda in a test helper), E741 ("l" loop var in a test), F841 (a documented unused var).
+ignore = ["E402", "E702", "E731", "E741", "F841"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Coverage is measured but not yet enforced. Add --cov-fail-under=<baseline> in a later
+# pass once the number is known, so the first CI run is green (REQ-017 calibration).
+addopts = "--cov=plugins --cov-report=term-missing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,6 @@ ignore = ["E402", "E702", "E731", "E741", "F841"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-# Coverage is measured but not yet enforced. Add --cov-fail-under=<baseline> in a later
-# pass once the number is known, so the first CI run is green (REQ-017 calibration).
-addopts = "--cov=plugins --cov-report=term-missing"
+# No --cov in addopts on purpose: a bare `pytest` then works without pytest-cov installed
+# (IDE runners, quick local runs). The CI gate and `dev.py cover` pass --cov explicitly;
+# a --cov-fail-under floor will be added once the baseline is locked (REQ-017 calibration).

--- a/tests/test_aggregation_class.py
+++ b/tests/test_aggregation_class.py
@@ -18,13 +18,14 @@ pytest.importorskip("sqlglot")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
-from catalog_helpers import col as _col, make_catalog_runner  # noqa: E402
 from semantic_model import build  # noqa: E402
 from semantic_model import curate as C  # noqa: E402
 from semantic_model import introspect as I  # noqa: E402
 from semantic_model import models as m  # noqa: E402
 from semantic_model import validator as V  # noqa: E402
 
+from catalog_helpers import col as _col  # noqa: E402
+from catalog_helpers import make_catalog_runner
 
 # --- classify_aggregation heuristic ----------------------------------------
 

--- a/tests/test_build_duckdb_attach.py
+++ b/tests/test_build_duckdb_attach.py
@@ -14,7 +14,6 @@ mysql_scanner. The init file must:
 
 from __future__ import annotations
 
-import io
 import stat
 import sys
 from pathlib import Path
@@ -35,6 +34,7 @@ def tmp_agami_home(tmp_path, monkeypatch):
 
     # Re-import so all module-level paths re-resolve to <art>/local.
     import importlib
+
     import setup_pgauth
     importlib.reload(setup_pgauth)
     import build_duckdb_attach

--- a/tests/test_choice_field_decode.py
+++ b/tests/test_choice_field_decode.py
@@ -18,11 +18,11 @@ pytest.importorskip("sqlglot")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
-from catalog_helpers import col, make_catalog_runner  # noqa: E402
 from semantic_model import curate as C  # noqa: E402
 from semantic_model import introspect as I  # noqa: E402
-from semantic_model import models as m  # noqa: E402
 from semantic_model import validator as V  # noqa: E402
+
+from catalog_helpers import col, make_catalog_runner  # noqa: E402
 
 
 # the sample query (SELECT ... LIMIT) → low-cardinality severity, varied free text

--- a/tests/test_connect_resolve.py
+++ b/tests/test_connect_resolve.py
@@ -25,8 +25,8 @@ def _run(monkeypatch, art: Path, **env) -> dict:
         monkeypatch.delenv(k, raising=False)
     for k, v in env.items():
         monkeypatch.setenv(k, v)
-    import io
     import contextlib
+    import io
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         CR.main([])

--- a/tests/test_connect_scripts.py
+++ b/tests/test_connect_scripts.py
@@ -13,8 +13,6 @@ import sys
 import types
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 sys.path.insert(0, str(REPO_ROOT / "tests"))
@@ -58,8 +56,8 @@ def test_prune_malformed_line_is_anomaly_not_dropped():
 def test_prune_kept_everything_flag(tmp_path):
     out = tmp_path / "k.txt"
     block = "keep tables: 2 of 2\na.x\na.y\ndone\n"
-    import io
     import contextlib
+    import io
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         P.main(["--block-file", _write(tmp_path / "b.txt", block), "--tables-out", str(out)])
@@ -67,9 +65,10 @@ def test_prune_kept_everything_flag(tmp_path):
 
 
 def test_curate_gate_counts_pii(tmp_path, capsys):
-    from catalog_helpers import col, make_catalog_runner
     from semantic_model import cli
     from semantic_model import introspect as I
+
+    from catalog_helpers import col, make_catalog_runner
     runner = make_catalog_runner(
         tables=["customers"],
         columns={"customers": [col("id", "integer", nullable=False), col("email", "varchar")]}, fks=[])

--- a/tests/test_discover_prune.py
+++ b/tests/test_discover_prune.py
@@ -19,9 +19,8 @@ pytest.importorskip("sqlglot")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
-from semantic_model import introspect as I  # noqa: E402
 import render_prune  # noqa: E402
-
+from semantic_model import introspect as I  # noqa: E402
 
 # --- canned runners ---------------------------------------------------------
 

--- a/tests/test_dsn_parsing.py
+++ b/tests/test_dsn_parsing.py
@@ -21,7 +21,6 @@ sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
 from execute_sql import _parse_dsn  # noqa: E402
 
-
 # --- Postgres family -------------------------------------------------------
 
 def test_plain_postgresql_scheme():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -331,7 +331,8 @@ def test_mcp_receipt_equals_shared_assembler(monkeypatch, tmp_path):
     pytest.importorskip("pydantic"); pytest.importorskip("sqlglot")
     art, profile, root = _write_rich_model(tmp_path)
     monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
-    from semantic_model import loader as L, runtime as RT
+    from semantic_model import loader as L
+    from semantic_model import runtime as RT
     shared = RT.assemble_receipt(L.load_organization(root), SQL)
     mcp = _resolve_receipt(profile, SQL)
     for key in ("tables_used", "relationships", "metrics", "assumptions", "warnings"):

--- a/tests/test_metadata_sources.py
+++ b/tests/test_metadata_sources.py
@@ -22,7 +22,6 @@ sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 from semantic_model import curate, loader  # noqa: E402
 from semantic_model import metadata_sources as M  # noqa: E402
 
-
 # --- canned ServiceNow-shaped source rows -----------------------------------
 
 SYS_CHOICE = [
@@ -164,7 +163,8 @@ def test_generated_ops_apply_and_stamp_metadata(tmp_path):
 def test_inheritance_inherited_reference_applies_to_all_children():
     # THE fix: `assignment_group → sys_user_group` is declared ONCE (as on base `task`), but the
     # COLUMN exists on both children — so both incident AND problem must get the join.
-    from semantic_model import cli, models as mm
+    from semantic_model import cli
+    from semantic_model import models as mm
     decls = M.reference_declarations(
         [{"element": "assignment_group", "internal_type": "reference", "reference": "sys_user_group"}],
         column_col="element", type_col="internal_type", reference_col="reference")
@@ -187,7 +187,8 @@ def test_inheritance_inherited_reference_applies_to_all_children():
 
 
 def test_route_references_intra_cross_and_skips_unmodelled():
-    from semantic_model import cli, models as mm
+    from semantic_model import cli
+    from semantic_model import models as mm
 
     def tbl(name):
         return mm.Table(name=name, schema="public", storage_connection="c", grain=["id"],
@@ -328,7 +329,10 @@ def test_enrich_metadata_drops_unverified_preset_reference(tmp_path, monkeypatch
 def test_verified_references_unverified_when_table_too_big():
     # the #7 guard: a FROM table above the row threshold must NOT be overlap-scanned — the ref is
     # kept UNVERIFIED (inferred/unreviewed), not dropped, not probed.
-    from semantic_model import cli, introspect as INTRO, models as mm, dialects as D
+    from semantic_model import cli
+    from semantic_model import dialects as D
+    from semantic_model import introspect as INTRO
+    from semantic_model import models as mm
     big = mm.PerformanceHints(estimated_row_count=INTRO._OVERLAP_PROBE_MAX_ROWS + 1)
 
     def tbl(name, cols, perf=None):

--- a/tests/test_model_snapshots.py
+++ b/tests/test_model_snapshots.py
@@ -21,9 +21,10 @@ pytest.importorskip("sqlglot")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
-from catalog_helpers import col, make_catalog_runner  # noqa: E402
 from semantic_model import introspect as I  # noqa: E402
 from semantic_model import snapshot as S  # noqa: E402
+
+from catalog_helpers import col, make_catalog_runner  # noqa: E402
 
 
 def _mini_model(root: Path) -> None:

--- a/tests/test_org_draft.py
+++ b/tests/test_org_draft.py
@@ -45,8 +45,8 @@ def _model(root):
 
 
 def test_derived_context_is_pure_summary(tmp_path):
-    from semantic_model.loader import load_organization
     from semantic_model import org_draft
+    from semantic_model.loader import load_organization
     _model(tmp_path)
     d = org_draft.derived_context(load_organization(tmp_path))
     # SUMMARY shape: counts + subject areas + conventions + glossary — NOT a model dump
@@ -62,8 +62,8 @@ def test_derived_context_is_pure_summary(tmp_path):
 def test_derived_context_can_exclude_curated_glossary(tmp_path):
     # the explorer renders the curated glossary as an EDITABLE panel, so it asks derived_context
     # to omit those terms — but the derived ENUM legends (from choice_field) still show read-only.
+    from semantic_model import curate, org_draft
     from semantic_model.loader import load_organization
-    from semantic_model import org_draft, curate
     _model(tmp_path)
     p = tmp_path / "subject_areas" / "s" / "tables" / "orders.yaml"
     d = yaml.safe_load(p.read_text())
@@ -89,8 +89,8 @@ def test_explorer_exposes_glossary_as_editable_field(tmp_path):
 
 
 def test_compose_keeps_human_narrative_and_derived_facts_separate(tmp_path):
-    from semantic_model.loader import load_organization
     from semantic_model import org_draft
+    from semantic_model.loader import load_organization
     _model(tmp_path)
     human = "# About this database\n\nWe are a lending startup. MRR = monthly recurring revenue.\n"
     md = org_draft.compose_context(human, load_organization(tmp_path))
@@ -106,8 +106,8 @@ def test_compose_keeps_human_narrative_and_derived_facts_separate(tmp_path):
 def test_key_terminology_seeded_from_glossary_and_enums(tmp_path):
     # the section is no longer a bare prompt: curated glossary terms + auto-derived enum
     # legends from choice_field columns both render.
+    from semantic_model import curate, org_draft
     from semantic_model.loader import load_organization
-    from semantic_model import org_draft, curate
     _model(tmp_path)
     p = tmp_path / "subject_areas" / "s" / "tables" / "orders.yaml"
     doc = yaml.safe_load(p.read_text())
@@ -124,8 +124,8 @@ def test_key_terminology_seeded_from_glossary_and_enums(tmp_path):
 
 
 def test_set_key_terminology_merges_then_replaces(tmp_path):
-    from semantic_model.loader import load_organization
     from semantic_model import curate
+    from semantic_model.loader import load_organization
     _model(tmp_path)
     assert curate.set_key_terminology(tmp_path, {"MRR": "monthly recurring revenue"}).validated
     curate.set_key_terminology(tmp_path, {"churn": "no order in 90 days"})             # merge (default)

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -20,7 +20,6 @@ sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
 from reconcile import diff, parse_csv, parse_value  # noqa: E402
 
-
 # --- parse_value ---------------------------------------------------------
 
 class TestParseValue:

--- a/tests/test_render_piping.py
+++ b/tests/test_render_piping.py
@@ -101,9 +101,10 @@ def test_main_multi_section_writes_array(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_receipt_from_sql(tmp_path, capsys):
-    from catalog_helpers import col, make_catalog_runner
     from semantic_model import cli
     from semantic_model import introspect as I
+
+    from catalog_helpers import col, make_catalog_runner
 
     runner = make_catalog_runner(
         tables=["customers", "orders"],

--- a/tests/test_semantic_model_cli.py
+++ b/tests/test_semantic_model_cli.py
@@ -500,6 +500,7 @@ def test_seed_validate_runs_through_safety_and_shapes_items(tmp_path, monkeypatc
     row_headers, row_preview, row_count, state}; (3) a failing seed surfaces its `error`
     instead of faking a result. The live-DB call is mocked so the test needs no DB."""
     import subprocess
+
     from semantic_model import curate
     _model(tmp_path)
     curate.add_examples(tmp_path, "s", [
@@ -549,7 +550,9 @@ def test_seed_validate_formats_numbers_with_model_units(tmp_path, monkeypatch):
     path uses — a column with a currency unit shows its symbol + grouping here too, not a
     bare number (the gap that made users re-type 'format as currency' on every example)."""
     import subprocess
-    from semantic_model import curate, runtime as RT
+
+    from semantic_model import curate
+    from semantic_model import runtime as RT
     _model(tmp_path)
     curate.add_examples(tmp_path, "s", [{"question": "total billed?", "sql": "SELECT SUM(total) AS total FROM orders"}])
 

--- a/tests/test_semantic_model_curate.py
+++ b/tests/test_semantic_model_curate.py
@@ -17,7 +17,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
 from semantic_model import curate, loader  # noqa: E402
-from semantic_model import models as m  # noqa: E402
 
 
 def _write_model(root: Path, *, git: bool = True) -> None:

--- a/tests/test_semantic_model_introspect.py
+++ b/tests/test_semantic_model_introspect.py
@@ -15,12 +15,12 @@ pytest.importorskip("sqlglot")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
-from catalog_helpers import col, make_catalog_runner  # noqa: E402
 from semantic_model import build  # noqa: E402
 from semantic_model import introspect as I  # noqa: E402
 from semantic_model import models as m  # noqa: E402
 from semantic_model import validator as V  # noqa: E402
 
+from catalog_helpers import col, make_catalog_runner  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Canned runners
@@ -325,7 +325,7 @@ def test_references_grouped_from_relationship_not_just_foreign_key():
     # The introspection pipeline records joins as Relationships, never on column.foreign_key,
     # so references must be classifiable from the relationship's FROM columns. caller_id has no
     # foreign_key set, but passing it as a reference column should file it under `references`.
-    cols = [m.Column(name=f"sys_id", type="string", primary_key=True)] + \
+    cols = [m.Column(name="sys_id", type="string", primary_key=True)] + \
            [m.Column(name="caller_id", type="string")] + \
            [m.Column(name=f"f_{i}", type="decimal") for i in range(35)]
     g_no = build.derive_column_groups(cols)

--- a/tests/test_semantic_model_models.py
+++ b/tests/test_semantic_model_models.py
@@ -17,8 +17,8 @@ pytest.importorskip("pydantic")
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
-from semantic_model import models as m  # noqa: E402
 from pydantic import ValidationError  # noqa: E402
+from semantic_model import models as m  # noqa: E402
 
 
 def _col(name, type="integer", **kw):

--- a/tests/test_setup_desktop_mcp.py
+++ b/tests/test_setup_desktop_mcp.py
@@ -22,7 +22,6 @@ sys.path.insert(0, str(SCRIPTS))
 
 import setup_desktop_mcp as sd  # noqa: E402
 
-
 # --- merge safety -----------------------------------------------------------
 
 def test_merge_preserves_other_keys_and_servers(tmp_path):

--- a/tests/test_setup_pgauth.py
+++ b/tests/test_setup_pgauth.py
@@ -16,8 +16,6 @@ These tests verify:
 
 from __future__ import annotations
 
-import io
-import os
 import stat
 import sys
 from pathlib import Path
@@ -39,6 +37,7 @@ def tmp_agami_home(tmp_path, monkeypatch):
 
     # Force re-import so AGAMI_HOME re-resolves to <art>/local
     import importlib
+
     import setup_pgauth
     importlib.reload(setup_pgauth)
     return setup_pgauth, local

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -66,7 +66,7 @@ def test_format_table_markdown_exact():
 
 def test_units_module_has_no_heavy_deps():
     # units.py must stay import-light so the pure-stdlib MCP path can use it
-    import importlib, sys as _sys
+    import sys as _sys
     assert "pydantic" not in _sys.modules or True  # informational
     src = (SCRIPTS / "semantic_model" / "units.py").read_text()
     assert "import pydantic" not in src and "import sqlglot" not in src
@@ -186,7 +186,7 @@ def test_format_table_applies_units_by_position():
 
 def test_unit_round_trips_on_column_and_surfaces_in_context(tmp_path):
     import yaml
-    from semantic_model.loader import load_organization, get_table_context
+    from semantic_model.loader import get_table_context, load_organization
     root = tmp_path
     (root / "datasources" / "c").mkdir(parents=True)
     (root / "subject_areas" / "s" / "tables").mkdir(parents=True)


### PR DESCRIPTION
**Spec:** OCR-022 · Requirement: REQ-019 · prerequisite for the CI gate (OCR-024).

## Summary
Adds a tooling-only `pyproject.toml` as the single source of ruff + pytest config (no `[build-system]` — this is a plugin repo). Calibrated so the CI gate is **green day one**, per REQ-017.

## Changes
- `pyproject.toml` — ruff lint set `E4/E7/E9/F/I` (correctness + import sorting); `ignore` a few intentional script/test patterns; pytest+cov config with **no `--cov-fail-under` yet** (baseline first). Line-length (~1900 hits) and naming deferred to a later ratchet.
- **ruff --fix** across the tree — removed unused imports + sorted imports (36 files, net −8 lines). Behavior-preserving: the test suite passes/fails identically to `main`.
- `.gitignore` — coverage/cache artifacts.

## Note for the reviewer
Bringing up the full suite (with `pydantic` as a test dep) surfaced **3 pre-existing test failures** on `main` (in `test_mcp_server` + `test_metric_binding_and_prune`) — not caused by this change. The CI PR (OCR-024) explicitly deselects them so the gate is green, and flags them for a fix. Worth a look.

Stacked: **OCR-024 (ci.yml) builds on this.**