### PR TITLE
ci: CI gate — ruff + pytest matrix + gitleaks (Spec: OCR-024)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: >-
           uvx --python ${{ matrix.python-version }}
           --with pytest --with pytest-cov --with pydantic --with pyyaml --with sqlglot
-          pytest tests/ -q
+          pytest tests/ -q --cov=plugins --cov-report=term-missing
 
   gitleaks:
     name: gitleaks (secret scan)
@@ -62,7 +62,8 @@ jobs:
           base="https://github.com/gitleaks/gitleaks/releases/download/v${V}"
           curl -sSfL -O "${base}/gitleaks_${V}_linux_x64.tar.gz"
           curl -sSfL -O "${base}/gitleaks_${V}_checksums.txt"
-          # Verify the download before extracting/running it (third-party binary).
-          sha256sum --check --ignore-missing "gitleaks_${V}_checksums.txt"
+          # Verify the download: pull the exact checksum line for our artifact and check it,
+          # failing if that line is absent (so a renamed/missing entry can't skip verification).
+          grep "gitleaks_${V}_linux_x64.tar.gz$" "gitleaks_${V}_checksums.txt" | sha256sum -c -
           tar -xzf "gitleaks_${V}_linux_x64.tar.gz" gitleaks
           ./gitleaks detect --source . --redact --no-banner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+# The unbypassable quality + secret gate on every PR (local hooks can be skipped;
+# CI can't). Config lives in pyproject.toml (OCR-022) so nothing is duplicated here.
+# Branch protection (OCR-025) is what makes these checks *required* to merge.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    name: lint + test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Lint + import sorting — blocking. Rules come from pyproject.toml.
+      - name: ruff check
+        run: uvx ruff@0.15.19 check plugins tests
+
+      # Format check is informational for now: the tree has a large unformatted
+      # backlog (~74 files). Flip `continue-on-error` off after a dedicated
+      # `ruff format` pass makes the tree clean.
+      - name: ruff format --check (informational)
+        run: uvx ruff@0.15.19 format --check plugins tests
+        continue-on-error: true
+
+      # pydantic/pyyaml are needed to import the semantic-model code; DB drivers are
+      # intentionally omitted (those tests skip without a database). The three
+      # --deselect'd tests are PRE-EXISTING failures on main (not introduced here),
+      # tracked for a fix — deselecting keeps the gate green and honest, not hidden.
+      - name: pytest --cov
+        run: >-
+          uvx --python ${{ matrix.python-version }}
+          --with pytest --with pytest-cov --with pydantic --with pyyaml
+          pytest tests/ -q
+          --deselect tests/test_mcp_server.py::test_resolve_units_maps_result_columns
+          --deselect tests/test_metric_binding_and_prune.py::test_binding_column_check_flags_unknown_column
+          --deselect tests/test_metric_binding_and_prune.py::test_binding_column_check_catches_excluded_column_metric
+
+  gitleaks:
+    name: gitleaks (secret scan)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # full history, so a secret in any commit is caught
+      # Run the gitleaks binary directly: the gitleaks-action requires a paid
+      # license for organization repos; the CLI does not. Pinned to a release.
+      - name: gitleaks detect
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar -xz gitleaks
+          ./gitleaks detect --source . --redact --no-banner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,15 @@ jobs:
         run: uvx ruff@0.15.19 format --check plugins tests
         continue-on-error: true
 
-      # pydantic/pyyaml are needed to import the semantic-model code; DB drivers are
-      # intentionally omitted (those tests skip without a database). The three
-      # --deselect'd tests are PRE-EXISTING failures on main (not introduced here),
-      # tracked for a fix — deselecting keeps the gate green and honest, not hidden.
+      # pydantic/pyyaml/sqlglot are the import deps the suite needs — sqlglot backs the
+      # binding-validation and unit-resolution code paths (without it ~287 tests skip and
+      # a few assert empty results). DB drivers are intentionally omitted: those tests skip
+      # cleanly without a database.
       - name: pytest --cov
         run: >-
           uvx --python ${{ matrix.python-version }}
-          --with pytest --with pytest-cov --with pydantic --with pyyaml
+          --with pytest --with pytest-cov --with pydantic --with pyyaml --with sqlglot
           pytest tests/ -q
-          --deselect tests/test_mcp_server.py::test_resolve_units_maps_result_columns
-          --deselect tests/test_metric_binding_and_prune.py::test_binding_column_check_flags_unknown_column
-          --deselect tests/test_metric_binding_and_prune.py::test_binding_column_check_catches_excluded_column_metric
 
   gitleaks:
     name: gitleaks (secret scan)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,11 @@ jobs:
       # license for organization repos; the CLI does not. Pinned to a release.
       - name: gitleaks detect
         run: |
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar -xz gitleaks
+          V=8.30.1
+          base="https://github.com/gitleaks/gitleaks/releases/download/v${V}"
+          curl -sSfL -O "${base}/gitleaks_${V}_linux_x64.tar.gz"
+          curl -sSfL -O "${base}/gitleaks_${V}_checksums.txt"
+          # Verify the download before extracting/running it (third-party binary).
+          sha256sum --check --ignore-missing "gitleaks_${V}_checksums.txt"
+          tar -xzf "gitleaks_${V}_linux_x64.tar.gz" gitleaks
           ./gitleaks detect --source . --redact --no-banner


### PR DESCRIPTION
**Spec:** OCR-024 · Requirement: REQ-017 · **stacked on #28 (OCR-022)** — base auto-retargets to main when #28 merges.

## Summary
Adds `.github/workflows/ci.yml` — the unbypassable gate on every PR: ruff lint, ruff format-check, pytest matrix (3.10–3.12), and a full-history gitleaks scan. OCR-025 makes these *required* to merge.

## Notes
- **Green day-one, verified locally:** ruff check passes; pytest passes with `pydantic`/`pyyaml`; gitleaks = 262 commits, **no leaks**.
- **gitleaks via pinned binary**, not the action (the action needs a paid license for org repos; the CLI doesn't).
- **Actions pinned to SHAs** (security-sensitive workflow — OCR-025 CODEOWNERS will guard it).
- **`ruff format --check` is informational** (`continue-on-error`) — the tree has ~74 unformatted files; flip it to blocking after a dedicated format pass.
- **3 pre-existing failing tests are `--deselect`'d** (in `test_mcp_server` + `test_metric_binding_and_prune`) and tracked for a fix — see #28's note. Not introduced here.

## ⚠️ Not blocking yet
This only *runs* the checks. They don't block merges until **OCR-025** adds them to branch protection.