### PR TITLE
ci: CODEOWNERS + full-strict branch protection (Spec: OCR-025)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# Code owners for agami-core (OCR-025).
+#
+# With branch protection's "require review from Code Owners" on, a PR touching any
+# path below needs approval from one of the listed maintainers. The point is that the
+# gate can't be weakened (CI workflow, branch-governance config, license/CLA) without a
+# maintainer signing off — and that every PR gets at least one maintainer review.
+
+# Default: every change requests a maintainer review.
+*                       @ashwin-agami @sandeep-agami
+
+# The gate itself — must not be changed without maintainer approval.
+/.github/               @ashwin-agami @sandeep-agami
+/.github/workflows/     @ashwin-agami @sandeep-agami
+/.github/CODEOWNERS     @ashwin-agami @sandeep-agami
+/pyproject.toml         @ashwin-agami @sandeep-agami
+
+# Legal / licensing surface.
+/LICENSE                @ashwin-agami @sandeep-agami
+/NOTICE                 @ashwin-agami @sandeep-agami
+/LICENSING.md           @ashwin-agami @sandeep-agami
+/CLA.md                 @ashwin-agami @sandeep-agami


### PR DESCRIPTION
**Spec:** OCR-025 · Requirement: REQ-017 · depends on OCR-024 (#29).

## Summary
Makes the CI gate **actually block** + guards it from being weakened. Two parts:
- **`.github/CODEOWNERS`** (this PR) — maintainer review required on every PR, and specifically on the CI workflow / pyproject / license files.
- **Branch-protection settings** (applied via API as the LAST step — see below).

## Branch-protection settings to apply (after #29's ci.yml is on `main`)
Full strict, per the spec — applied last so it doesn't lock up the 022/024/025 rollout:
- **Require status checks:** `lint + test (py3.10)`, `lint + test (py3.11)`, `lint + test (py3.12)`, `gitleaks (secret scan)`, `cla-assistant`
- **Require ≥1 approving review** + **require Code Owner review**
- **Enforce on admins / no bypass** (`enforce_admins: true`) — no direct pushes to `main`, for everyone
- **No force-pushes / no deletions**
- **GitHub Advanced Security:** secret scanning + **push protection** on; outside-contributor workflow runs require approval

## ⚠️ This changes the workflow
Once applied, **every PR needs a second maintainer's approval** (you can't solo-merge) and admins can't bypass — that's the full-strict choice. I will **not** apply these until you've merged #28 → #29 (so the CI check contexts exist), then I (or you) run the one API call. I'll hand you the exact `gh api` command / run it on your go.
