### PR TITLE
ci: local pre-commit hooks + dev docs (Spec: OCR-023)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,6 @@ plugins/agami/samples/store/model/curation_log.jsonl
 
 # Python tooling artifacts
 .coverage
+coverage.xml
 htmlcov/
-.pytest_cache/
 .ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,6 @@ repos:
         name: pytest (full suite)
         entry: uvx --with pytest-cov --with pydantic --with pyyaml --with sqlglot pytest tests/ -q
         language: system
-        types: [python]
+        always_run: true
         pass_filenames: false
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+# Local pre-commit hooks — fast feedback BEFORE code leaves your machine.
+#
+# These are a convenience, not the gate: they're bypassable (`git commit --no-verify`),
+# and the real, unbypassable check is CI (.github/workflows/ci.yml), which re-runs the
+# same tools. ruff config comes from pyproject.toml — nothing is duplicated here.
+#
+# Install once (both stages):
+#   uvx pre-commit install --hook-type pre-commit --hook-type pre-push
+# Run everything by hand anytime:
+#   uvx pre-commit run --all-files          # ruff + gitleaks on the whole tree
+#   uvx pre-commit run --hook-stage pre-push --all-files   # + the test suite
+
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  # ruff — lint + format, on the files you're committing. Rules live in pyproject.toml.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.19
+    hooks:
+      - id: ruff           # lint (E4/E7/E9/F/I)
+      - id: ruff-format    # auto-format the staged files
+
+  # gitleaks — credential-shaped secret scan (pattern-based, NO denylist). Catches a
+  # pasted key/connection string before it's ever committed.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  # Test suite — runs at PRE-PUSH (not on every commit) so commits stay fast but nothing
+  # red leaves your machine. Same deps + command CI uses.
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest (full suite)
+        entry: uvx --with pytest-cov --with pydantic --with pyyaml --with sqlglot pytest tests/ -q
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ When opening a PR that warrants a version bump, the checklist is:
 2. `plugins/agami/.claude-plugin/plugin.json` — bump `version`.
 3. Add a note to the PR description summarizing the user-visible change and which version it lands in.
 
-We don't keep a `CHANGELOG.md` yet. The git log + version bumps are the changelog.
+Record notable user-visible changes in [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format) under the version that ships them.
 
 ## A community Discord will land soon
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,18 @@ The same gate runs in CI on every PR — **ruff** (lint + format), the **test su
 **Prerequisite — install `uv` (the only thing you need globally):**
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh      # macOS / Linux
-# or: brew install uv   ·   docs: https://docs.astral.sh/uv/getting-started/installation/
+# macOS / Linux:
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# Windows (PowerShell):
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+# any platform, if you prefer a package manager:
+#   brew install uv   ·   winget install astral-sh.uv   ·   pipx install uv
+# docs: https://docs.astral.sh/uv/getting-started/installation/
 ```
 
 Every command below is `uvx …`, which uses [`uv`](https://docs.astral.sh/uv/) to fetch ruff /
-pre-commit / pytest **on demand** — so there's nothing else to install globally. Then wire the
-hooks once:
+pre-commit / pytest **on demand** — these all run the same on macOS, Linux, and Windows, so there's
+nothing else to install globally. Then wire the hooks once:
 
 ```bash
 uvx pre-commit install --hook-type pre-commit --hook-type pre-push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,22 +35,21 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 # docs: https://docs.astral.sh/uv/getting-started/installation/
 ```
 
-Every command below is `uvx …`, which uses [`uv`](https://docs.astral.sh/uv/) to fetch ruff /
-pre-commit / pytest **on demand** — these all run the same on macOS, Linux, and Windows, so there's
-nothing else to install globally. Then wire the hooks once:
+Everything else rides on `uv` — there's nothing else to install globally. From the repo root, a
+tiny cross-platform task runner (`dev.py`) wraps it all:
 
 ```bash
-uvx pre-commit install --hook-type pre-commit --hook-type pre-push
+uv run dev.py setup     # once: wire the pre-commit hooks (ruff + gitleaks on commit, tests on push)
+uv run dev.py check     # the whole gate locally — ruff + tests + gitleaks (same as CI)
+uv run dev.py cover     # did the lines I changed get tested? (patch coverage)
 ```
 
-Now `ruff` + `gitleaks` run automatically on every **commit**, and the test suite runs on every
-**push**. (Hooks are a convenience and bypassable with `git commit --no-verify`; CI is the real,
-unbypassable gate.) To run them by hand anytime:
+`dev.py` shells out to `uvx` (which fetches ruff / pre-commit / pytest on demand), so it runs the
+same on macOS, Linux, and Windows. Other tasks: `test`, `lint`, `fmt`. After `setup`, the hooks run
+automatically — `ruff` + `gitleaks` on every **commit**, the test suite on every **push**. They're a
+convenience (bypassable with `git commit --no-verify`); **CI is the real, unbypassable gate.**
 
-```bash
-uvx pre-commit run --all-files                        # ruff + gitleaks on the whole tree
-uvx pre-commit run --hook-stage pre-push --all-files  # + the full test suite
-```
+Prefer the raw tools? `dev.py` is only a wrapper — the equivalents are below.
 
 ### Tests on their own
 
@@ -66,8 +65,9 @@ network call — adding a network-egress primitive fails the build.
 
 ### Did I test the code I changed?
 
-Coverage of **the lines your PR touched** (fails on changed lines that no test exercises) — the
-quickest way to confirm a change is tested, regardless of overall coverage:
+`uv run dev.py cover` reports coverage of **the lines your PR touched** (fails on changed lines that
+no test exercises) — the quickest way to confirm a change is tested, regardless of overall coverage.
+Under the hood that's:
 
 ```bash
 uvx --with pytest-cov --with pydantic --with pyyaml --with sqlglot \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,18 @@ Maintainers and first-party (Agami AI) authors are allowlisted, so internal comm
 ## Running the checks locally
 
 The same gate runs in CI on every PR — **ruff** (lint + format), the **test suite**, and
-**gitleaks** (secret scan). To catch problems before you push, install the local hooks once:
+**gitleaks** (secret scan). To catch problems before you push, install the local hooks once.
+
+**Prerequisite — install `uv` (the only thing you need globally):**
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh      # macOS / Linux
+# or: brew install uv   ·   docs: https://docs.astral.sh/uv/getting-started/installation/
+```
+
+Every command below is `uvx …`, which uses [`uv`](https://docs.astral.sh/uv/) to fetch ruff /
+pre-commit / pytest **on demand** — so there's nothing else to install globally. Then wire the
+hooks once:
 
 ```bash
 uvx pre-commit install --hook-type pre-commit --hook-type pre-push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,17 +18,48 @@ The bot records your signature (stored in this repo) and flips the **CLA** statu
 
 Maintainers and first-party (Agami AI) authors are allowlisted, so internal commits aren't gated; the CLA is for contributions from outside the organization.
 
-## Running tests
+## Running the checks locally
 
-Privacy-invariant + unit tests (no DB required):
+The same gate runs in CI on every PR — **ruff** (lint + format), the **test suite**, and
+**gitleaks** (secret scan). To catch problems before you push, install the local hooks once:
 
 ```bash
-python3 -m pytest tests/ -q
+uvx pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
 
-The privacy test (`tests/test_privacy_no_network.py`) is a contract: no shipped script may make a network call — adding a network-egress primitive fails the build.
+Now `ruff` + `gitleaks` run automatically on every **commit**, and the test suite runs on every
+**push**. (Hooks are a convenience and bypassable with `git commit --no-verify`; CI is the real,
+unbypassable gate.) To run them by hand anytime:
 
-End-to-end integration tests (Postgres + MySQL fixtures):
+```bash
+uvx pre-commit run --all-files                        # ruff + gitleaks on the whole tree
+uvx pre-commit run --hook-stage pre-push --all-files  # + the full test suite
+```
+
+### Tests on their own
+
+The suite needs `pydantic`, `pyyaml`, and `sqlglot` to import the semantic-model code (DB-driver
+tests skip cleanly without a database). `uvx` pulls them in for the run:
+
+```bash
+uvx --with pytest-cov --with pydantic --with pyyaml --with sqlglot pytest tests/ -q
+```
+
+The privacy test (`tests/test_privacy_no_network.py`) is a contract: no shipped script may make a
+network call — adding a network-egress primitive fails the build.
+
+### Did I test the code I changed?
+
+Coverage of **the lines your PR touched** (fails on changed lines that no test exercises) — the
+quickest way to confirm a change is tested, regardless of overall coverage:
+
+```bash
+uvx --with pytest-cov --with pydantic --with pyyaml --with sqlglot \
+  pytest tests/ -q --cov=plugins --cov-report=xml
+uvx diff-cover coverage.xml --compare-branch=origin/main
+```
+
+### End-to-end integration tests (Postgres + MySQL fixtures)
 
 ```bash
 cd tests/integration

--- a/dev.py
+++ b/dev.py
@@ -14,7 +14,7 @@ Tasks:
   test    just the test suite
   lint    just ruff (lint + format check)
   fmt     apply ruff's auto-formatter to the tree
-  cover   patch coverage — did the lines this branch changed get tested?
+  cover   patch coverage — are the lines you changed covered by a test?
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ import sys
 RUFF = ["uvx", "ruff@0.15.19"]
 # The suite's import deps (DB drivers are omitted on purpose — those tests skip without a DB).
 TEST_DEPS = ["--with", "pytest-cov", "--with", "pydantic", "--with", "pyyaml", "--with", "sqlglot"]
-TARGETS = ["plugins", "tests"]
+TARGETS = ["plugins", "tests", "dev.py"]
 
 
 def run(cmd: list[str], *, allow_fail: bool = False) -> int:
@@ -76,7 +76,9 @@ def cover() -> int:
 
 def setup() -> int:
     """Install the local pre-commit hooks (convenience; CI is the real gate)."""
-    return run(["uvx", "pre-commit", "install", "--hook-type", "pre-commit", "--hook-type", "pre-push"])
+    return run(
+        ["uvx", "pre-commit", "install", "--hook-type", "pre-commit", "--hook-type", "pre-push"]
+    )
 
 
 TASKS = {"setup": setup, "check": check, "test": test, "lint": lint, "fmt": fmt, "cover": cover}

--- a/dev.py
+++ b/dev.py
@@ -68,6 +68,8 @@ def check() -> int:
 
 def cover() -> int:
     """Coverage of the lines THIS branch changed (fails on untested changed lines)."""
+    # Make sure origin/main exists locally (fresh clones / worktrees may not have it).
+    run(["git", "fetch", "--quiet", "origin", "main"], allow_fail=True)
     rc = run(["uvx", *TEST_DEPS, "pytest", "tests/", "-q", "--cov=plugins", "--cov-report=xml"])
     return rc or run(["uvx", "diff-cover", "coverage.xml", "--compare-branch=origin/main"])
 
@@ -97,4 +99,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    # Normalize to a clean 0/1 (a signal-killed child returns a negative code).
+    raise SystemExit(0 if main() == 0 else 1)

--- a/dev.py
+++ b/dev.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Cross-platform dev task runner for agami-core.
+
+Run a task with:  uv run dev.py <task>   (works the same on macOS, Linux, Windows).
+
+The ONLY prerequisite is `uv` (https://docs.astral.sh/uv/). Every task shells out to
+`uvx`, which fetches ruff / pre-commit / pytest on demand — so there is nothing else to
+install globally. These tasks mirror the CI gate (.github/workflows/ci.yml); CI is the
+unbypassable version that runs on every PR.
+
+Tasks:
+  setup   wire the local pre-commit hooks (ruff + gitleaks on commit; tests on push)
+  check   the full local gate: ruff lint + tests + gitleaks (what CI runs)
+  test    just the test suite
+  lint    just ruff (lint + format check)
+  fmt     apply ruff's auto-formatter to the tree
+  cover   patch coverage — did the lines this branch changed get tested?
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+
+RUFF = ["uvx", "ruff@0.15.19"]
+# The suite's import deps (DB drivers are omitted on purpose — those tests skip without a DB).
+TEST_DEPS = ["--with", "pytest-cov", "--with", "pydantic", "--with", "pyyaml", "--with", "sqlglot"]
+TARGETS = ["plugins", "tests"]
+
+
+def run(cmd: list[str], *, allow_fail: bool = False) -> int:
+    """Echo and run a command; return its exit code (0 == ok)."""
+    print(f"\n$ {' '.join(cmd)}")
+    code = subprocess.run(cmd).returncode
+    if code and not allow_fail:
+        print(f"  -> failed (exit {code})")
+    return code
+
+
+def lint() -> int:
+    rc = run([*RUFF, "check", *TARGETS])
+    # format is informational for now (the tree has an unformatted backlog) — report, don't fail.
+    run([*RUFF, "format", "--check", *TARGETS], allow_fail=True)
+    return rc
+
+
+def fmt() -> int:
+    return run([*RUFF, "format", *TARGETS])
+
+
+def test() -> int:
+    return run(["uvx", *TEST_DEPS, "pytest", "tests/", "-q"])
+
+
+def secrets() -> int:
+    return run(["uvx", "pre-commit", "run", "gitleaks", "--all-files"])
+
+
+def check() -> int:
+    """ruff lint + tests + gitleaks — the same checks CI gates on."""
+    rc = lint()
+    rc |= test()
+    rc |= secrets()
+    print("\n✓ all checks passed" if rc == 0 else "\n✗ some checks failed")
+    return rc
+
+
+def cover() -> int:
+    """Coverage of the lines THIS branch changed (fails on untested changed lines)."""
+    rc = run(["uvx", *TEST_DEPS, "pytest", "tests/", "-q", "--cov=plugins", "--cov-report=xml"])
+    return rc or run(["uvx", "diff-cover", "coverage.xml", "--compare-branch=origin/main"])
+
+
+def setup() -> int:
+    """Install the local pre-commit hooks (convenience; CI is the real gate)."""
+    return run(["uvx", "pre-commit", "install", "--hook-type", "pre-commit", "--hook-type", "pre-push"])
+
+
+TASKS = {"setup": setup, "check": check, "test": test, "lint": lint, "fmt": fmt, "cover": cover}
+
+
+def main() -> int:
+    if shutil.which("uvx") is None:
+        print(
+            "uv is required and was not found on PATH.\n"
+            "  macOS / Linux : curl -LsSf https://astral.sh/uv/install.sh | sh\n"
+            '  Windows       : powershell -c "irm https://astral.sh/uv/install.ps1 | iex"\n'
+            "  docs          : https://docs.astral.sh/uv/getting-started/installation/"
+        )
+        return 1
+    task = sys.argv[1] if len(sys.argv) > 1 else ""
+    if task not in TASKS:
+        print(f"usage: uv run dev.py [{' | '.join(TASKS)}]")
+        return 2
+    return TASKS[task]()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Spec:** OCR-023 · **stacked on #28 (OCR-022)** — base auto-retargets to main when #28 merges.

## Summary
The local mirror of the CI gate, so a developer gets the same feedback **before** pushing. Answers 'what can I run locally?' and 'did I test my change?'.

## Changes
- **`.pre-commit-config.yaml`** — ruff + ruff-format + gitleaks on **commit**; full test suite on **pre-push** (commits stay fast). ruff rules come from `pyproject.toml` (no duplication). No denylist (gitleaks is pattern-based).
- **CONTRIBUTING.md** — the real local flow: `pre-commit install`, run-everything commands, the test deps (`pydantic`/`pyyaml`/`sqlglot`), and a **`diff-cover` patch-coverage** recipe for 'did I cover the code I changed?'. Replaces the old `python3 -m pytest` line that silently failed without the deps.

## Verified locally
- ruff + gitleaks hooks **pass** on the clean tree.
- gitleaks **catches** a planted GitHub token (`github-pat` rule, 'leaks found: 1').

## The resulting dev experience
```
uvx pre-commit install --hook-type pre-commit --hook-type pre-push   # once
# ...commit → ruff+gitleaks auto-run; push → tests auto-run
uvx pre-commit run --all-files                                       # run all by hand
uvx diff-cover coverage.xml --compare-branch=origin/main             # did I test my change?
```