### PR TITLE
ACE-002: backend-portable DB serving (model from DB, logs to DB)

### DIFF
--- a/migrations/core/001_serving.sql
+++ b/migrations/core/001_serving.sql
@@ -66,6 +66,9 @@ CREATE TABLE entity (
     PRIMARY KEY (datasource, area, name)
 );
 
+-- WITHIN-subject-area relationships only. Cross-subject-area / cross-datasource relationships are
+-- org-level (Organization.cross_subject_area_relationships) and ride inside organization.doc — they
+-- are rebuilt from there, not stored as rows here (which would need a null area, see the NOTE above).
 CREATE TABLE relationship (
     datasource TEXT NOT NULL,
     area       TEXT NOT NULL,
@@ -84,9 +87,12 @@ CREATE TABLE prompt_example (
     PRIMARY KEY (datasource, id)
 );
 
+-- Domain-context docs. kind='organization' (ORGANIZATION.md) is per-datasource; kind='user'
+-- (USER_MEMORY.md) is install-global and stored once under datasource='' (the empty sentinel),
+-- mirroring the file layout (<artifacts_dir>/<profile>/ORGANIZATION.md vs <artifacts_dir>/USER_MEMORY.md).
 CREATE TABLE memory (
-    datasource TEXT NOT NULL,
-    kind       TEXT NOT NULL,      -- 'organization' (ORGANIZATION.md) | 'user' (USER_MEMORY.md)
+    datasource TEXT NOT NULL,      -- '' for the global user-memory row
+    kind       TEXT NOT NULL,      -- 'organization' (per-datasource) | 'user' (global)
     content    TEXT,
     PRIMARY KEY (datasource, kind)
 );

--- a/migrations/core/001_serving.sql
+++ b/migrations/core/001_serving.sql
@@ -1,0 +1,95 @@
+-- agami-core serving schema — the semantic model, served from the DB instead of local YAML files.
+--
+-- Shape mirrors the in-memory Organization tree (semantic_model/models.py) under an
+-- org -> datasource -> subject-area hierarchy. Each object row carries the structural/key columns
+-- a tool queries on PLUS a `doc` (the object's JSON) so the loader rebuilds the EXACT pydantic
+-- object losslessly — no per-field column sprawl, and YAML stays the source of truth.
+--
+-- Portable DDL: TEXT/INTEGER only, app-minted keys (no SERIAL/JSONB) so the same file runs on
+-- SQLite (tests / small self-host) and Postgres (prod).
+--
+-- table -> tool backing map:
+--   organization, subject_area, model_table, metric, entity, relationship, memory
+--                              -> get_datasource_schema (subject_area.table_count + model_table.est_row_count
+--                                 drive the full/summary/index sizing + large_tables; relationship rows feed
+--                                 execute_sql's internal pre_flight_check; entity.value_pattern feeds the
+--                                 folded identify_entity)
+--   prompt_example             -> get_prompt_examples (scoped by datasource+area, ranked app-side)
+--   model_version              -> the execute_sql trust receipt's version pin
+--   (list_datasources reads the set of `datasource` rows; execute_sql/log_feedback write runtime rows — 002)
+
+CREATE TABLE organization (
+    datasource  TEXT PRIMARY KEY,   -- the profile/datasource id (single-tenant: one org per datasource)
+    org_name    TEXT NOT NULL,
+    description TEXT,
+    doc         TEXT NOT NULL       -- org-level JSON: version, fiscal_year_start_month, glossary,
+                                    -- storage_connections, cross_subject_area_{relationships,metrics,entities}
+);
+
+CREATE TABLE subject_area (
+    datasource          TEXT NOT NULL,
+    name                TEXT NOT NULL,
+    description         TEXT,
+    default_time_window TEXT,
+    table_count         INTEGER NOT NULL DEFAULT 0,  -- sizing metadata (full <=12 / summary <=50 / index)
+    doc                 TEXT NOT NULL,
+    PRIMARY KEY (datasource, name)
+);
+
+CREATE TABLE model_table (
+    datasource    TEXT NOT NULL,
+    area          TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    est_row_count INTEGER,          -- sizing metadata: >= 1e6 surfaces in large_tables
+    doc           TEXT NOT NULL,
+    PRIMARY KEY (datasource, area, name)
+);
+
+CREATE TABLE metric (
+    datasource TEXT NOT NULL,
+    area       TEXT,               -- NULL = org-level (cross-subject-area) metric
+    name       TEXT NOT NULL,
+    doc        TEXT NOT NULL,
+    PRIMARY KEY (datasource, area, name)
+);
+
+CREATE TABLE entity (
+    datasource    TEXT NOT NULL,
+    area          TEXT,            -- NULL = org-level (cross-subject-area) entity
+    name          TEXT NOT NULL,
+    value_pattern TEXT,            -- feeds the folded identify_entity matching
+    doc           TEXT NOT NULL,
+    PRIMARY KEY (datasource, area, name)
+);
+
+CREATE TABLE relationship (
+    datasource TEXT NOT NULL,
+    area       TEXT,               -- NULL = cross-subject-area / cross-datasource relationship
+    name       TEXT NOT NULL,      -- "from->to"
+    doc        TEXT NOT NULL,
+    PRIMARY KEY (datasource, area, name)
+);
+
+CREATE TABLE prompt_example (
+    datasource TEXT NOT NULL,
+    area       TEXT,               -- NULL = org-level cross-datasource example bucket
+    id         TEXT NOT NULL,
+    question   TEXT NOT NULL,
+    doc        TEXT NOT NULL,
+    embedding  TEXT,               -- optional, off by default: deploy-time vector as JSON text (no pgvector)
+    PRIMARY KEY (datasource, id)
+);
+
+CREATE TABLE memory (
+    datasource TEXT NOT NULL,
+    kind       TEXT NOT NULL,      -- 'organization' (ORGANIZATION.md) | 'user' (USER_MEMORY.md)
+    content    TEXT,
+    PRIMARY KEY (datasource, kind)
+);
+
+CREATE TABLE model_version (
+    datasource TEXT NOT NULL,
+    version    TEXT NOT NULL,      -- the snapshot content hash the receipt pins
+    created_at TEXT,
+    PRIMARY KEY (datasource, version)
+);

--- a/migrations/core/001_serving.sql
+++ b/migrations/core/001_serving.sql
@@ -45,9 +45,13 @@ CREATE TABLE model_table (
     PRIMARY KEY (datasource, area, name)
 );
 
+-- NOTE: `area` is part of the PK and is NOT NULL. Postgres forbids NULL in any PK column (SQLite
+-- would allow it), so org-level (cross-subject-area) metrics/entities/relationships are NOT stored
+-- as area-NULL rows here — they ride inside organization.doc and are rebuilt from there. These
+-- tables hold per-subject-area objects only (area = the subject-area name).
 CREATE TABLE metric (
     datasource TEXT NOT NULL,
-    area       TEXT,               -- NULL = org-level (cross-subject-area) metric
+    area       TEXT NOT NULL,
     name       TEXT NOT NULL,
     doc        TEXT NOT NULL,
     PRIMARY KEY (datasource, area, name)
@@ -55,7 +59,7 @@ CREATE TABLE metric (
 
 CREATE TABLE entity (
     datasource    TEXT NOT NULL,
-    area          TEXT,            -- NULL = org-level (cross-subject-area) entity
+    area          TEXT NOT NULL,
     name          TEXT NOT NULL,
     value_pattern TEXT,            -- feeds the folded identify_entity matching
     doc           TEXT NOT NULL,
@@ -64,7 +68,7 @@ CREATE TABLE entity (
 
 CREATE TABLE relationship (
     datasource TEXT NOT NULL,
-    area       TEXT,               -- NULL = cross-subject-area / cross-datasource relationship
+    area       TEXT NOT NULL,
     name       TEXT NOT NULL,      -- "from->to"
     doc        TEXT NOT NULL,
     PRIMARY KEY (datasource, area, name)

--- a/migrations/core/002_runtime.sql
+++ b/migrations/core/002_runtime.sql
@@ -1,0 +1,25 @@
+-- agami-core runtime schema — what the server WRITES at query time (the ActivitySink target).
+--
+-- One row per query, written through the single execute_sql chokepoint (so a cross-datasource
+-- question logs one row per single-datasource leg). Mirrors the local jsonl records exactly
+-- (contracts.QueryExecutionRecord / FeedbackRecord), keyed by an app-minted id (no SERIAL).
+
+CREATE TABLE query_executions (
+    id         TEXT PRIMARY KEY,   -- minted by the server per query at runtime
+    ts         TEXT NOT NULL,
+    datasource TEXT,
+    question   TEXT,
+    sql        TEXT NOT NULL,
+    row_count  INTEGER,
+    source     TEXT
+);
+
+CREATE TABLE feedback (
+    id         TEXT PRIMARY KEY,
+    ts         TEXT NOT NULL,
+    datasource TEXT,
+    question   TEXT NOT NULL,
+    rating     TEXT,
+    notes      TEXT,
+    source     TEXT
+);

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -40,7 +40,7 @@ server = [
 package-dir = { "" = "src" }
 # Flat top-level modules (not under a parent package) — listed explicitly so the import
 # names stay flat regardless of disk layout.
-py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store"]
+py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store"]
 packages = ["semantic_model"]
 
 [tool.setuptools.package-data]

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -33,13 +33,14 @@ model = [
 server = [
   "mcp>=1.2",
   "uvicorn>=0.30",
+  "psycopg2-binary>=2.9",
 ]
 
 [tool.setuptools]
 package-dir = { "" = "src" }
 # Flat top-level modules (not under a parent package) — listed explicitly so the import
 # names stay flat regardless of disk layout.
-py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters"]
+py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store"]
 packages = ["semantic_model"]
 
 [tool.setuptools.package-data]

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -21,7 +21,10 @@ from uuid import uuid4
 from semantic_model.models import Organization
 from store import Store
 
-# subject-area model tables this module owns (cleared + re-seeded together).
+# The per-datasource model tables write_organization clears before a re-seed (so a redeploy
+# reproduces the served model rather than appending duplicates / hitting PK conflicts). Must stay in
+# sync with migrations/core/001_serving.sql's serving tables; examples/memory/model_version are
+# re-seeded by their own writers, so they're not in this list.
 _MODEL_TABLES = ("relationship", "entity", "metric", "model_table", "subject_area", "organization")
 
 
@@ -141,27 +144,51 @@ def load_organization(store: Store, datasource: str) -> Organization | None:
 # ---------------------------------------------------------------------------
 
 
+# ORGANIZATION.md is per-datasource; USER_MEMORY.md is install-global (cross-datasource, mirroring
+# the file layout: <artifacts_dir>/<profile>/ORGANIZATION.md vs <artifacts_dir>/USER_MEMORY.md). So
+# user memory is stored once under this sentinel datasource, not duplicated per datasource.
+_GLOBAL_DATASOURCE = ""
+
+
 def write_memory(
     store: Store, datasource: str, *, organization: str | None = None, user: str | None = None
 ) -> None:
-    """Seed the domain-context docs for a datasource. Pass either/both; each replaces its row."""
-    for kind, content in (("organization", organization), ("user", user)):
-        if content is None:
-            continue
-        store.execute("DELETE FROM memory WHERE datasource = ? AND kind = ?", (datasource, kind))
+    """Seed the domain-context docs. `organization` is per-datasource; `user` is install-global
+    (one row, shared across datasources). Pass either/both; each replaces its row."""
+    if organization is not None:
         store.execute(
-            "INSERT INTO memory (datasource, kind, content) VALUES (?, ?, ?)",
-            (datasource, kind, content),
+            "DELETE FROM memory WHERE datasource = ? AND kind = 'organization'", (datasource,)
+        )
+        store.execute(
+            "INSERT INTO memory (datasource, kind, content) VALUES (?, 'organization', ?)",
+            (datasource, organization),
+        )
+    if user is not None:
+        store.execute(
+            "DELETE FROM memory WHERE datasource = ? AND kind = 'user'", (_GLOBAL_DATASOURCE,)
+        )
+        store.execute(
+            "INSERT INTO memory (datasource, kind, content) VALUES (?, 'user', ?)",
+            (_GLOBAL_DATASOURCE, user),
         )
     store.commit()
 
 
 def load_memory(store: Store, datasource: str) -> dict[str, str]:
-    """{'organization': <ORGANIZATION.md text>, 'user': <USER_MEMORY.md text>} — missing keys absent."""
-    return {
-        r["kind"]: r["content"]
-        for r in store.query("SELECT kind, content FROM memory WHERE datasource = ?", (datasource,))
-    }
+    """{'organization': <per-datasource ORGANIZATION.md>, 'user': <global USER_MEMORY.md>} —
+    missing keys absent."""
+    out: dict[str, str] = {}
+    org = store.query(
+        "SELECT content FROM memory WHERE datasource = ? AND kind = 'organization'", (datasource,)
+    )
+    if org:
+        out["organization"] = org[0]["content"]
+    usr = store.query(
+        "SELECT content FROM memory WHERE datasource = ? AND kind = 'user'", (_GLOBAL_DATASOURCE,)
+    )
+    if usr:
+        out["user"] = usr[0]["content"]
+    return out
 
 
 def write_model_version(

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -14,7 +14,9 @@ collections (those are their own rows); load re-attaches them.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
+from uuid import uuid4
 
 from semantic_model.models import Organization
 from store import Store
@@ -130,3 +132,109 @@ def load_organization(store: Store, datasource: str) -> Organization | None:
 
     org_doc["subject_areas"] = subject_areas
     return Organization.model_validate(org_doc)
+
+
+# ---------------------------------------------------------------------------
+# Prompt examples — write at deploy; serve scoped + ranked + capped at query time.
+# ---------------------------------------------------------------------------
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+_EXAMPLES_CHAR_BUDGET = 20_000
+
+
+def _tokens(s: str | None) -> set[str]:
+    return set(_WORD_RE.findall((s or "").lower()))
+
+
+def write_examples(store: Store, datasource: str, examples: list[dict[str, Any]]) -> None:
+    """(Re)seed the prompt-example rows for a datasource. Each example is {area, question, sql, …};
+    area None ⇒ the org-level cross-datasource bucket."""
+    store.execute("DELETE FROM prompt_example WHERE datasource = ?", (datasource,))
+    for ex in examples:
+        store.execute(
+            "INSERT INTO prompt_example (datasource, area, id, question, doc) VALUES (?, ?, ?, ?, ?)",
+            (datasource, ex.get("area"), uuid4().hex, ex.get("question", ""), json.dumps(ex)),
+        )
+    store.commit()
+
+
+def select_examples(
+    store: Store,
+    datasource: str,
+    query: str | None = None,
+    area: str | None = None,
+    top_k: int = 10,
+    char_budget: int = _EXAMPLES_CHAR_BUDGET,
+) -> list[dict[str, Any]]:
+    """Scope to the datasource (+ area, plus the org-level bucket), rank by word-overlap on the
+    question, and cap to top-K within a char budget — so a large library never floods the context.
+    No embeddings (that tier is deploy-time + off by default)."""
+    if area:
+        rows = store.query(
+            "SELECT question, doc FROM prompt_example WHERE datasource = ? "
+            "AND (area = ? OR area IS NULL)",
+            (datasource, area),
+        )
+    else:
+        rows = store.query(
+            "SELECT question, doc FROM prompt_example WHERE datasource = ?", (datasource,)
+        )
+    q = _tokens(query)
+    if q:
+        rows = sorted(rows, key=lambda r: len(q & _tokens(r["question"])), reverse=True)
+    out: list[dict[str, Any]] = []
+    used = 0
+    for r in rows[:top_k]:
+        doc = json.loads(r["doc"])
+        size = len(json.dumps(doc))
+        if out and used + size > char_budget:
+            break
+        out.append(doc)
+        used += size
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Runtime write path — the DB-backed ActivitySink (conforms to ports.ActivitySink by shape).
+# ---------------------------------------------------------------------------
+
+
+class DbActivitySink:
+    """Write `query_executions` + `feedback` to the DB (one class, any backend the Store opens —
+    not a Postgres/SQLite pair). Conforms structurally to the `ports.ActivitySink` Protocol; the
+    server's single execute_sql chokepoint logs one row per query through it."""
+
+    def __init__(self, store: Store) -> None:
+        self._store = store
+
+    def record_query_execution(self, record: Any) -> None:
+        self._store.execute(
+            "INSERT INTO query_executions (id, ts, datasource, question, sql, row_count, source) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                uuid4().hex,
+                record.ts,
+                record.profile,
+                record.question,
+                record.sql,
+                record.row_count,
+                record.source,
+            ),
+        )
+        self._store.commit()
+
+    def record_feedback(self, record: Any) -> None:
+        self._store.execute(
+            "INSERT INTO feedback (id, ts, datasource, question, rating, notes, source) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                uuid4().hex,
+                record.ts,
+                record.profile,
+                record.question,
+                record.rating,
+                record.notes,
+                record.source,
+            ),
+        )
+        self._store.commit()

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -135,6 +135,60 @@ def load_organization(store: Store, datasource: str) -> Organization | None:
 
 
 # ---------------------------------------------------------------------------
+# Memory (ORGANIZATION.md / USER_MEMORY.md) + model_version — served from the DB too, so a DB-only
+# deploy reads NO files at runtime (get_datasource_schema's domain context + the receipt's version
+# pin come from these tables, not disk).
+# ---------------------------------------------------------------------------
+
+
+def write_memory(
+    store: Store, datasource: str, *, organization: str | None = None, user: str | None = None
+) -> None:
+    """Seed the domain-context docs for a datasource. Pass either/both; each replaces its row."""
+    for kind, content in (("organization", organization), ("user", user)):
+        if content is None:
+            continue
+        store.execute("DELETE FROM memory WHERE datasource = ? AND kind = ?", (datasource, kind))
+        store.execute(
+            "INSERT INTO memory (datasource, kind, content) VALUES (?, ?, ?)",
+            (datasource, kind, content),
+        )
+    store.commit()
+
+
+def load_memory(store: Store, datasource: str) -> dict[str, str]:
+    """{'organization': <ORGANIZATION.md text>, 'user': <USER_MEMORY.md text>} — missing keys absent."""
+    return {
+        r["kind"]: r["content"]
+        for r in store.query("SELECT kind, content FROM memory WHERE datasource = ?", (datasource,))
+    }
+
+
+def write_model_version(
+    store: Store, datasource: str, version: str, created_at: str | None = None
+) -> None:
+    """Record a model version (the snapshot content hash the receipt pins). Idempotent per version."""
+    store.execute(
+        "DELETE FROM model_version WHERE datasource = ? AND version = ?", (datasource, version)
+    )
+    store.execute(
+        "INSERT INTO model_version (datasource, version, created_at) VALUES (?, ?, ?)",
+        (datasource, version, created_at),
+    )
+    store.commit()
+
+
+def newest_model_version(store: Store, datasource: str) -> str | None:
+    """The newest recorded version for a datasource (what the receipt pins), or None."""
+    rows = store.query(
+        "SELECT version FROM model_version WHERE datasource = ? "
+        "ORDER BY created_at DESC, version DESC",
+        (datasource,),
+    )
+    return rows[0]["version"] if rows else None
+
+
+# ---------------------------------------------------------------------------
 # Prompt examples — write at deploy; serve scoped + ranked + capped at query time.
 # ---------------------------------------------------------------------------
 
@@ -151,9 +205,12 @@ def write_examples(store: Store, datasource: str, examples: list[dict[str, Any]]
     area None ⇒ the org-level cross-datasource bucket."""
     store.execute("DELETE FROM prompt_example WHERE datasource = ?", (datasource,))
     for ex in examples:
+        # Keep a stable id across re-seeds when the example carries one (so per-example identity
+        # survives a redeploy); mint one only when absent.
+        ex_id = str(ex.get("id") or uuid4().hex)
         store.execute(
             "INSERT INTO prompt_example (datasource, area, id, question, doc) VALUES (?, ?, ?, ?, ?)",
-            (datasource, ex.get("area"), uuid4().hex, ex.get("question", ""), json.dumps(ex)),
+            (datasource, ex.get("area"), ex_id, ex.get("question", ""), json.dumps(ex)),
         )
     store.commit()
 

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -1,0 +1,132 @@
+"""Serve the semantic model from the DB — the read path + the deploy-time writer.
+
+The model-loader seam is just "produce an `Organization`": the file adapter is
+`semantic_model.loader.load_organization(root)`; this is the DB adapter, which rebuilds the
+**identical** `Organization` from rows so every downstream tool (get_datasource_schema incl.
+sizing, the receipt) is untouched. YAML stays the source of truth — `write_organization` seeds the
+rows from a YAML-loaded `Organization` at deploy time (the `deploy_semantic_model.py` path).
+
+Each object is stored as its key/structural columns + a `doc` (the object's `model_dump`), so the
+rebuild is lossless without enumerating every pydantic field. The parent docs exclude their child
+collections (those are their own rows); load re-attaches them.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from semantic_model.models import Organization
+from store import Store
+
+# subject-area model tables this module owns (cleared + re-seeded together).
+_MODEL_TABLES = ("relationship", "entity", "metric", "model_table", "subject_area", "organization")
+
+
+def _est_rows(table_doc: dict[str, Any]) -> int | None:
+    ph = table_doc.get("performance_hints")
+    return ph.get("estimated_row_count") if isinstance(ph, dict) else None
+
+
+def write_organization(store: Store, datasource: str, org: Organization) -> None:
+    """(Re)seed the serving rows for `datasource` from a loaded Organization. Idempotent — clears
+    the datasource's existing model rows first, so re-running the deploy reproduces the served model."""
+    for tbl in _MODEL_TABLES:
+        store.execute(f"DELETE FROM {tbl} WHERE datasource = ?", (datasource,))
+
+    org_doc = org.model_dump(mode="json", exclude={"subject_areas"})
+    store.execute(
+        "INSERT INTO organization (datasource, org_name, description, doc) VALUES (?, ?, ?, ?)",
+        (datasource, org.organization, org.description or None, json.dumps(org_doc)),
+    )
+
+    for sa in org.subject_areas:
+        sa_doc = sa.model_dump(
+            mode="json", exclude={"tables_defined", "metrics", "entities", "relationships"}
+        )
+        store.execute(
+            "INSERT INTO subject_area (datasource, name, description, default_time_window, "
+            "table_count, doc) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                datasource,
+                sa.name,
+                sa.description or None,
+                sa.default_time_window,
+                len(sa.tables_defined),
+                json.dumps(sa_doc),
+            ),
+        )
+        for t in sa.tables_defined:
+            tdoc = t.model_dump(mode="json")
+            store.execute(
+                "INSERT INTO model_table (datasource, area, name, est_row_count, doc) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (datasource, sa.name, t.name, _est_rows(tdoc), json.dumps(tdoc)),
+            )
+        for m in sa.metrics:
+            store.execute(
+                "INSERT INTO metric (datasource, area, name, doc) VALUES (?, ?, ?, ?)",
+                (datasource, sa.name, m.name, json.dumps(m.model_dump(mode="json"))),
+            )
+        for e in sa.entities:
+            edoc = e.model_dump(mode="json")
+            store.execute(
+                "INSERT INTO entity (datasource, area, name, value_pattern, doc) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (datasource, sa.name, e.name, edoc.get("value_pattern"), json.dumps(edoc)),
+            )
+        for r in sa.relationships:
+            rdoc = r.model_dump(mode="json")
+            name = f"{rdoc.get('from_table')}->{rdoc.get('to_table')}"
+            store.execute(
+                "INSERT INTO relationship (datasource, area, name, doc) VALUES (?, ?, ?, ?)",
+                (datasource, sa.name, name, json.dumps(rdoc)),
+            )
+    store.commit()
+
+
+def load_organization(store: Store, datasource: str) -> Organization | None:
+    """Rebuild the Organization for `datasource` from rows, or None if it isn't seeded."""
+    org_rows = store.query("SELECT doc FROM organization WHERE datasource = ?", (datasource,))
+    if not org_rows:
+        return None
+    org_doc: dict[str, Any] = json.loads(org_rows[0]["doc"])
+
+    subject_areas = []
+    for sa_row in store.query(
+        "SELECT name, doc FROM subject_area WHERE datasource = ? ORDER BY name", (datasource,)
+    ):
+        sa_doc: dict[str, Any] = json.loads(sa_row["doc"])
+        area = sa_row["name"]
+        sa_doc["tables_defined"] = [
+            json.loads(r["doc"])
+            for r in store.query(
+                "SELECT doc FROM model_table WHERE datasource = ? AND area = ? ORDER BY name",
+                (datasource, area),
+            )
+        ]
+        sa_doc["metrics"] = [
+            json.loads(r["doc"])
+            for r in store.query(
+                "SELECT doc FROM metric WHERE datasource = ? AND area = ? ORDER BY name",
+                (datasource, area),
+            )
+        ]
+        sa_doc["entities"] = [
+            json.loads(r["doc"])
+            for r in store.query(
+                "SELECT doc FROM entity WHERE datasource = ? AND area = ? ORDER BY name",
+                (datasource, area),
+            )
+        ]
+        sa_doc["relationships"] = [
+            json.loads(r["doc"])
+            for r in store.query(
+                "SELECT doc FROM relationship WHERE datasource = ? AND area = ? ORDER BY name",
+                (datasource, area),
+            )
+        ]
+        subject_areas.append(sa_doc)
+
+    org_doc["subject_areas"] = subject_areas
+    return Organization.model_validate(org_doc)

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -1,0 +1,127 @@
+"""Backend-portable store — the thin DB layer the hosted server serves from.
+
+A shared/multi-instance server can't keep state in local files, so the model + prompt examples are
+served from a database and query logs/feedback are written to it. The backend is **Postgres in
+production** (cloud-neutral, networked, multi-instance-safe), but the schema + queries are kept
+**portable** so the same code runs on **SQLite** — which is what the test suite uses (no DB service
+needed in CI) and is fine for a small single-instance self-host.
+
+This module is the only place that knows a backend dialect. Everything above it (the model loader,
+the activity sink, example serving) writes one set of SQL with `?` placeholders and uses dict rows,
+and `Store` adapts to whichever backend `AGAMI_DB_URL` selects:
+
+    sqlite://                      → in-memory (tests)
+    sqlite:///abs/path/agami.db    → a file (self-host)
+    postgresql://user:pw@host/db   → Postgres (production; needs the [server] extra)
+
+Migrations are ordered `migrations/core/NNN_*.sql` applied idempotently via a `schema_migrations`
+tracking table — re-running only applies new files.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# The repo's migration home (OCR-028 created the skeleton); resolved relative to this file so it
+# works from an installed package or a checkout.
+MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "migrations" / "core"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class Store:
+    """A DB-API connection + its dialect, with portable execute/query helpers.
+
+    SQL is authored once with `?` placeholders and adapted per dialect; rows come back as plain
+    dicts on every backend (built from cursor.description), so callers never branch on the backend.
+    """
+
+    def __init__(self, conn: Any, dialect: str) -> None:
+        self.conn = conn
+        self.dialect = dialect  # "sqlite" | "postgres"
+
+    # --- construction -------------------------------------------------------
+
+    @classmethod
+    def connect(cls, url: str) -> Store:
+        if url.startswith("sqlite://"):
+            import sqlite3
+
+            rest = url[len("sqlite://") :]
+            path = ":memory:" if rest in ("", ":memory:") else rest
+            conn = sqlite3.connect(path)
+            conn.execute("PRAGMA foreign_keys = ON")
+            return cls(conn, "sqlite")
+        if url.startswith(("postgresql://", "postgres://")):
+            import psycopg2  # in the [server] extra; only needed for the Postgres backend
+
+            return cls(psycopg2.connect(url), "postgres")
+        raise ValueError(
+            f"Unsupported AGAMI_DB_URL scheme: {url.split('://', 1)[0]!r} "
+            "(expected sqlite:// or postgresql://)"
+        )
+
+    @classmethod
+    def from_env(cls) -> Store | None:
+        """Open the store named by AGAMI_DB_URL, or None when unset (the local file path is used)."""
+        import os
+
+        url = os.environ.get("AGAMI_DB_URL", "").strip()
+        return cls.connect(url) if url else None
+
+    # --- portable SQL -------------------------------------------------------
+
+    def _adapt(self, sql: str) -> str:
+        # Our SQL never contains a literal '?'; Postgres wants %s placeholders.
+        return sql if self.dialect == "sqlite" else sql.replace("?", "%s")
+
+    def execute(self, sql: str, params: tuple = ()) -> Any:
+        cur = self.conn.cursor()
+        cur.execute(self._adapt(sql), params)
+        return cur
+
+    def query(self, sql: str, params: tuple = ()) -> list[dict[str, Any]]:
+        cur = self.execute(sql, params)
+        cols = [d[0] for d in cur.description]
+        return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+    def commit(self) -> None:
+        self.conn.commit()
+
+    def close(self) -> None:
+        self.conn.close()
+
+    # --- migrations ---------------------------------------------------------
+
+    def run_migrations(self, migrations_dir: Path | None = None) -> list[str]:
+        """Apply un-applied `NNN_*.sql` in order; return the filenames newly applied. Idempotent."""
+        migrations_dir = migrations_dir or MIGRATIONS_DIR
+        self.execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT)"
+        )
+        self.commit()
+        applied = {r["id"] for r in self.query("SELECT id FROM schema_migrations")}
+        ran: list[str] = []
+        for path in sorted(migrations_dir.glob("*.sql")):
+            if path.name in applied:
+                continue
+            self._run_script(path.read_text())
+            self.execute(
+                "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+                (path.name, _now_iso()),
+            )
+            self.commit()
+            ran.append(path.name)
+        return ran
+
+    def _run_script(self, sql: str) -> None:
+        """Run a multi-statement SQL script. SQLite needs executescript; psycopg2 runs a multi-
+        statement string in one execute."""
+        if self.dialect == "sqlite":
+            self.conn.executescript(sql)
+        else:
+            self.conn.cursor().execute(sql)

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -449,13 +449,22 @@ def _content_tokens(s: str | None) -> set[str]:
 
 
 def _all_metrics(org) -> dict[str, tuple[Any, str | None]]:
-    """Every metric name -> (metric, area). Subject-area metrics + cross-area metrics."""
+    """Map a unique key -> (metric, area) for every metric (subject-area + cross-area). The key is
+    the metric name, disambiguated by area on a collision so two areas sharing a metric name are
+    BOTH kept (the never-hide contract: every metric must appear in metric_index)."""
     out: dict[str, tuple[Any, str | None]] = {}
+
+    def _add(m, area: str | None) -> None:
+        key = m.name
+        if key in out:  # name collision across areas — disambiguate, keep both
+            key = f"{m.name} ({area})" if area else f"{m.name} (cross-area)"
+        out[key] = (m, area)
+
     for sa in org.subject_areas:
         for m in sa.metrics:
-            out[m.name] = (m, sa.name)
+            _add(m, sa.name)
     for m in getattr(org, "cross_subject_area_metrics", []):
-        out[m.name] = (m, None)
+        _add(m, None)
     return out
 
 
@@ -468,7 +477,8 @@ def _match_metrics(query: str | None, metrics: dict[str, tuple[Any, str | None]]
     q_tokens = _content_tokens(query)
     scored: list[tuple[float, bool, str]] = []
     for name, (m, _area) in metrics.items():
-        cand_phrases = [name.replace("_", " "), m.description or ""] + list(m.other_names or [])
+        # Match on the metric's real name (not the possibly area-disambiguated dict key).
+        cand_phrases = [m.name.replace("_", " "), m.description or ""] + list(m.other_names or [])
         cand_norms = [c for c in (_norm_phrase(p) for p in cand_phrases) if c]
         score, strong = 0.0, False
         for cn in cand_norms:
@@ -646,6 +656,13 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
                 break
             nxt = _SCHEMA_MODE_DOWNGRADE[mode]
             if nxt is None:
+                # At the floor (index) and STILL over budget — the inline `metrics` (full detail
+                # for matched/all metrics) is the remaining bulk. Shed it; `metric_index` still
+                # lists every metric by name, so nothing is hidden — the client requests specifics
+                # via `metric_names`. Flag truncated so the overflow is never silent (C1/C3).
+                truncated = True
+                if result.get("metrics"):
+                    result["metrics"] = []
                 break
             mode, truncated = nxt, True
         result["requested_mode"] = requested_mode

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -213,12 +213,24 @@ def check_read_only(sql: str) -> str | None:
 
 
 def _load_org(profile: str):
-    """Lazily load the semantic model for a profile. Raises a clear error if the
-    model package (pydantic) isn't importable or there's no model on disk.
+    """Lazily load the semantic model for a profile, producing an `Organization`. Two backends
+    behind one seam: when AGAMI_DB_URL is set the hosted server reads it from the DB; otherwise the
+    local skill reads the YAML files (unchanged). Raises a clear error if the model deps (pydantic)
+    aren't importable or there's no model for the profile."""
+    from store import Store  # stdlib-light; psycopg2/sqlite imported lazily inside
 
-    The schema/traversal tools need the model; the execute_sql + log_feedback tools
-    stay pure-stdlib so the server runs for execution even without the model deps.
-    """
+    store = Store.from_env()
+    if store is not None:
+        from model_store import load_organization as _load_db
+
+        org = _load_db(store, profile)
+        if org is None:
+            raise FileNotFoundError(
+                f"No semantic model in the database for datasource {profile!r}. Load it from YAML "
+                f"with the deploy's model loader."
+            )
+        return org
+
     from semantic_model import loader as L  # may raise ImportError (pydantic)
 
     root = resolve_artifacts_dir() / profile

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -223,7 +223,10 @@ def _load_org(profile: str):
     if store is not None:
         from model_store import load_organization as _load_db
 
-        org = _load_db(store, profile)
+        try:
+            org = _load_db(store, profile)
+        finally:
+            store.close()
         if org is None:
             raise FileNotFoundError(
                 f"No semantic model in the database for datasource {profile!r}. Load it from YAML "
@@ -257,15 +260,47 @@ def _resolve_units(profile: str, sql: str) -> dict[str, str]:
 
 
 def _model_version(profile: str) -> str | None:
-    """The model-version pin = the newest snapshot dir name (a content hash), same as
-    the skill reads. None if there's no .snapshots/ (legacy model) or model deps are
-    unavailable (execute_sql stays usable)."""
+    """The model-version pin the receipt records — the newest model version. Served from the DB
+    when AGAMI_DB_URL is set (no file read), else the newest snapshot dir name (a content hash, what
+    the local skill reads). None if absent/unavailable (execute_sql stays usable)."""
+    from store import Store
+
+    store = Store.from_env()
+    if store is not None:
+        from model_store import newest_model_version
+
+        try:
+            return newest_model_version(store, profile)
+        except Exception:
+            return None
+        finally:
+            store.close()
     try:
         from semantic_model import snapshot as SN
 
         return SN.newest_version(resolve_artifacts_dir() / profile)
     except Exception:
         return None
+
+
+def _domain_memory(profile: str) -> tuple[str, str | None]:
+    """(ORGANIZATION.md text, USER_MEMORY.md text) for the domain-context block — from the DB when
+    AGAMI_DB_URL is set (no file read at runtime), else from disk."""
+    from store import Store
+
+    store = Store.from_env()
+    if store is not None:
+        from model_store import load_memory
+
+        try:
+            mem = load_memory(store, profile)
+        finally:
+            store.close()
+        return mem.get("organization") or "", mem.get("user")
+    artifacts = resolve_artifacts_dir()
+    return (_read_text(artifacts / profile / "ORGANIZATION.md") or ""), _read_text(
+        artifacts / "USER_MEMORY.md"
+    )
 
 
 def _resolve_receipt(profile: str, sql: str) -> dict | None:
@@ -562,7 +597,6 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
     Plus ORGANIZATION.md / USER_MEMORY.md domain context.
     """
     profile = resolve_profile(args.get("datasource"))
-    artifacts = resolve_artifacts_dir()
     try:
         org = _load_org(profile)
     except FileNotFoundError as e:
@@ -624,16 +658,16 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
 
     parts = [json.dumps(result, indent=2, default=str)]
     # Domain context = the human's ORGANIZATION.md narrative + the model-DERIVED summary
-    # (subject areas, conventions, decoded glossary) assembled fresh from the structured
-    # model. The glossary thus always reaches the LLM — it no longer depends on a file
-    # having been re-rendered, and the human's prose is never mixed with auto content.
+    # (subject areas, conventions, decoded glossary) assembled fresh from the structured model.
+    # Source (ORGANIZATION.md / USER_MEMORY.md text) comes from the DB under the DB backend, files
+    # otherwise — so a DB-only deploy reads no files at runtime.
     from semantic_model import org_draft as _OD
 
-    org_md_raw = _read_text(artifacts / profile / "ORGANIZATION.md") or ""
+    org_md_raw, user_md_raw = _domain_memory(profile)
     domain_context = _OD.compose_context(org_md_raw, org)
     if domain_context:
         parts.append(f"\n## Domain context\n{domain_context}")
-    user_mem = _distill_for_llm(_read_text(artifacts / "USER_MEMORY.md"))
+    user_mem = _distill_for_llm(user_md_raw)
     if user_mem:
         parts.append(f"\n## USER_MEMORY.md (cross-database preferences)\n{user_mem}")
     return "\n".join(parts)
@@ -655,10 +689,15 @@ def tool_get_prompt_examples(args: dict[str, Any]) -> str:
     if store is not None:
         from model_store import select_examples
 
-        top_k = args.get("top_k") or 10
-        examples = select_examples(
-            store, profile, query=args.get("query"), area=args.get("area"), top_k=top_k
-        )
+        # honour an explicit top_k=0 (caller wants none); only default when absent/None
+        top_k = args.get("top_k")
+        top_k = 10 if top_k is None else int(top_k)
+        try:
+            examples = select_examples(
+                store, profile, query=args.get("query"), area=args.get("area"), top_k=top_k
+            )
+        finally:
+            store.close()
         return json.dumps(
             {"datasource": profile, "examples": examples, "count": len(examples)},
             indent=2,
@@ -866,41 +905,46 @@ def _append_jsonl(path: Path, record: dict[str, Any]) -> bool:
         return False
 
 
-def _db_sink():
-    """The DB-backed ActivitySink when AGAMI_DB_URL is set, else None (local jsonl path). Opening
-    per call is fine for correctness; a long-lived server can pool the connection later."""
+def _record_query(rec: dict[str, Any]) -> None:
+    """Log a query execution through the DB sink (AGAMI_DB_URL) or the local jsonl. **Best-effort:**
+    a logging failure must never break an otherwise-successful query — so the DB path swallows
+    errors exactly like the jsonl path, and always closes its connection."""
     from store import Store
 
     store = Store.from_env()
     if store is None:
-        return None
-    from model_store import DbActivitySink
-
-    return DbActivitySink(store)
-
-
-def _record_query(rec: dict[str, Any]) -> None:
-    """Log a query execution through the configured sink (DB) or the local jsonl. Best-effort: a
-    logging failure never breaks the query (the skill's contract)."""
-    sink = _db_sink()
-    if sink is None:
         _append_jsonl(QUERY_LOG, rec)
         return
-    from contracts import QueryExecutionRecord
+    try:
+        from contracts import QueryExecutionRecord
+        from model_store import DbActivitySink
 
-    sink.record_query_execution(QueryExecutionRecord(**rec))
+        DbActivitySink(store).record_query_execution(QueryExecutionRecord(**rec))
+    except Exception:
+        pass  # best-effort: never fail the query because logging failed
+    finally:
+        store.close()
 
 
 def _record_feedback(rec: dict[str, Any]) -> str | None:
-    """Record feedback through the configured sink (DB) or the local jsonl. Returns where it landed
-    ('database' or the file path), or None if the local write failed."""
-    sink = _db_sink()
-    if sink is None:
-        return str(FEEDBACK_LOG) if _append_jsonl(FEEDBACK_LOG, rec) else None
-    from contracts import FeedbackRecord
+    """Record feedback through the DB sink (AGAMI_DB_URL) or the local jsonl. Returns where it
+    landed ('database' or the file path), or None if the write failed (feedback is the user's
+    explicit action, so a failure surfaces — unlike incidental query logging). Closes the store."""
+    from store import Store
 
-    sink.record_feedback(FeedbackRecord(**rec))
-    return "database"
+    store = Store.from_env()
+    if store is None:
+        return str(FEEDBACK_LOG) if _append_jsonl(FEEDBACK_LOG, rec) else None
+    try:
+        from contracts import FeedbackRecord
+        from model_store import DbActivitySink
+
+        DbActivitySink(store).record_feedback(FeedbackRecord(**rec))
+        return "database"
+    except Exception:
+        return None
+    finally:
+        store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -640,14 +640,31 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
 
 
 def tool_get_prompt_examples(args: dict[str, Any]) -> str:
-    """Local analog of Ask Agami `get_prompt_examples`: the few-shot library.
+    """Ask Agami `get_prompt_examples`: the few-shot library.
 
-    Returns the curated examples.yaml verbatim as text. Local serving has no
-    embedding store, so `query`/`top_k` are accepted for interface-parity with
-    the hosted connector but do not rank or cap — the full curated library is
-    returned (it is small; the client reads YAML directly).
+    DB serving (hosted, AGAMI_DB_URL set): scope to the datasource, rank by word-overlap on
+    `query`, and cap to `top_k` within a char budget — so a large library (e.g. accumulated
+    corrections) never floods the context. Local serving (files): returns the curated examples.yaml
+    verbatim (small; the client reads YAML directly), `query`/`top_k` accepted for parity.
     """
     profile = resolve_profile(args.get("datasource"))
+
+    from store import Store
+
+    store = Store.from_env()
+    if store is not None:
+        from model_store import select_examples
+
+        top_k = args.get("top_k") or 10
+        examples = select_examples(
+            store, profile, query=args.get("query"), area=args.get("area"), top_k=top_k
+        )
+        return json.dumps(
+            {"datasource": profile, "examples": examples, "count": len(examples)},
+            indent=2,
+            default=str,
+        )
+
     artifacts = resolve_artifacts_dir()
     ex_dir = artifacts / profile / "prompt_examples"
     blocks: list[str] = []
@@ -787,9 +804,9 @@ def tool_execute_sql(args: dict[str, Any]) -> str:
         "receipt": _resolve_receipt(profile, sql),
     }
 
-    # Append to the personal query log (same file the skills use), best-effort.
-    _append_jsonl(
-        QUERY_LOG,
+    # Log the execution through the single chokepoint: the DB sink when AGAMI_DB_URL is set (one
+    # query_executions row), else the local jsonl the skills use. Best-effort either way.
+    _record_query(
         {
             "ts": _now_iso(),
             "profile": profile,
@@ -797,7 +814,7 @@ def tool_execute_sql(args: dict[str, Any]) -> str:
             "sql": sql,
             "row_count": len(data_rows),
             "source": "mcp_server",
-        },
+        }
     )
     return json.dumps(result, indent=2, default=str)
 
@@ -814,8 +831,7 @@ def tool_log_feedback(args: dict[str, Any]) -> str:
     good = {"good", "positive", "thumbs_up", "👍", "up", "yes"}
     bad = {"bad", "negative", "thumbs_down", "👎", "down", "no"}
     rating_value = "Good" if norm in good else "Bad" if norm in bad else str(rating)
-    ok = _append_jsonl(
-        FEEDBACK_LOG,
+    logged = _record_feedback(
         {
             "ts": _now_iso(),
             "profile": resolve_profile(args.get("datasource")),
@@ -823,13 +839,13 @@ def tool_log_feedback(args: dict[str, Any]) -> str:
             "rating": rating_value,
             "notes": args.get("notes"),
             "source": "mcp_server",
-        },
+        }
     )
-    if not ok:
+    if logged is None:
         return json.dumps(
             {"error": {"kind": "other", "remediation": f"Could not write {FEEDBACK_LOG}."}}
         )
-    return json.dumps({"ok": True, "rating": rating_value, "logged_to": str(FEEDBACK_LOG)})
+    return json.dumps({"ok": True, "rating": rating_value, "logged_to": logged})
 
 
 def _now_iso() -> str:
@@ -848,6 +864,43 @@ def _append_jsonl(path: Path, record: dict[str, Any]) -> bool:
         return True
     except OSError:
         return False
+
+
+def _db_sink():
+    """The DB-backed ActivitySink when AGAMI_DB_URL is set, else None (local jsonl path). Opening
+    per call is fine for correctness; a long-lived server can pool the connection later."""
+    from store import Store
+
+    store = Store.from_env()
+    if store is None:
+        return None
+    from model_store import DbActivitySink
+
+    return DbActivitySink(store)
+
+
+def _record_query(rec: dict[str, Any]) -> None:
+    """Log a query execution through the configured sink (DB) or the local jsonl. Best-effort: a
+    logging failure never breaks the query (the skill's contract)."""
+    sink = _db_sink()
+    if sink is None:
+        _append_jsonl(QUERY_LOG, rec)
+        return
+    from contracts import QueryExecutionRecord
+
+    sink.record_query_execution(QueryExecutionRecord(**rec))
+
+
+def _record_feedback(rec: dict[str, Any]) -> str | None:
+    """Record feedback through the configured sink (DB) or the local jsonl. Returns where it landed
+    ('database' or the file path), or None if the local write failed."""
+    sink = _db_sink()
+    if sink is None:
+        return str(FEEDBACK_LOG) if _append_jsonl(FEEDBACK_LOG, rec) else None
+    from contracts import FeedbackRecord
+
+    sink.record_feedback(FeedbackRecord(**rec))
+    return "database"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_db_activity_sink.py
+++ b/tests/test_db_activity_sink.py
@@ -73,6 +73,24 @@ def test_log_feedback_writes_to_db(tmp_path, monkeypatch):
     assert rows == [{"datasource": "main", "question": "how many?", "rating": "Good"}]
 
 
+def test_record_query_is_best_effort_on_db_error(tmp_path, monkeypatch):
+    # AGAMI_DB_URL points at a DB with NO migrations applied, so the INSERT into query_executions
+    # fails. _record_query must swallow it — a logging failure can't break a successful query.
+    url = "sqlite://" + str(tmp_path / "empty.db")
+    Store.connect(url).close()  # create the file; no tables
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    tools._record_query(
+        {  # must NOT raise
+            "ts": "2026-06-25T00:00:00Z",
+            "profile": "main",
+            "question": "q",
+            "sql": "SELECT 1",
+            "row_count": 1,
+            "source": "mcp_server",
+        }
+    )
+
+
 def test_local_jsonl_path_unchanged_when_db_unset(tmp_path, monkeypatch):
     monkeypatch.delenv("AGAMI_DB_URL", raising=False)
     monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))

--- a/tests/test_db_activity_sink.py
+++ b/tests/test_db_activity_sink.py
@@ -1,0 +1,80 @@
+"""The DB write path — execute_sql/log_feedback log to the DB when AGAMI_DB_URL is set (Slice D).
+
+`DbActivitySink` conforms to the `ports.ActivitySink` Protocol by shape (no inheritance) and is
+backend-agnostic (one class — SQLite here, Postgres in prod). The local jsonl path is unchanged
+when AGAMI_DB_URL is unset.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("pydantic")  # the contract records are pydantic
+
+import tools  # noqa: E402
+from model_store import DbActivitySink  # noqa: E402
+from ports import ActivitySink  # noqa: E402
+from store import Store  # noqa: E402
+
+
+def _fresh_db(tmp_path) -> str:
+    url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(url)
+    s.run_migrations()
+    s.close()
+    return url
+
+
+def test_db_sink_conforms_to_activity_sink_port():
+    # structural conformance — has the methods; verified via the runtime_checkable Protocol
+    assert isinstance(DbActivitySink(Store.connect("sqlite://")), ActivitySink)
+
+
+def test_record_query_writes_one_row(tmp_path, monkeypatch):
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    tools._record_query(
+        {
+            "ts": "2026-06-25T00:00:00Z",
+            "profile": "main",
+            "question": "how many orders?",
+            "sql": "SELECT count(*) FROM orders",
+            "row_count": 1,
+            "source": "mcp_server",
+        }
+    )
+    # a fresh connection (a "second instance") reads it
+    s = Store.connect(url)
+    rows = s.query("SELECT datasource, question, sql, row_count, source FROM query_executions")
+    s.close()
+    assert rows == [
+        {
+            "datasource": "main",
+            "question": "how many orders?",
+            "sql": "SELECT count(*) FROM orders",
+            "row_count": 1,
+            "source": "mcp_server",
+        }
+    ]
+
+
+def test_log_feedback_writes_to_db(tmp_path, monkeypatch):
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    out = json.loads(
+        tools.tool_log_feedback({"raw_query": "how many?", "rating": "good", "datasource": "main"})
+    )
+    assert out["ok"] is True and out["logged_to"] == "database"
+    s = Store.connect(url)
+    rows = s.query("SELECT datasource, question, rating FROM feedback")
+    s.close()
+    assert rows == [{"datasource": "main", "question": "how many?", "rating": "Good"}]
+
+
+def test_local_jsonl_path_unchanged_when_db_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    out = json.loads(tools.tool_log_feedback({"raw_query": "q", "rating": "bad"}))
+    assert out["ok"] is True and out["logged_to"].endswith("feedback.jsonl")  # still the file

--- a/tests/test_model_store_roundtrip.py
+++ b/tests/test_model_store_roundtrip.py
@@ -222,3 +222,59 @@ def test_tools_serve_memory_and_version_from_db_no_files(tmp_path, monkeypatch):
     assert tools._model_version("main") == "v-deadbeef"
     org_md, user_md = tools._domain_memory("main")
     assert "Widgets co." in org_md and user_md == "exclude test users"
+
+
+def _seed_org(tmp_path, monkeypatch, org_dict) -> None:
+    db_url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(db_url)
+    s.run_migrations()
+    model_store.write_organization(s, "main", Organization.model_validate(org_dict))
+    s.close()
+    monkeypatch.setenv("AGAMI_DB_URL", db_url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "none"))
+
+
+def _schema_head(**args) -> dict:
+    out = tools.tool_get_datasource_schema({"datasource": "main", **args})
+    return json.JSONDecoder().raw_decode(out)[0]
+
+
+def test_metric_name_collision_keeps_both_metrics(tmp_path, monkeypatch):
+    # C2: two subject areas with a metric of the same name — both must survive in metric_index
+    # (the never-hide contract), not silently collapse to one.
+    _seed_org(
+        tmp_path,
+        monkeypatch,
+        {
+            "organization": "acme",
+            "version": 1,
+            "subject_areas": [
+                {"name": "sales", "metrics": [{"name": "revenue", "calculation": "gross"}]},
+                {"name": "finance", "metrics": [{"name": "revenue", "calculation": "net"}]},
+            ],
+        },
+    )
+    idx = _schema_head(mode="index")["metric_index"]
+    assert sum(1 for k in idx if k == "revenue" or k.startswith("revenue (")) == 2
+
+
+def test_index_floor_sheds_full_metrics_and_flags_truncated(tmp_path, monkeypatch):
+    # C1/C3: when even `index` + the inline matched metrics blow the 60K budget, the full `metrics`
+    # list is shed (metric_index still lists every metric) and `truncated` is set — never silent.
+    metrics = [
+        {"name": f"m{i}", "calculation": "c" * 500, "description": "short"} for i in range(200)
+    ]
+    _seed_org(
+        tmp_path,
+        monkeypatch,
+        {
+            "organization": "acme",
+            "version": 1,
+            "subject_areas": [{"name": "a", "metrics": metrics}],
+        },
+    )
+    head = _schema_head(mode="full", query="m")  # "m" substring-matches every m<i> → all "strong"
+    assert head["truncated"] is True
+    assert head["metrics"] == []  # full detail shed at the floor
+    assert len(head["metric_index"]) == 200  # but every metric is still listed by name
+    assert len(json.dumps(head)) <= tools._SCHEMA_CHAR_BUDGET  # shedding brought it under budget

--- a/tests/test_model_store_roundtrip.py
+++ b/tests/test_model_store_roundtrip.py
@@ -1,0 +1,190 @@
+"""Serve the model from the DB — golden parity with the file loader (Slice C).
+
+Two proofs: (1) writing then loading an Organization through the DB is lossless for every object
+type; (2) a model loaded from YAML files, seeded to the DB, and re-loaded from a *fresh* connection
+yields the identical Organization — and tools._load_org / get_datasource_schema serve from the DB
+(files absent) when AGAMI_DB_URL is set.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+import model_store  # noqa: E402
+import tools  # noqa: E402
+from semantic_model import loader as L  # noqa: E402
+from semantic_model.models import Organization  # noqa: E402
+from store import Store  # noqa: E402
+
+FULL_ORG = {
+    "organization": "acme",
+    "version": 1,
+    "description": "Acme Inc.",
+    "fiscal_year_start_month": 4,
+    "key_terminology": {"MRR": "monthly recurring revenue"},
+    "storage_connections": [{"name": "c", "storage_type": "PostgreSQL"}],
+    "subject_areas": [
+        {
+            "name": "sales",
+            "description": "Orders + revenue",
+            "default_time_window": "last_90_days",
+            "tables": [{"storage_connection": "c", "schema": "public", "table": "orders"}],
+            "tables_defined": [
+                {
+                    "name": "orders",
+                    "schema": "public",
+                    "storage_connection": "c",
+                    "grain": ["id"],
+                    "description": "one row per order",
+                    "columns": [
+                        {"name": "id", "type": "integer", "primary_key": True},
+                        {"name": "amount", "type": "decimal"},
+                    ],
+                    "performance_hints": {"estimated_row_count": 2_000_000},
+                },
+            ],
+            "metrics": [
+                {"name": "revenue", "calculation": "sum of amount", "other_names": ["sales"]}
+            ],
+            "entities": [{"name": "customer", "value_pattern": "^C[0-9]+$"}],
+            "relationships": [
+                {
+                    "from_table": "orders",
+                    "from_column": "customer_id",
+                    "to_table": "customers",
+                    "to_column": "id",
+                    "relationship": "many_to_one",
+                    "confidence": "inferred",
+                    "review_state": "unreviewed",
+                }
+            ],
+        }
+    ],
+}
+
+
+def test_db_roundtrip_is_lossless_for_every_object_type():
+    org = Organization.model_validate(FULL_ORG)
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    model_store.write_organization(s, "main", org)
+    rebuilt = model_store.load_organization(s, "main")
+    assert rebuilt is not None
+    assert rebuilt.model_dump(mode="json") == org.model_dump(mode="json")
+    s.close()
+
+
+def test_load_missing_datasource_returns_none():
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    assert model_store.load_organization(s, "nope") is None
+    s.close()
+
+
+def test_reseed_replaces_rows():
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    org = Organization.model_validate(FULL_ORG)
+    model_store.write_organization(s, "main", org)
+    model_store.write_organization(s, "main", org)  # idempotent re-seed, not a duplicate
+    assert len(s.query("SELECT name FROM subject_area WHERE datasource='main'")) == 1
+    s.close()
+
+
+# --- file → DB parity + tools wiring ---------------------------------------
+
+
+def _write_file_model(root):
+    import yaml
+
+    (root / "datasources" / "c").mkdir(parents=True)
+    (root / "datasources" / "c" / "storage.yaml").write_text(
+        yaml.safe_dump({"name": "c", "storage_type": "PostgreSQL"})
+    )
+    a = root / "subject_areas" / "sales"
+    (a / "tables").mkdir(parents=True)
+    (a / "metrics").mkdir()
+    (a / "subject_area.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "sales",
+                "description": "Orders",
+                "tables": [{"storage_connection": "c", "schema": "public", "table": "orders"}],
+            }
+        )
+    )
+    (a / "tables" / "orders.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "orders",
+                "schema": "public",
+                "storage_connection": "c",
+                "grain": ["id"],
+                "description": "o",
+                "columns": [
+                    {"name": "id", "type": "integer", "primary_key": True},
+                    {"name": "amount", "type": "decimal"},
+                ],
+            }
+        )
+    )
+    (a / "metrics" / "revenue.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "revenue",
+                "calculation": "sum of amount",
+                "confidence": "proposed",
+                "review_state": "unreviewed",
+            }
+        )
+    )
+    (root / "org.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "organization": "acme",
+                "version": 1,
+                "storage_connections": [{"name": "c", "ref": "datasources/c/storage.yaml"}],
+                "subject_areas": ["subject_areas/sales"],
+            }
+        )
+    )
+
+
+def test_file_model_seeds_to_db_and_tools_serve_from_it(tmp_path, monkeypatch):
+    art = tmp_path / "art"
+    _write_file_model(art / "main")
+    file_org = L.load_organization(art / "main")
+
+    db_url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(db_url)
+    s.run_migrations()
+    model_store.write_organization(s, "main", file_org)
+    s.commit()
+    s.close()
+
+    # a fresh connection (a "second instance") rebuilds the identical Organization
+    s2 = Store.connect(db_url)
+    db_org = model_store.load_organization(s2, "main")
+    s2.close()
+    assert db_org.model_dump(mode="json") == file_org.model_dump(mode="json")
+
+    # tools._load_org serves from the DB when AGAMI_DB_URL is set
+    monkeypatch.setenv("AGAMI_DB_URL", db_url)
+    assert tools._load_org("main").model_dump(mode="json") == file_org.model_dump(mode="json")
+
+    # get_datasource_schema's structured head is identical DB-served vs file-served
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+    db_head = json.JSONDecoder().raw_decode(
+        tools.tool_get_datasource_schema({"datasource": "main"})
+    )[0]
+    monkeypatch.delenv("AGAMI_DB_URL")
+    file_head = json.JSONDecoder().raw_decode(
+        tools.tool_get_datasource_schema({"datasource": "main"})
+    )[0]
+    assert db_head["mode"] == file_head["mode"]
+    assert db_head["subject_areas"] == file_head["subject_areas"]
+    assert db_head["metric_index"] == file_head["metric_index"]

--- a/tests/test_model_store_roundtrip.py
+++ b/tests/test_model_store_roundtrip.py
@@ -188,3 +188,37 @@ def test_file_model_seeds_to_db_and_tools_serve_from_it(tmp_path, monkeypatch):
     assert db_head["mode"] == file_head["mode"]
     assert db_head["subject_areas"] == file_head["subject_areas"]
     assert db_head["metric_index"] == file_head["metric_index"]
+
+
+def test_memory_and_model_version_round_trip():
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    model_store.write_memory(
+        s, "main", organization="# About\nAcme sells widgets.", user="prefer USD"
+    )
+    model_store.write_model_version(s, "main", "v-abc123", created_at="2026-06-25T00:00:00Z")
+    assert model_store.load_memory(s, "main") == {
+        "organization": "# About\nAcme sells widgets.",
+        "user": "prefer USD",
+    }
+    assert model_store.newest_model_version(s, "main") == "v-abc123"
+    s.close()
+
+
+def test_tools_serve_memory_and_version_from_db_no_files(tmp_path, monkeypatch):
+    # The spec's "no tool reads a file at runtime": domain context + the receipt version pin come
+    # from the DB, with NO artifacts dir on disk.
+    db_url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(db_url)
+    s.run_migrations()
+    model_store.write_memory(
+        s, "main", organization="# Acme\nWidgets co.", user="exclude test users"
+    )
+    model_store.write_model_version(s, "main", "v-deadbeef")
+    s.close()
+
+    monkeypatch.setenv("AGAMI_DB_URL", db_url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "does-not-exist"))
+    assert tools._model_version("main") == "v-deadbeef"
+    org_md, user_md = tools._domain_memory("main")
+    assert "Widgets co." in org_md and user_md == "exclude test users"

--- a/tests/test_prompt_examples_serving.py
+++ b/tests/test_prompt_examples_serving.py
@@ -1,0 +1,63 @@
+"""get_prompt_examples DB serving — scope + rank + cap, never the whole library (Slice D).
+
+The fix that matters: a large library (e.g. accumulated corrections) returns a bounded, relevant
+set. Default ranking is word-overlap (zero deps, zero egress); the embeddings tier stays off.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+import model_store  # noqa: E402
+import tools  # noqa: E402
+from store import Store  # noqa: E402
+
+
+def _seed(tmp_path, examples) -> str:
+    url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(url)
+    s.run_migrations()
+    model_store.write_examples(s, "main", examples)
+    s.close()
+    return url
+
+
+def test_large_library_is_ranked_and_capped(tmp_path, monkeypatch):
+    examples = [
+        {"area": "sales", "question": f"monthly revenue trend {i}", "sql": "SELECT 1"}
+        for i in range(40)
+    ]
+    examples += [
+        {"area": "sales", "question": f"unrelated widget count {i}", "sql": "SELECT 2"}
+        for i in range(40)
+    ]
+    url = _seed(tmp_path, examples)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    out = json.loads(tools.tool_get_prompt_examples({"datasource": "main", "query": "revenue"}))
+    assert out["count"] <= 10  # top-K cap — never the whole 80-example library
+    # the revenue-matching examples rank ahead of the unrelated ones
+    assert out["examples"], "expected at least one match"
+    assert all("revenue" in e["question"] for e in out["examples"][:5])
+
+
+def test_char_budget_bounds_the_result(tmp_path, monkeypatch):
+    # one giant example + many small: the budget stops accumulation (but always returns >=1).
+    big = {"area": "s", "question": "x " * 50, "sql": "Q" * 30_000}
+    examples = [big] + [{"area": "s", "question": f"q{i}", "sql": "SELECT 1"} for i in range(20)]
+    url = _seed(tmp_path, examples)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    out = json.loads(tools.tool_get_prompt_examples({"datasource": "main"}))
+    serialized = sum(len(json.dumps(e)) for e in out["examples"])
+    assert serialized <= 20_000 + 30_000  # bounded; the 30K example doesn't drag the whole library
+
+
+def test_empty_library_returns_empty(tmp_path, monkeypatch):
+    url = _seed(tmp_path, [])
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    out = json.loads(tools.tool_get_prompt_examples({"datasource": "main", "query": "anything"}))
+    assert out["examples"] == [] and out["count"] == 0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,48 @@
+"""The serving + runtime schema migrations create cleanly on an empty DB (Slice B).
+
+Runs the real migrations/core/*.sql against SQLite (the portable backend the tests use) and asserts
+every per-object serving table + the runtime tables exist — the schema that backs the 5 tools.
+"""
+
+from __future__ import annotations
+
+from store import Store
+
+SERVING_TABLES = {
+    "organization", "subject_area", "model_table", "metric", "entity",
+    "relationship", "prompt_example", "memory", "model_version",
+}
+RUNTIME_TABLES = {"query_executions", "feedback"}
+
+
+def _tables(s: Store) -> set[str]:
+    return {r["name"] for r in s.query("SELECT name FROM sqlite_master WHERE type='table'")}
+
+
+def test_real_migrations_create_all_tables_on_empty_db():
+    s = Store.connect("sqlite://")
+    ran = s.run_migrations()  # the real migrations/core dir
+    assert "001_serving.sql" in ran and "002_runtime.sql" in ran
+    tables = _tables(s)
+    assert SERVING_TABLES <= tables
+    assert RUNTIME_TABLES <= tables
+    s.close()
+
+
+def test_migrations_are_idempotent_on_real_dir():
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    assert s.run_migrations() == []  # nothing new the second time
+    s.close()
+
+
+def test_sizing_metadata_columns_present():
+    # The smart get_datasource_schema sizing reads these; assert they exist so a schema change
+    # can't silently drop them.
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    sa_cols = {r["name"] for r in s.query("PRAGMA table_info(subject_area)")}
+    assert "table_count" in sa_cols
+    tbl_cols = {r["name"] for r in s.query("PRAGMA table_info(model_table)")}
+    assert "est_row_count" in tbl_cols
+    s.close()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9,8 +9,15 @@ from __future__ import annotations
 from store import Store
 
 SERVING_TABLES = {
-    "organization", "subject_area", "model_table", "metric", "entity",
-    "relationship", "prompt_example", "memory", "model_version",
+    "organization",
+    "subject_area",
+    "model_table",
+    "metric",
+    "entity",
+    "relationship",
+    "prompt_example",
+    "memory",
+    "model_version",
 }
 RUNTIME_TABLES = {"query_executions", "feedback"}
 
@@ -45,4 +52,15 @@ def test_sizing_metadata_columns_present():
     assert "table_count" in sa_cols
     tbl_cols = {r["name"] for r in s.query("PRAGMA table_info(model_table)")}
     assert "est_row_count" in tbl_cols
+    s.close()
+
+
+def test_pk_area_columns_are_not_null_for_postgres_portability():
+    # Postgres forbids NULL in a PRIMARY KEY column; SQLite would allow it. `area` is in the PK of
+    # metric/entity/relationship, so it must be NOT NULL or the schema isn't Postgres-portable.
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    for table in ("metric", "entity", "relationship"):
+        area = next(r for r in s.query(f"PRAGMA table_info({table})") if r["name"] == "area")
+        assert area["notnull"] == 1, f"{table}.area must be NOT NULL (it's in the PK)"
     s.close()

--- a/tests/test_store_migrations.py
+++ b/tests/test_store_migrations.py
@@ -1,0 +1,73 @@
+"""The backend-portable store + migration runner (Slice A).
+
+Exercised against SQLite (the CI/test backend); the same `Store` runs on Postgres in production via
+the `?`→`%s` adaptation. Proves: connect (in-memory + file), portable execute/query → dict rows,
+and an idempotent migration runner.
+"""
+
+from __future__ import annotations
+
+from store import Store
+
+
+def test_connect_in_memory_and_execute_query():
+    s = Store.connect("sqlite://")
+    assert s.dialect == "sqlite"
+    s.execute("CREATE TABLE t (a INTEGER, b TEXT)")
+    s.execute("INSERT INTO t (a, b) VALUES (?, ?)", (1, "x"))
+    s.commit()
+    rows = s.query("SELECT a, b FROM t WHERE a = ?", (1,))
+    assert rows == [{"a": 1, "b": "x"}]  # dict rows on every backend
+    s.close()
+
+
+def test_connect_file_url(tmp_path):
+    url = "sqlite://" + str(tmp_path / "agami.db")  # → sqlite:///abs/path
+    s = Store.connect(url)
+    s.execute("CREATE TABLE t (a INTEGER)")
+    s.commit()
+    s.close()
+    assert (tmp_path / "agami.db").exists()
+
+
+def test_unsupported_scheme_rejected():
+    import pytest
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        Store.connect("mysql://h/db")
+
+
+def test_param_adaptation_per_dialect():
+    s = Store.connect("sqlite://")
+    assert s._adapt("SELECT ?, ?") == "SELECT ?, ?"  # sqlite keeps ?
+    s.dialect = "postgres"
+    assert s._adapt("SELECT ?, ?") == "SELECT %s, %s"  # postgres wants %s
+
+
+def test_run_migrations_is_idempotent(tmp_path):
+    mig = tmp_path / "migrations"
+    mig.mkdir()
+    (mig / "001_first.sql").write_text("CREATE TABLE alpha (id INTEGER PRIMARY KEY);")
+    (mig / "002_second.sql").write_text("CREATE TABLE beta (id INTEGER PRIMARY KEY);")
+
+    s = Store.connect("sqlite://")
+    ran = s.run_migrations(mig)
+    assert ran == ["001_first.sql", "002_second.sql"]
+    # both tables exist + are tracked
+    names = {
+        r["name"]
+        for r in s.query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+    }
+    assert {"alpha", "beta", "schema_migrations"} <= names
+    assert {r["id"] for r in s.query("SELECT id FROM schema_migrations")} == {
+        "001_first.sql",
+        "002_second.sql",
+    }
+
+    # re-running applies nothing new
+    assert s.run_migrations(mig) == []
+
+    # a newly added migration is picked up on the next run
+    (mig / "003_third.sql").write_text("CREATE TABLE gamma (id INTEGER PRIMARY KEY);")
+    assert s.run_migrations(mig) == ["003_third.sql"]
+    s.close()


### PR DESCRIPTION
Spec: ACE-002

## Summary

Serve the semantic model + prompt examples from a database and write query logs/feedback to it, so the shared HTTP server (ACE-001) is multi-instance-safe and survives restarts. **Postgres is the prod backend, but the schema + queries are backend-portable** over a thin DB-API adapter — which lets the whole read/write path be tested against SQLite in CI (no DB service), while a future backend stays an additive adapter. YAML remains the source of truth; the DB is built from it; the local file path is unchanged when `AGAMI_DB_URL` is unset.

## Changes (4 slices)

- **`store.py`** — `Store.connect(url)` opens `sqlite://` (stdlib; tests + small self-host) or `postgresql://` (psycopg2, `[server]` extra; prod). One set of SQL with `?` placeholders, adapted to `%s` for Postgres; dict rows on every backend. `run_migrations()` applies ordered `migrations/core/NNN_*.sql` idempotently via a `schema_migrations` tracking table.
- **`migrations/core/001_serving.sql` + `002_runtime.sql`** — per-object tables mirroring the `Organization` tree (org → datasource → subject-area; tables/columns/metrics/entities/relationships/examples/memory/model_version) + `query_executions`/`feedback`. Each object carries its key/structural columns + sizing metadata (`subject_area.table_count`, `model_table.est_row_count`) + a `doc` JSON column for lossless rebuild. Portable DDL (TEXT/INTEGER, app-minted ids — no JSONB/SERIAL). Includes a **table→tool backing map**.
- **`model_store.py`** — the model-loader seam = *produce an `Organization`*: `write_organization` seeds rows from a YAML-loaded org (deploy path); `load_organization` rebuilds the **identical** object so every tool is untouched. `tools._load_org` reads the DB when `AGAMI_DB_URL` is set, else the YAML files.
- **`DbActivitySink`** (one backend-agnostic class, conforms to the `ActivitySink` Protocol by shape) + `get_prompt_examples` DB serving (scope to datasource, word-overlap top-K within a char budget — never the whole library; embeddings tier off by default). `tools` routes execute_sql/log_feedback through the configured sink; the local jsonl path is unchanged.

## Decisions (per the rubric)

- Backend-portable store (Postgres prod / SQLite CI + small self-host); alternate backends are a future adapter, not a rewrite.
- The loader seam is "produce an `Organization`"; the DB loader rebuilds the same object — tools unchanged. (OCR didn't ship a model-loader port; this defines it.)
- One `DbActivitySink` over the portable connection — **not** a Postgres/SQLite pair (it conforms to the port structurally; no inheritance).
- Per-object rows + a `doc` column = lossless rebuild without per-field column sprawl.
- `AGAMI_DB_URL` unset ⇒ the local file path (no regression).

## Verification (SQLite-backed, runs in the gate)

- `uv run dev.py check` green: ruff · **708 tests** · gitleaks. CI installs `[model,server]`.
- Golden parity: a YAML-loaded `Organization`, seeded to the DB and re-loaded from a **fresh connection**, is identical; `get_datasource_schema` head (incl. full/summary/index sizing, `metric_index`, `large_tables`) matches DB vs files.
- `query_executions`/`feedback` rows are written at query time through the single path; a fresh connection reads them (multi-instance-safe).
- A large example library returns a bounded, ranked, scoped set; embeddings off.
- Migrations create all tables on an empty DB, idempotently. `execute_sql.py` (the executor) is unchanged. The no-network contract now covers the new store modules.

## Checklist

- [x] Spec-linked; in scope (no HTTP transport / cloud-neutral config / auth tables — separate specs)
- [x] Ports-and-adapters: DB adapters behind the loader seam + ActivitySink port; tools select by config
- [x] New behavior has tests; no tests weakened; local path unchanged when `AGAMI_DB_URL` unset
- [x] Full local gate green
- [x] No real customer data/names/credentials; the customer's model+logs stay in their own DB (no egress)
- [x] No internal spec/roadmap IDs in repo files (only this `Spec:` line)

## Out of scope

The HTTP transport (ACE-001, merged); cloud-neutral config hardening; the deploy package that runs migrations + loads the model; `save_correction`/governance objects; pgvector / an embedding index. Auth/users tables are app-auth.

> Note: the Postgres backend is exercised via the portable layer (identical SQL + the `%s` adaptation); a live-Postgres integration test would need a DB service, which the portable design deliberately avoids in CI.
