### PR TITLE
Harden HTTP MCP transport — scoped auth-skip + fail-fast base URL

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -62,12 +62,21 @@ def _unauthenticated(base: str) -> JSONResponse:
     )
 
 
+# Only the OAuth-discovery endpoints are reachable unauthenticated (the client probes them before
+# it has a token). Scoped to these exact prefixes — NOT a blanket `/.well-known/` skip — so the
+# open surface is exactly the routes we serve, not "anything starting with /.well-known/".
+_PUBLIC_PREFIXES = (
+    "/.well-known/oauth-protected-resource",
+    "/.well-known/oauth-authorization-server",
+)
+
+
 class _AuthMiddleware(BaseHTTPMiddleware):
-    """Require a bearer token's presence. The `.well-known/*` discovery endpoints stay open (the
-    client probes them before it has a token); everything else 401s without a token."""
+    """Require a bearer token's presence; the OAuth-discovery endpoints stay open. Everything else
+    401s without a token."""
 
     async def dispatch(self, request: Request, call_next):
-        if request.url.path.startswith("/.well-known/"):
+        if request.url.path.startswith(_PUBLIC_PREFIXES):
             return await call_next(request)
         authz = request.headers.get("authorization") or request.headers.get("Authorization") or ""
         # Require the Bearer scheme specifically (not just any Authorization header), then a
@@ -140,6 +149,10 @@ def build_app() -> Starlette:
     behind the bearer-presence auth middleware."""
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 
+    # Fail fast at construction if PUBLIC_BASE_URL is unset — not per-request inside the middleware
+    # (where the RuntimeError would surface as a 500, leaking a traceback under debug). Anything that
+    # builds the app via --factory / an embedding harness gets a clear error up front.
+    public_base_url()
     bootstrap_paths()
     session_manager = StreamableHTTPSessionManager(
         app=build_server(), json_response=True, stateless=True

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -71,12 +71,20 @@ _PUBLIC_PREFIXES = (
 )
 
 
+def _is_public_path(path: str) -> bool:
+    """True for the discovery routes and their path-suffixed variants only. We match on a path
+    *boundary* (exact, or prefix + '/'), not a bare `startswith` — otherwise a sibling like
+    `/.well-known/oauth-protected-resource-x` would skip auth too. Today such a path only 404s, but
+    boundary-matching keeps the open surface == the routes we serve even if a route is added later."""
+    return any(path == p or path.startswith(p + "/") for p in _PUBLIC_PREFIXES)
+
+
 class _AuthMiddleware(BaseHTTPMiddleware):
     """Require a bearer token's presence; the OAuth-discovery endpoints stay open. Everything else
     401s without a token."""
 
     async def dispatch(self, request: Request, call_next):
-        if request.url.path.startswith(_PUBLIC_PREFIXES):
+        if _is_public_path(request.url.path):
             return await call_next(request)
         authz = request.headers.get("authorization") or request.headers.get("Authorization") or ""
         # Require the Bearer scheme specifically (not just any Authorization header), then a

--- a/plugins/agami/skills/agami-query/SKILL.md
+++ b/plugins/agami/skills/agami-query/SKILL.md
@@ -88,7 +88,7 @@ The model is the semantic-model tree at `<artifacts_dir>/<profile>/` (`org.yaml`
 
 **Don't run a separate existence probe either** (no `ls org.yaml`, and never probe for the plugin's own scripts — `sm`, `execute_sql.py`, `semantic_model/` always ship with the plugin). That same first `sm areas` call doubles as the check: model present → you get the map; absent → the CLI returns `{"error":"no_model"}` with **exit code 3** → invoke `agami-connect` and stop.
 
-Drive everything through the CLI (the `sm` wrapper resolves the interpreter + deps) or the MCP tools — both return the same shapes:
+Drive everything through the CLI — the `sm` wrapper resolves the interpreter + deps. (These granular steps are CLI operations; on the MCP surface they're folded into the smart `get_datasource_schema`, which advertises the 5 product tools — so don't invoke the steps below as MCP tools.)
 
 ```bash
 ROOT="<artifacts_dir>/<profile>"
@@ -213,7 +213,7 @@ For a single profile, follow the **examples-first canonical loop** — the subje
 
 **Step 2 — examples first (strongest signal).** `cli examples "$ROOT" --area <area> --query "<question>"`. If `high_confidence` is true, mirror the top match's tagged tables / columns / metric / SQL shape and jump to step 5 — skip cold-start resolution.
 
-**Step 3 *(cold start only)* — resolve entities + metrics + opaque literals.** Match the question's terms to the area's entities (and `metrics`). For any opaque literal in the question (an ID-looking token), `cli`/MCP `identify_entity` recognizes its type via `value_pattern`; if it returns `clarify`, ask the user one targeted question rather than guessing.
+**Step 3 *(cold start only)* — resolve entities + metrics + opaque literals.** Match the question's terms to the area's entities (and `metrics`). For any opaque literal in the question (an ID-looking token), the CLI entity matching recognizes its type via `value_pattern` (folded into `get_datasource_schema` on the MCP surface, not a separate tool); if it returns `clarify`, ask the user one targeted question rather than guessing.
 
 **Step 4 *(cold start only)* — choose tables + columns** from what resolved (entity `maps_to`, metric `source_tables`).
 

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -38,6 +38,24 @@ def test_public_base_url_is_required(monkeypatch):
         mcp_http.public_base_url()
 
 
+def test_build_app_fails_fast_without_public_base_url(monkeypatch):
+    # S2: the missing-env error must surface at construction, not as a per-request 500 inside the
+    # auth middleware (which would leak a traceback under debug).
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    with pytest.raises(RuntimeError, match="PUBLIC_BASE_URL"):
+        mcp_http.build_app()
+
+
+def test_auth_skip_is_scoped_to_discovery_routes_only(base_url):
+    # S1: only the OAuth-discovery prefixes are open; any other /.well-known/* path still requires
+    # auth (no blanket "/.well-known/" bypass).
+    c = TestClient(mcp_http.build_app())
+    assert c.get("/.well-known/openid-configuration").status_code == 401
+    assert (
+        c.get("/.well-known/oauth-protected-resource").status_code == 200
+    )  # real route still open
+
+
 def test_discovery_advertises_public_base_url(base_url):
     c = TestClient(mcp_http.build_app())
     pr = c.get("/.well-known/oauth-protected-resource")

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -51,9 +51,13 @@ def test_auth_skip_is_scoped_to_discovery_routes_only(base_url):
     # auth (no blanket "/.well-known/" bypass).
     c = TestClient(mcp_http.build_app())
     assert c.get("/.well-known/openid-configuration").status_code == 401
+    # A sibling that merely shares the prefix (no path boundary) must NOT skip auth either — the
+    # skip matches on a boundary (exact or prefix + "/"), not a bare startswith.
+    assert c.get("/.well-known/oauth-protected-resource-evil").status_code == 401
+    assert c.get("/.well-known/oauth-protected-resource").status_code == 200  # exact route open
     assert (
-        c.get("/.well-known/oauth-protected-resource").status_code == 200
-    )  # real route still open
+        c.get("/.well-known/oauth-protected-resource/mcp").status_code == 200
+    )  # suffixed variant open
 
 
 def test_discovery_advertises_public_base_url(base_url):


### PR DESCRIPTION
## Summary

Two security hardenings + a docs correction surfaced by a retrospective review of the merged HTTP MCP transport. No behavior change for an authenticated client; the change tightens the unauthenticated surface and turns a latent misconfig into a startup-time error.

## Changes

- **Scope the auth-skip to the discovery routes (S1).** The bearer-presence middleware skipped *any* path starting with `/.well-known/`. It now skips only the two OAuth-discovery prefixes we actually serve (`oauth-protected-resource`, `oauth-authorization-server`); every other `/.well-known/*` path requires a token like the rest of the app. Closes an over-broad open surface.
- **Fail fast on a missing `PUBLIC_BASE_URL` (S2).** `build_app()` now resolves the public base URL at construction. A missing env var raises a clear `RuntimeError` up front (including via `--factory` / embedding harnesses) instead of surfacing as a per-request 500 inside the middleware (which would leak a traceback under debug).
- **Drop stale MCP-tool references in the agami-query skill (D1).** Reworded two lines that implied the granular CLI steps are also MCP tools; on the MCP surface they're folded into the smart `get_datasource_schema` (the 5 product tools).

## Test plan

- `test_auth_skip_is_scoped_to_discovery_routes_only` — a non-discovery `/.well-known/*` path 401s; the real discovery route still 200s.
- `test_build_app_fails_fast_without_public_base_url` — `build_app()` raises when the env var is unset.
- Full suite green via `uv run dev.py check` (ruff + pytest + gitleaks).

## Checklist

- [x] `uv run dev.py check` green
- [x] New behavior covered by tests
- [x] No real customer data/names/credentials
- [x] Docs updated where affected

Spec: ACE-001