### PR TITLE
Cloud-neutral config hardening — any cloud, no GCP lock-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ cloud (a multi-tenant model registry over a remote MCP endpoint, shared governed
 always-on evals). The boundary, stated plainly:
 [docs/open-vs-hosted.md](docs/open-vs-hosted.md).
 
+## Self-hosting the HTTP server (any cloud)
+
+The HTTP MCP server (the `[server]` extra) is **cloud-neutral** — a VM + Postgres, or a stateless
+platform (Cloud Run / Container Apps) + managed Postgres. No GCP service is required to boot: no
+Cloud SQL connector, no Secret Manager, no Cloud Logging (a regression test enforces this). Config
+is entirely environment variables:
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `AGAMI_DB_URL` | yes (server) | The store: `postgresql://…` in prod, `sqlite://…` for a small/local run. `APP_DATABASE_URL` is accepted as an alias for the cloud-platform convention (`AGAMI_DB_URL` wins if both are set). Unset ⇒ the local file path. |
+| `PUBLIC_BASE_URL` | yes (server) | Backs OAuth/MCP discovery + the `WWW-Authenticate` resource URL. Set it explicitly — it can't be auto-detected behind a proxy/LB; the server fails fast at startup if it's missing. |
+| `AGAMI_ORG_ID` | no | The single configured org id (default `local`). The server is single-tenant by default. |
+
+All serving state lives in Postgres — a fresh instance with only `AGAMI_DB_URL` serves identically,
+so the server survives restarts and stateless platforms. The serving path is **LLM-free and
+zero-egress by default**: the client is the brain, `execute_sql` runs SQL against your own database,
+and the other tools just read the model. Nothing leaves your environment.
+
 ## Documentation
 
 - [Quickstart & usage](docs/usage.md) — first-run walkthrough + common workflows

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 import contextlib
 import os
 
-from oss_adapters import PresenceAuthProvider
+from oss_adapters import PresenceAuthProvider, SingleTenantOrgResolver
+from ports import Org
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -31,6 +32,14 @@ from tools import SERVER_INSTRUCTIONS, SERVER_NAME, TOOLS, bootstrap_paths, serv
 
 # Bearer-presence is the OSS default; real identity providers are a later feature.
 _AUTH = PresenceAuthProvider()
+
+
+def _build_org_resolver() -> SingleTenantOrgResolver:
+    """The OSS default tenancy: single-tenant, one configured org (id from AGAMI_ORG_ID, default
+    "local"). Multi-tenant is a future change at the *schema* layer (rows key on datasource, not
+    (org, datasource)) plus an authz check — not a resolver swap, so the seam lives here now."""
+    org_id = os.environ.get("AGAMI_ORG_ID", "").strip() or "local"
+    return SingleTenantOrgResolver(Org(id=org_id))
 
 
 def public_base_url() -> str:
@@ -81,7 +90,12 @@ def _is_public_path(path: str) -> bool:
 
 class _AuthMiddleware(BaseHTTPMiddleware):
     """Require a bearer token's presence; the OAuth-discovery endpoints stay open. Everything else
-    401s without a token."""
+    401s without a token. On a request that passes auth, resolve the single-tenant org and attach
+    it to request.state.org — the explicit single-tenant contract + the multi-tenant seam."""
+
+    def __init__(self, app, resolver: SingleTenantOrgResolver) -> None:
+        super().__init__(app)
+        self._resolver = resolver
 
     async def dispatch(self, request: Request, call_next):
         if _is_public_path(request.url.path):
@@ -93,6 +107,10 @@ class _AuthMiddleware(BaseHTTPMiddleware):
             return _unauthenticated(public_base_url())
         if _AUTH.validate_token(authz[7:].strip()) is None:
             return _unauthenticated(public_base_url())
+        # Resolve the org for this request. Single-tenant returns the one configured org regardless
+        # of context; nothing downstream consumes it yet (tools key on `datasource`), so this asserts
+        # the contract and reserves the seam — it does not add org-scoped behavior.
+        request.state.org = self._resolver.resolve_org(request)
         return await call_next(request)
 
 
@@ -181,7 +199,8 @@ def build_app() -> Starlette:
         Route("/.well-known/oauth-authorization-server/{rest:path}", _auth_server),
         Mount("/mcp", app=handle_mcp),
     ]
-    return Starlette(routes=routes, middleware=[Middleware(_AuthMiddleware)], lifespan=lifespan)
+    middleware = [Middleware(_AuthMiddleware, resolver=_build_org_resolver())]
+    return Starlette(routes=routes, middleware=middleware, lifespan=lifespan)
 
 
 def main() -> int:

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -24,8 +24,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-# The repo's migration home (OCR-028 created the skeleton); resolved relative to this file so it
-# works from an installed package or a checkout.
+# The repo's migration home; resolved relative to this file so it works from an installed package
+# or a checkout.
 MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "migrations" / "core"
 
 

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -67,10 +67,17 @@ class Store:
 
     @classmethod
     def from_env(cls) -> Store | None:
-        """Open the store named by AGAMI_DB_URL, or None when unset (the local file path is used)."""
+        """Open the store named by the DB env var, or None when unset (the local file path is used).
+
+        `AGAMI_DB_URL` is canonical; `APP_DATABASE_URL` is accepted as an alias for the common
+        cloud-platform convention (Cloud Run/ACA/Heroku-style `*_DATABASE_URL`). Canonical wins if
+        both are set, so a deliberate override is unambiguous."""
         import os
 
-        url = os.environ.get("AGAMI_DB_URL", "").strip()
+        url = (
+            os.environ.get("AGAMI_DB_URL", "").strip()
+            or os.environ.get("APP_DATABASE_URL", "").strip()
+        )
         return cls.connect(url) if url else None
 
     # --- portable SQL -------------------------------------------------------

--- a/tests/test_cloud_neutral_config.py
+++ b/tests/test_cloud_neutral_config.py
@@ -108,3 +108,54 @@ def test_server_extra_declares_no_gcp_platform_package():
     text = (REPO_ROOT / "packages" / "agami-core" / "pyproject.toml").read_text().lower()
     for pkg in ("google-cloud-logging", "google-cloud-secret", "cloud-sql-python-connector"):
         assert pkg not in text, f"{pkg} must not be a declared dependency (GCP lock-in)"
+
+
+# --- 3. Single-tenant org resolver wired into the HTTP server ----------------
+
+
+def test_org_resolver_defaults_to_local(monkeypatch):
+    pytest.importorskip("starlette")
+    pytest.importorskip("mcp")
+    import mcp_http
+
+    monkeypatch.delenv("AGAMI_ORG_ID", raising=False)
+    assert mcp_http._build_org_resolver().resolve_org().id == "local"
+
+
+def test_org_resolver_reads_agami_org_id(monkeypatch):
+    pytest.importorskip("starlette")
+    pytest.importorskip("mcp")
+    import mcp_http
+
+    monkeypatch.setenv("AGAMI_ORG_ID", "acme")
+    assert mcp_http._build_org_resolver().resolve_org().id == "acme"
+
+
+def test_auth_middleware_attaches_resolved_org_after_auth(monkeypatch):
+    # An authed request gets the resolved org on request.state.org; the seam is live even though
+    # nothing downstream consumes it yet.
+    pytest.importorskip("starlette")
+    pytest.importorskip("mcp")
+    import asyncio
+
+    import mcp_http
+    from ports import Org
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    mw = mcp_http._AuthMiddleware(app=None, resolver=mcp_http.SingleTenantOrgResolver(Org(id="acme")))
+    captured: dict[str, object] = {}
+
+    async def call_next(request):
+        captured["org"] = request.state.org
+        return Response("ok")
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": [(b"authorization", b"Bearer present")],
+    }
+    resp = asyncio.run(mw.dispatch(Request(scope), call_next))
+    assert resp.status_code == 200
+    assert isinstance(captured["org"], Org) and captured["org"].id == "acme"

--- a/tests/test_cloud_neutral_config.py
+++ b/tests/test_cloud_neutral_config.py
@@ -11,6 +11,7 @@ Postgres). These tests pin the config contract so it can't silently regress:
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -52,3 +53,58 @@ def test_no_db_env_means_local_file_path(monkeypatch):
     monkeypatch.delenv("AGAMI_DB_URL", raising=False)
     monkeypatch.delenv("APP_DATABASE_URL", raising=False)
     assert Store.from_env() is None  # unset ⇒ the local file path is used (unchanged)
+
+
+# --- 2. No required GCP platform dependency to boot --------------------------
+
+# The library + server must run on any cloud — so they may not *require* a GCP platform service
+# (Cloud Logging, Secret Manager, the Cloud SQL connector, ADC). These are matched only at module
+# top level (a required import). An opt-in datasource driver imported lazily inside a function body
+# is NOT a platform coupling — it connects to the user's own warehouse — exactly how execute_sql.py
+# imports `google.cloud.bigquery`; such indented imports are intentionally allowed.
+_FORBIDDEN_GCP = [
+    re.compile(p)
+    for p in (
+        r"google\.cloud\.logging",
+        r"google\.cloud\.secret_?manager",
+        r"google\.cloud\.sql",  # the Cloud SQL Python connector namespace
+        r"cloud[_-]sql[_-]python[_-]connector",
+        r"\bgoogle\.auth\b",  # Application Default Credentials
+    )
+]
+# bigquery is a user-chosen warehouse driver, not a platform coupling — never forbidden (mirrors
+# the allowance in tests/test_privacy_no_network.py).
+_LIBRARY_MODULES = sorted(PKG_SRC.glob("*.py")) + sorted((PKG_SRC / "semantic_model").glob("*.py"))
+
+
+def _is_module_level_import(line: str) -> bool:
+    # No leading whitespace ⇒ top level (required at import time); indented ⇒ inside a function
+    # body (lazy / opt-in). This is the seam between "required to boot" and "imported on demand".
+    return line == line.lstrip() and (line.startswith("import ") or line.startswith("from "))
+
+
+def test_there_are_library_modules_to_scan():
+    # Guard against the glob silently matching nothing (a vacuous pass).
+    assert _LIBRARY_MODULES, f"no modules found under {PKG_SRC}"
+
+
+@pytest.mark.parametrize("module", _LIBRARY_MODULES, ids=lambda p: p.name)
+def test_no_required_gcp_platform_import(module: Path):
+    hits = []
+    for line_no, raw in enumerate(module.read_text().splitlines(), 1):
+        line = raw.rstrip()
+        if _is_module_level_import(line) and any(rx.search(line) for rx in _FORBIDDEN_GCP):
+            hits.append(f"  {module.name}:{line_no}: {line.strip()}")
+    assert not hits, (
+        f"required (module-level) GCP platform import in {module.name} — the server must boot on "
+        f"any cloud with no GCP service required. Import it lazily inside the function that needs "
+        f"it (the opt-in-driver pattern), or remove the coupling:\n" + "\n".join(hits)
+    )
+
+
+def test_server_extra_declares_no_gcp_platform_package():
+    # The [server] extra must not pull a GCP platform package (logging / secret-manager / cloud-sql
+    # connector). A text scan keeps this 3.10-safe (no tomllib) and is precise enough for package names.
+    text = (REPO_ROOT / "packages" / "agami-core" / "pyproject.toml").read_text().lower()
+    for pkg in ("google-cloud-logging", "google-cloud-secret", "cloud-sql-python-connector"):
+        assert pkg not in text, f"{pkg} must not be a declared dependency (GCP lock-in)"

--- a/tests/test_cloud_neutral_config.py
+++ b/tests/test_cloud_neutral_config.py
@@ -159,3 +159,42 @@ def test_auth_middleware_attaches_resolved_org_after_auth(monkeypatch):
     resp = asyncio.run(mw.dispatch(Request(scope), call_next))
     assert resp.status_code == 200
     assert isinstance(captured["org"], Org) and captured["org"].id == "acme"
+
+
+# --- 4. No local-disk state required to serve (stateless-platform-safe) -------
+
+
+def test_db_backed_serve_needs_no_artifacts_dir(tmp_path, monkeypatch):
+    # A fresh instance on a stateless platform has no local model files — only AGAMI_DB_URL. The
+    # serving path must answer from the DB alone. (ACE-002 delivers this; ACE-003 re-owns the
+    # criterion so cloud-neutrality is self-checked, not inherited.)
+    pytest.importorskip("pydantic")
+    import json
+
+    import model_store
+    import tools
+    from semantic_model.models import Organization
+    from store import Store
+
+    db_url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(db_url)
+    s.run_migrations()
+    model_store.write_organization(
+        s,
+        "main",
+        Organization.model_validate(
+            {
+                "organization": "acme",
+                "version": 1,
+                "subject_areas": [
+                    {"name": "sales", "metrics": [{"name": "revenue", "calculation": "sum"}]}
+                ],
+            }
+        ),
+    )
+    s.close()
+
+    monkeypatch.setenv("AGAMI_DB_URL", db_url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "does-not-exist"))  # no disk state
+    head = json.JSONDecoder().raw_decode(tools.tool_get_datasource_schema({"datasource": "main"}))[0]
+    assert head["subject_areas"] and head["subject_areas"][0]["name"] == "sales"

--- a/tests/test_cloud_neutral_config.py
+++ b/tests/test_cloud_neutral_config.py
@@ -1,0 +1,54 @@
+"""Cloud-neutral config hardening — lock in the no-GCP-lock-in invariants.
+
+agami-core is self-hostable on any cloud (VM + Postgres, or a stateless platform + managed
+Postgres). These tests pin the config contract so it can't silently regress:
+
+  1. the DB env var (canonical `AGAMI_DB_URL`, alias `APP_DATABASE_URL`) opens the same store;
+  2. the server boots with NO required GCP platform dependency (opt-in datasource drivers excepted);
+  3. the single-tenant org resolver is wired into the HTTP server;
+  4. a DB-backed instance serves with no local-disk artifacts (stateless-platform-safe).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+
+# --- 1. DB env var: canonical + alias resolve to the same store --------------
+
+
+def test_app_database_url_is_accepted_as_an_alias(tmp_path, monkeypatch):
+    from store import Store
+
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.setenv("APP_DATABASE_URL", "sqlite://" + str(tmp_path / "a.db"))
+    s = Store.from_env()
+    assert s is not None and s.dialect == "sqlite"
+    s.close()
+
+
+def test_canonical_agami_db_url_wins_over_alias(tmp_path, monkeypatch):
+    # Both set → the canonical name is the unambiguous override.
+    from store import Store
+
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "canonical.db"))
+    monkeypatch.setenv("APP_DATABASE_URL", "postgresql://should-not-be-used/db")
+    s = Store.from_env()
+    assert s is not None and s.dialect == "sqlite"  # picked canonical, not the postgres alias
+    s.close()
+
+
+def test_no_db_env_means_local_file_path(monkeypatch):
+    from store import Store
+
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    assert Store.from_env() is None  # unset ⇒ the local file path is used (unchanged)

--- a/tests/test_cloud_neutral_config.py
+++ b/tests/test_cloud_neutral_config.py
@@ -143,7 +143,9 @@ def test_auth_middleware_attaches_resolved_org_after_auth(monkeypatch):
     from starlette.requests import Request
     from starlette.responses import Response
 
-    mw = mcp_http._AuthMiddleware(app=None, resolver=mcp_http.SingleTenantOrgResolver(Org(id="acme")))
+    mw = mcp_http._AuthMiddleware(
+        app=None, resolver=mcp_http.SingleTenantOrgResolver(Org(id="acme"))
+    )
     captured: dict[str, object] = {}
 
     async def call_next(request):
@@ -166,8 +168,8 @@ def test_auth_middleware_attaches_resolved_org_after_auth(monkeypatch):
 
 def test_db_backed_serve_needs_no_artifacts_dir(tmp_path, monkeypatch):
     # A fresh instance on a stateless platform has no local model files — only AGAMI_DB_URL. The
-    # serving path must answer from the DB alone. (ACE-002 delivers this; ACE-003 re-owns the
-    # criterion so cloud-neutrality is self-checked, not inherited.)
+    # serving path must answer from the DB alone, so cloud-neutrality is self-checked here rather
+    # than relying on the DB-serving tests elsewhere.
     pytest.importorskip("pydantic")
     import json
 
@@ -196,5 +198,7 @@ def test_db_backed_serve_needs_no_artifacts_dir(tmp_path, monkeypatch):
 
     monkeypatch.setenv("AGAMI_DB_URL", db_url)
     monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "does-not-exist"))  # no disk state
-    head = json.JSONDecoder().raw_decode(tools.tool_get_datasource_schema({"datasource": "main"}))[0]
+    head = json.JSONDecoder().raw_decode(tools.tool_get_datasource_schema({"datasource": "main"}))[
+        0
+    ]
     assert head["subject_areas"] and head["subject_areas"][0]["name"] == "sales"


### PR DESCRIPTION
## Summary

Locks in the self-hostable, cloud-neutral config contract for the HTTP server: it boots on any cloud (VM + Postgres, or a stateless platform + managed Postgres) with **no GCP service required**. The server was built fresh rather than ported, so the originally-assumed GCP couplings (Cloud SQL connector, Secret Manager, Cloud Logging, an LLM provider) never existed here — most cloud-neutral rules were already satisfied by the transport + DB-serving work. This PR closes the two real gaps and adds a regression guard so cloud-neutrality can't silently erode.

## Changes

- **DB env alias** — `Store.from_env()` accepts `APP_DATABASE_URL` (the common cloud-platform convention) as an alias for the canonical `AGAMI_DB_URL`; canonical wins if both are set. All store access already routes through `from_env`, so the alias applies everywhere.
- **No-GCP-to-boot guard** — a new test scans every library module for **module-level** (required) GCP-platform imports (Cloud Logging, Secret Manager, the Cloud SQL connector, ADC) and asserts the `[server]` extra declares none. Lazily-imported, opt-in datasource drivers (e.g. `google-cloud-bigquery`) are allowed, mirroring the privacy test's stance.
- **Single-tenant resolver wired in** — the HTTP server now builds a `SingleTenantOrgResolver` (org id from `AGAMI_ORG_ID`, default `local`) and resolves the org per request after auth, attaching it to `request.state.org`. This makes the single-tenant contract explicit and reserves the multi-tenant seam; nothing downstream consumes the org id yet (tools key on `datasource`), so it adds no org-scoped behavior — called out in a comment.
- **Self-host docs** — a README section listing required vs optional env and the zero-egress-by-default posture.
- **Hygiene** — dropped a stale internal ticket id from a `store.py` comment.

## Test plan

- New `tests/test_cloud_neutral_config.py`: alias precedence; the module-level GCP-import guard (parametrized over every module, with a non-vacuous-pass guard); resolver default + `AGAMI_ORG_ID` override + middleware attaches the resolved org after auth; a DB-backed serve with no artifacts dir answers end-to-end.
- Full gate green: `uv run dev.py check` (ruff + pytest + gitleaks). Reviewed with code-review + a security pass on the auth-middleware change (org resolved only post-auth; no tenant confusion; auth decision unchanged).

## Checklist

- [x] `uv run dev.py check` green
- [x] New behavior covered by tests
- [x] No real customer data/names/credentials; no internal IDs in repo files
- [x] Docs updated (README self-host section)

Spec: ACE-003