### PR TITLE
User store + username/password auth (argon2id)

### DIFF
--- a/migrations/core/003_users.sql
+++ b/migrations/core/003_users.sql
@@ -1,0 +1,15 @@
+-- agami-core auth schema — per-user identity for the hosted server.
+--
+-- Flat access: there is deliberately NO role/permission column (roles are a paid tier). `status`
+-- is the create/disable flag ('active' | 'disabled'); a disabled user cannot authenticate. The
+-- password_hash is an argon2id PHC string (algo + cost params encoded inline) — never plaintext.
+-- Keyed by an app-minted id (no SERIAL), like the runtime tables.
+
+CREATE TABLE users (
+    id            TEXT PRIMARY KEY,        -- minted by the server at create time (uuid4 hex)
+    username      TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,           -- argon2id PHC string
+    email         TEXT,
+    status        TEXT NOT NULL DEFAULT 'active',
+    created       TEXT NOT NULL
+);

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -34,6 +34,7 @@ server = [
   "mcp>=1.2",
   "uvicorn>=0.30",
   "psycopg2-binary>=2.9",
+  "argon2-cffi>=23",
 ]
 
 [tool.setuptools]

--- a/packages/agami-core/src/passwords.py
+++ b/packages/agami-core/src/passwords.py
@@ -1,0 +1,41 @@
+"""Password hashing — argon2id, the only place credentials are turned into a stored secret.
+
+We never hand-roll the KDF: hashing goes through `argon2-cffi` (the OWASP-first argon2id, a
+`[server]`-extra dependency — never in the local install). The stored value is a PHC string
+(`$argon2id$v=19$m=...,t=...,p=...$salt$hash`) that encodes the algorithm and every cost parameter
+inline, so it verifies in any language and a future backend can read the same column unchanged.
+
+`verify_password` returns a bool (never raises on a wrong password) and is timing-safe — argon2's
+verify compares in constant time, so a caller can't distinguish "no such user" from "wrong password"
+by timing as long as both paths run a verify (the user store does).
+"""
+
+from __future__ import annotations
+
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHashError, VerifyMismatchError
+
+# One shared hasher — its parameters define the cost. Defaults are argon2-cffi's recommended profile;
+# `needs_rehash` lets us raise them later and upgrade existing hashes on next login (the cross-tier
+# cost-bump path) without a migration.
+_PH = PasswordHasher()
+
+
+def hash_password(plain: str) -> str:
+    """Hash a plaintext password to an argon2id PHC string. The salt is generated per call."""
+    return _PH.hash(plain)
+
+
+def verify_password(stored: str, plain: str) -> bool:
+    """True iff `plain` matches the stored argon2id hash. Returns False (never raises) on a mismatch
+    or a malformed stored hash, so callers branch on a bool, not an exception."""
+    try:
+        return _PH.verify(stored, plain)
+    except (VerifyMismatchError, InvalidHashError):
+        return False
+
+
+def needs_rehash(stored: str) -> bool:
+    """True if the stored hash was made with weaker parameters than the current profile — the caller
+    re-hashes on the next successful login to upgrade it in place."""
+    return _PH.check_needs_rehash(stored)

--- a/packages/agami-core/src/passwords.py
+++ b/packages/agami-core/src/passwords.py
@@ -5,9 +5,10 @@ We never hand-roll the KDF: hashing goes through `argon2-cffi` (the OWASP-first 
 (`$argon2id$v=19$m=...,t=...,p=...$salt$hash`) that encodes the algorithm and every cost parameter
 inline, so it verifies in any language and a future backend can read the same column unchanged.
 
-`verify_password` returns a bool (never raises on a wrong password) and is timing-safe — argon2's
-verify compares in constant time, so a caller can't distinguish "no such user" from "wrong password"
-by timing as long as both paths run a verify (the user store does).
+`verify_password` returns a bool (never raises on a wrong password). Verifying runs the fixed-cost
+argon2 KDF whose runtime is dominated by the (input-independent) memory-hard work, so a caller that
+runs a verify on every path — including a dummy verify when the user is absent — doesn't leak whether
+a username exists by timing. `user_store.authenticate` does exactly that.
 """
 
 from __future__ import annotations

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -22,7 +22,11 @@ from ports import Principal
 from store import Store
 
 _ACTIVE = "active"
-_DISABLED = "disabled"
+
+# A throwaway argon2id hash that no password verifies against. `authenticate` verifies against it on
+# the user-absent path so every code path pays the same KDF cost — without it, a missing username
+# returns far faster than a wrong password and leaks which usernames exist (an enumeration oracle).
+_DUMMY_HASH = hash_password(uuid4().hex)
 
 
 def _now_iso() -> str:
@@ -38,6 +42,8 @@ def create_user(
 ) -> str:
     """Create a user with an argon2id-hashed password; returns the minted id. Raises if the username
     already exists (the UNIQUE constraint) — callers that want create-if-absent check first."""
+    if not password:
+        raise ValueError("password must not be empty")
     user_id = uuid4().hex
     store.execute(
         "INSERT INTO users (id, username, password_hash, email, status, created) "
@@ -66,19 +72,26 @@ def set_status(store: Store, username: str, status: str) -> None:
 def authenticate(store: Store, username: str, password: str) -> Principal | None:
     """The credential check: an active user whose password verifies → a `Principal`, else None.
 
-    A disabled user fails even with the right password. On success, opportunistically upgrade the
-    stored hash if the cost profile has risen (the cross-tier cost-bump path)."""
+    A disabled user fails even with the right password. Every path runs exactly one argon2 verify
+    (against a dummy hash when the user is absent/ineligible), so response time never reveals whether
+    a username exists — closing a timing-enumeration oracle. On success, opportunistically upgrade
+    the stored hash if the cost profile has risen (the cross-tier cost-bump path)."""
     user = get_user(store, username)
-    if user is None or user["status"] != _ACTIVE:
-        return None
-    if not verify_password(user["password_hash"], password):
+    stored_hash = user["password_hash"] if user else _DUMMY_HASH
+    verified = verify_password(stored_hash, password)
+    if user is None or user["status"] != _ACTIVE or not verified:
         return None
     if needs_rehash(user["password_hash"]):
-        store.execute(
-            "UPDATE users SET password_hash = ? WHERE username = ?",
-            (hash_password(password), username),
-        )
-        store.commit()
+        try:
+            store.execute(
+                "UPDATE users SET password_hash = ? WHERE username = ?",
+                (hash_password(password), username),
+            )
+            store.commit()
+        except Exception:
+            # Best-effort upgrade — a DB hiccup on the opportunistic rehash must not fail an
+            # otherwise-valid login.
+            pass
     return Principal(subject=username)
 
 

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -1,0 +1,98 @@
+"""The `users` store + the password credential check — per-user identity for the hosted server.
+
+This is the credential authenticator that ACE-005's OAuth authorize page calls: `authenticate`
+turns a username/password into a `Principal` (the identity ACE-005 then mints a JWT for). It is NOT
+the bearer-token `AuthProvider` (that validates the issued token — a later, separate adapter). Flat
+access only: there is no role column (roles are paid).
+
+Thin SQL over the portable `Store` (same shape as `model_store.py`), so it runs on SQLite (CI) and
+Postgres (prod) unchanged. Passwords never touch this module in plaintext beyond the moment they're
+hashed/verified via `passwords.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from passwords import hash_password, needs_rehash, verify_password
+from ports import Principal
+from store import Store
+
+_ACTIVE = "active"
+_DISABLED = "disabled"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def create_user(
+    store: Store,
+    username: str,
+    password: str,
+    email: str | None = None,
+    status: str = _ACTIVE,
+) -> str:
+    """Create a user with an argon2id-hashed password; returns the minted id. Raises if the username
+    already exists (the UNIQUE constraint) — callers that want create-if-absent check first."""
+    user_id = uuid4().hex
+    store.execute(
+        "INSERT INTO users (id, username, password_hash, email, status, created) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (user_id, username, hash_password(password), email, status, _now_iso()),
+    )
+    store.commit()
+    return user_id
+
+
+def get_user(store: Store, username: str) -> dict[str, Any] | None:
+    rows = store.query("SELECT * FROM users WHERE username = ?", (username,))
+    return rows[0] if rows else None
+
+
+def list_users(store: Store) -> list[dict[str, Any]]:
+    """Identity rows only — never selects `password_hash` (so a listing can't leak the secret)."""
+    return store.query("SELECT id, username, email, status, created FROM users ORDER BY username")
+
+
+def set_status(store: Store, username: str, status: str) -> None:
+    store.execute("UPDATE users SET status = ? WHERE username = ?", (status, username))
+    store.commit()
+
+
+def authenticate(store: Store, username: str, password: str) -> Principal | None:
+    """The credential check: an active user whose password verifies → a `Principal`, else None.
+
+    A disabled user fails even with the right password. On success, opportunistically upgrade the
+    stored hash if the cost profile has risen (the cross-tier cost-bump path)."""
+    user = get_user(store, username)
+    if user is None or user["status"] != _ACTIVE:
+        return None
+    if not verify_password(user["password_hash"], password):
+        return None
+    if needs_rehash(user["password_hash"]):
+        store.execute(
+            "UPDATE users SET password_hash = ? WHERE username = ?",
+            (hash_password(password), username),
+        )
+        store.commit()
+    return Principal(subject=username)
+
+
+def seed_admin_from_env(store: Store) -> str | None:
+    """Seed the initial admin from AGAMI_ADMIN_USERNAME / AGAMI_ADMIN_PASSWORD if both are set.
+
+    Create-if-absent and idempotent: a redeploy never duplicates the admin or clobbers a
+    password the admin has since changed. Returns the username seeded, or None if unset/already
+    present. (Rotating the seed password is out of scope — that's a later reset path.)"""
+    username = os.environ.get("AGAMI_ADMIN_USERNAME", "").strip()
+    password = os.environ.get("AGAMI_ADMIN_PASSWORD", "")
+    if not username or not password:
+        return None
+    if get_user(store, username) is not None:
+        return None
+    create_user(store, username, password, status=_ACTIVE)
+    return username

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -37,14 +37,16 @@ def test_real_migrations_create_all_tables_on_empty_db():
 
 
 def test_users_table_is_flat_no_role_column():
-    # ACE-004: the users table exists with the identity columns and, crucially, NO role/permission
-    # column — flat access is the open-core contract (roles are paid).
+    # The users table exists with the identity columns and, crucially, NO role/permission column —
+    # flat access is the open-core contract (roles are paid).
     s = Store.connect("sqlite://")
     s.run_migrations()
     assert "users" in _tables(s)
     cols = {r["name"] for r in s.query("PRAGMA table_info(users)")}
     assert {"id", "username", "password_hash", "email", "status", "created"} <= cols
-    assert not (cols & {"role", "roles", "permission", "permissions"}), "flat access — no role column"
+    assert not (cols & {"role", "roles", "permission", "permissions"}), (
+        "flat access — no role column"
+    )
     s.close()
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -36,6 +36,18 @@ def test_real_migrations_create_all_tables_on_empty_db():
     s.close()
 
 
+def test_users_table_is_flat_no_role_column():
+    # ACE-004: the users table exists with the identity columns and, crucially, NO role/permission
+    # column — flat access is the open-core contract (roles are paid).
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    assert "users" in _tables(s)
+    cols = {r["name"] for r in s.query("PRAGMA table_info(users)")}
+    assert {"id", "username", "password_hash", "email", "status", "created"} <= cols
+    assert not (cols & {"role", "roles", "permission", "permissions"}), "flat access — no role column"
+    s.close()
+
+
 def test_migrations_are_idempotent_on_real_dir():
     s = Store.connect("sqlite://")
     s.run_migrations()

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -1,0 +1,115 @@
+"""User store + password authentication (ACE-004).
+
+SQLite-backed (the portable backend the gate runs on). Proves: argon2id hashing (never plaintext),
+correct/wrong verify, the disabled-status gate, the env-seeded admin (idempotent), the rehash
+upgrade path, and that a listing never leaks the hash.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("argon2")  # the password path needs the [server]-extra argon2-cffi
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import user_store  # noqa: E402
+from store import Store  # noqa: E402
+
+
+def _store() -> Store:
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    return s
+
+
+def test_create_then_authenticate_round_trip():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw", email="you@example.com")
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
+    s.close()
+
+
+def test_wrong_password_fails():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    assert user_store.authenticate(s, "admin", "wrong") is None
+    assert user_store.authenticate(s, "nobody", "s3cret-pw") is None  # unknown user
+    s.close()
+
+
+def test_password_is_argon2id_and_never_plaintext():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    stored = user_store.get_user(s, "admin")["password_hash"]
+    assert stored.startswith("$argon2id$")
+    assert "s3cret-pw" not in stored
+    s.close()
+
+
+def test_disabled_status_blocks_login():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    user_store.set_status(s, "admin", "disabled")
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is None  # right pw, but disabled
+    user_store.set_status(s, "admin", "active")
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
+    s.close()
+
+
+def test_authenticate_returns_principal_with_username_subject():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    principal = user_store.authenticate(s, "admin", "s3cret-pw")
+    assert principal is not None and principal.subject == "admin"
+    s.close()
+
+
+def test_list_users_never_exposes_the_hash():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    rows = user_store.list_users(s)
+    assert rows and "password_hash" not in rows[0]
+    s.close()
+
+
+def test_seed_admin_from_env_creates_and_is_idempotent(monkeypatch):
+    s = _store()
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", "admin")
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", "seed-pw")
+    assert user_store.seed_admin_from_env(s) == "admin"
+    assert user_store.authenticate(s, "admin", "seed-pw") is not None
+    # second run is a no-op (no duplicate, no clobber)
+    assert user_store.seed_admin_from_env(s) is None
+    assert len(user_store.list_users(s)) == 1
+    s.close()
+
+
+def test_seed_admin_noop_when_env_unset(monkeypatch):
+    s = _store()
+    monkeypatch.delenv("AGAMI_ADMIN_USERNAME", raising=False)
+    monkeypatch.delenv("AGAMI_ADMIN_PASSWORD", raising=False)
+    assert user_store.seed_admin_from_env(s) is None
+    assert user_store.list_users(s) == []
+    s.close()
+
+
+def test_needs_rehash_upgrade_path(monkeypatch):
+    # Simulate a stored hash made with a weaker profile: authenticate should re-store an upgraded
+    # hash in place (the cross-tier cost-bump path) without changing the verified password.
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    before = user_store.get_user(s, "admin")["password_hash"]
+    # user_store imported needs_rehash by name, so patch the binding it actually calls.
+    monkeypatch.setattr(user_store, "needs_rehash", lambda stored: True)
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
+    after = user_store.get_user(s, "admin")["password_hash"]
+    assert after != before and after.startswith("$argon2id$")
+    # the upgraded hash still verifies the same password
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
+    s.close()

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -43,6 +43,28 @@ def test_wrong_password_fails():
     s.close()
 
 
+def test_empty_password_is_rejected_at_create():
+    s = _store()
+    with pytest.raises(ValueError):
+        user_store.create_user(s, "admin", "")
+    assert user_store.list_users(s) == []  # nothing created
+    s.close()
+
+
+def test_authenticate_runs_a_verify_even_for_unknown_user(monkeypatch):
+    # The anti-enumeration guard: a missing username still runs a verify (against the dummy hash),
+    # so the call can't be distinguished by "did verify run". We assert the spy fired.
+    s = _store()
+    calls: list[str] = []
+    real = user_store.verify_password
+    monkeypatch.setattr(
+        user_store, "verify_password", lambda h, p: (calls.append(h), real(h, p))[1]
+    )
+    assert user_store.authenticate(s, "ghost", "whatever") is None
+    assert calls == [user_store._DUMMY_HASH]  # verified against the dummy, not skipped
+    s.close()
+
+
 def test_password_is_argon2id_and_never_plaintext():
     s = _store()
     user_store.create_user(s, "admin", "s3cret-pw")


### PR DESCRIPTION
## Summary

Adds per-user identity for the hosted server: a `users` table + argon2id password verification, wired as the credential authenticator that the OAuth authorize page will call. Flat access (no roles — paid tier). **Targets `feature/app-auth`** (the integration branch) — main stays validated-only until the auth feature is assembled and smoke-tested end-to-end.

This is the **credential check**, not the bearer-token gate: `authenticate(username, password) -> Principal` produces the identity that the authorize/token endpoints will mint a JWT for. The token-validating `AuthProvider` (JWT) and the transport wiring are the next spec; the presence-only default stays until then.

## Changes

- **`migrations/core/003_users.sql`** — `users (id, username UNIQUE, password_hash, email, status, created)`, portable DDL (SQLite in CI / Postgres in prod). No role/permission column.
- **`passwords.py`** — argon2id via `argon2-cffi` (`[server]` extra only, never the local install): `hash_password` (PHC string), timing-safe `verify_password` (bool, never raises), `needs_rehash`.
- **`user_store.py`** — `create_user` / `get_user` / `list_users` (never selects the hash) / `set_status` / `authenticate` / `seed_admin_from_env` (idempotent, create-if-absent from `AGAMI_ADMIN_USERNAME`/`AGAMI_ADMIN_PASSWORD`).
- **`argon2-cffi>=23`** added to the `[server]` extra.

## Security review (high lane — mandatory)

Ran `/code-review` + a dedicated security pass. Both independently flagged a **timing/username-enumeration oracle** (the no-user/disabled paths skipped the verify) — **fixed**: `authenticate` now runs a verify on every path (against a dummy hash when the user is absent), so response time can't reveal which usernames exist. Also fixed from review: reject empty passwords at create; made the opportunistic rehash best-effort (a DB hiccup can't fail a valid login); dropped a dead constant. Confirmed clean: no plaintext/hash in logs or errors, parameterized SQL (no injection), `list_users` omits the hash, seed reads the env password once and never persists it plaintext.

## Test plan

`tests/test_user_store.py` + a `users` case in `test_schema.py`: argon2id hash (not plaintext), correct/wrong verify, disabled-status gate, dummy-verify on unknown user, empty-password rejection, idempotent env-seed, rehash upgrade path, no-hash-leak, flat no-role schema. Full gate green (`uv run dev.py check` — ruff + 766 tests + gitleaks).

## Checklist

- [x] `uv run dev.py check` green
- [x] New behavior covered by tests; security review done (high lane)
- [x] No real customer data/names/credentials; no internal IDs in repo files
- [x] Targets the `feature/app-auth` integration branch

Spec: ACE-004