### PR TITLE
OAuth provider — authorize + token + PKCE + JWT issuance (1 of 2)

### DIFF
--- a/migrations/core/004_oauth.sql
+++ b/migrations/core/004_oauth.sql
@@ -14,8 +14,8 @@ CREATE TABLE oauth_client (
 CREATE TABLE oauth_state (
     code           TEXT PRIMARY KEY,        -- the authorization code (secrets.token_urlsafe)
     client_id      TEXT,
-    redirect_uri   TEXT,
-    code_challenge TEXT,                     -- PKCE S256 challenge; verified at token exchange
+    redirect_uri   TEXT NOT NULL,           -- always validated + present before a code is issued
+    code_challenge TEXT NOT NULL,           -- PKCE S256 challenge (required); verified at token exchange
     username       TEXT NOT NULL,           -- the authenticated principal the code stands in for
     expires_at     TEXT NOT NULL,           -- short-lived; expired codes are rejected
     used           INTEGER NOT NULL DEFAULT 0,  -- single-use: set on first successful exchange

--- a/migrations/core/004_oauth.sql
+++ b/migrations/core/004_oauth.sql
@@ -1,0 +1,23 @@
+-- agami-core OAuth provider schema — the server's own authorize/token flow.
+--
+-- oauth_client: clients that registered (claude.ai via the minimal RFC-7591 endpoint). Minimal by
+-- design — full DCR (client auth, rotation) is deferred. oauth_state: one row per issued
+-- authorization code, bound to its PKCE challenge + redirect_uri + the authenticated username, with
+-- a short expiry and a single-use flag. Keyed by app-minted values (no SERIAL), like the rest.
+
+CREATE TABLE oauth_client (
+    client_id     TEXT PRIMARY KEY,        -- minted by /oauth/register (uuid4 hex)
+    redirect_uris TEXT,                     -- space-separated, as registered (may be empty)
+    created       TEXT NOT NULL
+);
+
+CREATE TABLE oauth_state (
+    code           TEXT PRIMARY KEY,        -- the authorization code (secrets.token_urlsafe)
+    client_id      TEXT,
+    redirect_uri   TEXT,
+    code_challenge TEXT,                     -- PKCE S256 challenge; verified at token exchange
+    username       TEXT NOT NULL,           -- the authenticated principal the code stands in for
+    expires_at     TEXT NOT NULL,           -- short-lived; expired codes are rejected
+    used           INTEGER NOT NULL DEFAULT 0,  -- single-use: set on first successful exchange
+    created        TEXT NOT NULL
+);

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -35,6 +35,7 @@ server = [
   "uvicorn>=0.30",
   "psycopg2-binary>=2.9",
   "argon2-cffi>=23",
+  "PyJWT>=2.8",
 ]
 
 [tool.setuptools]

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -80,12 +80,18 @@ _PUBLIC_PREFIXES = (
 )
 
 
+# The OAuth flow endpoints are pre-auth by definition — the user has no bearer token yet (they're
+# obtaining one). They enforce their own validation (credential check, PKCE, single-use codes,
+# redirect allow-listing), so they're public at the transport layer.
+_OAUTH_PATHS = ("/oauth/authorize", "/oauth/token", "/oauth/register")
+
+
 def _is_public_path(path: str) -> bool:
-    """True for the discovery routes and their path-suffixed variants only. We match on a path
-    *boundary* (exact, or prefix + '/'), not a bare `startswith` — otherwise a sibling like
-    `/.well-known/oauth-protected-resource-x` would skip auth too. Today such a path only 404s, but
-    boundary-matching keeps the open surface == the routes we serve even if a route is added later."""
-    return any(path == p or path.startswith(p + "/") for p in _PUBLIC_PREFIXES)
+    """True for the discovery routes and the OAuth-flow endpoints — the surface reachable before a
+    client has a token. We match on a path *boundary* (exact, or prefix + '/'), not a bare
+    `startswith`, so a sibling like `/.well-known/oauth-protected-resource-x` doesn't skip auth."""
+    prefixes = _PUBLIC_PREFIXES + _OAUTH_PATHS
+    return any(path == p or path.startswith(p + "/") for p in prefixes)
 
 
 class _AuthMiddleware(BaseHTTPMiddleware):
@@ -192,11 +198,16 @@ def build_app() -> Starlette:
         async with session_manager.run():
             yield
 
+    from oauth_server import authorize, register, token
+
     routes = [
         Route("/.well-known/oauth-protected-resource", _protected_resource),
         Route("/.well-known/oauth-protected-resource/{rest:path}", _protected_resource),
         Route("/.well-known/oauth-authorization-server", _auth_server),
         Route("/.well-known/oauth-authorization-server/{rest:path}", _auth_server),
+        Route("/oauth/authorize", authorize, methods=["GET", "POST"]),
+        Route("/oauth/token", token, methods=["POST"]),
+        Route("/oauth/register", register, methods=["POST"]),
         Mount("/mcp", app=handle_mcp),
     ]
     middleware = [Middleware(_AuthMiddleware, resolver=_build_org_resolver())]

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -88,10 +88,13 @@ _OAUTH_PATHS = ("/oauth/authorize", "/oauth/token", "/oauth/register")
 
 def _is_public_path(path: str) -> bool:
     """True for the discovery routes and the OAuth-flow endpoints — the surface reachable before a
-    client has a token. We match on a path *boundary* (exact, or prefix + '/'), not a bare
-    `startswith`, so a sibling like `/.well-known/oauth-protected-resource-x` doesn't skip auth."""
-    prefixes = _PUBLIC_PREFIXES + _OAUTH_PATHS
-    return any(path == p or path.startswith(p + "/") for p in prefixes)
+    client has a token. Discovery uses boundary matching (it has `{rest:path}` suffix routes, and a
+    bare `startswith` would let `/.well-known/oauth-protected-resource-x` skip auth); the OAuth
+    endpoints are matched *exactly* (only those three paths are routed), so a future
+    `/oauth/token/...` route can't inherit public access by accident."""
+    if any(path == p or path.startswith(p + "/") for p in _PUBLIC_PREFIXES):
+        return True
+    return path in _OAUTH_PATHS
 
 
 class _AuthMiddleware(BaseHTTPMiddleware):

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -1,0 +1,264 @@
+"""The server's OAuth 2.1 authorize/token/register endpoints — what claude.ai's connector completes.
+
+The transport's discovery metadata points here; this module is the actual provider:
+`/oauth/register` (minimal RFC 7591), `/oauth/authorize` (login → authorization code), `/oauth/token`
+(code + PKCE verifier → a self-signed HS256 JWT). Credentials are checked by `user_store.authenticate`;
+the issued JWT is what the transport will trust once a follow-up change wires the token validator in.
+
+Security invariants enforced here: authorization codes are single-use + short-lived; PKCE (S256) is
+required; redirect URIs are allow-listed (the claude.ai callback, the public base URL, or a URI the
+client registered) so a code can't be sent to an attacker; the signing secret and tokens are never
+logged or echoed in an error body. This module makes NO network call — it only mints/validates
+locally and tells the browser where to redirect.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import html
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlencode, urlsplit
+from uuid import uuid4
+
+import jwt
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from store import Store
+from user_store import authenticate
+
+_CODE_TTL = timedelta(minutes=10)  # authorization codes are short-lived
+_JWT_TTL = timedelta(hours=1)
+# Claude's fixed OAuth callback (the connector redirects here after authorize). The .com host is the
+# announced future move; allow both so the connection survives the switch.
+_CLAUDE_CALLBACKS = (
+    "https://claude.ai/api/mcp/auth_callback",
+    "https://claude.com/api/mcp/auth_callback",
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# HS256 forgeability scales with secret weakness; RFC 7518 §3.2 wants a key ≥ the hash output.
+_MIN_SECRET_BYTES = 32
+
+
+def _signing_secret() -> str:
+    """The HS256 signing secret. Required when the OAuth provider is active — fail fast (like
+    PUBLIC_BASE_URL) rather than mint a token under a weak/absent key."""
+    secret = os.environ.get("AGAMI_SIGNING_SECRET", "")
+    if not secret:
+        raise RuntimeError(
+            "AGAMI_SIGNING_SECRET must be set to issue OAuth tokens (the deploy generates it)."
+        )
+    if len(secret.encode()) < _MIN_SECRET_BYTES:
+        raise RuntimeError(
+            f"AGAMI_SIGNING_SECRET must be at least {_MIN_SECRET_BYTES} bytes (HS256 strength)."
+        )
+    return secret
+
+
+def issue_jwt(subject: str) -> str:
+    """A self-signed HS256 JWT for `subject` — the Bearer token the transport will accept."""
+    from mcp_http import public_base_url  # lazy: mcp_http imports these handlers at module load
+
+    now = _now()
+    payload = {
+        "sub": subject,
+        "iss": public_base_url(),
+        "iat": int(now.timestamp()),
+        "exp": int((now + _JWT_TTL).timestamp()),
+    }
+    return jwt.encode(payload, _signing_secret(), algorithm="HS256")
+
+
+def _b64url_nopad(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _verify_pkce(code_verifier: str, code_challenge: str | None) -> bool:
+    """PKCE S256: the challenge must equal base64url(sha256(verifier)), compared constant-time."""
+    if not code_verifier or not code_challenge:
+        return False
+    expected = _b64url_nopad(hashlib.sha256(code_verifier.encode()).digest())
+    return hmac.compare_digest(expected, code_challenge)
+
+
+def _same_origin(a: str, b: str) -> bool:
+    """Scheme + host(:port) equality. NOT a string prefix — `startswith` would accept
+    `https://host.com.evil.com` for a base of `https://host.com` (an open redirect)."""
+    pa, pb = urlsplit(a), urlsplit(b)
+    return bool(pa.scheme) and pa.scheme == pb.scheme and pa.netloc == pb.netloc
+
+
+def _redirect_allowed(redirect_uri: str, registered: str | None) -> bool:
+    """Allow only the claude.ai callback, a same-origin URI under PUBLIC_BASE_URL, or one the client
+    registered (exact match) — so an authorization code can never be redirected to an attacker host."""
+    from mcp_http import public_base_url
+
+    if not redirect_uri:
+        return False
+    if redirect_uri in _CLAUDE_CALLBACKS:
+        return True
+    if registered and redirect_uri in registered.split():
+        return True
+    return _same_origin(redirect_uri, public_base_url())
+
+
+async def _form(request: Request) -> dict[str, str]:
+    """Parse an application/x-www-form-urlencoded body without pulling in python-multipart."""
+    body = (await request.body()).decode()
+    return {k: v[0] for k, v in parse_qs(body).items()}
+
+
+def _oauth_error(error: str, description: str, status: int = 400) -> JSONResponse:
+    # OAuth-style error; never includes a token, secret, or the submitted password.
+    return JSONResponse({"error": error, "error_description": description}, status_code=status)
+
+
+def _open_store() -> Store | None:
+    return Store.from_env()
+
+
+async def register(request: Request) -> Response:
+    """Minimal RFC 7591 dynamic client registration — mint a client_id so the connector can proceed.
+    Full DCR (client auth, rotation) is deferred."""
+    store = _open_store()
+    if store is None:
+        return _oauth_error("server_error", "no datastore configured", status=500)
+    try:
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        redirect_uris = body.get("redirect_uris") or []
+        client_id = uuid4().hex
+        store.execute(
+            "INSERT INTO oauth_client (client_id, redirect_uris, created) VALUES (?, ?, ?)",
+            (client_id, " ".join(redirect_uris), _now().isoformat()),
+        )
+        store.commit()
+        return JSONResponse(
+            {
+                "client_id": client_id,
+                "redirect_uris": redirect_uris,
+                "token_endpoint_auth_method": "none",
+            },
+            status_code=201,
+        )
+    finally:
+        store.close()
+
+
+def _login_form(params: dict[str, str], error: str = "") -> HTMLResponse:
+    """A minimal login form that carries the OAuth params forward as hidden fields. Neutral
+    placeholders only — no real names or secrets."""
+    # Escape every interpolated value — these come from attacker-controllable query/body params and
+    # land in HTML attributes on the password-entry page; unescaped, they're a reflected-XSS vector.
+    hidden = "".join(
+        f'<input type="hidden" name="{k}" value="{html.escape(params.get(k, ""), quote=True)}">'
+        for k in ("client_id", "redirect_uri", "code_challenge", "state")
+    )
+    msg = f'<p role="alert">{html.escape(error)}</p>' if error else ""
+    return HTMLResponse(
+        f"""<!doctype html><html><head><meta charset="utf-8"><title>Sign in</title></head>
+<body><h1>Sign in</h1>{msg}
+<form method="post">{hidden}
+<label>Username <input name="username" autocomplete="username" placeholder="admin"></label>
+<label>Password <input name="password" type="password" autocomplete="current-password"></label>
+<button type="submit">Sign in</button></form></body></html>"""
+    )
+
+
+async def authorize(request: Request) -> Response:
+    """GET → the login form (carrying the OAuth params); POST → verify credentials and redirect to
+    the client with a fresh authorization code, or re-render with an error."""
+    if request.method == "GET":
+        return _login_form(dict(request.query_params))
+
+    form = await _form(request)
+    store = _open_store()
+    if store is None:
+        return _oauth_error("server_error", "no datastore configured", status=500)
+    try:
+        redirect_uri = form.get("redirect_uri", "")
+        client_id = form.get("client_id", "")
+        client = store.query(
+            "SELECT redirect_uris FROM oauth_client WHERE client_id = ?", (client_id,)
+        )
+        registered = client[0]["redirect_uris"] if client else None
+        # Validate the redirect target BEFORE authenticating — never send a code to an unvetted URL.
+        if not _redirect_allowed(redirect_uri, registered):
+            return _oauth_error("invalid_request", "redirect_uri not allowed")
+
+        principal = authenticate(store, form.get("username", ""), form.get("password", ""))
+        if principal is None:
+            return _login_form(form, error="Invalid username or password.")
+
+        code = secrets.token_urlsafe(32)
+        store.execute(
+            "INSERT INTO oauth_state (code, client_id, redirect_uri, code_challenge, username, "
+            "expires_at, used, created) VALUES (?, ?, ?, ?, ?, ?, 0, ?)",
+            (
+                code,
+                client_id,
+                redirect_uri,
+                form.get("code_challenge"),
+                principal.subject,
+                (_now() + _CODE_TTL).isoformat(),
+                _now().isoformat(),
+            ),
+        )
+        store.commit()
+        query = urlencode({"code": code, "state": form.get("state", "")})
+        return RedirectResponse(f"{redirect_uri}?{query}", status_code=302)
+    finally:
+        store.close()
+
+
+async def token(request: Request) -> Response:
+    """Exchange an authorization code + PKCE verifier for a self-signed JWT. Enforces single-use,
+    expiry, redirect match, and PKCE — any failure is a 400 with no token in the body."""
+    form = await _form(request)
+    if form.get("grant_type") != "authorization_code":
+        return _oauth_error("unsupported_grant_type", "only authorization_code is supported")
+
+    store = _open_store()
+    if store is None:
+        return _oauth_error("server_error", "no datastore configured", status=500)
+    try:
+        rows = store.query("SELECT * FROM oauth_state WHERE code = ?", (form.get("code", ""),))
+        row = rows[0] if rows else None
+        if row is None or row["used"]:
+            return _oauth_error("invalid_grant", "code is invalid or already used")
+        if _now().isoformat() > row["expires_at"]:
+            return _oauth_error("invalid_grant", "code has expired")
+        if form.get("redirect_uri", "") != (row["redirect_uri"] or ""):
+            return _oauth_error("invalid_grant", "redirect_uri mismatch")
+        if not _verify_pkce(form.get("code_verifier", ""), row["code_challenge"]):
+            return _oauth_error("invalid_grant", "PKCE verification failed")
+        # Confirm we can sign (secret present AND strong enough) BEFORE burning the code, so a
+        # misconfigured server doesn't consume the code on a request it can't fulfil.
+        try:
+            _signing_secret()
+        except RuntimeError:
+            return _oauth_error("server_error", "token signing is not configured", status=500)
+
+        # Single-use: burn the code before issuing, so a replay finds it already used.
+        store.execute("UPDATE oauth_state SET used = 1 WHERE code = ?", (row["code"],))
+        store.commit()
+        access_token = issue_jwt(row["username"])
+        return JSONResponse(
+            {
+                "access_token": access_token,
+                "token_type": "Bearer",
+                "expires_in": int(_JWT_TTL.total_seconds()),
+            }
+        )
+    finally:
+        store.close()

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -137,6 +137,10 @@ async def register(request: Request) -> Response:
         except Exception:
             body = {}
         redirect_uris = body.get("redirect_uris") or []
+        if not isinstance(redirect_uris, list) or not all(
+            isinstance(u, str) for u in redirect_uris
+        ):
+            return _oauth_error("invalid_request", "redirect_uris must be a list of strings")
         client_id = uuid4().hex
         store.execute(
             "INSERT INTO oauth_client (client_id, redirect_uris, created) VALUES (?, ?, ?)",
@@ -195,6 +199,11 @@ async def authorize(request: Request) -> Response:
         # Validate the redirect target BEFORE authenticating — never send a code to an unvetted URL.
         if not _redirect_allowed(redirect_uri, registered):
             return _oauth_error("invalid_request", "redirect_uri not allowed")
+        # PKCE is mandatory: reject a missing challenge now rather than persist a code that could
+        # never be redeemed (the token step requires a verifier that matches it).
+        code_challenge = form.get("code_challenge", "")
+        if not code_challenge:
+            return _oauth_error("invalid_request", "code_challenge is required (PKCE)")
 
         principal = authenticate(store, form.get("username", ""), form.get("password", ""))
         if principal is None:
@@ -208,7 +217,7 @@ async def authorize(request: Request) -> Response:
                 code,
                 client_id,
                 redirect_uri,
-                form.get("code_challenge"),
+                code_challenge,
                 principal.subject,
                 (_now() + _CODE_TTL).isoformat(),
                 _now().isoformat(),
@@ -249,9 +258,15 @@ async def token(request: Request) -> Response:
         except RuntimeError:
             return _oauth_error("server_error", "token signing is not configured", status=500)
 
-        # Single-use: burn the code before issuing, so a replay finds it already used.
-        store.execute("UPDATE oauth_state SET used = 1 WHERE code = ?", (row["code"],))
+        # Single-use, atomically: only the request that flips used 0→1 may issue a token. The
+        # conditional UPDATE + rowcount check closes the read-then-write race two concurrent
+        # exchanges would otherwise win together (double-issued JWTs for one code).
+        burned = store.execute(
+            "UPDATE oauth_state SET used = 1 WHERE code = ? AND used = 0", (row["code"],)
+        )
         store.commit()
+        if burned.rowcount != 1:
+            return _oauth_error("invalid_grant", "code is invalid or already used")
         access_token = issue_jwt(row["username"])
         return JSONResponse(
             {

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -1,9 +1,9 @@
 """The `users` store + the password credential check — per-user identity for the hosted server.
 
-This is the credential authenticator that ACE-005's OAuth authorize page calls: `authenticate`
-turns a username/password into a `Principal` (the identity ACE-005 then mints a JWT for). It is NOT
-the bearer-token `AuthProvider` (that validates the issued token — a later, separate adapter). Flat
-access only: there is no role column (roles are paid).
+This is the credential authenticator the OAuth authorize page calls: `authenticate` turns a
+username/password into a `Principal` (the identity the token endpoint then mints a JWT for). It is
+NOT the bearer-token `AuthProvider` (that validates the issued token — a later, separate adapter).
+Flat access only: there is no role column (roles are paid).
 
 Thin SQL over the portable `Store` (same shape as `model_store.py`), so it runs on SQLite (CI) and
 Postgres (prod) unchanged. Passwords never touch this module in plaintext beyond the moment they're

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -116,10 +116,32 @@ def test_bad_credentials_re_render_form_without_a_code(env):
     c = TestClient(mcp_http.build_app())
     r = c.post(
         "/oauth/authorize",
-        data={"username": "admin", "password": "wrong", "redirect_uri": REDIRECT},
+        data={
+            "username": "admin",
+            "password": "wrong",
+            "redirect_uri": REDIRECT,
+            "code_challenge": _challenge(VERIFIER),  # valid PKCE so we reach the credential check
+        },
         follow_redirects=False,
     )
     assert r.status_code == 200 and "Invalid username or password" in r.text
+
+
+def test_authorize_requires_pkce_challenge(env):
+    # PKCE is mandatory — a submission without a code_challenge is rejected before any code is minted.
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={"username": "admin", "password": "s3cret-pw", "redirect_uri": REDIRECT},
+        follow_redirects=False,
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
+
+
+def test_register_rejects_malformed_redirect_uris(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post("/oauth/register", json={"redirect_uris": "not-a-list"})
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
 
 
 def test_wrong_pkce_verifier_is_rejected(env):
@@ -268,3 +290,6 @@ def test_oauth_endpoints_are_public_but_mcp_still_requires_auth(env):
     assert c.get("/oauth/authorize", params={"redirect_uri": REDIRECT}).status_code == 200
     r = c.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
     assert r.status_code == 401  # the MCP endpoint still demands a bearer
+    # The OAuth skip is EXACT-match: a sibling under /oauth/* that isn't a real route doesn't get a
+    # free pass — it still hits auth (401) rather than being treated as public.
+    assert c.post("/oauth/token/extra").status_code == 401

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -1,0 +1,270 @@
+"""The OAuth provider — authorize + token + register, end to end over the Starlette app.
+
+SQLite-backed (the portable backend the gate runs on). Proves the full authorization-code + PKCE
+round trip yields a verifiable JWT, and that every guard fires: wrong PKCE verifier, reused code,
+expired code, redirect mismatch, bad credentials, missing signing secret. Also that the /oauth/*
+endpoints are reachable without a bearer while /mcp still 401s.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+pytest.importorskip("starlette")
+pytest.importorskip("mcp")
+pytest.importorskip("jwt")
+pytest.importorskip("argon2")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import jwt  # noqa: E402
+import mcp_http  # noqa: E402
+import user_store  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+from store import Store  # noqa: E402
+
+BASE = "https://your-host.example.com"
+SECRET = "x" * 40  # a throwaway HS256 key for tests (≥32 bytes); obviously not a real secret
+REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+VERIFIER = "a" * 64  # a fixed PKCE code_verifier
+
+
+def _challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    db_url = "sqlite://" + str(tmp_path / "oauth.db")
+    monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    monkeypatch.setenv("AGAMI_DB_URL", db_url)
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    # Seed the schema + a user the authorize step can authenticate.
+    s = Store.connect(db_url)
+    s.run_migrations()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    s.close()
+    return db_url
+
+
+def _authorize_code(
+    client: TestClient, *, redirect: str = REDIRECT, challenge: str | None = None
+) -> str:
+    """Run the authorize POST and return the issued authorization code from the redirect."""
+    resp = client.post(
+        "/oauth/authorize",
+        data={
+            "username": "admin",
+            "password": "s3cret-pw",
+            "redirect_uri": redirect,
+            "client_id": "cid",
+            "code_challenge": challenge if challenge is not None else _challenge(VERIFIER),
+            "state": "xyz",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    loc = resp.headers["location"]
+    assert loc.startswith(redirect)
+    qs = parse_qs(urlparse(loc).query)
+    assert qs["state"] == ["xyz"]
+    return qs["code"][0]
+
+
+def test_register_mints_a_client_id(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post("/oauth/register", json={"redirect_uris": [REDIRECT]})
+    assert r.status_code == 201
+    assert r.json()["client_id"]
+
+
+def test_authorize_get_renders_a_login_form(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.get("/oauth/authorize", params={"redirect_uri": REDIRECT, "state": "xyz"})
+    assert r.status_code == 200 and "<form" in r.text and 'name="password"' in r.text
+
+
+def test_full_pkce_flow_yields_a_verifiable_jwt(env):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["token_type"] == "Bearer" and body["expires_in"] == 3600
+    claims = jwt.decode(body["access_token"], SECRET, algorithms=["HS256"])
+    assert claims["sub"] == "admin" and claims["iss"] == BASE
+
+
+def test_bad_credentials_re_render_form_without_a_code(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={"username": "admin", "password": "wrong", "redirect_uri": REDIRECT},
+        follow_redirects=False,
+    )
+    assert r.status_code == 200 and "Invalid username or password" in r.text
+
+
+def test_wrong_pkce_verifier_is_rejected(env):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": "b" * 64,  # wrong verifier
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_grant"
+
+
+def test_code_is_single_use(env):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": VERIFIER,
+        "redirect_uri": REDIRECT,
+    }
+    assert c.post("/oauth/token", data=data).status_code == 200
+    assert c.post("/oauth/token", data=data).status_code == 400  # reuse rejected
+
+
+def test_expired_code_is_rejected(env, monkeypatch):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    # Force the stored code to be in the past.
+    s = Store.from_env()
+    s.execute(
+        "UPDATE oauth_state SET expires_at = ? WHERE code = ?",
+        ("2000-01-01T00:00:00+00:00", code),
+    )
+    s.commit()
+    s.close()
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 400 and "expired" in r.json()["error_description"]
+
+
+def test_redirect_uri_mismatch_is_rejected_at_token(env):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": BASE + "/different",  # not what the code was issued for
+        },
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_grant"
+
+
+def test_disallowed_redirect_is_rejected_at_authorize(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={
+            "username": "admin",
+            "password": "s3cret-pw",
+            "redirect_uri": "https://evil.example.com/steal",
+            "client_id": "cid",
+            "code_challenge": _challenge(VERIFIER),
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
+
+
+def test_missing_signing_secret_fails_cleanly_without_burning_the_code(env, monkeypatch):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    monkeypatch.delenv("AGAMI_SIGNING_SECRET", raising=False)
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": VERIFIER,
+        "redirect_uri": REDIRECT,
+    }
+    r = c.post("/oauth/token", data=data)
+    assert r.status_code == 500 and r.json()["error"] == "server_error"
+    # the code was NOT consumed — it works once the secret is restored
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    assert c.post("/oauth/token", data=data).status_code == 200
+
+
+def test_prefix_confusion_redirect_is_rejected(env):
+    # Open-redirect guard: a host that merely *prefixes* PUBLIC_BASE_URL is a different origin and
+    # must be rejected (startswith would have wrongly allowed it).
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={
+            "username": "admin",
+            "password": "s3cret-pw",
+            "redirect_uri": BASE + ".evil.example.com/cb",  # same prefix, different origin
+            "code_challenge": _challenge(VERIFIER),
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
+
+
+def test_same_origin_redirect_under_public_base_url_is_allowed(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={
+            "username": "admin",
+            "password": "s3cret-pw",
+            "redirect_uri": BASE + "/callback",  # same scheme+host as PUBLIC_BASE_URL
+            "code_challenge": _challenge(VERIFIER),
+            "state": "xyz",
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 302 and r.headers["location"].startswith(BASE + "/callback")
+
+
+def test_login_form_escapes_params_no_reflected_xss(env):
+    # The carried OAuth params land in HTML attributes on the password page; they must be escaped.
+    c = TestClient(mcp_http.build_app())
+    r = c.get("/oauth/authorize", params={"state": '"><script>alert(1)</script>'})
+    assert r.status_code == 200
+    assert "<script>alert(1)</script>" not in r.text  # not reflected raw
+    assert "&lt;script&gt;" in r.text  # escaped instead
+
+
+def test_oauth_endpoints_are_public_but_mcp_still_requires_auth(env):
+    c = TestClient(mcp_http.build_app())
+    assert c.get("/oauth/authorize", params={"redirect_uri": REDIRECT}).status_code == 200
+    r = c.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert r.status_code == 401  # the MCP endpoint still demands a bearer

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -36,6 +36,24 @@ def test_real_migrations_create_all_tables_on_empty_db():
     s.close()
 
 
+def test_oauth_tables_exist():
+    # The OAuth provider owns these: oauth_client (registered clients) + oauth_state (authorization
+    # codes bound to their PKCE challenge + redirect + the authenticated username).
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    assert {"oauth_client", "oauth_state"} <= _tables(s)
+    state_cols = {r["name"] for r in s.query("PRAGMA table_info(oauth_state)")}
+    assert {
+        "code",
+        "code_challenge",
+        "redirect_uri",
+        "username",
+        "expires_at",
+        "used",
+    } <= state_cols
+    s.close()
+
+
 def test_users_table_is_flat_no_role_column():
     # The users table exists with the identity columns and, crucially, NO role/permission column —
     # flat access is the open-core contract (roles are paid).

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -1,4 +1,4 @@
-"""User store + password authentication (ACE-004).
+"""User store + password authentication.
 
 SQLite-backed (the portable backend the gate runs on). Proves: argon2id hashing (never plaintext),
 correct/wrong verify, the disabled-status gate, the env-seeded admin (idempotent), the rehash


### PR DESCRIPTION
## Summary

Implements the server's OAuth 2.1 endpoints that the discovery metadata already advertises, so claude.ai's connector can complete its handshake (confirmed: the connector is OAuth-only — no static-key mode). Backed by the existing user store. **PR 1 of 2** into `feature/app-auth`: this is the **provider (issuance)**. PR2 adds the JWT-validating `AuthProvider` + transport wiring + the end-to-end claude.ai smoke.

## Changes

- **`migrations/core/004_oauth.sql`** — `oauth_client` (registered clients) + `oauth_state` (authorization codes bound to their PKCE challenge + redirect + username; single-use + short-lived). Portable DDL.
- **`oauth_server.py`** — `/oauth/register` (minimal RFC 7591 → mints a `client_id`), `/oauth/authorize` (login form → authorization code via the credential check), `/oauth/token` (code + PKCE verifier → self-signed HS256 JWT). Enforces: PKCE S256, single-use + 10-min codes, redirect allow-listing, ≥32-byte signing secret, no secret/token in error bodies.
- **`mcp_http.py`** — routes the three `/oauth/*` endpoints; they're public at the transport layer (pre-auth by definition, boundary-matched), `/mcp` still requires a bearer.
- **`PyJWT`** added to the `[server]` extra.

## Security review (high lane — mandatory)

Ran `/code-review` + a dedicated security pass. The security pass caught **two account-takeover-class must-fix bugs**, both **fixed + regression-tested** in this PR:
- **Open redirect** — redirect validation used `startswith(PUBLIC_BASE_URL)`, so `https://host.com.evil.com` prefix-matched `https://host.com`. Now compares parsed **scheme+host** (same-origin); registered/claude callbacks are exact-match.
- **Reflected XSS** — the login form interpolated OAuth params into HTML attributes unescaped on the password page. Now `html.escape(quote=True)` on every value.

Cleared on review: auth-code single-use ordering, ISO expiry compare, PKCE required (a challenge-less code is unredeemable), HS256-only issuance, parameterized SQL, `/oauth/*` scoping (doesn't open `/mcp`), no password/secret in logs or errors.

## Test plan

`tests/test_oauth_server.py` (14 tests): full PKCE round-trip → verifiable JWT; wrong verifier / reused code / expired code / redirect mismatch → 400; bad creds re-render; **prefix-confusion redirect rejected**; same-origin redirect allowed; **login form escapes params (no XSS)**; missing signing secret fails without burning the code; `/oauth/*` public while `/mcp` 401s. Full gate green (`uv run dev.py check` — 783 tests + ruff + gitleaks).

## Checklist

- [x] `uv run dev.py check` green
- [x] New behavior covered by tests; security review done (high lane), 2 must-fix bugs fixed
- [x] No real customer data/names/credentials; no internal IDs in repo files
- [x] Targets `feature/app-auth`

Spec: ACE-005