### PR TITLE
JWT-validating AuthProvider + transport wiring (2 of 2)

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -4,9 +4,9 @@
 Advertises the **same** shared `tools.TOOLS` registry as the stdio entrypoint, but over a network
 endpoint a remote client (claude.ai) can reach — plus the OAuth-discovery surface and a bearer
 auth shim. This is the network product: unlike the stdio harness it binds a port, so it carries
-auth — an unauthenticated request gets a `401` + `WWW-Authenticate` challenge, which is what
-triggers the client's OAuth flow. The authorize page + real identity are a later concern; here we
-emit the challenge and require a bearer token's presence (the OSS `AuthProvider` default).
+auth — an unauthenticated request gets a `401` + `WWW-Authenticate` challenge, which triggers the
+client's OAuth flow against the authorize/token endpoints (see `oauth_server`). The issued JWT then
+gates `/mcp`; with no signing secret configured the OSS bearer-presence default applies instead.
 
 Requires the **[server]** extra (the MCP SDK + ASGI stack). `PUBLIC_BASE_URL` must be set
 explicitly — it backs the discovery documents + the `WWW-Authenticate` resource URL and cannot be
@@ -30,8 +30,16 @@ from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 from tools import SERVER_INSTRUCTIONS, SERVER_NAME, TOOLS, bootstrap_paths, server_version
 
-# Bearer-presence is the OSS default; real identity providers are a later feature.
-_AUTH = PresenceAuthProvider()
+
+def _build_auth_provider():
+    """Pick the token validator: the JWT provider when a signing secret is configured (the hosted
+    OAuth path — only tokens this server issued are accepted), else bearer-presence (the no-secret
+    local fallback, where any non-empty token passes)."""
+    if os.environ.get("AGAMI_SIGNING_SECRET", "").strip():
+        from oauth_server import JwtAuthProvider
+
+        return JwtAuthProvider()
+    return PresenceAuthProvider()
 
 
 def _build_org_resolver() -> SingleTenantOrgResolver:
@@ -98,23 +106,26 @@ def _is_public_path(path: str) -> bool:
 
 
 class _AuthMiddleware(BaseHTTPMiddleware):
-    """Require a bearer token's presence; the OAuth-discovery endpoints stay open. Everything else
-    401s without a token. On a request that passes auth, resolve the single-tenant org and attach
-    it to request.state.org — the explicit single-tenant contract + the multi-tenant seam."""
+    """Gate every request on a Bearer token via the configured `AuthProvider` (a real JWT validator
+    in the hosted OAuth path, or bearer-presence locally); the discovery + OAuth-flow endpoints stay
+    open. On a request that passes auth, resolve the single-tenant org and attach it to
+    request.state.org — the explicit single-tenant contract + the multi-tenant seam."""
 
-    def __init__(self, app, resolver: SingleTenantOrgResolver) -> None:
+    def __init__(self, app, resolver: SingleTenantOrgResolver, auth) -> None:
         super().__init__(app)
         self._resolver = resolver
+        self._auth = auth
 
     async def dispatch(self, request: Request, call_next):
         if _is_public_path(request.url.path):
             return await call_next(request)
         authz = request.headers.get("authorization") or request.headers.get("Authorization") or ""
-        # Require the Bearer scheme specifically (not just any Authorization header), then a
-        # non-empty token. Real token validation is a later feature; this is presence-only.
+        # Require the Bearer scheme specifically (not just any Authorization header), then hand the
+        # token to the configured provider — a real JWT validator in the hosted OAuth path, or
+        # bearer-presence locally.
         if not authz.lower().startswith("bearer "):
             return _unauthenticated(public_base_url())
-        if _AUTH.validate_token(authz[7:].strip()) is None:
+        if self._auth.validate_token(authz[7:].strip()) is None:
             return _unauthenticated(public_base_url())
         # Resolve the org for this request. Single-tenant returns the one configured org regardless
         # of context; nothing downstream consumes it yet (tools key on `datasource`), so this asserts
@@ -137,8 +148,8 @@ async def _protected_resource(request: Request) -> JSONResponse:
 
 
 async def _auth_server(request: Request) -> JSONResponse:
-    """RFC 8414 — the authorization-server metadata. The authorize/token endpoints it names are a
-    later feature; this transport only advertises them so the client can begin discovery."""
+    """RFC 8414 — the authorization-server metadata advertising the authorize/token/register
+    endpoints (served by `oauth_server`) so the client can run the OAuth flow."""
     base = public_base_url()
     return JSONResponse(
         {
@@ -213,7 +224,9 @@ def build_app() -> Starlette:
         Route("/oauth/register", register, methods=["POST"]),
         Mount("/mcp", app=handle_mcp),
     ]
-    middleware = [Middleware(_AuthMiddleware, resolver=_build_org_resolver())]
+    middleware = [
+        Middleware(_AuthMiddleware, resolver=_build_org_resolver(), auth=_build_auth_provider())
+    ]
     return Starlette(routes=routes, middleware=middleware, lifespan=lifespan)
 
 

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -21,7 +21,7 @@ import contextlib
 import os
 
 from oss_adapters import PresenceAuthProvider, SingleTenantOrgResolver
-from ports import Org
+from ports import AuthProvider, Org
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -31,13 +31,15 @@ from starlette.routing import Mount, Route
 from tools import SERVER_INSTRUCTIONS, SERVER_NAME, TOOLS, bootstrap_paths, server_version
 
 
-def _build_auth_provider():
-    """Pick the token validator: the JWT provider when a signing secret is configured (the hosted
-    OAuth path — only tokens this server issued are accepted), else bearer-presence (the no-secret
-    local fallback, where any non-empty token passes)."""
-    if os.environ.get("AGAMI_SIGNING_SECRET", "").strip():
-        from oauth_server import JwtAuthProvider
+def _build_auth_provider() -> AuthProvider:
+    """Pick the token validator. Presence (any non-empty bearer) is the local OSS default ONLY when
+    no signing secret is configured *at all*. If `AGAMI_SIGNING_SECRET` is present — even empty or
+    too weak — that signals intent to run real JWT auth, so we validate it now (fail fast at
+    construction) rather than silently downgrade a misconfigured hosted deploy to presence."""
+    if "AGAMI_SIGNING_SECRET" in os.environ:
+        from oauth_server import JwtAuthProvider, _signing_secret
 
+        _signing_secret()  # raises on an empty/weak secret — no insecure fallback on misconfig
         return JwtAuthProvider()
     return PresenceAuthProvider()
 
@@ -111,7 +113,7 @@ class _AuthMiddleware(BaseHTTPMiddleware):
     open. On a request that passes auth, resolve the single-tenant org and attach it to
     request.state.org — the explicit single-tenant contract + the multi-tenant seam."""
 
-    def __init__(self, app, resolver: SingleTenantOrgResolver, auth) -> None:
+    def __init__(self, app, resolver: SingleTenantOrgResolver, auth: AuthProvider) -> None:
         super().__init__(app)
         self._resolver = resolver
         self._auth = auth

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -100,7 +100,11 @@ class JwtAuthProvider:
             # Invalid signature, expired, wrong issuer, malformed, or no secret → reject.
             return None
         sub = claims.get("sub")
-        return Principal(subject=sub) if sub else None
+        # `Principal.subject` is a str — reject a non-string or blank sub rather than carry a
+        # malformed identity forward.
+        if not isinstance(sub, str) or not sub.strip():
+            return None
+        return Principal(subject=sub)
 
 
 def _b64url_nopad(raw: bytes) -> str:

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -25,6 +25,7 @@ from urllib.parse import parse_qs, urlencode, urlsplit
 from uuid import uuid4
 
 import jwt
+from ports import Principal
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from store import Store
@@ -75,6 +76,31 @@ def issue_jwt(subject: str) -> str:
         "exp": int((now + _JWT_TTL).timestamp()),
     }
     return jwt.encode(payload, _signing_secret(), algorithm="HS256")
+
+
+class JwtAuthProvider:
+    """Validates the self-signed HS256 JWTs `issue_jwt` mints — the transport's real token gate.
+
+    Conforms structurally to the `ports.AuthProvider` protocol (validate_token → Principal | None).
+    Pins the algorithm to HS256 (no `alg=none`/confusion), requires sub/exp/iss, and checks the
+    issuer == PUBLIC_BASE_URL. Any bad/expired/forged token returns None (fail closed → 401)."""
+
+    def validate_token(self, token: str) -> Principal | None:
+        from mcp_http import public_base_url  # lazy: avoid the import cycle
+
+        try:
+            claims = jwt.decode(
+                token,
+                _signing_secret(),
+                algorithms=["HS256"],
+                issuer=public_base_url(),
+                options={"require": ["exp", "sub", "iss"]},
+            )
+        except Exception:
+            # Invalid signature, expired, wrong issuer, malformed, or no secret → reject.
+            return None
+        sub = claims.get("sub")
+        return Principal(subject=sub) if sub else None
 
 
 def _b64url_nopad(raw: bytes) -> str:

--- a/tests/test_cloud_neutral_config.py
+++ b/tests/test_cloud_neutral_config.py
@@ -144,7 +144,9 @@ def test_auth_middleware_attaches_resolved_org_after_auth(monkeypatch):
     from starlette.responses import Response
 
     mw = mcp_http._AuthMiddleware(
-        app=None, resolver=mcp_http.SingleTenantOrgResolver(Org(id="acme"))
+        app=None,
+        resolver=mcp_http.SingleTenantOrgResolver(Org(id="acme")),
+        auth=mcp_http.PresenceAuthProvider(),
     )
     captured: dict[str, object] = {}
 

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -29,6 +29,10 @@ PRODUCT_TOOLS = {
 @pytest.fixture
 def base_url(monkeypatch):
     monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    # These tests exercise the bearer-presence default — clear any ambient signing secret so the
+    # provider selection is deterministic (a dev with AGAMI_SIGNING_SECRET exported would otherwise
+    # get JWT mode and see "Bearer present" rejected).
+    monkeypatch.delenv("AGAMI_SIGNING_SECRET", raising=False)
     return BASE
 
 

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -328,6 +328,26 @@ def test_jwt_provider_accepts_issued_token_and_rejects_junk(env):
     assert provider.validate_token(forged) is None
 
 
+def test_jwt_provider_rejects_alg_none_and_alg_confusion(env):
+    # The two classic JWT forgeries: an unsigned alg=none token, and a token whose header claims a
+    # different algorithm than the HS256 we pin. Both must be rejected.
+    from oauth_server import JwtAuthProvider
+
+    provider = JwtAuthProvider()
+    claims = {"sub": "admin", "iss": BASE, "exp": 9_999_999_999}
+    assert provider.validate_token(jwt.encode(claims, None, algorithm="none")) is None
+    assert provider.validate_token(jwt.encode(claims, SECRET, algorithm="HS512")) is None
+
+
+def test_jwt_provider_rejects_token_from_a_different_issuer(env):
+    from oauth_server import JwtAuthProvider
+
+    forged = jwt.encode(
+        {"sub": "admin", "iss": "https://evil.example.com", "exp": 9_999_999_999}, SECRET, "HS256"
+    )
+    assert JwtAuthProvider().validate_token(forged) is None
+
+
 def test_end_to_end_oauth_then_mcp_tools_list(env):
     # The whole point: a token minted via the OAuth flow is accepted by the transport, and the
     # tools/list comes back with exactly the 5 product tools.

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -348,6 +348,26 @@ def test_jwt_provider_rejects_token_from_a_different_issuer(env):
     assert JwtAuthProvider().validate_token(forged) is None
 
 
+def test_jwt_provider_rejects_non_string_or_blank_sub(env):
+    from oauth_server import JwtAuthProvider
+
+    provider = JwtAuthProvider()
+    numeric = jwt.encode({"sub": 123, "iss": BASE, "exp": 9_999_999_999}, SECRET, "HS256")
+    blank = jwt.encode({"sub": "   ", "iss": BASE, "exp": 9_999_999_999}, SECRET, "HS256")
+    assert provider.validate_token(numeric) is None
+    assert provider.validate_token(blank) is None
+
+
+def test_build_app_fails_fast_on_present_but_weak_signing_secret(env, monkeypatch):
+    # A configured-but-invalid secret must not silently downgrade to presence auth — build fails.
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", "")  # present but empty
+    with pytest.raises(RuntimeError, match="AGAMI_SIGNING_SECRET"):
+        mcp_http.build_app()
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", "too-short")  # present but below 32 bytes
+    with pytest.raises(RuntimeError, match="AGAMI_SIGNING_SECRET"):
+        mcp_http.build_app()
+
+
 def test_end_to_end_oauth_then_mcp_tools_list(env):
     # The whole point: a token minted via the OAuth flow is accepted by the transport, and the
     # tools/list comes back with exactly the 5 product tools.

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
+import re
 import sys
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -293,3 +295,86 @@ def test_oauth_endpoints_are_public_but_mcp_still_requires_auth(env):
     # The OAuth skip is EXACT-match: a sibling under /oauth/* that isn't a real route doesn't get a
     # free pass — it still hits auth (401) rather than being treated as public.
     assert c.post("/oauth/token/extra").status_code == 401
+
+
+# --- the JWT-validating provider + end-to-end (the issued token gates /mcp) ---
+
+
+def _mint_jwt(c: TestClient) -> str:
+    """Run the full authorize→token flow and return the issued access token (a JWT)."""
+    code = _authorize_code(c)
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def test_jwt_provider_accepts_issued_token_and_rejects_junk(env):
+    from oauth_server import JwtAuthProvider, issue_jwt
+
+    provider = JwtAuthProvider()
+    principal = provider.validate_token(issue_jwt("admin"))
+    assert principal is not None and principal.subject == "admin"
+    assert provider.validate_token("not-a-jwt") is None
+    # a token signed with the WRONG secret must not validate
+    forged = jwt.encode({"sub": "admin", "iss": BASE, "exp": 9_999_999_999}, "wrong", "HS256")
+    assert provider.validate_token(forged) is None
+
+
+def test_end_to_end_oauth_then_mcp_tools_list(env):
+    # The whole point: a token minted via the OAuth flow is accepted by the transport, and the
+    # tools/list comes back with exactly the 5 product tools.
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    with TestClient(mcp_http.build_app()) as c:
+        bearer = {"Authorization": f"Bearer {_mint_jwt(c)}", **headers}
+        init = c.post(
+            "/mcp",
+            headers=bearer,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "t", "version": "1"},
+                },
+            },
+        )
+        assert init.status_code == 200
+        sid = init.headers.get("mcp-session-id")
+        h2 = {**bearer, **({"mcp-session-id": sid} if sid else {})}
+        c.post("/mcp", headers=h2, json={"jsonrpc": "2.0", "method": "notifications/initialized"})
+        tl = c.post("/mcp", headers=h2, json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        assert tl.status_code == 200
+        payload = json.loads(re.search(r"\{.*\}", tl.text, re.DOTALL).group(0))
+        names = {t["name"] for t in payload["result"]["tools"]}
+    assert names == {
+        "list_datasources",
+        "get_datasource_schema",
+        "get_prompt_examples",
+        "execute_sql",
+        "log_feedback",
+    }
+
+
+def test_non_jwt_bearer_is_rejected_when_signing_secret_set(env):
+    # With a signing secret configured the transport uses the JWT provider, so a bare presence token
+    # ("Bearer present") that worked in the no-secret fallback is now rejected.
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/mcp",
+        headers={"Authorization": "Bearer present"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary

The **consumption side** of the OAuth flow: validates the JWT the provider (PR1, #42) issues and wires it into the transport, so the hosted server trusts only tokens it issued. **PR 2 of 2** into `feature/app-auth` — this completes the app-auth feature; after it the whole branch gets the end-to-end smoke and merges to main as one reviewed PR.

## Changes

- **`oauth_server.JwtAuthProvider`** — validates the HS256 JWT: algorithm pinned to `HS256` (no `alg=none`/confusion), requires `sub`/`exp`/`iss`, verifies the issuer == `PUBLIC_BASE_URL`, fails closed (any bad/expired/forged token → `None` → 401). Conforms structurally to the `AuthProvider` port.
- **`mcp_http._build_auth_provider()`** — selects the JWT validator when `AGAMI_SIGNING_SECRET` is set (only this server's tokens are accepted), else the bearer-presence default (the no-secret local fallback); threaded through the auth middleware. The choice is frozen at `build_app` time — a deployment with the secret set never falls back to presence.
- Refreshed the now-stale "later feature" docstrings (authorize/token/JWT exist now).

## Security review (high lane — mandatory)

Ran `/code-review` + a dedicated security pass — both came back clean. The security pass verified the validator is airtight against the classic JWT attacks (alg-confusion / `alg=none`, signature, expiry, issuer) and fails closed. Per its suggestion, added explicit tests asserting `alg=none`, `alg:HS512`, and wrong-issuer tokens are all rejected.

## Test plan

`tests/test_oauth_server.py`: `JwtAuthProvider` accepts an issued token, rejects junk / wrong-secret / `alg=none` / `alg:HS512` / wrong-issuer; **end-to-end** register→authorize→token→use the JWT as Bearer on `/mcp` → `tools/list` returns exactly the 5 product tools; a non-JWT bearer is rejected when the secret is set; presence still works with no secret. Full gate green (790 tests + ruff + gitleaks).

## Checklist

- [x] `uv run dev.py check` green
- [x] New behavior covered by tests; security review done (high lane), both reviews clean
- [x] No real customer data/names/credentials; no internal IDs in repo files
- [x] Targets `feature/app-auth`

Spec: ACE-005