### PR TITLE
App-auth: user store + OAuth provider + JWT-gated MCP transport

### DIFF
--- a/migrations/core/003_users.sql
+++ b/migrations/core/003_users.sql
@@ -1,0 +1,15 @@
+-- agami-core auth schema — per-user identity for the hosted server.
+--
+-- Flat access: there is deliberately NO role/permission column (roles are a paid tier). `status`
+-- is the create/disable flag ('active' | 'disabled'); a disabled user cannot authenticate. The
+-- password_hash is an argon2id PHC string (algo + cost params encoded inline) — never plaintext.
+-- Keyed by an app-minted id (no SERIAL), like the runtime tables.
+
+CREATE TABLE users (
+    id            TEXT PRIMARY KEY,        -- minted by the server at create time (uuid4 hex)
+    username      TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,           -- argon2id PHC string
+    email         TEXT,
+    status        TEXT NOT NULL DEFAULT 'active',
+    created       TEXT NOT NULL
+);

--- a/migrations/core/004_oauth.sql
+++ b/migrations/core/004_oauth.sql
@@ -14,8 +14,8 @@ CREATE TABLE oauth_client (
 CREATE TABLE oauth_state (
     code           TEXT PRIMARY KEY,        -- the authorization code (secrets.token_urlsafe)
     client_id      TEXT,
-    redirect_uri   TEXT,
-    code_challenge TEXT,                     -- PKCE S256 challenge; verified at token exchange
+    redirect_uri   TEXT NOT NULL,           -- always validated + present before a code is issued
+    code_challenge TEXT NOT NULL,           -- PKCE S256 challenge (required); verified at token exchange
     username       TEXT NOT NULL,           -- the authenticated principal the code stands in for
     expires_at     TEXT NOT NULL,           -- short-lived; expired codes are rejected
     used           INTEGER NOT NULL DEFAULT 0,  -- single-use: set on first successful exchange

--- a/migrations/core/004_oauth.sql
+++ b/migrations/core/004_oauth.sql
@@ -1,0 +1,23 @@
+-- agami-core OAuth provider schema — the server's own authorize/token flow.
+--
+-- oauth_client: clients that registered (claude.ai via the minimal RFC-7591 endpoint). Minimal by
+-- design — full DCR (client auth, rotation) is deferred. oauth_state: one row per issued
+-- authorization code, bound to its PKCE challenge + redirect_uri + the authenticated username, with
+-- a short expiry and a single-use flag. Keyed by app-minted values (no SERIAL), like the rest.
+
+CREATE TABLE oauth_client (
+    client_id     TEXT PRIMARY KEY,        -- minted by /oauth/register (uuid4 hex)
+    redirect_uris TEXT,                     -- space-separated, as registered (may be empty)
+    created       TEXT NOT NULL
+);
+
+CREATE TABLE oauth_state (
+    code           TEXT PRIMARY KEY,        -- the authorization code (secrets.token_urlsafe)
+    client_id      TEXT,
+    redirect_uri   TEXT,
+    code_challenge TEXT,                     -- PKCE S256 challenge; verified at token exchange
+    username       TEXT NOT NULL,           -- the authenticated principal the code stands in for
+    expires_at     TEXT NOT NULL,           -- short-lived; expired codes are rejected
+    used           INTEGER NOT NULL DEFAULT 0,  -- single-use: set on first successful exchange
+    created        TEXT NOT NULL
+);

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -35,6 +35,7 @@ server = [
   "uvicorn>=0.30",
   "psycopg2-binary>=2.9",
   "argon2-cffi>=23",
+  "PyJWT>=2.8",
 ]
 
 [tool.setuptools]

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -34,6 +34,7 @@ server = [
   "mcp>=1.2",
   "uvicorn>=0.30",
   "psycopg2-binary>=2.9",
+  "argon2-cffi>=23",
 ]
 
 [tool.setuptools]

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -4,9 +4,9 @@
 Advertises the **same** shared `tools.TOOLS` registry as the stdio entrypoint, but over a network
 endpoint a remote client (claude.ai) can reach — plus the OAuth-discovery surface and a bearer
 auth shim. This is the network product: unlike the stdio harness it binds a port, so it carries
-auth — an unauthenticated request gets a `401` + `WWW-Authenticate` challenge, which is what
-triggers the client's OAuth flow. The authorize page + real identity are a later concern; here we
-emit the challenge and require a bearer token's presence (the OSS `AuthProvider` default).
+auth — an unauthenticated request gets a `401` + `WWW-Authenticate` challenge, which triggers the
+client's OAuth flow against the authorize/token endpoints (see `oauth_server`). The issued JWT then
+gates `/mcp`; with no signing secret configured the OSS bearer-presence default applies instead.
 
 Requires the **[server]** extra (the MCP SDK + ASGI stack). `PUBLIC_BASE_URL` must be set
 explicitly — it backs the discovery documents + the `WWW-Authenticate` resource URL and cannot be
@@ -30,8 +30,16 @@ from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 from tools import SERVER_INSTRUCTIONS, SERVER_NAME, TOOLS, bootstrap_paths, server_version
 
-# Bearer-presence is the OSS default; real identity providers are a later feature.
-_AUTH = PresenceAuthProvider()
+
+def _build_auth_provider():
+    """Pick the token validator: the JWT provider when a signing secret is configured (the hosted
+    OAuth path — only tokens this server issued are accepted), else bearer-presence (the no-secret
+    local fallback, where any non-empty token passes)."""
+    if os.environ.get("AGAMI_SIGNING_SECRET", "").strip():
+        from oauth_server import JwtAuthProvider
+
+        return JwtAuthProvider()
+    return PresenceAuthProvider()
 
 
 def _build_org_resolver() -> SingleTenantOrgResolver:
@@ -98,23 +106,26 @@ def _is_public_path(path: str) -> bool:
 
 
 class _AuthMiddleware(BaseHTTPMiddleware):
-    """Require a bearer token's presence; the OAuth-discovery endpoints stay open. Everything else
-    401s without a token. On a request that passes auth, resolve the single-tenant org and attach
-    it to request.state.org — the explicit single-tenant contract + the multi-tenant seam."""
+    """Gate every request on a Bearer token via the configured `AuthProvider` (a real JWT validator
+    in the hosted OAuth path, or bearer-presence locally); the discovery + OAuth-flow endpoints stay
+    open. On a request that passes auth, resolve the single-tenant org and attach it to
+    request.state.org — the explicit single-tenant contract + the multi-tenant seam."""
 
-    def __init__(self, app, resolver: SingleTenantOrgResolver) -> None:
+    def __init__(self, app, resolver: SingleTenantOrgResolver, auth) -> None:
         super().__init__(app)
         self._resolver = resolver
+        self._auth = auth
 
     async def dispatch(self, request: Request, call_next):
         if _is_public_path(request.url.path):
             return await call_next(request)
         authz = request.headers.get("authorization") or request.headers.get("Authorization") or ""
-        # Require the Bearer scheme specifically (not just any Authorization header), then a
-        # non-empty token. Real token validation is a later feature; this is presence-only.
+        # Require the Bearer scheme specifically (not just any Authorization header), then hand the
+        # token to the configured provider — a real JWT validator in the hosted OAuth path, or
+        # bearer-presence locally.
         if not authz.lower().startswith("bearer "):
             return _unauthenticated(public_base_url())
-        if _AUTH.validate_token(authz[7:].strip()) is None:
+        if self._auth.validate_token(authz[7:].strip()) is None:
             return _unauthenticated(public_base_url())
         # Resolve the org for this request. Single-tenant returns the one configured org regardless
         # of context; nothing downstream consumes it yet (tools key on `datasource`), so this asserts
@@ -137,8 +148,8 @@ async def _protected_resource(request: Request) -> JSONResponse:
 
 
 async def _auth_server(request: Request) -> JSONResponse:
-    """RFC 8414 — the authorization-server metadata. The authorize/token endpoints it names are a
-    later feature; this transport only advertises them so the client can begin discovery."""
+    """RFC 8414 — the authorization-server metadata advertising the authorize/token/register
+    endpoints (served by `oauth_server`) so the client can run the OAuth flow."""
     base = public_base_url()
     return JSONResponse(
         {
@@ -213,7 +224,9 @@ def build_app() -> Starlette:
         Route("/oauth/register", register, methods=["POST"]),
         Mount("/mcp", app=handle_mcp),
     ]
-    middleware = [Middleware(_AuthMiddleware, resolver=_build_org_resolver())]
+    middleware = [
+        Middleware(_AuthMiddleware, resolver=_build_org_resolver(), auth=_build_auth_provider())
+    ]
     return Starlette(routes=routes, middleware=middleware, lifespan=lifespan)
 
 

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -80,12 +80,18 @@ _PUBLIC_PREFIXES = (
 )
 
 
+# The OAuth flow endpoints are pre-auth by definition — the user has no bearer token yet (they're
+# obtaining one). They enforce their own validation (credential check, PKCE, single-use codes,
+# redirect allow-listing), so they're public at the transport layer.
+_OAUTH_PATHS = ("/oauth/authorize", "/oauth/token", "/oauth/register")
+
+
 def _is_public_path(path: str) -> bool:
-    """True for the discovery routes and their path-suffixed variants only. We match on a path
-    *boundary* (exact, or prefix + '/'), not a bare `startswith` — otherwise a sibling like
-    `/.well-known/oauth-protected-resource-x` would skip auth too. Today such a path only 404s, but
-    boundary-matching keeps the open surface == the routes we serve even if a route is added later."""
-    return any(path == p or path.startswith(p + "/") for p in _PUBLIC_PREFIXES)
+    """True for the discovery routes and the OAuth-flow endpoints — the surface reachable before a
+    client has a token. We match on a path *boundary* (exact, or prefix + '/'), not a bare
+    `startswith`, so a sibling like `/.well-known/oauth-protected-resource-x` doesn't skip auth."""
+    prefixes = _PUBLIC_PREFIXES + _OAUTH_PATHS
+    return any(path == p or path.startswith(p + "/") for p in prefixes)
 
 
 class _AuthMiddleware(BaseHTTPMiddleware):
@@ -192,11 +198,16 @@ def build_app() -> Starlette:
         async with session_manager.run():
             yield
 
+    from oauth_server import authorize, register, token
+
     routes = [
         Route("/.well-known/oauth-protected-resource", _protected_resource),
         Route("/.well-known/oauth-protected-resource/{rest:path}", _protected_resource),
         Route("/.well-known/oauth-authorization-server", _auth_server),
         Route("/.well-known/oauth-authorization-server/{rest:path}", _auth_server),
+        Route("/oauth/authorize", authorize, methods=["GET", "POST"]),
+        Route("/oauth/token", token, methods=["POST"]),
+        Route("/oauth/register", register, methods=["POST"]),
         Mount("/mcp", app=handle_mcp),
     ]
     middleware = [Middleware(_AuthMiddleware, resolver=_build_org_resolver())]

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -88,10 +88,13 @@ _OAUTH_PATHS = ("/oauth/authorize", "/oauth/token", "/oauth/register")
 
 def _is_public_path(path: str) -> bool:
     """True for the discovery routes and the OAuth-flow endpoints — the surface reachable before a
-    client has a token. We match on a path *boundary* (exact, or prefix + '/'), not a bare
-    `startswith`, so a sibling like `/.well-known/oauth-protected-resource-x` doesn't skip auth."""
-    prefixes = _PUBLIC_PREFIXES + _OAUTH_PATHS
-    return any(path == p or path.startswith(p + "/") for p in prefixes)
+    client has a token. Discovery uses boundary matching (it has `{rest:path}` suffix routes, and a
+    bare `startswith` would let `/.well-known/oauth-protected-resource-x` skip auth); the OAuth
+    endpoints are matched *exactly* (only those three paths are routed), so a future
+    `/oauth/token/...` route can't inherit public access by accident."""
+    if any(path == p or path.startswith(p + "/") for p in _PUBLIC_PREFIXES):
+        return True
+    return path in _OAUTH_PATHS
 
 
 class _AuthMiddleware(BaseHTTPMiddleware):

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -21,7 +21,7 @@ import contextlib
 import os
 
 from oss_adapters import PresenceAuthProvider, SingleTenantOrgResolver
-from ports import Org
+from ports import AuthProvider, Org
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -31,13 +31,15 @@ from starlette.routing import Mount, Route
 from tools import SERVER_INSTRUCTIONS, SERVER_NAME, TOOLS, bootstrap_paths, server_version
 
 
-def _build_auth_provider():
-    """Pick the token validator: the JWT provider when a signing secret is configured (the hosted
-    OAuth path — only tokens this server issued are accepted), else bearer-presence (the no-secret
-    local fallback, where any non-empty token passes)."""
-    if os.environ.get("AGAMI_SIGNING_SECRET", "").strip():
-        from oauth_server import JwtAuthProvider
+def _build_auth_provider() -> AuthProvider:
+    """Pick the token validator. Presence (any non-empty bearer) is the local OSS default ONLY when
+    no signing secret is configured *at all*. If `AGAMI_SIGNING_SECRET` is present — even empty or
+    too weak — that signals intent to run real JWT auth, so we validate it now (fail fast at
+    construction) rather than silently downgrade a misconfigured hosted deploy to presence."""
+    if "AGAMI_SIGNING_SECRET" in os.environ:
+        from oauth_server import JwtAuthProvider, _signing_secret
 
+        _signing_secret()  # raises on an empty/weak secret — no insecure fallback on misconfig
         return JwtAuthProvider()
     return PresenceAuthProvider()
 
@@ -111,7 +113,7 @@ class _AuthMiddleware(BaseHTTPMiddleware):
     open. On a request that passes auth, resolve the single-tenant org and attach it to
     request.state.org — the explicit single-tenant contract + the multi-tenant seam."""
 
-    def __init__(self, app, resolver: SingleTenantOrgResolver, auth) -> None:
+    def __init__(self, app, resolver: SingleTenantOrgResolver, auth: AuthProvider) -> None:
         super().__init__(app)
         self._resolver = resolver
         self._auth = auth

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -100,7 +100,11 @@ class JwtAuthProvider:
             # Invalid signature, expired, wrong issuer, malformed, or no secret → reject.
             return None
         sub = claims.get("sub")
-        return Principal(subject=sub) if sub else None
+        # `Principal.subject` is a str — reject a non-string or blank sub rather than carry a
+        # malformed identity forward.
+        if not isinstance(sub, str) or not sub.strip():
+            return None
+        return Principal(subject=sub)
 
 
 def _b64url_nopad(raw: bytes) -> str:

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -25,6 +25,7 @@ from urllib.parse import parse_qs, urlencode, urlsplit
 from uuid import uuid4
 
 import jwt
+from ports import Principal
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from store import Store
@@ -75,6 +76,31 @@ def issue_jwt(subject: str) -> str:
         "exp": int((now + _JWT_TTL).timestamp()),
     }
     return jwt.encode(payload, _signing_secret(), algorithm="HS256")
+
+
+class JwtAuthProvider:
+    """Validates the self-signed HS256 JWTs `issue_jwt` mints — the transport's real token gate.
+
+    Conforms structurally to the `ports.AuthProvider` protocol (validate_token → Principal | None).
+    Pins the algorithm to HS256 (no `alg=none`/confusion), requires sub/exp/iss, and checks the
+    issuer == PUBLIC_BASE_URL. Any bad/expired/forged token returns None (fail closed → 401)."""
+
+    def validate_token(self, token: str) -> Principal | None:
+        from mcp_http import public_base_url  # lazy: avoid the import cycle
+
+        try:
+            claims = jwt.decode(
+                token,
+                _signing_secret(),
+                algorithms=["HS256"],
+                issuer=public_base_url(),
+                options={"require": ["exp", "sub", "iss"]},
+            )
+        except Exception:
+            # Invalid signature, expired, wrong issuer, malformed, or no secret → reject.
+            return None
+        sub = claims.get("sub")
+        return Principal(subject=sub) if sub else None
 
 
 def _b64url_nopad(raw: bytes) -> str:

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -1,0 +1,264 @@
+"""The server's OAuth 2.1 authorize/token/register endpoints — what claude.ai's connector completes.
+
+The transport's discovery metadata points here; this module is the actual provider:
+`/oauth/register` (minimal RFC 7591), `/oauth/authorize` (login → authorization code), `/oauth/token`
+(code + PKCE verifier → a self-signed HS256 JWT). Credentials are checked by `user_store.authenticate`;
+the issued JWT is what the transport will trust once a follow-up change wires the token validator in.
+
+Security invariants enforced here: authorization codes are single-use + short-lived; PKCE (S256) is
+required; redirect URIs are allow-listed (the claude.ai callback, the public base URL, or a URI the
+client registered) so a code can't be sent to an attacker; the signing secret and tokens are never
+logged or echoed in an error body. This module makes NO network call — it only mints/validates
+locally and tells the browser where to redirect.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import html
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlencode, urlsplit
+from uuid import uuid4
+
+import jwt
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from store import Store
+from user_store import authenticate
+
+_CODE_TTL = timedelta(minutes=10)  # authorization codes are short-lived
+_JWT_TTL = timedelta(hours=1)
+# Claude's fixed OAuth callback (the connector redirects here after authorize). The .com host is the
+# announced future move; allow both so the connection survives the switch.
+_CLAUDE_CALLBACKS = (
+    "https://claude.ai/api/mcp/auth_callback",
+    "https://claude.com/api/mcp/auth_callback",
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# HS256 forgeability scales with secret weakness; RFC 7518 §3.2 wants a key ≥ the hash output.
+_MIN_SECRET_BYTES = 32
+
+
+def _signing_secret() -> str:
+    """The HS256 signing secret. Required when the OAuth provider is active — fail fast (like
+    PUBLIC_BASE_URL) rather than mint a token under a weak/absent key."""
+    secret = os.environ.get("AGAMI_SIGNING_SECRET", "")
+    if not secret:
+        raise RuntimeError(
+            "AGAMI_SIGNING_SECRET must be set to issue OAuth tokens (the deploy generates it)."
+        )
+    if len(secret.encode()) < _MIN_SECRET_BYTES:
+        raise RuntimeError(
+            f"AGAMI_SIGNING_SECRET must be at least {_MIN_SECRET_BYTES} bytes (HS256 strength)."
+        )
+    return secret
+
+
+def issue_jwt(subject: str) -> str:
+    """A self-signed HS256 JWT for `subject` — the Bearer token the transport will accept."""
+    from mcp_http import public_base_url  # lazy: mcp_http imports these handlers at module load
+
+    now = _now()
+    payload = {
+        "sub": subject,
+        "iss": public_base_url(),
+        "iat": int(now.timestamp()),
+        "exp": int((now + _JWT_TTL).timestamp()),
+    }
+    return jwt.encode(payload, _signing_secret(), algorithm="HS256")
+
+
+def _b64url_nopad(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _verify_pkce(code_verifier: str, code_challenge: str | None) -> bool:
+    """PKCE S256: the challenge must equal base64url(sha256(verifier)), compared constant-time."""
+    if not code_verifier or not code_challenge:
+        return False
+    expected = _b64url_nopad(hashlib.sha256(code_verifier.encode()).digest())
+    return hmac.compare_digest(expected, code_challenge)
+
+
+def _same_origin(a: str, b: str) -> bool:
+    """Scheme + host(:port) equality. NOT a string prefix — `startswith` would accept
+    `https://host.com.evil.com` for a base of `https://host.com` (an open redirect)."""
+    pa, pb = urlsplit(a), urlsplit(b)
+    return bool(pa.scheme) and pa.scheme == pb.scheme and pa.netloc == pb.netloc
+
+
+def _redirect_allowed(redirect_uri: str, registered: str | None) -> bool:
+    """Allow only the claude.ai callback, a same-origin URI under PUBLIC_BASE_URL, or one the client
+    registered (exact match) — so an authorization code can never be redirected to an attacker host."""
+    from mcp_http import public_base_url
+
+    if not redirect_uri:
+        return False
+    if redirect_uri in _CLAUDE_CALLBACKS:
+        return True
+    if registered and redirect_uri in registered.split():
+        return True
+    return _same_origin(redirect_uri, public_base_url())
+
+
+async def _form(request: Request) -> dict[str, str]:
+    """Parse an application/x-www-form-urlencoded body without pulling in python-multipart."""
+    body = (await request.body()).decode()
+    return {k: v[0] for k, v in parse_qs(body).items()}
+
+
+def _oauth_error(error: str, description: str, status: int = 400) -> JSONResponse:
+    # OAuth-style error; never includes a token, secret, or the submitted password.
+    return JSONResponse({"error": error, "error_description": description}, status_code=status)
+
+
+def _open_store() -> Store | None:
+    return Store.from_env()
+
+
+async def register(request: Request) -> Response:
+    """Minimal RFC 7591 dynamic client registration — mint a client_id so the connector can proceed.
+    Full DCR (client auth, rotation) is deferred."""
+    store = _open_store()
+    if store is None:
+        return _oauth_error("server_error", "no datastore configured", status=500)
+    try:
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        redirect_uris = body.get("redirect_uris") or []
+        client_id = uuid4().hex
+        store.execute(
+            "INSERT INTO oauth_client (client_id, redirect_uris, created) VALUES (?, ?, ?)",
+            (client_id, " ".join(redirect_uris), _now().isoformat()),
+        )
+        store.commit()
+        return JSONResponse(
+            {
+                "client_id": client_id,
+                "redirect_uris": redirect_uris,
+                "token_endpoint_auth_method": "none",
+            },
+            status_code=201,
+        )
+    finally:
+        store.close()
+
+
+def _login_form(params: dict[str, str], error: str = "") -> HTMLResponse:
+    """A minimal login form that carries the OAuth params forward as hidden fields. Neutral
+    placeholders only — no real names or secrets."""
+    # Escape every interpolated value — these come from attacker-controllable query/body params and
+    # land in HTML attributes on the password-entry page; unescaped, they're a reflected-XSS vector.
+    hidden = "".join(
+        f'<input type="hidden" name="{k}" value="{html.escape(params.get(k, ""), quote=True)}">'
+        for k in ("client_id", "redirect_uri", "code_challenge", "state")
+    )
+    msg = f'<p role="alert">{html.escape(error)}</p>' if error else ""
+    return HTMLResponse(
+        f"""<!doctype html><html><head><meta charset="utf-8"><title>Sign in</title></head>
+<body><h1>Sign in</h1>{msg}
+<form method="post">{hidden}
+<label>Username <input name="username" autocomplete="username" placeholder="admin"></label>
+<label>Password <input name="password" type="password" autocomplete="current-password"></label>
+<button type="submit">Sign in</button></form></body></html>"""
+    )
+
+
+async def authorize(request: Request) -> Response:
+    """GET → the login form (carrying the OAuth params); POST → verify credentials and redirect to
+    the client with a fresh authorization code, or re-render with an error."""
+    if request.method == "GET":
+        return _login_form(dict(request.query_params))
+
+    form = await _form(request)
+    store = _open_store()
+    if store is None:
+        return _oauth_error("server_error", "no datastore configured", status=500)
+    try:
+        redirect_uri = form.get("redirect_uri", "")
+        client_id = form.get("client_id", "")
+        client = store.query(
+            "SELECT redirect_uris FROM oauth_client WHERE client_id = ?", (client_id,)
+        )
+        registered = client[0]["redirect_uris"] if client else None
+        # Validate the redirect target BEFORE authenticating — never send a code to an unvetted URL.
+        if not _redirect_allowed(redirect_uri, registered):
+            return _oauth_error("invalid_request", "redirect_uri not allowed")
+
+        principal = authenticate(store, form.get("username", ""), form.get("password", ""))
+        if principal is None:
+            return _login_form(form, error="Invalid username or password.")
+
+        code = secrets.token_urlsafe(32)
+        store.execute(
+            "INSERT INTO oauth_state (code, client_id, redirect_uri, code_challenge, username, "
+            "expires_at, used, created) VALUES (?, ?, ?, ?, ?, ?, 0, ?)",
+            (
+                code,
+                client_id,
+                redirect_uri,
+                form.get("code_challenge"),
+                principal.subject,
+                (_now() + _CODE_TTL).isoformat(),
+                _now().isoformat(),
+            ),
+        )
+        store.commit()
+        query = urlencode({"code": code, "state": form.get("state", "")})
+        return RedirectResponse(f"{redirect_uri}?{query}", status_code=302)
+    finally:
+        store.close()
+
+
+async def token(request: Request) -> Response:
+    """Exchange an authorization code + PKCE verifier for a self-signed JWT. Enforces single-use,
+    expiry, redirect match, and PKCE — any failure is a 400 with no token in the body."""
+    form = await _form(request)
+    if form.get("grant_type") != "authorization_code":
+        return _oauth_error("unsupported_grant_type", "only authorization_code is supported")
+
+    store = _open_store()
+    if store is None:
+        return _oauth_error("server_error", "no datastore configured", status=500)
+    try:
+        rows = store.query("SELECT * FROM oauth_state WHERE code = ?", (form.get("code", ""),))
+        row = rows[0] if rows else None
+        if row is None or row["used"]:
+            return _oauth_error("invalid_grant", "code is invalid or already used")
+        if _now().isoformat() > row["expires_at"]:
+            return _oauth_error("invalid_grant", "code has expired")
+        if form.get("redirect_uri", "") != (row["redirect_uri"] or ""):
+            return _oauth_error("invalid_grant", "redirect_uri mismatch")
+        if not _verify_pkce(form.get("code_verifier", ""), row["code_challenge"]):
+            return _oauth_error("invalid_grant", "PKCE verification failed")
+        # Confirm we can sign (secret present AND strong enough) BEFORE burning the code, so a
+        # misconfigured server doesn't consume the code on a request it can't fulfil.
+        try:
+            _signing_secret()
+        except RuntimeError:
+            return _oauth_error("server_error", "token signing is not configured", status=500)
+
+        # Single-use: burn the code before issuing, so a replay finds it already used.
+        store.execute("UPDATE oauth_state SET used = 1 WHERE code = ?", (row["code"],))
+        store.commit()
+        access_token = issue_jwt(row["username"])
+        return JSONResponse(
+            {
+                "access_token": access_token,
+                "token_type": "Bearer",
+                "expires_in": int(_JWT_TTL.total_seconds()),
+            }
+        )
+    finally:
+        store.close()

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -137,6 +137,10 @@ async def register(request: Request) -> Response:
         except Exception:
             body = {}
         redirect_uris = body.get("redirect_uris") or []
+        if not isinstance(redirect_uris, list) or not all(
+            isinstance(u, str) for u in redirect_uris
+        ):
+            return _oauth_error("invalid_request", "redirect_uris must be a list of strings")
         client_id = uuid4().hex
         store.execute(
             "INSERT INTO oauth_client (client_id, redirect_uris, created) VALUES (?, ?, ?)",
@@ -195,6 +199,11 @@ async def authorize(request: Request) -> Response:
         # Validate the redirect target BEFORE authenticating — never send a code to an unvetted URL.
         if not _redirect_allowed(redirect_uri, registered):
             return _oauth_error("invalid_request", "redirect_uri not allowed")
+        # PKCE is mandatory: reject a missing challenge now rather than persist a code that could
+        # never be redeemed (the token step requires a verifier that matches it).
+        code_challenge = form.get("code_challenge", "")
+        if not code_challenge:
+            return _oauth_error("invalid_request", "code_challenge is required (PKCE)")
 
         principal = authenticate(store, form.get("username", ""), form.get("password", ""))
         if principal is None:
@@ -208,7 +217,7 @@ async def authorize(request: Request) -> Response:
                 code,
                 client_id,
                 redirect_uri,
-                form.get("code_challenge"),
+                code_challenge,
                 principal.subject,
                 (_now() + _CODE_TTL).isoformat(),
                 _now().isoformat(),
@@ -249,9 +258,15 @@ async def token(request: Request) -> Response:
         except RuntimeError:
             return _oauth_error("server_error", "token signing is not configured", status=500)
 
-        # Single-use: burn the code before issuing, so a replay finds it already used.
-        store.execute("UPDATE oauth_state SET used = 1 WHERE code = ?", (row["code"],))
+        # Single-use, atomically: only the request that flips used 0→1 may issue a token. The
+        # conditional UPDATE + rowcount check closes the read-then-write race two concurrent
+        # exchanges would otherwise win together (double-issued JWTs for one code).
+        burned = store.execute(
+            "UPDATE oauth_state SET used = 1 WHERE code = ? AND used = 0", (row["code"],)
+        )
         store.commit()
+        if burned.rowcount != 1:
+            return _oauth_error("invalid_grant", "code is invalid or already used")
         access_token = issue_jwt(row["username"])
         return JSONResponse(
             {

--- a/packages/agami-core/src/passwords.py
+++ b/packages/agami-core/src/passwords.py
@@ -1,0 +1,41 @@
+"""Password hashing — argon2id, the only place credentials are turned into a stored secret.
+
+We never hand-roll the KDF: hashing goes through `argon2-cffi` (the OWASP-first argon2id, a
+`[server]`-extra dependency — never in the local install). The stored value is a PHC string
+(`$argon2id$v=19$m=...,t=...,p=...$salt$hash`) that encodes the algorithm and every cost parameter
+inline, so it verifies in any language and a future backend can read the same column unchanged.
+
+`verify_password` returns a bool (never raises on a wrong password) and is timing-safe — argon2's
+verify compares in constant time, so a caller can't distinguish "no such user" from "wrong password"
+by timing as long as both paths run a verify (the user store does).
+"""
+
+from __future__ import annotations
+
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHashError, VerifyMismatchError
+
+# One shared hasher — its parameters define the cost. Defaults are argon2-cffi's recommended profile;
+# `needs_rehash` lets us raise them later and upgrade existing hashes on next login (the cross-tier
+# cost-bump path) without a migration.
+_PH = PasswordHasher()
+
+
+def hash_password(plain: str) -> str:
+    """Hash a plaintext password to an argon2id PHC string. The salt is generated per call."""
+    return _PH.hash(plain)
+
+
+def verify_password(stored: str, plain: str) -> bool:
+    """True iff `plain` matches the stored argon2id hash. Returns False (never raises) on a mismatch
+    or a malformed stored hash, so callers branch on a bool, not an exception."""
+    try:
+        return _PH.verify(stored, plain)
+    except (VerifyMismatchError, InvalidHashError):
+        return False
+
+
+def needs_rehash(stored: str) -> bool:
+    """True if the stored hash was made with weaker parameters than the current profile — the caller
+    re-hashes on the next successful login to upgrade it in place."""
+    return _PH.check_needs_rehash(stored)

--- a/packages/agami-core/src/passwords.py
+++ b/packages/agami-core/src/passwords.py
@@ -5,9 +5,10 @@ We never hand-roll the KDF: hashing goes through `argon2-cffi` (the OWASP-first 
 (`$argon2id$v=19$m=...,t=...,p=...$salt$hash`) that encodes the algorithm and every cost parameter
 inline, so it verifies in any language and a future backend can read the same column unchanged.
 
-`verify_password` returns a bool (never raises on a wrong password) and is timing-safe — argon2's
-verify compares in constant time, so a caller can't distinguish "no such user" from "wrong password"
-by timing as long as both paths run a verify (the user store does).
+`verify_password` returns a bool (never raises on a wrong password). Verifying runs the fixed-cost
+argon2 KDF whose runtime is dominated by the (input-independent) memory-hard work, so a caller that
+runs a verify on every path — including a dummy verify when the user is absent — doesn't leak whether
+a username exists by timing. `user_store.authenticate` does exactly that.
 """
 
 from __future__ import annotations

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -22,7 +22,11 @@ from ports import Principal
 from store import Store
 
 _ACTIVE = "active"
-_DISABLED = "disabled"
+
+# A throwaway argon2id hash that no password verifies against. `authenticate` verifies against it on
+# the user-absent path so every code path pays the same KDF cost — without it, a missing username
+# returns far faster than a wrong password and leaks which usernames exist (an enumeration oracle).
+_DUMMY_HASH = hash_password(uuid4().hex)
 
 
 def _now_iso() -> str:
@@ -38,6 +42,8 @@ def create_user(
 ) -> str:
     """Create a user with an argon2id-hashed password; returns the minted id. Raises if the username
     already exists (the UNIQUE constraint) — callers that want create-if-absent check first."""
+    if not password:
+        raise ValueError("password must not be empty")
     user_id = uuid4().hex
     store.execute(
         "INSERT INTO users (id, username, password_hash, email, status, created) "
@@ -66,19 +72,26 @@ def set_status(store: Store, username: str, status: str) -> None:
 def authenticate(store: Store, username: str, password: str) -> Principal | None:
     """The credential check: an active user whose password verifies → a `Principal`, else None.
 
-    A disabled user fails even with the right password. On success, opportunistically upgrade the
-    stored hash if the cost profile has risen (the cross-tier cost-bump path)."""
+    A disabled user fails even with the right password. Every path runs exactly one argon2 verify
+    (against a dummy hash when the user is absent/ineligible), so response time never reveals whether
+    a username exists — closing a timing-enumeration oracle. On success, opportunistically upgrade
+    the stored hash if the cost profile has risen (the cross-tier cost-bump path)."""
     user = get_user(store, username)
-    if user is None or user["status"] != _ACTIVE:
-        return None
-    if not verify_password(user["password_hash"], password):
+    stored_hash = user["password_hash"] if user else _DUMMY_HASH
+    verified = verify_password(stored_hash, password)
+    if user is None or user["status"] != _ACTIVE or not verified:
         return None
     if needs_rehash(user["password_hash"]):
-        store.execute(
-            "UPDATE users SET password_hash = ? WHERE username = ?",
-            (hash_password(password), username),
-        )
-        store.commit()
+        try:
+            store.execute(
+                "UPDATE users SET password_hash = ? WHERE username = ?",
+                (hash_password(password), username),
+            )
+            store.commit()
+        except Exception:
+            # Best-effort upgrade — a DB hiccup on the opportunistic rehash must not fail an
+            # otherwise-valid login.
+            pass
     return Principal(subject=username)
 
 

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -1,0 +1,98 @@
+"""The `users` store + the password credential check — per-user identity for the hosted server.
+
+This is the credential authenticator that ACE-005's OAuth authorize page calls: `authenticate`
+turns a username/password into a `Principal` (the identity ACE-005 then mints a JWT for). It is NOT
+the bearer-token `AuthProvider` (that validates the issued token — a later, separate adapter). Flat
+access only: there is no role column (roles are paid).
+
+Thin SQL over the portable `Store` (same shape as `model_store.py`), so it runs on SQLite (CI) and
+Postgres (prod) unchanged. Passwords never touch this module in plaintext beyond the moment they're
+hashed/verified via `passwords.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from passwords import hash_password, needs_rehash, verify_password
+from ports import Principal
+from store import Store
+
+_ACTIVE = "active"
+_DISABLED = "disabled"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def create_user(
+    store: Store,
+    username: str,
+    password: str,
+    email: str | None = None,
+    status: str = _ACTIVE,
+) -> str:
+    """Create a user with an argon2id-hashed password; returns the minted id. Raises if the username
+    already exists (the UNIQUE constraint) — callers that want create-if-absent check first."""
+    user_id = uuid4().hex
+    store.execute(
+        "INSERT INTO users (id, username, password_hash, email, status, created) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (user_id, username, hash_password(password), email, status, _now_iso()),
+    )
+    store.commit()
+    return user_id
+
+
+def get_user(store: Store, username: str) -> dict[str, Any] | None:
+    rows = store.query("SELECT * FROM users WHERE username = ?", (username,))
+    return rows[0] if rows else None
+
+
+def list_users(store: Store) -> list[dict[str, Any]]:
+    """Identity rows only — never selects `password_hash` (so a listing can't leak the secret)."""
+    return store.query("SELECT id, username, email, status, created FROM users ORDER BY username")
+
+
+def set_status(store: Store, username: str, status: str) -> None:
+    store.execute("UPDATE users SET status = ? WHERE username = ?", (status, username))
+    store.commit()
+
+
+def authenticate(store: Store, username: str, password: str) -> Principal | None:
+    """The credential check: an active user whose password verifies → a `Principal`, else None.
+
+    A disabled user fails even with the right password. On success, opportunistically upgrade the
+    stored hash if the cost profile has risen (the cross-tier cost-bump path)."""
+    user = get_user(store, username)
+    if user is None or user["status"] != _ACTIVE:
+        return None
+    if not verify_password(user["password_hash"], password):
+        return None
+    if needs_rehash(user["password_hash"]):
+        store.execute(
+            "UPDATE users SET password_hash = ? WHERE username = ?",
+            (hash_password(password), username),
+        )
+        store.commit()
+    return Principal(subject=username)
+
+
+def seed_admin_from_env(store: Store) -> str | None:
+    """Seed the initial admin from AGAMI_ADMIN_USERNAME / AGAMI_ADMIN_PASSWORD if both are set.
+
+    Create-if-absent and idempotent: a redeploy never duplicates the admin or clobbers a
+    password the admin has since changed. Returns the username seeded, or None if unset/already
+    present. (Rotating the seed password is out of scope — that's a later reset path.)"""
+    username = os.environ.get("AGAMI_ADMIN_USERNAME", "").strip()
+    password = os.environ.get("AGAMI_ADMIN_PASSWORD", "")
+    if not username or not password:
+        return None
+    if get_user(store, username) is not None:
+        return None
+    create_user(store, username, password, status=_ACTIVE)
+    return username

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -1,9 +1,9 @@
 """The `users` store + the password credential check — per-user identity for the hosted server.
 
-This is the credential authenticator that ACE-005's OAuth authorize page calls: `authenticate`
-turns a username/password into a `Principal` (the identity ACE-005 then mints a JWT for). It is NOT
-the bearer-token `AuthProvider` (that validates the issued token — a later, separate adapter). Flat
-access only: there is no role column (roles are paid).
+This is the credential authenticator the OAuth authorize page calls: `authenticate` turns a
+username/password into a `Principal` (the identity the token endpoint then mints a JWT for). It is
+NOT the bearer-token `AuthProvider` (that validates the issued token — a later, separate adapter).
+Flat access only: there is no role column (roles are paid).
 
 Thin SQL over the portable `Store` (same shape as `model_store.py`), so it runs on SQLite (CI) and
 Postgres (prod) unchanged. Passwords never touch this module in plaintext beyond the moment they're

--- a/tests/test_cloud_neutral_config.py
+++ b/tests/test_cloud_neutral_config.py
@@ -144,7 +144,9 @@ def test_auth_middleware_attaches_resolved_org_after_auth(monkeypatch):
     from starlette.responses import Response
 
     mw = mcp_http._AuthMiddleware(
-        app=None, resolver=mcp_http.SingleTenantOrgResolver(Org(id="acme"))
+        app=None,
+        resolver=mcp_http.SingleTenantOrgResolver(Org(id="acme")),
+        auth=mcp_http.PresenceAuthProvider(),
     )
     captured: dict[str, object] = {}
 

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -29,6 +29,10 @@ PRODUCT_TOOLS = {
 @pytest.fixture
 def base_url(monkeypatch):
     monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    # These tests exercise the bearer-presence default — clear any ambient signing secret so the
+    # provider selection is deterministic (a dev with AGAMI_SIGNING_SECRET exported would otherwise
+    # get JWT mode and see "Bearer present" rejected).
+    monkeypatch.delenv("AGAMI_SIGNING_SECRET", raising=False)
     return BASE
 
 

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -116,10 +116,32 @@ def test_bad_credentials_re_render_form_without_a_code(env):
     c = TestClient(mcp_http.build_app())
     r = c.post(
         "/oauth/authorize",
-        data={"username": "admin", "password": "wrong", "redirect_uri": REDIRECT},
+        data={
+            "username": "admin",
+            "password": "wrong",
+            "redirect_uri": REDIRECT,
+            "code_challenge": _challenge(VERIFIER),  # valid PKCE so we reach the credential check
+        },
         follow_redirects=False,
     )
     assert r.status_code == 200 and "Invalid username or password" in r.text
+
+
+def test_authorize_requires_pkce_challenge(env):
+    # PKCE is mandatory — a submission without a code_challenge is rejected before any code is minted.
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={"username": "admin", "password": "s3cret-pw", "redirect_uri": REDIRECT},
+        follow_redirects=False,
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
+
+
+def test_register_rejects_malformed_redirect_uris(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post("/oauth/register", json={"redirect_uris": "not-a-list"})
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
 
 
 def test_wrong_pkce_verifier_is_rejected(env):
@@ -268,3 +290,6 @@ def test_oauth_endpoints_are_public_but_mcp_still_requires_auth(env):
     assert c.get("/oauth/authorize", params={"redirect_uri": REDIRECT}).status_code == 200
     r = c.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
     assert r.status_code == 401  # the MCP endpoint still demands a bearer
+    # The OAuth skip is EXACT-match: a sibling under /oauth/* that isn't a real route doesn't get a
+    # free pass — it still hits auth (401) rather than being treated as public.
+    assert c.post("/oauth/token/extra").status_code == 401

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -328,6 +328,26 @@ def test_jwt_provider_accepts_issued_token_and_rejects_junk(env):
     assert provider.validate_token(forged) is None
 
 
+def test_jwt_provider_rejects_alg_none_and_alg_confusion(env):
+    # The two classic JWT forgeries: an unsigned alg=none token, and a token whose header claims a
+    # different algorithm than the HS256 we pin. Both must be rejected.
+    from oauth_server import JwtAuthProvider
+
+    provider = JwtAuthProvider()
+    claims = {"sub": "admin", "iss": BASE, "exp": 9_999_999_999}
+    assert provider.validate_token(jwt.encode(claims, None, algorithm="none")) is None
+    assert provider.validate_token(jwt.encode(claims, SECRET, algorithm="HS512")) is None
+
+
+def test_jwt_provider_rejects_token_from_a_different_issuer(env):
+    from oauth_server import JwtAuthProvider
+
+    forged = jwt.encode(
+        {"sub": "admin", "iss": "https://evil.example.com", "exp": 9_999_999_999}, SECRET, "HS256"
+    )
+    assert JwtAuthProvider().validate_token(forged) is None
+
+
 def test_end_to_end_oauth_then_mcp_tools_list(env):
     # The whole point: a token minted via the OAuth flow is accepted by the transport, and the
     # tools/list comes back with exactly the 5 product tools.

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -348,6 +348,26 @@ def test_jwt_provider_rejects_token_from_a_different_issuer(env):
     assert JwtAuthProvider().validate_token(forged) is None
 
 
+def test_jwt_provider_rejects_non_string_or_blank_sub(env):
+    from oauth_server import JwtAuthProvider
+
+    provider = JwtAuthProvider()
+    numeric = jwt.encode({"sub": 123, "iss": BASE, "exp": 9_999_999_999}, SECRET, "HS256")
+    blank = jwt.encode({"sub": "   ", "iss": BASE, "exp": 9_999_999_999}, SECRET, "HS256")
+    assert provider.validate_token(numeric) is None
+    assert provider.validate_token(blank) is None
+
+
+def test_build_app_fails_fast_on_present_but_weak_signing_secret(env, monkeypatch):
+    # A configured-but-invalid secret must not silently downgrade to presence auth — build fails.
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", "")  # present but empty
+    with pytest.raises(RuntimeError, match="AGAMI_SIGNING_SECRET"):
+        mcp_http.build_app()
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", "too-short")  # present but below 32 bytes
+    with pytest.raises(RuntimeError, match="AGAMI_SIGNING_SECRET"):
+        mcp_http.build_app()
+
+
 def test_end_to_end_oauth_then_mcp_tools_list(env):
     # The whole point: a token minted via the OAuth flow is accepted by the transport, and the
     # tools/list comes back with exactly the 5 product tools.

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -1,0 +1,270 @@
+"""The OAuth provider — authorize + token + register, end to end over the Starlette app.
+
+SQLite-backed (the portable backend the gate runs on). Proves the full authorization-code + PKCE
+round trip yields a verifiable JWT, and that every guard fires: wrong PKCE verifier, reused code,
+expired code, redirect mismatch, bad credentials, missing signing secret. Also that the /oauth/*
+endpoints are reachable without a bearer while /mcp still 401s.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+pytest.importorskip("starlette")
+pytest.importorskip("mcp")
+pytest.importorskip("jwt")
+pytest.importorskip("argon2")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import jwt  # noqa: E402
+import mcp_http  # noqa: E402
+import user_store  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+from store import Store  # noqa: E402
+
+BASE = "https://your-host.example.com"
+SECRET = "x" * 40  # a throwaway HS256 key for tests (≥32 bytes); obviously not a real secret
+REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+VERIFIER = "a" * 64  # a fixed PKCE code_verifier
+
+
+def _challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    db_url = "sqlite://" + str(tmp_path / "oauth.db")
+    monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    monkeypatch.setenv("AGAMI_DB_URL", db_url)
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    # Seed the schema + a user the authorize step can authenticate.
+    s = Store.connect(db_url)
+    s.run_migrations()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    s.close()
+    return db_url
+
+
+def _authorize_code(
+    client: TestClient, *, redirect: str = REDIRECT, challenge: str | None = None
+) -> str:
+    """Run the authorize POST and return the issued authorization code from the redirect."""
+    resp = client.post(
+        "/oauth/authorize",
+        data={
+            "username": "admin",
+            "password": "s3cret-pw",
+            "redirect_uri": redirect,
+            "client_id": "cid",
+            "code_challenge": challenge if challenge is not None else _challenge(VERIFIER),
+            "state": "xyz",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    loc = resp.headers["location"]
+    assert loc.startswith(redirect)
+    qs = parse_qs(urlparse(loc).query)
+    assert qs["state"] == ["xyz"]
+    return qs["code"][0]
+
+
+def test_register_mints_a_client_id(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post("/oauth/register", json={"redirect_uris": [REDIRECT]})
+    assert r.status_code == 201
+    assert r.json()["client_id"]
+
+
+def test_authorize_get_renders_a_login_form(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.get("/oauth/authorize", params={"redirect_uri": REDIRECT, "state": "xyz"})
+    assert r.status_code == 200 and "<form" in r.text and 'name="password"' in r.text
+
+
+def test_full_pkce_flow_yields_a_verifiable_jwt(env):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["token_type"] == "Bearer" and body["expires_in"] == 3600
+    claims = jwt.decode(body["access_token"], SECRET, algorithms=["HS256"])
+    assert claims["sub"] == "admin" and claims["iss"] == BASE
+
+
+def test_bad_credentials_re_render_form_without_a_code(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={"username": "admin", "password": "wrong", "redirect_uri": REDIRECT},
+        follow_redirects=False,
+    )
+    assert r.status_code == 200 and "Invalid username or password" in r.text
+
+
+def test_wrong_pkce_verifier_is_rejected(env):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": "b" * 64,  # wrong verifier
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_grant"
+
+
+def test_code_is_single_use(env):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": VERIFIER,
+        "redirect_uri": REDIRECT,
+    }
+    assert c.post("/oauth/token", data=data).status_code == 200
+    assert c.post("/oauth/token", data=data).status_code == 400  # reuse rejected
+
+
+def test_expired_code_is_rejected(env, monkeypatch):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    # Force the stored code to be in the past.
+    s = Store.from_env()
+    s.execute(
+        "UPDATE oauth_state SET expires_at = ? WHERE code = ?",
+        ("2000-01-01T00:00:00+00:00", code),
+    )
+    s.commit()
+    s.close()
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 400 and "expired" in r.json()["error_description"]
+
+
+def test_redirect_uri_mismatch_is_rejected_at_token(env):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": BASE + "/different",  # not what the code was issued for
+        },
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_grant"
+
+
+def test_disallowed_redirect_is_rejected_at_authorize(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={
+            "username": "admin",
+            "password": "s3cret-pw",
+            "redirect_uri": "https://evil.example.com/steal",
+            "client_id": "cid",
+            "code_challenge": _challenge(VERIFIER),
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
+
+
+def test_missing_signing_secret_fails_cleanly_without_burning_the_code(env, monkeypatch):
+    c = TestClient(mcp_http.build_app())
+    code = _authorize_code(c)
+    monkeypatch.delenv("AGAMI_SIGNING_SECRET", raising=False)
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": VERIFIER,
+        "redirect_uri": REDIRECT,
+    }
+    r = c.post("/oauth/token", data=data)
+    assert r.status_code == 500 and r.json()["error"] == "server_error"
+    # the code was NOT consumed — it works once the secret is restored
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    assert c.post("/oauth/token", data=data).status_code == 200
+
+
+def test_prefix_confusion_redirect_is_rejected(env):
+    # Open-redirect guard: a host that merely *prefixes* PUBLIC_BASE_URL is a different origin and
+    # must be rejected (startswith would have wrongly allowed it).
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={
+            "username": "admin",
+            "password": "s3cret-pw",
+            "redirect_uri": BASE + ".evil.example.com/cb",  # same prefix, different origin
+            "code_challenge": _challenge(VERIFIER),
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"
+
+
+def test_same_origin_redirect_under_public_base_url_is_allowed(env):
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/oauth/authorize",
+        data={
+            "username": "admin",
+            "password": "s3cret-pw",
+            "redirect_uri": BASE + "/callback",  # same scheme+host as PUBLIC_BASE_URL
+            "code_challenge": _challenge(VERIFIER),
+            "state": "xyz",
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 302 and r.headers["location"].startswith(BASE + "/callback")
+
+
+def test_login_form_escapes_params_no_reflected_xss(env):
+    # The carried OAuth params land in HTML attributes on the password page; they must be escaped.
+    c = TestClient(mcp_http.build_app())
+    r = c.get("/oauth/authorize", params={"state": '"><script>alert(1)</script>'})
+    assert r.status_code == 200
+    assert "<script>alert(1)</script>" not in r.text  # not reflected raw
+    assert "&lt;script&gt;" in r.text  # escaped instead
+
+
+def test_oauth_endpoints_are_public_but_mcp_still_requires_auth(env):
+    c = TestClient(mcp_http.build_app())
+    assert c.get("/oauth/authorize", params={"redirect_uri": REDIRECT}).status_code == 200
+    r = c.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert r.status_code == 401  # the MCP endpoint still demands a bearer

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
+import re
 import sys
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -293,3 +295,86 @@ def test_oauth_endpoints_are_public_but_mcp_still_requires_auth(env):
     # The OAuth skip is EXACT-match: a sibling under /oauth/* that isn't a real route doesn't get a
     # free pass — it still hits auth (401) rather than being treated as public.
     assert c.post("/oauth/token/extra").status_code == 401
+
+
+# --- the JWT-validating provider + end-to-end (the issued token gates /mcp) ---
+
+
+def _mint_jwt(c: TestClient) -> str:
+    """Run the full authorize→token flow and return the issued access token (a JWT)."""
+    code = _authorize_code(c)
+    r = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def test_jwt_provider_accepts_issued_token_and_rejects_junk(env):
+    from oauth_server import JwtAuthProvider, issue_jwt
+
+    provider = JwtAuthProvider()
+    principal = provider.validate_token(issue_jwt("admin"))
+    assert principal is not None and principal.subject == "admin"
+    assert provider.validate_token("not-a-jwt") is None
+    # a token signed with the WRONG secret must not validate
+    forged = jwt.encode({"sub": "admin", "iss": BASE, "exp": 9_999_999_999}, "wrong", "HS256")
+    assert provider.validate_token(forged) is None
+
+
+def test_end_to_end_oauth_then_mcp_tools_list(env):
+    # The whole point: a token minted via the OAuth flow is accepted by the transport, and the
+    # tools/list comes back with exactly the 5 product tools.
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    with TestClient(mcp_http.build_app()) as c:
+        bearer = {"Authorization": f"Bearer {_mint_jwt(c)}", **headers}
+        init = c.post(
+            "/mcp",
+            headers=bearer,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "t", "version": "1"},
+                },
+            },
+        )
+        assert init.status_code == 200
+        sid = init.headers.get("mcp-session-id")
+        h2 = {**bearer, **({"mcp-session-id": sid} if sid else {})}
+        c.post("/mcp", headers=h2, json={"jsonrpc": "2.0", "method": "notifications/initialized"})
+        tl = c.post("/mcp", headers=h2, json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        assert tl.status_code == 200
+        payload = json.loads(re.search(r"\{.*\}", tl.text, re.DOTALL).group(0))
+        names = {t["name"] for t in payload["result"]["tools"]}
+    assert names == {
+        "list_datasources",
+        "get_datasource_schema",
+        "get_prompt_examples",
+        "execute_sql",
+        "log_feedback",
+    }
+
+
+def test_non_jwt_bearer_is_rejected_when_signing_secret_set(env):
+    # With a signing secret configured the transport uses the JWT provider, so a bare presence token
+    # ("Bearer present") that worked in the no-secret fallback is now rejected.
+    c = TestClient(mcp_http.build_app())
+    r = c.post(
+        "/mcp",
+        headers={"Authorization": "Bearer present"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert r.status_code == 401

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -36,6 +36,24 @@ def test_real_migrations_create_all_tables_on_empty_db():
     s.close()
 
 
+def test_oauth_tables_exist():
+    # The OAuth provider owns these: oauth_client (registered clients) + oauth_state (authorization
+    # codes bound to their PKCE challenge + redirect + the authenticated username).
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    assert {"oauth_client", "oauth_state"} <= _tables(s)
+    state_cols = {r["name"] for r in s.query("PRAGMA table_info(oauth_state)")}
+    assert {
+        "code",
+        "code_challenge",
+        "redirect_uri",
+        "username",
+        "expires_at",
+        "used",
+    } <= state_cols
+    s.close()
+
+
 def test_users_table_is_flat_no_role_column():
     # The users table exists with the identity columns and, crucially, NO role/permission column —
     # flat access is the open-core contract (roles are paid).

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -37,14 +37,16 @@ def test_real_migrations_create_all_tables_on_empty_db():
 
 
 def test_users_table_is_flat_no_role_column():
-    # ACE-004: the users table exists with the identity columns and, crucially, NO role/permission
-    # column — flat access is the open-core contract (roles are paid).
+    # The users table exists with the identity columns and, crucially, NO role/permission column —
+    # flat access is the open-core contract (roles are paid).
     s = Store.connect("sqlite://")
     s.run_migrations()
     assert "users" in _tables(s)
     cols = {r["name"] for r in s.query("PRAGMA table_info(users)")}
     assert {"id", "username", "password_hash", "email", "status", "created"} <= cols
-    assert not (cols & {"role", "roles", "permission", "permissions"}), "flat access — no role column"
+    assert not (cols & {"role", "roles", "permission", "permissions"}), (
+        "flat access — no role column"
+    )
     s.close()
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -36,6 +36,18 @@ def test_real_migrations_create_all_tables_on_empty_db():
     s.close()
 
 
+def test_users_table_is_flat_no_role_column():
+    # ACE-004: the users table exists with the identity columns and, crucially, NO role/permission
+    # column — flat access is the open-core contract (roles are paid).
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    assert "users" in _tables(s)
+    cols = {r["name"] for r in s.query("PRAGMA table_info(users)")}
+    assert {"id", "username", "password_hash", "email", "status", "created"} <= cols
+    assert not (cols & {"role", "roles", "permission", "permissions"}), "flat access — no role column"
+    s.close()
+
+
 def test_migrations_are_idempotent_on_real_dir():
     s = Store.connect("sqlite://")
     s.run_migrations()

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -1,4 +1,4 @@
-"""User store + password authentication (ACE-004).
+"""User store + password authentication.
 
 SQLite-backed (the portable backend the gate runs on). Proves: argon2id hashing (never plaintext),
 correct/wrong verify, the disabled-status gate, the env-seeded admin (idempotent), the rehash

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -1,0 +1,115 @@
+"""User store + password authentication (ACE-004).
+
+SQLite-backed (the portable backend the gate runs on). Proves: argon2id hashing (never plaintext),
+correct/wrong verify, the disabled-status gate, the env-seeded admin (idempotent), the rehash
+upgrade path, and that a listing never leaks the hash.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("argon2")  # the password path needs the [server]-extra argon2-cffi
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import user_store  # noqa: E402
+from store import Store  # noqa: E402
+
+
+def _store() -> Store:
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    return s
+
+
+def test_create_then_authenticate_round_trip():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw", email="you@example.com")
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
+    s.close()
+
+
+def test_wrong_password_fails():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    assert user_store.authenticate(s, "admin", "wrong") is None
+    assert user_store.authenticate(s, "nobody", "s3cret-pw") is None  # unknown user
+    s.close()
+
+
+def test_password_is_argon2id_and_never_plaintext():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    stored = user_store.get_user(s, "admin")["password_hash"]
+    assert stored.startswith("$argon2id$")
+    assert "s3cret-pw" not in stored
+    s.close()
+
+
+def test_disabled_status_blocks_login():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    user_store.set_status(s, "admin", "disabled")
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is None  # right pw, but disabled
+    user_store.set_status(s, "admin", "active")
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
+    s.close()
+
+
+def test_authenticate_returns_principal_with_username_subject():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    principal = user_store.authenticate(s, "admin", "s3cret-pw")
+    assert principal is not None and principal.subject == "admin"
+    s.close()
+
+
+def test_list_users_never_exposes_the_hash():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    rows = user_store.list_users(s)
+    assert rows and "password_hash" not in rows[0]
+    s.close()
+
+
+def test_seed_admin_from_env_creates_and_is_idempotent(monkeypatch):
+    s = _store()
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", "admin")
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", "seed-pw")
+    assert user_store.seed_admin_from_env(s) == "admin"
+    assert user_store.authenticate(s, "admin", "seed-pw") is not None
+    # second run is a no-op (no duplicate, no clobber)
+    assert user_store.seed_admin_from_env(s) is None
+    assert len(user_store.list_users(s)) == 1
+    s.close()
+
+
+def test_seed_admin_noop_when_env_unset(monkeypatch):
+    s = _store()
+    monkeypatch.delenv("AGAMI_ADMIN_USERNAME", raising=False)
+    monkeypatch.delenv("AGAMI_ADMIN_PASSWORD", raising=False)
+    assert user_store.seed_admin_from_env(s) is None
+    assert user_store.list_users(s) == []
+    s.close()
+
+
+def test_needs_rehash_upgrade_path(monkeypatch):
+    # Simulate a stored hash made with a weaker profile: authenticate should re-store an upgraded
+    # hash in place (the cross-tier cost-bump path) without changing the verified password.
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw")
+    before = user_store.get_user(s, "admin")["password_hash"]
+    # user_store imported needs_rehash by name, so patch the binding it actually calls.
+    monkeypatch.setattr(user_store, "needs_rehash", lambda stored: True)
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
+    after = user_store.get_user(s, "admin")["password_hash"]
+    assert after != before and after.startswith("$argon2id$")
+    # the upgraded hash still verifies the same password
+    assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
+    s.close()

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -43,6 +43,28 @@ def test_wrong_password_fails():
     s.close()
 
 
+def test_empty_password_is_rejected_at_create():
+    s = _store()
+    with pytest.raises(ValueError):
+        user_store.create_user(s, "admin", "")
+    assert user_store.list_users(s) == []  # nothing created
+    s.close()
+
+
+def test_authenticate_runs_a_verify_even_for_unknown_user(monkeypatch):
+    # The anti-enumeration guard: a missing username still runs a verify (against the dummy hash),
+    # so the call can't be distinguished by "did verify run". We assert the spy fired.
+    s = _store()
+    calls: list[str] = []
+    real = user_store.verify_password
+    monkeypatch.setattr(
+        user_store, "verify_password", lambda h, p: (calls.append(h), real(h, p))[1]
+    )
+    assert user_store.authenticate(s, "ghost", "whatever") is None
+    assert calls == [user_store._DUMMY_HASH]  # verified against the dummy, not skipped
+    s.close()
+
+
 def test_password_is_argon2id_and_never_plaintext():
     s = _store()
     user_store.create_user(s, "admin", "s3cret-pw")


### PR DESCRIPTION
## Summary

Brings **per-user authentication** to the hosted MCP server, completing the app-auth feature. A user logs in through the server's OAuth flow, receives a self-signed JWT, and that JWT gates the MCP tools. Assembled and validated on the `feature/app-auth` integration branch across three already-reviewed PRs (#41, #42, #43); this merges the finished feature to main.

The local/OSS path is unchanged: with no `AGAMI_SIGNING_SECRET` configured, the server keeps the bearer-presence default.

## What's included

- **User store (#41)** — `users` table (flat, no roles), argon2id password hashing (`argon2-cffi`, server-extra only), `authenticate(username, password) → Principal`, env-seeded initial admin. Anti-enumeration (dummy-verify on miss), timing-safe.
- **OAuth provider (#42)** — `/oauth/register` (minimal RFC 7591), `/oauth/authorize` (login → code), `/oauth/token` (code + PKCE S256 → HS256 JWT). Single-use + expiring codes (atomic burn), redirect allow-listing by parsed scheme+host, HTML-escaped login form, ≥32-byte signing-secret enforcement.
- **JWT-gated transport (#43)** — `JwtAuthProvider` validates the issued token (alg-pinned, requires sub/exp/iss, checks issuer, fails closed); selected automatically when `AGAMI_SIGNING_SECRET` is set (no silent downgrade on misconfig), else presence.

## Config (hosted)

`AGAMI_DB_URL` (or `APP_DATABASE_URL`), `PUBLIC_BASE_URL`, `AGAMI_SIGNING_SECRET` (≥32 bytes), optional `AGAMI_ADMIN_USERNAME`/`AGAMI_ADMIN_PASSWORD` (seed the first admin), optional `AGAMI_ORG_ID`.

## Review & tests

Every slice had `/code-review` + a dedicated **security pass** (high lane) + a **Copilot** review, all findings resolved — including real catches: the auth-code concurrency race (atomic CAS), an open-redirect (parsed-origin match), a reflected-XSS on the login page (escaping), and a no-silent-downgrade hardening. Full gate green on each (`uv run dev.py check` — ruff + 792 tests + gitleaks). End-to-end test: register→authorize→token→JWT gates `/mcp` tools/list.

**Deferred (not in scope here):** the live claude.ai connector smoke against a deployed instance (manual, ties to deploy-experience); OIDC; admin UI; refresh tokens; full DCR.

## Checklist

- [x] `uv run dev.py check` green; CI green on all merged slices
- [x] Security review done (high lane) on every slice
- [x] No real customer data/names/credentials; no internal IDs in repo files

Spec: ACE-004
Spec: ACE-005