### PR TITLE
OIDC social login — generic client + Google + onboarded-only (1 of 2)

### DIFF
--- a/migrations/core/005_users_passwordless.sql
+++ b/migrations/core/005_users_passwordless.sql
@@ -1,0 +1,23 @@
+-- Allow passwordless users (OIDC social login) — an OIDC user has no password_hash.
+--
+-- SQLite has no ALTER COLUMN to drop NOT NULL, so rebuild the table (the portable way that runs on
+-- both SQLite and Postgres as a single script): new table with a nullable password_hash, copy the
+-- rows by explicit column list, drop + rename, then recreate the email index OIDC looks users up by.
+-- The users table is recent and not yet deployed, so the copy is cheap.
+
+CREATE TABLE users_new (
+    id            TEXT PRIMARY KEY,
+    username      TEXT NOT NULL UNIQUE,
+    password_hash TEXT,                     -- nullable now: NULL for an OIDC-only user
+    email         TEXT,
+    status        TEXT NOT NULL DEFAULT 'active',
+    created       TEXT NOT NULL
+);
+
+INSERT INTO users_new (id, username, password_hash, email, status, created)
+    SELECT id, username, password_hash, email, status, created FROM users;
+
+DROP TABLE users;
+ALTER TABLE users_new RENAME TO users;
+
+CREATE INDEX idx_users_email ON users (email);

--- a/migrations/core/005_users_passwordless.sql
+++ b/migrations/core/005_users_passwordless.sql
@@ -20,4 +20,6 @@ INSERT INTO users_new (id, username, password_hash, email, status, created)
 DROP TABLE users;
 ALTER TABLE users_new RENAME TO users;
 
-CREATE INDEX idx_users_email ON users (email);
+-- UNIQUE so OIDC's email lookup resolves to exactly one user (NULLs stay distinct on both SQLite and
+-- Postgres, so multiple password-only users with no email are fine). Emails are stored lowercased.
+CREATE UNIQUE INDEX idx_users_email ON users (email);

--- a/migrations/core/005_users_passwordless.sql
+++ b/migrations/core/005_users_passwordless.sql
@@ -14,8 +14,10 @@ CREATE TABLE users_new (
     created       TEXT NOT NULL
 );
 
+-- Normalize existing emails (trim + lowercase) on the way over, matching how the app now stores
+-- them — so the UNIQUE index below can't be tripped by a case/whitespace variant of an existing row.
 INSERT INTO users_new (id, username, password_hash, email, status, created)
-    SELECT id, username, password_hash, email, status, created FROM users;
+    SELECT id, username, password_hash, LOWER(TRIM(email)), status, created FROM users;
 
 DROP TABLE users;
 ALTER TABLE users_new RENAME TO users;

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -36,6 +36,8 @@ server = [
   "psycopg2-binary>=2.9",
   "argon2-cffi>=23",
   "PyJWT>=2.8",
+  "httpx>=0.27",        # OIDC discovery + token exchange (the server's one outbound egress)
+  "cryptography>=43",   # RS256 backend for PyJWT id-token verification
 ]
 
 [tool.setuptools]

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -93,7 +93,13 @@ _PUBLIC_PREFIXES = (
 # The OAuth flow endpoints are pre-auth by definition — the user has no bearer token yet (they're
 # obtaining one). They enforce their own validation (credential check, PKCE, single-use codes,
 # redirect allow-listing), so they're public at the transport layer.
-_OAUTH_PATHS = ("/oauth/authorize", "/oauth/token", "/oauth/register")
+_OAUTH_PATHS = (
+    "/oauth/authorize",
+    "/oauth/token",
+    "/oauth/register",
+    "/oauth/oidc/start",
+    "/oauth/oidc/callback",
+)
 
 
 def _is_public_path(path: str) -> bool:
@@ -214,7 +220,7 @@ def build_app() -> Starlette:
         async with session_manager.run():
             yield
 
-    from oauth_server import authorize, register, token
+    from oauth_server import authorize, oidc_callback, oidc_start, register, token
 
     routes = [
         Route("/.well-known/oauth-protected-resource", _protected_resource),
@@ -224,6 +230,8 @@ def build_app() -> Starlette:
         Route("/oauth/authorize", authorize, methods=["GET", "POST"]),
         Route("/oauth/token", token, methods=["POST"]),
         Route("/oauth/register", register, methods=["POST"]),
+        Route("/oauth/oidc/start", oidc_start, methods=["GET"]),
+        Route("/oauth/oidc/callback", oidc_callback, methods=["GET"]),
         Mount("/mcp", app=handle_mcp),
     ]
     middleware = [

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -29,7 +29,7 @@ from ports import Principal
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from store import Store
-from user_store import authenticate
+from user_store import authenticate, get_user_by_email
 
 _CODE_TTL = timedelta(minutes=10)  # authorization codes are short-lived
 _JWT_TTL = timedelta(hours=1)
@@ -189,31 +189,48 @@ async def register(request: Request) -> Response:
         store.close()
 
 
-def _login_form(params: dict[str, str], error: str = "") -> HTMLResponse:
-    """A minimal login form that carries the OAuth params forward as hidden fields. Neutral
-    placeholders only — no real names or secrets."""
+_OAUTH_CONTEXT_KEYS = ("client_id", "redirect_uri", "code_challenge", "state")
+
+
+def _login_form(
+    params: dict[str, str], error: str = "", providers: tuple[str, ...] = ()
+) -> HTMLResponse:
+    """A minimal login form that carries the OAuth params forward as hidden fields, plus a
+    "Sign in with <provider>" link per configured OIDC provider. Neutral placeholders only."""
     # Escape every interpolated value — these come from attacker-controllable query/body params and
     # land in HTML attributes on the password-entry page; unescaped, they're a reflected-XSS vector.
     hidden = "".join(
         f'<input type="hidden" name="{k}" value="{html.escape(params.get(k, ""), quote=True)}">'
-        for k in ("client_id", "redirect_uri", "code_challenge", "state")
+        for k in _OAUTH_CONTEXT_KEYS
     )
     msg = f'<p role="alert">{html.escape(error)}</p>' if error else ""
+    # OIDC links carry the same OAuth context to /oauth/oidc/start so the flow can resume after the
+    # IdP round-trip. urlencode escapes the values for the query string.
+    carried = {k: params.get(k, "") for k in _OAUTH_CONTEXT_KEYS}
+    oidc_links = "".join(
+        f'<a href="/oauth/oidc/start?{urlencode({**carried, "provider": key})}">'
+        f"Sign in with {html.escape(key.title())}</a>"
+        for key in providers
+    )
     return HTMLResponse(
         f"""<!doctype html><html><head><meta charset="utf-8"><title>Sign in</title></head>
 <body><h1>Sign in</h1>{msg}
 <form method="post">{hidden}
 <label>Username <input name="username" autocomplete="username" placeholder="admin"></label>
 <label>Password <input name="password" type="password" autocomplete="current-password"></label>
-<button type="submit">Sign in</button></form></body></html>"""
+<button type="submit">Sign in</button></form>
+{oidc_links}</body></html>"""
     )
 
 
 async def authorize(request: Request) -> Response:
     """GET → the login form (carrying the OAuth params); POST → verify credentials and redirect to
     the client with a fresh authorization code, or re-render with an error."""
+    import oidc
+
+    providers = tuple(oidc.available_providers())
     if request.method == "GET":
-        return _login_form(dict(request.query_params))
+        return _login_form(dict(request.query_params), providers=providers)
 
     form = await _form(request)
     store = _open_store()
@@ -237,27 +254,48 @@ async def authorize(request: Request) -> Response:
 
         principal = authenticate(store, form.get("username", ""), form.get("password", ""))
         if principal is None:
-            return _login_form(form, error="Invalid username or password.")
+            return _login_form(form, error="Invalid username or password.", providers=providers)
 
-        code = secrets.token_urlsafe(32)
-        store.execute(
-            "INSERT INTO oauth_state (code, client_id, redirect_uri, code_challenge, username, "
-            "expires_at, used, created) VALUES (?, ?, ?, ?, ?, ?, 0, ?)",
-            (
-                code,
-                client_id,
-                redirect_uri,
-                code_challenge,
-                principal.subject,
-                (_now() + _CODE_TTL).isoformat(),
-                _now().isoformat(),
-            ),
+        return _issue_authorization_code(
+            store,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            code_challenge=code_challenge,
+            username=principal.subject,
+            client_state=form.get("state", ""),
         )
-        store.commit()
-        query = urlencode({"code": code, "state": form.get("state", "")})
-        return RedirectResponse(f"{redirect_uri}?{query}", status_code=302)
     finally:
         store.close()
+
+
+def _issue_authorization_code(
+    store: Store,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    username: str,
+    client_state: str,
+) -> RedirectResponse:
+    """Mint a fresh authorization code for an authenticated user and 302 back to the client. Shared
+    by the password path and the OIDC callback so both resume the same OAuth token exchange."""
+    code = secrets.token_urlsafe(32)
+    store.execute(
+        "INSERT INTO oauth_state (code, client_id, redirect_uri, code_challenge, username, "
+        "expires_at, used, created) VALUES (?, ?, ?, ?, ?, ?, 0, ?)",
+        (
+            code,
+            client_id,
+            redirect_uri,
+            code_challenge,
+            username,
+            (_now() + _CODE_TTL).isoformat(),
+            _now().isoformat(),
+        ),
+    )
+    store.commit()
+    query = urlencode({"code": code, "state": client_state})
+    return RedirectResponse(f"{redirect_uri}?{query}", status_code=302)
 
 
 async def token(request: Request) -> Response:
@@ -307,3 +345,148 @@ async def token(request: Request) -> Response:
         )
     finally:
         store.close()
+
+
+# ---------------------------------------------------------------------------
+# OIDC social login ("Sign in with Google/Microsoft")
+#
+# The OIDC leg nests inside the OAuth authorize flow: we send the user to the IdP, and on callback
+# resume minting the OAuth authorization code for the original MCP client. The original authorize
+# context (client_id, redirect_uri, code_challenge, the client's state) + a fresh nonce ride across
+# the IdP round-trip in a short-lived **signed** `state` JWT, bound to an **HttpOnly CSRF cookie** so
+# a forged callback can't complete the flow. User resolution is **onboarded-only** — no auto-create.
+# ---------------------------------------------------------------------------
+
+_OIDC_STATE_TTL = timedelta(minutes=10)
+_CSRF_COOKIE = "agami_oidc_csrf"
+
+
+def _oidc_callback_uri() -> str:
+    from mcp_http import public_base_url
+
+    return f"{public_base_url()}/oauth/oidc/callback"
+
+
+def _mint_oidc_state(payload: dict, csrf: str) -> str:
+    """Sign the carried authorize context + a CSRF binding into a short-lived HS256 state JWT."""
+    claims = {
+        **payload,
+        "csrf": hashlib.sha256(csrf.encode()).hexdigest(),
+        "iat": int(_now().timestamp()),
+        "exp": int((_now() + _OIDC_STATE_TTL).timestamp()),
+    }
+    return jwt.encode(claims, _signing_secret(), algorithm="HS256")
+
+
+def _verify_oidc_state(state: str, csrf_cookie: str | None) -> dict | None:
+    """Validate the state JWT (signature + expiry) AND that it's bound to the caller's CSRF cookie.
+    Returns the claims, or None on any failure (treated identically to avoid an oracle)."""
+    try:
+        claims = jwt.decode(
+            state, _signing_secret(), algorithms=["HS256"], options={"require": ["exp"]}
+        )
+    except Exception:
+        return None
+    expected = claims.get("csrf")
+    if not csrf_cookie or not expected:
+        return None
+    if not hmac.compare_digest(hashlib.sha256(csrf_cookie.encode()).hexdigest(), expected):
+        return None
+    return claims
+
+
+async def oidc_start(request: Request) -> Response:
+    """Begin OIDC: re-apply the password path's gates (redirect allow-list + PKCE) on the carried
+    OAuth params, then redirect to the IdP with a signed state (context + nonce) + a CSRF cookie."""
+    import oidc
+
+    q = request.query_params
+    p = oidc.provider(q.get("provider", ""))
+    if p is None:
+        return _oauth_error("invalid_request", "unknown or unconfigured provider")
+    redirect_uri = q.get("redirect_uri", "")
+    code_challenge = q.get("code_challenge", "")
+    store = _open_store()
+    if store is None:
+        return _oauth_error("server_error", "no datastore configured", status=500)
+    try:
+        client = store.query(
+            "SELECT redirect_uris FROM oauth_client WHERE client_id = ?", (q.get("client_id", ""),)
+        )
+        registered = client[0]["redirect_uris"] if client else None
+    finally:
+        store.close()
+    if not _redirect_allowed(redirect_uri, registered):
+        return _oauth_error("invalid_request", "redirect_uri not allowed")
+    if not code_challenge:
+        return _oauth_error("invalid_request", "code_challenge is required (PKCE)")
+
+    nonce = secrets.token_urlsafe(16)
+    csrf = secrets.token_urlsafe(16)
+    state = _mint_oidc_state(
+        {
+            "provider": p.key,
+            "client_id": q.get("client_id", ""),
+            "redirect_uri": redirect_uri,
+            "code_challenge": code_challenge,
+            "client_state": q.get("state", ""),
+            "nonce": nonce,
+        },
+        csrf,
+    )
+    url = oidc.authorize_url(p, state=state, nonce=nonce, redirect_uri=_oidc_callback_uri())
+    resp = RedirectResponse(url, status_code=302)
+    resp.set_cookie(
+        _CSRF_COOKIE,
+        csrf,
+        max_age=int(_OIDC_STATE_TTL.total_seconds()),
+        httponly=True,
+        secure=True,
+        samesite="lax",
+    )
+    return resp
+
+
+async def oidc_callback(request: Request) -> Response:
+    """Complete OIDC: verify state + CSRF, exchange the code, verify the ID token, resolve the user
+    **onboarded-only**, then resume the OAuth code mint. Any verification failure is a generic
+    403 — never an auto-created account."""
+    import oidc
+
+    q = request.query_params
+    claims = _verify_oidc_state(q.get("state", ""), request.cookies.get(_CSRF_COOKIE))
+    if claims is None:
+        return _oauth_error("invalid_request", "invalid or expired state")
+    p = oidc.provider(claims.get("provider", ""))
+    if p is None:
+        return _oauth_error("invalid_request", "unknown or unconfigured provider")
+    if not q.get("code"):
+        return _oauth_error("invalid_request", "missing code")
+    try:
+        id_token = oidc.exchange_code(p, code=q.get("code", ""), redirect_uri=_oidc_callback_uri())
+        email = oidc.verify_id_token(p, id_token, nonce=claims.get("nonce", ""))
+    except Exception:
+        # Bad signature/aud/iss/nonce/unverified-email/exchange error — all collapse to one verdict.
+        return _oauth_error("access_denied", "OIDC verification failed", status=403)
+
+    store = _open_store()
+    if store is None:
+        return _oauth_error("server_error", "no datastore configured", status=500)
+    try:
+        user = get_user_by_email(store, email)
+        # Onboarded-only: the verified email must already be an active user (admin-created). An
+        # unknown email is rejected, never auto-provisioned.
+        if user is None or user["status"] != "active":
+            return _oauth_error("access_denied", "this account is not authorized", status=403)
+        resp = _issue_authorization_code(
+            store,
+            client_id=claims.get("client_id", ""),
+            redirect_uri=claims.get("redirect_uri", ""),
+            code_challenge=claims.get("code_challenge", ""),
+            username=user["username"],
+            client_state=claims.get("client_state", ""),
+        )
+    finally:
+        store.close()
+    resp.delete_cookie(_CSRF_COOKIE)
+    return resp

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -476,6 +476,10 @@ async def oidc_callback(request: Request) -> Response:
         user = get_user_by_email(store, email)
         # Onboarded-only: the verified email must already be an active user (admin-created). An
         # unknown email is rejected, never auto-provisioned.
+        #
+        # LOAD-BEARING: resolution is by email alone, which is safe ONLY while a single IdP is
+        # enabled. Before enabling a second provider, bind identity to (provider, subject) — else an
+        # attacker with the same email at another IdP would resolve to this user (IdP confusion).
         if user is None or user["status"] != "active":
             return _oauth_error("access_denied", "this account is not authorized", status=403)
         resp = _issue_authorization_code(

--- a/packages/agami-core/src/oidc.py
+++ b/packages/agami-core/src/oidc.py
@@ -1,0 +1,128 @@
+"""Generic OIDC client — "Sign in with Google/Microsoft" behind the OAuth authorize page.
+
+This is the server's ONE deliberate outbound egress: it calls the IdP's discovery, token, and JWKS
+endpoints (httpx + PyJWT's JWKS fetch). It is server-only (the `[server]` extra) and excluded from
+the zero-egress privacy contract — the local skill never imports it; users who want no egress run the
+local `agami serve`.
+
+Verification is **explicit and uniform** for every provider (a provider is just a discovery URL +
+client id/secret): the ID token's RS256 signature is checked against the IdP JWKS, and
+`aud`/`iss`/`exp`/`nonce`/`email_verified` are all asserted *here*, not left implicit to a provider
+SDK. That is the whole reason this is a generic client rather than google-auth/msal.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+import httpx
+import jwt
+
+# A short timeout: the IdP is a fast hop; we never want a hung login to wedge a worker.
+_TIMEOUT = httpx.Timeout(10.0)
+
+# Discovery URLs are fixed per provider (the HTTPS trust anchor); client creds come from env. Google
+# ships first; Microsoft (with tenant pinning) follows.
+_DISCOVERY = {
+    "google": "https://accounts.google.com/.well-known/openid-configuration",
+}
+
+_discovery_cache: dict[str, dict] = {}
+
+
+@dataclass(frozen=True)
+class Provider:
+    key: str
+    discovery_url: str
+    client_id: str
+    client_secret: str
+
+
+def provider(key: str) -> Provider | None:
+    """The configured provider for `key`, or None when its client id/secret env is absent (so the
+    option is simply hidden). Env: AGAMI_OIDC_<KEY>_CLIENT_ID / _CLIENT_SECRET."""
+    discovery_url = _DISCOVERY.get(key)
+    if discovery_url is None:
+        return None
+    client_id = os.environ.get(f"AGAMI_OIDC_{key.upper()}_CLIENT_ID", "").strip()
+    client_secret = os.environ.get(f"AGAMI_OIDC_{key.upper()}_CLIENT_SECRET", "").strip()
+    if not client_id or not client_secret:
+        return None
+    return Provider(key, discovery_url, client_id, client_secret)
+
+
+def available_providers() -> list[str]:
+    """The provider keys that are configured (have client id/secret) — what the login page offers."""
+    return [k for k in _DISCOVERY if provider(k) is not None]
+
+
+def _discover(p: Provider) -> dict:
+    """The IdP's OpenID discovery document (authorization/token/jwks URIs + issuer), cached."""
+    if p.discovery_url not in _discovery_cache:
+        resp = httpx.get(p.discovery_url, timeout=_TIMEOUT)
+        resp.raise_for_status()
+        _discovery_cache[p.discovery_url] = resp.json()
+    return _discovery_cache[p.discovery_url]
+
+
+def authorize_url(p: Provider, *, state: str, nonce: str, redirect_uri: str) -> str:
+    """The IdP authorize URL to send the user to (authorization-code flow, `openid email`)."""
+    meta = _discover(p)
+    params = {
+        "client_id": p.client_id,
+        "response_type": "code",
+        "scope": "openid email",
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "nonce": nonce,
+    }
+    return f"{meta['authorization_endpoint']}?{urlencode(params)}"
+
+
+def exchange_code(p: Provider, *, code: str, redirect_uri: str) -> str:
+    """Exchange the authorization code for the IdP's `id_token` (raises on any failure)."""
+    meta = _discover(p)
+    resp = httpx.post(
+        meta["token_endpoint"],
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": p.client_id,
+            "client_secret": p.client_secret,
+        },
+        timeout=_TIMEOUT,
+    )
+    resp.raise_for_status()
+    id_token = resp.json().get("id_token")
+    if not id_token:
+        raise ValueError("token response missing id_token")
+    return id_token
+
+
+def verify_id_token(p: Provider, id_token: str, *, nonce: str) -> str:
+    """Verify the ID token and return the **verified** email. Raises on any verification failure.
+
+    Explicit and uniform: RS256 signature against the IdP JWKS, `aud` == our client_id, `iss` == the
+    discovered issuer, `exp` enforced, the `nonce` matches the one we sent (replay defense), and
+    `email_verified` is true (never trust an unverified email as identity)."""
+    meta = _discover(p)
+    signing_key = jwt.PyJWKClient(meta["jwks_uri"]).get_signing_key_from_jwt(id_token).key
+    claims = jwt.decode(
+        id_token,
+        signing_key,
+        algorithms=["RS256"],
+        audience=p.client_id,
+        issuer=meta["issuer"],
+        options={"require": ["exp", "aud", "iss", "nonce"]},
+    )
+    if claims.get("nonce") != nonce:
+        raise ValueError("nonce mismatch")
+    if claims.get("email_verified") is not True:
+        raise ValueError("email_verified is not true")
+    email = claims.get("email")
+    if not email:
+        raise ValueError("id token has no email claim")
+    return email

--- a/packages/agami-core/src/oidc.py
+++ b/packages/agami-core/src/oidc.py
@@ -30,6 +30,7 @@ _DISCOVERY = {
 }
 
 _discovery_cache: dict[str, dict] = {}
+_jwks_clients: dict[str, "jwt.PyJWKClient"] = {}
 
 
 @dataclass(frozen=True)
@@ -109,7 +110,12 @@ def verify_id_token(p: Provider, id_token: str, *, nonce: str) -> str:
     discovered issuer, `exp` enforced, the `nonce` matches the one we sent (replay defense), and
     `email_verified` is true (never trust an unverified email as identity)."""
     meta = _discover(p)
-    signing_key = jwt.PyJWKClient(meta["jwks_uri"]).get_signing_key_from_jwt(id_token).key
+    # Reuse the JWKS client per provider — it keeps its own key cache, so steady-state logins don't
+    # re-fetch the IdP's keys on every request (and don't amplify into the IdP under load).
+    jwks_uri = meta["jwks_uri"]
+    if jwks_uri not in _jwks_clients:
+        _jwks_clients[jwks_uri] = jwt.PyJWKClient(jwks_uri)
+    signing_key = _jwks_clients[jwks_uri].get_signing_key_from_jwt(id_token).key
     claims = jwt.decode(
         id_token,
         signing_key,

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -36,22 +36,33 @@ def _now_iso() -> str:
 def create_user(
     store: Store,
     username: str,
-    password: str,
+    password: str | None = None,
     email: str | None = None,
     status: str = _ACTIVE,
 ) -> str:
-    """Create a user with an argon2id-hashed password; returns the minted id. Raises if the username
-    already exists (the UNIQUE constraint) — callers that want create-if-absent check first."""
-    if not password:
-        raise ValueError("password must not be empty")
+    """Create a user; returns the minted id. `password=None` makes a **passwordless** user (OIDC-only —
+    no password login); a non-None password is argon2id-hashed and must be non-empty. Raises if the
+    username already exists (the UNIQUE constraint) — callers that want create-if-absent check first."""
+    if password is not None and not password.strip():
+        raise ValueError("password must not be empty (pass None for a passwordless OIDC user)")
     user_id = uuid4().hex
+    password_hash = hash_password(password) if password is not None else None
     store.execute(
         "INSERT INTO users (id, username, password_hash, email, status, created) "
         "VALUES (?, ?, ?, ?, ?, ?)",
-        (user_id, username, hash_password(password), email, status, _now_iso()),
+        (user_id, username, password_hash, email, status, _now_iso()),
     )
     store.commit()
     return user_id
+
+
+def get_user_by_email(store: Store, email: str) -> dict[str, Any] | None:
+    """Look up a user by email — the onboarded-only lookup OIDC uses. Returns the first match (email
+    is indexed; uniqueness is enforced by how users are onboarded, not the schema)."""
+    if not email:
+        return None
+    rows = store.query("SELECT * FROM users WHERE email = ?", (email,))
+    return rows[0] if rows else None
 
 
 def get_user(store: Store, username: str) -> dict[str, Any] | None:
@@ -77,9 +88,11 @@ def authenticate(store: Store, username: str, password: str) -> Principal | None
     a username exists — closing a timing-enumeration oracle. On success, opportunistically upgrade
     the stored hash if the cost profile has risen (the cross-tier cost-bump path)."""
     user = get_user(store, username)
-    stored_hash = user["password_hash"] if user else _DUMMY_HASH
+    # A passwordless (OIDC-only) user has a NULL hash and can never password-login; verify against the
+    # dummy hash so the timing is identical to a missing/active-password user.
+    stored_hash = user["password_hash"] if (user and user["password_hash"]) else _DUMMY_HASH
     verified = verify_password(stored_hash, password)
-    if user is None or user["status"] != _ACTIVE or not verified:
+    if user is None or user["status"] != _ACTIVE or user["password_hash"] is None or not verified:
         return None
     if needs_rehash(user["password_hash"]):
         try:

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -33,6 +33,14 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _normalize_email(email: str | None) -> str | None:
+    """Canonical email form for storage + lookup: trimmed + lowercased, or None. Both paths use this
+    so a stray-whitespace or mixed-case address can't dodge the one-to-one (UNIQUE) email identity."""
+    if not email:
+        return None
+    return email.strip().lower() or None
+
+
 def create_user(
     store: Store,
     username: str,
@@ -47,9 +55,9 @@ def create_user(
         raise ValueError("password must not be empty (pass None for a passwordless OIDC user)")
     user_id = uuid4().hex
     password_hash = hash_password(password) if password is not None else None
-    # Emails are the OIDC lookup key — store them lowercased so the (case-insensitive) identity
-    # matches regardless of how the IdP cases the address; the UNIQUE index keeps them one-to-one.
-    normalized_email = email.lower() if email else None
+    # Emails are the OIDC lookup key — store them normalized (trim + lowercase) so the identity
+    # matches regardless of casing/whitespace; the UNIQUE index keeps them one-to-one.
+    normalized_email = _normalize_email(email)
     store.execute(
         "INSERT INTO users (id, username, password_hash, email, status, created) "
         "VALUES (?, ?, ?, ?, ?, ?)",
@@ -62,9 +70,10 @@ def create_user(
 def get_user_by_email(store: Store, email: str) -> dict[str, Any] | None:
     """Look up a user by email — the onboarded-only lookup OIDC uses. Case-insensitive (emails are
     stored lowercased) and one-to-one (the email index is UNIQUE)."""
-    if not email:
+    normalized = _normalize_email(email)
+    if normalized is None:
         return None
-    rows = store.query("SELECT * FROM users WHERE email = ?", (email.lower(),))
+    rows = store.query("SELECT * FROM users WHERE email = ?", (normalized,))
     return rows[0] if rows else None
 
 

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -47,21 +47,24 @@ def create_user(
         raise ValueError("password must not be empty (pass None for a passwordless OIDC user)")
     user_id = uuid4().hex
     password_hash = hash_password(password) if password is not None else None
+    # Emails are the OIDC lookup key — store them lowercased so the (case-insensitive) identity
+    # matches regardless of how the IdP cases the address; the UNIQUE index keeps them one-to-one.
+    normalized_email = email.lower() if email else None
     store.execute(
         "INSERT INTO users (id, username, password_hash, email, status, created) "
         "VALUES (?, ?, ?, ?, ?, ?)",
-        (user_id, username, password_hash, email, status, _now_iso()),
+        (user_id, username, password_hash, normalized_email, status, _now_iso()),
     )
     store.commit()
     return user_id
 
 
 def get_user_by_email(store: Store, email: str) -> dict[str, Any] | None:
-    """Look up a user by email — the onboarded-only lookup OIDC uses. Returns the first match (email
-    is indexed; uniqueness is enforced by how users are onboarded, not the schema)."""
+    """Look up a user by email — the onboarded-only lookup OIDC uses. Case-insensitive (emails are
+    stored lowercased) and one-to-one (the email index is UNIQUE)."""
     if not email:
         return None
-    rows = store.query("SELECT * FROM users WHERE email = ?", (email,))
+    rows = store.query("SELECT * FROM users WHERE email = ?", (email.lower(),))
     return rows[0] if rows else None
 
 

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1,0 +1,258 @@
+"""OIDC social login — the generic client + the onboarded-only flow, with NO real egress.
+
+Verification is exercised for real: we generate an RSA keypair in-test, sign an ID token with it, and
+feed the public key in as the IdP's signing key — so `verify_id_token` runs the actual RS256 +
+aud/iss/exp/nonce/email_verified checks. The network seams (discovery, token exchange, JWKS) are
+monkeypatched, so the suite makes no outbound call.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+pytest.importorskip("starlette")
+pytest.importorskip("mcp")
+pytest.importorskip("jwt")
+pytest.importorskip("argon2")
+pytest.importorskip("httpx")
+pytest.importorskip("cryptography")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import jwt  # noqa: E402
+import mcp_http  # noqa: E402
+import oidc  # noqa: E402
+import user_store  # noqa: E402
+from cryptography.hazmat.primitives import serialization  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import rsa  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+from store import Store  # noqa: E402
+
+BASE = "https://your-host.example.com"
+SECRET = "x" * 40  # throwaway HS256 server secret (>=32 bytes); not real
+ISSUER = "https://idp.example.com"
+CLIENT_ID = "test-client-id"
+REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+META = {
+    "authorization_endpoint": f"{ISSUER}/authorize",
+    "token_endpoint": f"{ISSUER}/token",
+    "jwks_uri": f"{ISSUER}/jwks",
+    "issuer": ISSUER,
+}
+
+VERIFIER = "v" * 64
+CHALLENGE = (
+    base64.urlsafe_b64encode(hashlib.sha256(VERIFIER.encode()).digest()).rstrip(b"=").decode()
+)
+
+_PRIV = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIV_PEM = _PRIV.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+)
+_PUB = _PRIV.public_key()
+
+
+def _id_token(**overrides) -> str:
+    claims = {
+        "iss": ISSUER,
+        "aud": CLIENT_ID,
+        "exp": 9_999_999_999,
+        "email": "you@example.com",
+        "email_verified": True,
+        "nonce": "the-nonce",
+        **overrides,
+    }
+    return jwt.encode(claims, _PRIV_PEM, algorithm="RS256", headers={"kid": "test"})
+
+
+class _FakeJWKClient:
+    def __init__(self, uri):  # noqa: D401 - signature parity with jwt.PyJWKClient
+        pass
+
+    def get_signing_key_from_jwt(self, token):
+        return type("K", (), {"key": _PUB})()
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    db_url = "sqlite://" + str(tmp_path / "oidc.db")
+    monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    monkeypatch.setenv("AGAMI_DB_URL", db_url)
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    monkeypatch.setenv("AGAMI_OIDC_GOOGLE_CLIENT_ID", CLIENT_ID)
+    monkeypatch.setenv("AGAMI_OIDC_GOOGLE_CLIENT_SECRET", "test-client-secret")
+    # Point the provider's discovery + JWKS at our in-test IdP, and never touch the network.
+    monkeypatch.setattr(oidc, "_discover", lambda p: META)
+    monkeypatch.setattr(jwt, "PyJWKClient", _FakeJWKClient)
+    s = Store.connect(db_url)
+    s.run_migrations()
+    user_store.create_user(
+        s, "alice", password=None, email="you@example.com"
+    )  # onboarded OIDC user
+    s.close()
+    return db_url
+
+
+# --- the OIDC verifier in isolation (the security-critical core) -------------
+
+
+def test_verify_id_token_accepts_a_valid_token(env):
+    p = oidc.provider("google")
+    assert oidc.verify_id_token(p, _id_token(), nonce="the-nonce") == "you@example.com"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"aud": "someone-else"},  # wrong audience
+        {"iss": "https://evil.example.com"},  # wrong issuer
+        {"email_verified": False},  # unverified email
+        {"exp": 1},  # expired
+    ],
+)
+def test_verify_id_token_rejects_bad_claims(env, bad):
+    p = oidc.provider("google")
+    with pytest.raises(Exception):
+        oidc.verify_id_token(p, _id_token(**bad), nonce="the-nonce")
+
+
+def test_verify_id_token_rejects_nonce_mismatch(env):
+    p = oidc.provider("google")
+    with pytest.raises(Exception):
+        oidc.verify_id_token(p, _id_token(nonce="other"), nonce="the-nonce")
+
+
+def test_verify_id_token_rejects_a_token_signed_by_a_different_key(env):
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048).private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    forged = jwt.encode(
+        {
+            "iss": ISSUER,
+            "aud": CLIENT_ID,
+            "exp": 9_999_999_999,
+            "nonce": "the-nonce",
+            "email": "you@example.com",
+            "email_verified": True,
+        },
+        other,
+        algorithm="RS256",
+    )
+    with pytest.raises(Exception):
+        oidc.verify_id_token(oidc.provider("google"), forged, nonce="the-nonce")
+
+
+# --- the end-to-end flow over the transport ----------------------------------
+
+
+def _client() -> TestClient:
+    # https base_url so the Secure CSRF cookie round-trips in the test client.
+    return TestClient(mcp_http.build_app(), base_url="https://testserver")
+
+
+def _start_and_capture(c: TestClient):
+    """Run /oauth/oidc/start, return (state_jwt, nonce) parsed from the IdP redirect."""
+    r = c.get(
+        "/oauth/oidc/start",
+        params={
+            "provider": "google",
+            "client_id": CLIENT_ID,
+            "redirect_uri": REDIRECT,
+            "code_challenge": CHALLENGE,
+            "state": "client-xyz",
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    loc = urlparse(r.headers["location"])
+    assert f"{ISSUER}/authorize" == f"{loc.scheme}://{loc.netloc}{loc.path}"
+    q = parse_qs(loc.query)
+    return q["state"][0], q["nonce"][0]
+
+
+def test_full_oidc_flow_resumes_ace005_and_issues_a_jwt(env, monkeypatch):
+    c = _client()
+    state, nonce = _start_and_capture(c)
+    # The IdP "redirects back": exchange returns an id_token carrying the nonce we minted.
+    monkeypatch.setattr(
+        oidc, "exchange_code", lambda p, *, code, redirect_uri: _id_token(nonce=nonce)
+    )
+    cb = c.get(
+        "/oauth/oidc/callback",
+        params={"code": "idp-code", "state": state},
+        follow_redirects=False,
+    )
+    assert cb.status_code == 302
+    back = urlparse(cb.headers["location"])
+    assert f"{back.scheme}://{back.netloc}{back.path}" == REDIRECT
+    code = parse_qs(back.query)["code"][0]
+    assert parse_qs(back.query)["state"][0] == "client-xyz"
+    # The minted OAuth code exchanges (with the matching PKCE verifier) for a JWT whose subject is
+    # the resolved onboarded user — proving the OIDC leg resumed the OAuth flow end to end.
+    tok = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert tok.status_code == 200
+    claims = jwt.decode(tok.json()["access_token"], SECRET, algorithms=["HS256"], issuer=BASE)
+    assert claims["sub"] == "alice"
+
+
+def test_callback_rejects_unknown_email_onboarded_only(env, monkeypatch):
+    c = _client()
+    state, nonce = _start_and_capture(c)
+    monkeypatch.setattr(
+        oidc,
+        "exchange_code",
+        lambda p, *, code, redirect_uri: _id_token(nonce=nonce, email="stranger@example.com"),
+    )
+    cb = c.get(
+        "/oauth/oidc/callback",
+        params={"code": "idp-code", "state": state},
+        follow_redirects=False,
+    )
+    assert cb.status_code == 403  # not onboarded → rejected, never auto-created
+
+
+def test_callback_rejects_tampered_state_or_missing_cookie(env, monkeypatch):
+    c = _client()
+    state, nonce = _start_and_capture(c)
+    monkeypatch.setattr(
+        oidc, "exchange_code", lambda p, *, code, redirect_uri: _id_token(nonce=nonce)
+    )
+    # Drop the CSRF cookie → the state can't be bound to this caller.
+    c.cookies.clear()
+    cb = c.get(
+        "/oauth/oidc/callback",
+        params={"code": "idp-code", "state": state},
+        follow_redirects=False,
+    )
+    assert cb.status_code == 400
+
+
+def test_provider_option_hidden_when_unconfigured(monkeypatch, tmp_path):
+    monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    monkeypatch.delenv("AGAMI_OIDC_GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("AGAMI_OIDC_GOOGLE_CLIENT_SECRET", raising=False)
+    r = TestClient(mcp_http.build_app()).get("/oauth/authorize", params={"redirect_uri": REDIRECT})
+    assert r.status_code == 200
+    assert "Sign in with Google" not in r.text  # hidden when unconfigured
+    assert "<form" in r.text  # password login still present

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -94,6 +94,7 @@ def env(tmp_path, monkeypatch):
     # Point the provider's discovery + JWKS at our in-test IdP, and never touch the network.
     monkeypatch.setattr(oidc, "_discover", lambda p: META)
     monkeypatch.setattr(jwt, "PyJWKClient", _FakeJWKClient)
+    oidc._jwks_clients.clear()  # the JWKS client is cached per process — reset between tests
     s = Store.connect(db_url)
     s.run_migrations()
     user_store.create_user(

--- a/tests/test_privacy_no_network.py
+++ b/tests/test_privacy_no_network.py
@@ -34,9 +34,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = REPO_ROOT / "plugins" / "agami" / "scripts"
 PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
 # The local serving path — skill scripts + the agami-core library (executor, stdio harness, the
-# shared tool registry, the semantic model) — must stay network-free. `mcp_http` is the ONE
-# deliberate network surface (the HTTP product: it binds a port and speaks HTTP), excluded by design.
-NETWORK_MODULE = "mcp_http.py"
+# shared tool registry, the semantic model) — must stay network-free. Two modules are deliberate
+# network surfaces of the HOSTED server (server-extra only; never imported by the local skill),
+# excluded by design: `mcp_http` (binds a port, speaks HTTP) and `oidc` (the OIDC client's outbound
+# calls to the identity provider). Users who want zero egress run the local `agami serve`.
+NETWORK_MODULES = {"mcp_http.py", "oidc.py"}
 
 # Regexes for network-egress primitives. Deliberately precise: `urllib.request`
 # is forbidden but `urllib.parse` is not; DB-driver imports are not matched.
@@ -60,7 +62,7 @@ _FORBIDDEN_RE = [re.compile(p) for p in FORBIDDEN]
 
 SCRIPTS = (
     sorted(SCRIPTS_DIR.glob("*.py"))
-    + sorted(p for p in PKG_SRC.glob("*.py") if p.name != NETWORK_MODULE)
+    + sorted(p for p in PKG_SRC.glob("*.py") if p.name not in NETWORK_MODULES)
     + sorted((PKG_SRC / "semantic_model").glob("*.py"))
 )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -68,6 +68,21 @@ def test_users_table_is_flat_no_role_column():
     s.close()
 
 
+def test_users_password_hash_nullable_and_email_indexed():
+    # OIDC users have no password, and we look them up by email — so password_hash is nullable and
+    # email is indexed after the passwordless migration.
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    pw = next(r for r in s.query("PRAGMA table_info(users)") if r["name"] == "password_hash")
+    assert pw["notnull"] == 0, "password_hash must be nullable for OIDC users"
+    # username must STILL be unique (the rebuild preserves the constraint)
+    uname = next(r for r in s.query("PRAGMA table_info(users)") if r["name"] == "username")
+    assert uname["notnull"] == 1
+    indexes = {r["name"] for r in s.query("PRAGMA index_list(users)")}
+    assert "idx_users_email" in indexes
+    s.close()
+
+
 def test_migrations_are_idempotent_on_real_dir():
     s = Store.connect("sqlite://")
     s.run_migrations()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -78,8 +78,10 @@ def test_users_password_hash_nullable_and_email_indexed():
     # username must STILL be unique (the rebuild preserves the constraint)
     uname = next(r for r in s.query("PRAGMA table_info(users)") if r["name"] == "username")
     assert uname["notnull"] == 1
-    indexes = {r["name"] for r in s.query("PRAGMA index_list(users)")}
-    assert "idx_users_email" in indexes
+    email_idx = next(
+        (r for r in s.query("PRAGMA index_list(users)") if r["name"] == "idx_users_email"), None
+    )
+    assert email_idx is not None and email_idx["unique"] == 1, "email must be uniquely indexed"
     s.close()
 
 

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -51,6 +51,25 @@ def test_empty_password_is_rejected_at_create():
     s.close()
 
 
+def test_passwordless_user_cannot_password_login():
+    # An OIDC-only user has no password_hash and must never be loginable via the password path.
+    s = _store()
+    user_store.create_user(s, "oidc-user", password=None, email="you@example.com")
+    assert user_store.get_user(s, "oidc-user")["password_hash"] is None
+    assert user_store.authenticate(s, "oidc-user", "") is None
+    assert user_store.authenticate(s, "oidc-user", "anything") is None
+    s.close()
+
+
+def test_get_user_by_email():
+    s = _store()
+    user_store.create_user(s, "admin", "s3cret-pw", email="you@example.com")
+    assert user_store.get_user_by_email(s, "you@example.com")["username"] == "admin"
+    assert user_store.get_user_by_email(s, "missing@example.com") is None
+    assert user_store.get_user_by_email(s, "") is None
+    s.close()
+
+
 def test_authenticate_runs_a_verify_even_for_unknown_user(monkeypatch):
     # The anti-enumeration guard: a missing username still runs a verify (against the dummy hash),
     # so the call can't be distinguished by "did verify run". We assert the spy fired.

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -61,12 +61,26 @@ def test_passwordless_user_cannot_password_login():
     s.close()
 
 
-def test_get_user_by_email():
+def test_get_user_by_email_is_case_insensitive():
     s = _store()
-    user_store.create_user(s, "admin", "s3cret-pw", email="you@example.com")
+    user_store.create_user(s, "admin", "s3cret-pw", email="You@Example.com")
+    # stored lowercased; lookup normalizes too, so any casing resolves to the one user
     assert user_store.get_user_by_email(s, "you@example.com")["username"] == "admin"
+    assert user_store.get_user_by_email(s, "YOU@EXAMPLE.COM")["username"] == "admin"
     assert user_store.get_user_by_email(s, "missing@example.com") is None
     assert user_store.get_user_by_email(s, "") is None
+    s.close()
+
+
+def test_duplicate_email_is_rejected():
+    # The UNIQUE email index makes OIDC's lookup one-to-one — a second user with the same email
+    # (any casing) can't be created.
+    import sqlite3
+
+    s = _store()
+    user_store.create_user(s, "alice", password=None, email="you@example.com")
+    with pytest.raises(sqlite3.IntegrityError):
+        user_store.create_user(s, "bob", password=None, email="YOU@example.com")
     s.close()
 
 

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -61,14 +61,14 @@ def test_passwordless_user_cannot_password_login():
     s.close()
 
 
-def test_get_user_by_email_is_case_insensitive():
+def test_get_user_by_email_normalizes_case_and_whitespace():
     s = _store()
-    user_store.create_user(s, "admin", "s3cret-pw", email="You@Example.com")
-    # stored lowercased; lookup normalizes too, so any casing resolves to the one user
+    user_store.create_user(s, "admin", "s3cret-pw", email="  You@Example.com  ")
+    # stored trimmed + lowercased; lookup normalizes the same, so casing/whitespace all resolve
     assert user_store.get_user_by_email(s, "you@example.com")["username"] == "admin"
-    assert user_store.get_user_by_email(s, "YOU@EXAMPLE.COM")["username"] == "admin"
+    assert user_store.get_user_by_email(s, " YOU@EXAMPLE.COM ")["username"] == "admin"
     assert user_store.get_user_by_email(s, "missing@example.com") is None
-    assert user_store.get_user_by_email(s, "") is None
+    assert user_store.get_user_by_email(s, "   ") is None
     s.close()
 
 


### PR DESCRIPTION
## Summary

"Sign in with Google" behind the shipped OAuth authorize page, built **clean** (an audit ruled out porting the data-agent OIDC — implicit verification, no `email_verified`, unpinned tenant, hard-coded customer names, AWS coupling). **PR 1 of 2** into `feature/oidc`: a **generic OIDC client** + Google + **onboarded-only** resolution + the passwordless-user schema. PR2 adds Microsoft (tenant-pinned), the opt-in public-demo mode, and the README egress note.

## Changes

- **`oidc.py`** — a generic OIDC client: `httpx` discovery + code exchange, and **PyJWT `PyJWKClient`** for **explicit, visible** ID-token verification (RS256 pinned, `aud`/`iss`/`exp` asserted in our code, `nonce` matched, `email_verified` required). One verification path for any provider. It is the server's **one deliberate outbound egress** — server-extra only, carved out of `test_privacy_no_network` with a documented rationale; the local skill stays zero-egress (`agami serve`).
- **`005_users_passwordless.sql`** — nullable `password_hash` + a **UNIQUE** email index (portable table-rebuild); `user_store` gains `get_user_by_email` (case-insensitive, one-to-one), passwordless `create_user`, and a guard so a passwordless user can never password-login.
- **`oauth_server.py`** — "Sign in with Google" link + `/oauth/oidc/start` + `/oauth/oidc/callback`. The OIDC leg carries the authorize context in a **signed, CSRF-cookie-bound** state and resumes the existing authorization-code mint. Resolution is **onboarded-only**: unknown/disabled email → 403, never auto-created.

## Security review (high lane — mandatory)

Ran `/code-review` (clean) + a dedicated security pass (no must-fix). Verified: RS256-pinned verification (alg=none/HS-confusion rejected), CSRF state binding (constant-time, fail-closed), nonce replay defense, onboarded-only (no auto-create), redirect taken from the signed state (no open redirect), passwordless no-login guard, no SSRF (only IdP URLs from the pinned discovery doc), no secret/PII in logs/errors. Acted on the should-fix items: **lowercased + UNIQUE email** (closes a casing-403 + duplicate-email non-determinism) and a **load-bearing single-provider guard** (binding to provider+subject is required before a second IdP is enabled — done in PR2). Plus a JWKS-client cache (perf).

## Test plan

`tests/test_oidc.py`: real RS256 verification (a token signed by a different key is rejected), the full flow (start → IdP → callback → onboarded resolution → authorization code → JWT `sub=alice`), and each guard (bad `aud`/`iss`/`exp`/`nonce`/signature, unverified email, unknown email → 403, tampered state / missing cookie → 400, provider hidden when unconfigured). **No real egress** — the IdP seams are mocked. Schema + user-store tests for nullability, unique/case-insensitive email, passwordless no-login. Full gate green (807 tests + ruff + gitleaks).

## Checklist

- [x] `uv run dev.py check` green
- [x] New behavior covered by tests; security review done (high lane)
- [x] No real customer data/names/credentials; no internal IDs in repo files
- [x] Targets `feature/oidc`

Spec: ACE-006