### PR TITLE
OIDC: Microsoft (tenant-pinned) + provider-binding + public-demo (2 of 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,28 @@ is entirely environment variables:
 | `AGAMI_DB_URL` | yes (server) | The store: `postgresql://…` in prod, `sqlite://…` for a small/local run. `APP_DATABASE_URL` is accepted as an alias for the cloud-platform convention (`AGAMI_DB_URL` wins if both are set). Unset ⇒ the local file path. |
 | `PUBLIC_BASE_URL` | yes (server) | Backs OAuth/MCP discovery + the `WWW-Authenticate` resource URL. Set it explicitly — it can't be auto-detected behind a proxy/LB; the server fails fast at startup if it's missing. |
 | `AGAMI_ORG_ID` | no | The single configured org id (default `local`). The server is single-tenant by default. |
+| `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its own session JWTs with. When set, the server validates real tokens (the password / OIDC login flow); unset ⇒ the bearer-presence local default. |
 
 All serving state lives in Postgres — a fresh instance with only `AGAMI_DB_URL` serves identically,
 so the server survives restarts and stateless platforms. The serving path is **LLM-free and
 zero-egress by default**: the client is the brain, `execute_sql` runs SQL against your own database,
 and the other tools just read the model. Nothing leaves your environment.
+
+### Optional: social login (OIDC)
+
+"Sign in with Google / Microsoft" is **off by default**. Configure a provider's client id/secret to
+enable it (the option is hidden when unset; username/password still works):
+
+| Variable | Provider | Notes |
+|----------|----------|-------|
+| `AGAMI_OIDC_GOOGLE_CLIENT_ID` / `_SECRET` | Google | requires `email_verified` |
+| `AGAMI_OIDC_MICROSOFT_CLIENT_ID` / `_SECRET` | Microsoft | also set `AGAMI_OIDC_MICROSOFT_TENANT` to a **pinned** tenant id (not `common`/`organizations`) — the tenant is the trust boundary |
+| `AGAMI_PUBLIC_SIGNUP` | — | default off. When on, an unknown verified email self-provisions a **demo** account — intended only for a dedicated "Try for free" instance whose data is non-sensitive. Leave off for any real deployment (it's onboarded-only: an admin must add the user first). |
+
+**Egress note:** OIDC is the one feature where the **hosted** server reaches out — it calls the
+identity provider to verify a login. Everything else stays local. If you want a strictly no-egress
+deployment, leave OIDC unconfigured (or run the local `agami serve`); the skill and the query path
+never make a network call regardless.
 
 ## Documentation
 

--- a/migrations/core/006_oidc_identity.sql
+++ b/migrations/core/006_oidc_identity.sql
@@ -1,0 +1,8 @@
+-- Bind an OIDC user to a single identity provider + subject, so a second IdP can't be confused for
+-- the first (an attacker with the same email at another provider must still fail the provider check).
+-- oidc_provider is set at onboarding (which IdP the user signs in with); oidc_subject (the IdP's
+-- immutable `sub`) is captured on first login and must match thereafter. Both NULL for a
+-- password-only user. Plain ADD COLUMN is portable across SQLite and Postgres (no table rebuild).
+
+ALTER TABLE users ADD COLUMN oidc_provider TEXT;
+ALTER TABLE users ADD COLUMN oidc_subject TEXT;

--- a/migrations/core/006_oidc_identity.sql
+++ b/migrations/core/006_oidc_identity.sql
@@ -6,3 +6,8 @@
 
 ALTER TABLE users ADD COLUMN oidc_provider TEXT;
 ALTER TABLE users ADD COLUMN oidc_subject TEXT;
+
+-- Bind any pre-existing passwordless (OIDC-only) user to Google — the only provider that existed
+-- before this binding — so the new provider-binding gate doesn't lock them out on upgrade. (A
+-- password user has a non-NULL hash and is left untouched.)
+UPDATE users SET oidc_provider = 'google' WHERE oidc_provider IS NULL AND password_hash IS NULL;

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -21,6 +21,7 @@ import html
 import os
 import secrets
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlencode, urlsplit
 from uuid import uuid4
 
@@ -30,6 +31,9 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from store import Store
 from user_store import authenticate, bind_oidc_subject, create_user, get_user_by_email
+
+if TYPE_CHECKING:
+    from oidc import Identity  # for type hints only — runtime imports oidc lazily (egress module)
 
 _CODE_TTL = timedelta(minutes=10)  # authorization codes are short-lived
 _JWT_TTL = timedelta(hours=1)
@@ -367,6 +371,17 @@ def _oidc_callback_uri() -> str:
     return f"{public_base_url()}/oauth/oidc/callback"
 
 
+def _safe_provider(key: str):
+    """`oidc.provider`, but a misconfigured provider (e.g. an unpinned Microsoft tenant, which raises)
+    resolves to None so the handler answers a clean 400 instead of an unhandled 500."""
+    import oidc
+
+    try:
+        return oidc.provider(key)
+    except ValueError:
+        return None
+
+
 def _mint_oidc_state(payload: dict, csrf: str) -> str:
     """Sign the carried authorize context + a CSRF binding into a short-lived HS256 state JWT."""
     claims = {
@@ -401,7 +416,7 @@ async def oidc_start(request: Request) -> Response:
     import oidc
 
     q = request.query_params
-    p = oidc.provider(q.get("provider", ""))
+    p = _safe_provider(q.get("provider", ""))
     if p is None:
         return _oauth_error("invalid_request", "unknown or unconfigured provider")
     redirect_uri = q.get("redirect_uri", "")
@@ -457,7 +472,7 @@ async def oidc_callback(request: Request) -> Response:
     claims = _verify_oidc_state(q.get("state", ""), request.cookies.get(_CSRF_COOKIE))
     if claims is None:
         return _oauth_error("invalid_request", "invalid or expired state")
-    p = oidc.provider(claims.get("provider", ""))
+    p = _safe_provider(claims.get("provider", ""))
     if p is None:
         return _oauth_error("invalid_request", "unknown or unconfigured provider")
     if not q.get("code"):
@@ -495,7 +510,7 @@ async def oidc_callback(request: Request) -> Response:
 _LOGIN_STATUSES = {"active", "demo"}
 
 
-def _resolve_oidc_user(store: Store, provider_key: str, identity) -> str | None:
+def _resolve_oidc_user(store: Store, provider_key: str, identity: Identity) -> str | None:
     """Map a verified OIDC identity to a username, or None to reject. Onboarded-only by default; with
     public signup enabled an unknown email self-provisions a demo user.
 
@@ -514,19 +529,26 @@ def _resolve_oidc_user(store: Store, provider_key: str, identity) -> str | None:
             if user["oidc_subject"] != identity.subject:
                 return None  # same provider, different account → refuse
         else:
-            bind_oidc_subject(store, user["username"], identity.subject)  # first login pins the subject
+            bind_oidc_subject(
+                store, user["username"], identity.subject
+            )  # first login pins the subject
         return user["username"]
 
     # Unknown email: only a public-demo instance may self-provision (fail-closed default).
     if not oidc.public_signup_enabled():
         return None
-    create_user(
-        store,
-        username=identity.email,
-        password=None,
-        email=identity.email,
-        status="demo",
-        oidc_provider=provider_key,
-        oidc_subject=identity.subject,
-    )
+    try:
+        create_user(
+            store,
+            username=identity.email,
+            password=None,
+            email=identity.email,
+            status="demo",
+            oidc_provider=provider_key,
+            oidc_subject=identity.subject,
+        )
+    except Exception:
+        # A UNIQUE collision (e.g. a concurrent signup, or the email already used as a username) is
+        # not an authorization — reject cleanly rather than 500.
+        return None
     return identity.email

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -30,7 +30,13 @@ from ports import Principal
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from store import Store
-from user_store import authenticate, bind_oidc_subject, create_user, get_user_by_email
+from user_store import (
+    authenticate,
+    bind_oidc_subject,
+    create_user,
+    get_user,
+    get_user_by_email,
+)
 
 if TYPE_CHECKING:
     from oidc import Identity  # for type hints only — runtime imports oidc lazily (egress module)
@@ -525,13 +531,15 @@ def _resolve_oidc_user(store: Store, provider_key: str, identity: Identity) -> s
             return None
         if user["oidc_provider"] != provider_key:
             return None  # bound to a different IdP (or password-only) → not an OIDC login for this provider
-        if user["oidc_subject"] is not None:
-            if user["oidc_subject"] != identity.subject:
-                return None  # same provider, different account → refuse
-        else:
-            bind_oidc_subject(
-                store, user["username"], identity.subject
-            )  # first login pins the subject
+        # Bind the subject on first login (a no-clobber UPDATE that only sets it when NULL), then
+        # **re-read and require the stored subject is ours**. The re-read is what closes the
+        # concurrent first-login race: if another subject bound first, our guarded UPDATE is a no-op,
+        # the stored subject won't match, and we reject — rather than logging in against someone
+        # else's binding. It also covers the steady state (an already-bound, mismatched subject).
+        bind_oidc_subject(store, user["username"], identity.subject)
+        bound = get_user(store, user["username"])
+        if bound is None or bound["oidc_subject"] != identity.subject:
+            return None
         return user["username"]
 
     # Unknown email: only a public-demo instance may self-provision (fail-closed default).

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -29,7 +29,7 @@ from ports import Principal
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from store import Store
-from user_store import authenticate, get_user_by_email
+from user_store import authenticate, bind_oidc_subject, create_user, get_user_by_email
 
 _CODE_TTL = timedelta(minutes=10)  # authorization codes are short-lived
 _JWT_TTL = timedelta(hours=1)
@@ -464,33 +464,69 @@ async def oidc_callback(request: Request) -> Response:
         return _oauth_error("invalid_request", "missing code")
     try:
         id_token = oidc.exchange_code(p, code=q.get("code", ""), redirect_uri=_oidc_callback_uri())
-        email = oidc.verify_id_token(p, id_token, nonce=claims.get("nonce", ""))
+        identity = oidc.verify_id_token(p, id_token, nonce=claims.get("nonce", ""))
     except Exception:
-        # Bad signature/aud/iss/nonce/unverified-email/exchange error — all collapse to one verdict.
+        # Bad signature/aud/iss/sub/nonce/unverified-email/exchange error — all collapse to one verdict.
         return _oauth_error("access_denied", "OIDC verification failed", status=403)
 
     store = _open_store()
     if store is None:
         return _oauth_error("server_error", "no datastore configured", status=500)
     try:
-        user = get_user_by_email(store, email)
-        # Onboarded-only: the verified email must already be an active user (admin-created). An
-        # unknown email is rejected, never auto-provisioned.
-        #
-        # LOAD-BEARING: resolution is by email alone, which is safe ONLY while a single IdP is
-        # enabled. Before enabling a second provider, bind identity to (provider, subject) — else an
-        # attacker with the same email at another IdP would resolve to this user (IdP confusion).
-        if user is None or user["status"] != "active":
+        username = _resolve_oidc_user(store, p.key, identity)
+        if username is None:
             return _oauth_error("access_denied", "this account is not authorized", status=403)
         resp = _issue_authorization_code(
             store,
             client_id=claims.get("client_id", ""),
             redirect_uri=claims.get("redirect_uri", ""),
             code_challenge=claims.get("code_challenge", ""),
-            username=user["username"],
+            username=username,
             client_state=claims.get("client_state", ""),
         )
     finally:
         store.close()
     resp.delete_cookie(_CSRF_COOKIE)
     return resp
+
+
+# Statuses that may complete a login. `demo` is admitted so a public-demo instance works; `disabled`
+# (or anything else) is refused.
+_LOGIN_STATUSES = {"active", "demo"}
+
+
+def _resolve_oidc_user(store: Store, provider_key: str, identity) -> str | None:
+    """Map a verified OIDC identity to a username, or None to reject. Onboarded-only by default; with
+    public signup enabled an unknown email self-provisions a demo user.
+
+    Provider-binding closes IdP confusion: an existing user must be bound to THIS provider, and (once
+    set) THIS subject — so an attacker with the same email at another IdP, or a different account at
+    the same IdP, is refused rather than resolved to the victim."""
+    import oidc
+
+    user = get_user_by_email(store, identity.email)
+    if user is not None:
+        if user["status"] not in _LOGIN_STATUSES:
+            return None
+        if user["oidc_provider"] != provider_key:
+            return None  # bound to a different IdP (or password-only) → not an OIDC login for this provider
+        if user["oidc_subject"] is not None:
+            if user["oidc_subject"] != identity.subject:
+                return None  # same provider, different account → refuse
+        else:
+            bind_oidc_subject(store, user["username"], identity.subject)  # first login pins the subject
+        return user["username"]
+
+    # Unknown email: only a public-demo instance may self-provision (fail-closed default).
+    if not oidc.public_signup_enabled():
+        return None
+    create_user(
+        store,
+        username=identity.email,
+        password=None,
+        email=identity.email,
+        status="demo",
+        oidc_provider=provider_key,
+        oidc_subject=identity.subject,
+    )
+    return identity.email

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -555,8 +555,13 @@ def _resolve_oidc_user(store: Store, provider_key: str, identity: Identity) -> s
             oidc_provider=provider_key,
             oidc_subject=identity.subject,
         )
-    except Exception:
-        # A UNIQUE collision (e.g. a concurrent signup, or the email already used as a username) is
-        # not an authorization — reject cleanly rather than 500.
-        return None
+    except Exception as exc:
+        # A UNIQUE collision (concurrent signup, or the email already used as a username) is not an
+        # authorization → reject cleanly. But a real failure (datastore down, unexpected SQL error)
+        # must surface, not masquerade as a 403 — so only swallow integrity errors. The MRO check is
+        # portable across backends (sqlite3.IntegrityError / psycopg2.errors.UniqueViolation) without
+        # importing psycopg2 here.
+        if any(cls.__name__ == "IntegrityError" for cls in type(exc).__mro__):
+            return None
+        raise
     return identity.email

--- a/packages/agami-core/src/oidc.py
+++ b/packages/agami-core/src/oidc.py
@@ -83,12 +83,15 @@ def provider(key: str) -> Provider | None:
     discovery_url = _discovery_url(key)  # may raise for an unpinned MS tenant
     if discovery_url is None:
         return None
-    return Provider(key, discovery_url, client_id, client_secret, require_email_verified=key == "google")
+    return Provider(
+        key, discovery_url, client_id, client_secret, require_email_verified=key == "google"
+    )
 
 
 def available_providers() -> list[str]:
     """The provider keys that are configured (have client id/secret) — what the login page offers. A
-    misconfigured Microsoft tenant is skipped here (it surfaces as a config error on actual use)."""
+    misconfigured Microsoft tenant is skipped here, so its button is simply hidden; if it's invoked
+    directly the handler answers a clean 400 (via `_safe_provider`), not a 500."""
     out = []
     for key in _PROVIDERS:
         try:
@@ -179,4 +182,9 @@ def verify_id_token(p: Provider, id_token: str, *, nonce: str) -> Identity:
     email = claims.get("email")
     if not email:
         raise ValueError("id token has no email claim")
-    return Identity(email=email, subject=claims["sub"])
+    subject = claims.get("sub")
+    # sub is the long-term binding key — fail closed on a missing/blank/non-string value rather than
+    # persist an invalid identity binding.
+    if not isinstance(subject, str) or not subject.strip():
+        raise ValueError("id token has no usable sub claim")
+    return Identity(email=email, subject=subject)

--- a/packages/agami-core/src/oidc.py
+++ b/packages/agami-core/src/oidc.py
@@ -25,9 +25,10 @@ _TIMEOUT = httpx.Timeout(10.0)
 
 # Discovery URLs are fixed per provider (the HTTPS trust anchor); client creds come from env. Google
 # ships first; Microsoft (with tenant pinning) follows.
-_DISCOVERY = {
-    "google": "https://accounts.google.com/.well-known/openid-configuration",
-}
+_PROVIDERS = ("google", "microsoft")
+# Microsoft authorities that admit ANY tenant — refused, so a deployer must pin a single tenant (the
+# tenant pin is Microsoft's trust boundary; without it, any Azure AD account would be accepted).
+_UNPINNED_MS_TENANTS = {"common", "organizations", "consumers"}
 
 _discovery_cache: dict[str, dict] = {}
 _jwks_clients: dict[str, "jwt.PyJWKClient"] = {}
@@ -39,24 +40,69 @@ class Provider:
     discovery_url: str
     client_id: str
     client_secret: str
+    # Google (a consumer IdP serving any email) must prove email_verified. Microsoft is pinned to one
+    # tenant, so the org controls the addresses — its tokens often omit email_verified and that's OK.
+    require_email_verified: bool
+
+
+@dataclass(frozen=True)
+class Identity:
+    """The verified identity from an ID token: the email (the lookup key) + the IdP's immutable
+    subject (`sub`, used to bind the user to one provider account)."""
+
+    email: str
+    subject: str
+
+
+def _discovery_url(key: str) -> str | None:
+    """The provider's OpenID discovery URL. Google is fixed; Microsoft is tenant-specific (and the
+    tenant must be pinned — an any-tenant authority is refused)."""
+    if key == "google":
+        return "https://accounts.google.com/.well-known/openid-configuration"
+    if key == "microsoft":
+        tenant = os.environ.get("AGAMI_OIDC_MICROSOFT_TENANT", "").strip()
+        if not tenant or tenant.lower() in _UNPINNED_MS_TENANTS:
+            raise ValueError(
+                "AGAMI_OIDC_MICROSOFT_TENANT must pin a single tenant id "
+                "(not 'common'/'organizations'/'consumers') — the tenant pin is the trust boundary."
+            )
+        return f"https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration"
+    return None
 
 
 def provider(key: str) -> Provider | None:
     """The configured provider for `key`, or None when its client id/secret env is absent (so the
-    option is simply hidden). Env: AGAMI_OIDC_<KEY>_CLIENT_ID / _CLIENT_SECRET."""
-    discovery_url = _DISCOVERY.get(key)
-    if discovery_url is None:
+    option is simply hidden). Env: AGAMI_OIDC_<KEY>_CLIENT_ID / _CLIENT_SECRET (+ _TENANT for MS).
+    Raises ValueError on a misconfigured Microsoft tenant (an unpinned authority is refused)."""
+    if key not in _PROVIDERS:
         return None
     client_id = os.environ.get(f"AGAMI_OIDC_{key.upper()}_CLIENT_ID", "").strip()
     client_secret = os.environ.get(f"AGAMI_OIDC_{key.upper()}_CLIENT_SECRET", "").strip()
     if not client_id or not client_secret:
         return None
-    return Provider(key, discovery_url, client_id, client_secret)
+    discovery_url = _discovery_url(key)  # may raise for an unpinned MS tenant
+    if discovery_url is None:
+        return None
+    return Provider(key, discovery_url, client_id, client_secret, require_email_verified=key == "google")
 
 
 def available_providers() -> list[str]:
-    """The provider keys that are configured (have client id/secret) — what the login page offers."""
-    return [k for k in _DISCOVERY if provider(k) is not None]
+    """The provider keys that are configured (have client id/secret) — what the login page offers. A
+    misconfigured Microsoft tenant is skipped here (it surfaces as a config error on actual use)."""
+    out = []
+    for key in _PROVIDERS:
+        try:
+            if provider(key) is not None:
+                out.append(key)
+        except ValueError:
+            continue
+    return out
+
+
+def public_signup_enabled() -> bool:
+    """Whether unknown verified emails may self-provision a demo user. Default OFF (fail-closed) —
+    intended only for a dedicated demo instance whose datasource holds only demo data."""
+    return os.environ.get("AGAMI_PUBLIC_SIGNUP", "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _discover(p: Provider) -> dict:
@@ -103,12 +149,14 @@ def exchange_code(p: Provider, *, code: str, redirect_uri: str) -> str:
     return id_token
 
 
-def verify_id_token(p: Provider, id_token: str, *, nonce: str) -> str:
-    """Verify the ID token and return the **verified** email. Raises on any verification failure.
+def verify_id_token(p: Provider, id_token: str, *, nonce: str) -> Identity:
+    """Verify the ID token and return the verified `Identity` (email + subject). Raises on any failure.
 
     Explicit and uniform: RS256 signature against the IdP JWKS, `aud` == our client_id, `iss` == the
-    discovered issuer, `exp` enforced, the `nonce` matches the one we sent (replay defense), and
-    `email_verified` is true (never trust an unverified email as identity)."""
+    discovered issuer, `exp` enforced, `sub` present, and the `nonce` matches the one we sent (replay
+    defense). `email_verified` is required for providers that serve any email (Google); for a
+    tenant-pinned provider (Microsoft) the pin is the trust, so email_verified may be absent.
+    `preferred_username` is never used as identity."""
     meta = _discover(p)
     # Reuse the JWKS client per provider — it keeps its own key cache, so steady-state logins don't
     # re-fetch the IdP's keys on every request (and don't amplify into the IdP under load).
@@ -122,13 +170,13 @@ def verify_id_token(p: Provider, id_token: str, *, nonce: str) -> str:
         algorithms=["RS256"],
         audience=p.client_id,
         issuer=meta["issuer"],
-        options={"require": ["exp", "aud", "iss", "nonce"]},
+        options={"require": ["exp", "aud", "iss", "sub", "nonce"]},
     )
     if claims.get("nonce") != nonce:
         raise ValueError("nonce mismatch")
-    if claims.get("email_verified") is not True:
+    if p.require_email_verified and claims.get("email_verified") is not True:
         raise ValueError("email_verified is not true")
     email = claims.get("email")
     if not email:
         raise ValueError("id token has no email claim")
-    return email
+    return Identity(email=email, subject=claims["sub"])

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -47,10 +47,13 @@ def create_user(
     password: str | None = None,
     email: str | None = None,
     status: str = _ACTIVE,
+    oidc_provider: str | None = None,
+    oidc_subject: str | None = None,
 ) -> str:
     """Create a user; returns the minted id. `password=None` makes a **passwordless** user (OIDC-only —
-    no password login); a non-None password is argon2id-hashed and must be non-empty. Raises if the
-    username already exists (the UNIQUE constraint) — callers that want create-if-absent check first."""
+    no password login); a non-None password is argon2id-hashed and must be non-empty. `oidc_provider`
+    pins which IdP the user signs in with; `oidc_subject` (the IdP `sub`) is usually bound on first
+    login. Raises if the username/email already exists (the UNIQUE constraints)."""
     if password is not None and not password.strip():
         raise ValueError("password must not be empty (pass None for a passwordless OIDC user)")
     user_id = uuid4().hex
@@ -59,12 +62,32 @@ def create_user(
     # matches regardless of casing/whitespace; the UNIQUE index keeps them one-to-one.
     normalized_email = _normalize_email(email)
     store.execute(
-        "INSERT INTO users (id, username, password_hash, email, status, created) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
-        (user_id, username, password_hash, normalized_email, status, _now_iso()),
+        "INSERT INTO users (id, username, password_hash, email, status, created, oidc_provider, "
+        "oidc_subject) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            user_id,
+            username,
+            password_hash,
+            normalized_email,
+            status,
+            _now_iso(),
+            oidc_provider,
+            oidc_subject,
+        ),
     )
     store.commit()
     return user_id
+
+
+def bind_oidc_subject(store: Store, username: str, subject: str) -> None:
+    """Pin the IdP subject to a user on first OIDC login — only when it isn't already set, so a later
+    login can't silently rebind the account to a different IdP identity (the WHERE guard makes it a
+    one-time, no-clobber bind)."""
+    store.execute(
+        "UPDATE users SET oidc_subject = ? WHERE username = ? AND oidc_subject IS NULL",
+        (subject, username),
+    )
+    store.commit()
 
 
 def get_user_by_email(store: Store, email: str) -> dict[str, Any] | None:

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -33,8 +33,12 @@ import oidc  # noqa: E402
 import user_store  # noqa: E402
 from cryptography.hazmat.primitives import serialization  # noqa: E402
 from cryptography.hazmat.primitives.asymmetric import rsa  # noqa: E402
+from oauth_server import _resolve_oidc_user  # noqa: E402
+from oidc import Identity  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 from store import Store  # noqa: E402
+
+MS_TENANT = "00000000-0000-0000-0000-000000000000"  # a fake pinned tenant guid
 
 BASE = "https://your-host.example.com"
 SECRET = "x" * 40  # throwaway HS256 server secret (>=32 bytes); not real
@@ -67,6 +71,7 @@ def _id_token(**overrides) -> str:
         "iss": ISSUER,
         "aud": CLIENT_ID,
         "exp": 9_999_999_999,
+        "sub": "google-sub-123",
         "email": "you@example.com",
         "email_verified": True,
         "nonce": "the-nonce",
@@ -98,8 +103,8 @@ def env(tmp_path, monkeypatch):
     s = Store.connect(db_url)
     s.run_migrations()
     user_store.create_user(
-        s, "alice", password=None, email="you@example.com"
-    )  # onboarded OIDC user
+        s, "alice", password=None, email="you@example.com", oidc_provider="google"
+    )  # onboarded OIDC user, bound to Google
     s.close()
     return db_url
 
@@ -109,7 +114,8 @@ def env(tmp_path, monkeypatch):
 
 def test_verify_id_token_accepts_a_valid_token(env):
     p = oidc.provider("google")
-    assert oidc.verify_id_token(p, _id_token(), nonce="the-nonce") == "you@example.com"
+    identity = oidc.verify_id_token(p, _id_token(), nonce="the-nonce")
+    assert identity.email == "you@example.com" and identity.subject == "google-sub-123"
 
 
 @pytest.mark.parametrize(
@@ -257,3 +263,101 @@ def test_provider_option_hidden_when_unconfigured(monkeypatch, tmp_path):
     assert r.status_code == 200
     assert "Sign in with Google" not in r.text  # hidden when unconfigured
     assert "<form" in r.text  # password login still present
+
+
+# --- Microsoft (tenant-pinned) + provider-binding + demo signup --------------
+
+
+def test_microsoft_requires_a_pinned_tenant(monkeypatch):
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_CLIENT_ID", "ms-client")
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_CLIENT_SECRET", "ms-secret")
+    for bad in ("", "common", "organizations", "consumers"):
+        monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_TENANT", bad)
+        with pytest.raises(ValueError):
+            oidc.provider("microsoft")
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_TENANT", MS_TENANT)
+    p = oidc.provider("microsoft")
+    assert p is not None and p.require_email_verified is False  # tenant pin is the trust
+
+
+def test_microsoft_token_without_email_verified_is_accepted(env, monkeypatch):
+    # MS v2.0 tokens often omit email_verified; with a pinned tenant that's fine.
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_CLIENT_ID", CLIENT_ID)
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_CLIENT_SECRET", "ms-secret")
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_TENANT", MS_TENANT)
+    p = oidc.provider("microsoft")
+    tok = jwt.encode(
+        {
+            "iss": ISSUER,
+            "aud": CLIENT_ID,
+            "exp": 9_999_999_999,
+            "sub": "ms-sub",
+            "email": "you@example.com",
+            "nonce": "n",
+        },  # no email_verified claim at all
+        _PRIV_PEM,
+        algorithm="RS256",
+        headers={"kid": "test"},
+    )
+    identity = oidc.verify_id_token(p, tok, nonce="n")
+    assert identity.email == "you@example.com" and identity.subject == "ms-sub"
+
+
+def test_google_token_without_email_verified_is_rejected(env):
+    # Google (consumer IdP) MUST prove email_verified.
+    p = oidc.provider("google")
+    tok = jwt.encode(
+        {
+            "iss": ISSUER,
+            "aud": CLIENT_ID,
+            "exp": 9_999_999_999,
+            "sub": "s",
+            "email": "you@example.com",
+            "nonce": "the-nonce",
+        },  # no email_verified
+        _PRIV_PEM,
+        algorithm="RS256",
+        headers={"kid": "test"},
+    )
+    with pytest.raises(Exception):
+        oidc.verify_id_token(p, tok, nonce="the-nonce")
+
+
+def test_provider_mismatch_is_rejected_idp_confusion(env):
+    # alice is bound to Google; a Microsoft identity with her email must NOT resolve to her.
+    s = Store.from_env()
+    assert _resolve_oidc_user(s, "microsoft", Identity("you@example.com", "ms-sub")) is None
+    s.close()
+
+
+def test_subject_tofu_binds_then_enforces(env):
+    s = Store.from_env()
+    # first Google login binds the subject; a different subject at Google is then refused
+    assert _resolve_oidc_user(s, "google", Identity("you@example.com", "sub-1")) == "alice"
+    assert _resolve_oidc_user(s, "google", Identity("you@example.com", "sub-2")) is None
+    assert _resolve_oidc_user(s, "google", Identity("you@example.com", "sub-1")) == "alice"  # bound
+    s.close()
+
+
+def test_demo_signup_off_rejects_unknown_email(env):
+    s = Store.from_env()  # AGAMI_PUBLIC_SIGNUP unset → fail-closed
+    assert _resolve_oidc_user(s, "google", Identity("stranger@example.com", "s")) is None
+    s.close()
+
+
+def test_demo_signup_on_creates_a_demo_user(env, monkeypatch):
+    monkeypatch.setenv("AGAMI_PUBLIC_SIGNUP", "true")
+    s = Store.from_env()
+    uname = _resolve_oidc_user(s, "google", Identity("newbie@example.com", "ns"))
+    assert uname == "newbie@example.com"
+    row = user_store.get_user_by_email(s, "newbie@example.com")
+    assert row["status"] == "demo"
+    assert row["oidc_provider"] == "google" and row["oidc_subject"] == "ns"
+    s.close()
+
+
+def test_disabled_user_cannot_oidc_login(env):
+    s = Store.from_env()
+    user_store.set_status(s, "alice", "disabled")
+    assert _resolve_oidc_user(s, "google", Identity("you@example.com", "sub-1")) is None
+    s.close()

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -361,3 +361,24 @@ def test_disabled_user_cannot_oidc_login(env):
     user_store.set_status(s, "alice", "disabled")
     assert _resolve_oidc_user(s, "google", Identity("you@example.com", "sub-1")) is None
     s.close()
+
+
+def test_misconfigured_microsoft_tenant_is_a_clean_400_not_500(env, monkeypatch):
+    # An unpinned MS tenant makes oidc.provider() raise; the handler must answer a clean 400
+    # (a stale/bookmarked ?provider=microsoft link must not 500).
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_CLIENT_ID", "ms-client")
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_CLIENT_SECRET", "ms-secret")
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_TENANT", "common")  # unpinned → provider() raises
+    c = _client()
+    r = c.get(
+        "/oauth/oidc/start",
+        params={
+            "provider": "microsoft",
+            "client_id": CLIENT_ID,
+            "redirect_uri": REDIRECT,
+            "code_challenge": CHALLENGE,
+            "state": "s",
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 400 and r.json()["error"] == "invalid_request"

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -382,3 +382,10 @@ def test_misconfigured_microsoft_tenant_is_a_clean_400_not_500(env, monkeypatch)
         follow_redirects=False,
     )
     assert r.status_code == 400 and r.json()["error"] == "invalid_request"
+
+
+def test_verify_id_token_rejects_blank_sub(env):
+    # `sub` is the binding key — a present-but-blank sub must be rejected (require only checks presence).
+    p = oidc.provider("google")
+    with pytest.raises(Exception):
+        oidc.verify_id_token(p, _id_token(sub="   "), nonce="the-nonce")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,6 +62,8 @@ def test_users_table_is_flat_no_role_column():
     assert "users" in _tables(s)
     cols = {r["name"] for r in s.query("PRAGMA table_info(users)")}
     assert {"id", "username", "password_hash", "email", "status", "created"} <= cols
+    # OIDC identity binding columns (provider + subject) exist; still NO role/permission column.
+    assert {"oidc_provider", "oidc_subject"} <= cols
     assert not (cols & {"role", "roles", "permission", "permissions"}), (
         "flat access — no role column"
     )

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -168,3 +168,19 @@ def test_needs_rehash_upgrade_path(monkeypatch):
     # the upgraded hash still verifies the same password
     assert user_store.authenticate(s, "admin", "s3cret-pw") is not None
     s.close()
+
+
+def test_create_with_oidc_fields_and_bind_subject_no_clobber():
+    s = _store()
+    user_store.create_user(
+        s, "alice", password=None, email="you@example.com", oidc_provider="google"
+    )
+    row = user_store.get_user(s, "alice")
+    assert row["oidc_provider"] == "google" and row["oidc_subject"] is None
+    # first bind sets it
+    user_store.bind_oidc_subject(s, "alice", "sub-1")
+    assert user_store.get_user(s, "alice")["oidc_subject"] == "sub-1"
+    # a second bind is a no-op (the WHERE oidc_subject IS NULL guard) — can't rebind
+    user_store.bind_oidc_subject(s, "alice", "sub-2")
+    assert user_store.get_user(s, "alice")["oidc_subject"] == "sub-1"
+    s.close()


### PR DESCRIPTION
## Summary

Completes OIDC social login. **PR 2 of 2** into `feature/oidc`: adds **Microsoft** (tenant-pinned), the **provider-binding** that closes the IdP-confusion risk PR1 flagged, and the opt-in **public-demo signup** mode. After this, `feature/oidc` → main.

## Changes

- **Microsoft provider** — discovery from a **pinned** tenant (`AGAMI_OIDC_MICROSOFT_TENANT`; `common`/`organizations`/`consumers` are refused — the tenant is the trust boundary). `verify_id_token` returns `Identity(email, subject)` and applies `email_verified` **per provider**: required for Google (consumer IdP), not for tenant-pinned Microsoft (which often omits it). `preferred_username` is never used as identity.
- **Provider-binding (the IdP-confusion fix)** — `006_oidc_identity.sql` adds `oidc_provider` + `oidc_subject`. A user is bound to **one** provider (set at onboarding) and **one** subject (TOFU on first login, no-clobber). A token from another IdP, or a different account at the same IdP, is **refused** rather than resolved to the victim.
- **Public-demo signup** — `AGAMI_PUBLIC_SIGNUP` (default **off**, fail-closed) lets an unknown verified email self-provision a `status='demo'` user — for a dedicated "Try for free" instance whose data is non-sensitive. Demo users get no elevated capability.
- **README** — per-provider env, the tenant pin, the demo flag, and the hosted-only **egress** note.

## Security review (high lane — mandatory)

Ran `/code-review` + a dedicated security pass. The **security pass came back clean** — verified the provider-binding (provider + subject) closes IdP confusion, the MS tenant pin is unbypassable (and is the trust for relaxing `email_verified`), demo-signup is fail-closed + un-elevated + can't hijack an existing user, all failures collapse to a generic 403, no secret/PII leak, no SSRF. Acted on the code review's findings: a misconfigured Microsoft tenant now returns a clean **400 (not a 500)** at the HTTP layer, the demo `create_user` is guarded against a UNIQUE race, and `_resolve_oidc_user` is typed.

## Test plan

`tests/test_oidc.py` (mocked IdP, real RS256, no egress): Microsoft flow **without** `email_verified`; Google **rejected** without it; **unpinned tenant refused**; **provider mismatch → reject** (IdP confusion); **subject TOFU** bind-then-enforce; demo signup **on** creates a demo user, **off** rejects; disabled user rejected; misconfigured-tenant `/oauth/oidc/start` → 400. Full gate green (818 tests + ruff + gitleaks).

## Checklist

- [x] `uv run dev.py check` green
- [x] New behavior covered by tests; security review done (high lane), clean
- [x] No real customer data/names/credentials; no internal IDs in repo files
- [x] Targets `feature/oidc`

Spec: ACE-006