### PR TITLE
Admin social login (Google/Microsoft → admin session)

### DIFF
--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -46,7 +46,6 @@ AGAMI_SIGNING_SECRET=$(openssl rand -hex 32) \
 AGAMI_DB_URL=postgresql://… \
 AGAMI_ADMIN_USERNAME=you@example.com \
 AGAMI_ADMIN_FIRST_NAME=Alex AGAMI_ADMIN_LAST_NAME=Kim \
-# the admin's credential — a password and/or a pinned social provider (at least one):
 AGAMI_ADMIN_PASSWORD=… \
 AGAMI_ADMIN_PROVIDER=google \
 AGAMI_OIDC_GOOGLE_CLIENT_ID=… AGAMI_OIDC_GOOGLE_CLIENT_SECRET=… \
@@ -54,10 +53,11 @@ python -m mcp_http
 ```
 
 The admin is identified by **email** (`AGAMI_ADMIN_USERNAME`). Their sign-in method is whatever you
-configure: a password, and/or a **pinned** social provider (`AGAMI_ADMIN_PROVIDER` = `google` |
-`microsoft`, which must also have its `AGAMI_OIDC_<PROVIDER>_CLIENT_ID/SECRET` set). The admin login
-then offers the same Google/Microsoft option as the MCP login. Register **one** OAuth redirect URI
-with the provider — `{base}/oauth/oidc/callback` — it serves both the connector and the admin flows.
+configure — **a password and/or a pinned social provider, at least one**: set `AGAMI_ADMIN_PASSWORD`,
+and/or `AGAMI_ADMIN_PROVIDER` (`google` | `microsoft`, which must also have its
+`AGAMI_OIDC_<PROVIDER>_CLIENT_ID/SECRET` set). The admin login then offers the same Google/Microsoft
+option as the MCP login. Register **one** OAuth redirect URI with the provider —
+`{base}/oauth/oidc/callback` — it serves both the connector and the admin flows.
 
 ### One host, two entry points
 

--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -44,9 +44,20 @@ console. It's the self-host shape of the hosted product.
 PUBLIC_BASE_URL=https://your-host \
 AGAMI_SIGNING_SECRET=$(openssl rand -hex 32) \
 AGAMI_DB_URL=postgresql://… \
-AGAMI_ADMIN_USERNAME=you@example.com AGAMI_ADMIN_PASSWORD=… \
+AGAMI_ADMIN_USERNAME=you@example.com \
+AGAMI_ADMIN_FIRST_NAME=Alex AGAMI_ADMIN_LAST_NAME=Kim \
+# the admin's credential — a password and/or a pinned social provider (at least one):
+AGAMI_ADMIN_PASSWORD=… \
+AGAMI_ADMIN_PROVIDER=google \
+AGAMI_OIDC_GOOGLE_CLIENT_ID=… AGAMI_OIDC_GOOGLE_CLIENT_SECRET=… \
 python -m mcp_http
 ```
+
+The admin is identified by **email** (`AGAMI_ADMIN_USERNAME`). Their sign-in method is whatever you
+configure: a password, and/or a **pinned** social provider (`AGAMI_ADMIN_PROVIDER` = `google` |
+`microsoft`, which must also have its `AGAMI_OIDC_<PROVIDER>_CLIENT_ID/SECRET` set). The admin login
+then offers the same Google/Microsoft option as the MCP login. Register **one** OAuth redirect URI
+with the provider — `{base}/oauth/oidc/callback` — it serves both the connector and the admin flows.
 
 ### One host, two entry points
 
@@ -63,8 +74,10 @@ A deployment is one host (`PUBLIC_BASE_URL`). Everything lives under it:
   who signs in can query (that's the product). No token → `401` + `WWW-Authenticate`, which starts
   Claude's OAuth. Admin-ness does **not** gate `/mcp`.
 - **Admin surface (`/admin`)** — gated by a **session cookie** *and* the admin-gate
-  (`AGAMI_ADMIN_USERNAME`). A valid non-admin is refused; an `/mcp` bearer token is useless here
-  (different credential). Unset `AGAMI_ADMIN_USERNAME` ⇒ the admin console is disabled entirely.
+  (`AGAMI_ADMIN_USERNAME`). The admin signs in with their **pinned** social provider or a password; a
+  valid non-admin is refused (and a social identity for the admin email via a *different* provider is
+  refused — the pin closes IdP-confusion). An `/mcp` bearer token is useless here (different
+  credential). Unset `AGAMI_ADMIN_USERNAME` ⇒ the admin console is disabled entirely.
 
 The admin adds a teammate by **email + name**; the teammate then signs in at the connector. (Letting
 that teammate choose their own sign-in method on first login — Google/Microsoft or a self-set

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -421,8 +421,10 @@ async def admin_login(request: Request) -> Response:
             store.close()
     if principal is None:
         # Same generic message for wrong password, unknown user, or disabled — no enumeration oracle.
+        # Keep the social button on the re-render so a failed password attempt doesn't hide it.
         return HTMLResponse(
-            admin_login_body_html(error="Invalid email or password."), status_code=401
+            admin_login_body_html(error="Invalid email or password.", provider=_admin_provider()),
+            status_code=401,
         )
     if principal.subject != _admin_username():
         # Valid credentials, but not THE admin: no session minted; a friendly "use via Claude" page.

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -234,8 +234,10 @@ _SESSION_PURPOSE = "admin_session"
 
 
 def _admin_username() -> str | None:
-    """The single admin's username (the admin-gate). Unset ⇒ the admin UI is disabled entirely."""
-    name = os.environ.get("AGAMI_ADMIN_USERNAME", "").strip()
+    """The single admin's username = the **normalized** admin email (the admin-gate). Lowercased+trimmed
+    to match how the seed stores it + how OIDC resolves it, so the gate is case-insensitive. Unset ⇒ the
+    admin UI is disabled entirely."""
+    name = os.environ.get("AGAMI_ADMIN_USERNAME", "").strip().lower()
     return name or None
 
 
@@ -375,10 +377,13 @@ async def admin_login(request: Request) -> Response:
         return HTMLResponse(admin_login_body_html())
 
     form = await _form(request)
+    # Email is the identity: normalize the typed address (trim + lowercase) so login is
+    # case-insensitive and matches the normalized username the seed stored.
+    typed = form.get("username", "").strip().lower()
     store = _open_store()
     try:
         principal = (
-            user_store.authenticate(store, form.get("username", ""), form.get("password", ""))
+            user_store.authenticate(store, typed, form.get("password", ""))
             if store is not None
             else None
         )

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -21,9 +21,10 @@ import jwt
 import ui
 import user_store
 
-# Reuse the OAuth provider's shared HS256 secret accessor + store opener so the admin surface signs
-# with the same key and reads the same datastore (no second source of truth).
-from oauth_server import _open_store, _signing_secret
+# Reuse the OAuth provider's shared HS256 secret accessor + store opener + the admin OIDC-start handler
+# so the admin surface signs with the same key, reads the same datastore, and runs the same hardened
+# OIDC flow (no second source of truth).
+from oauth_server import _open_store, _signing_secret, admin_oidc_start
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse, Response
 
@@ -39,12 +40,17 @@ def _full_name(user: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def admin_login_body_html(error: str = "") -> str:
-    """The admin sign-in page — password only. (Admin social login isn't part of this surface yet;
-    rendering a Google/Microsoft button here would point at a route that doesn't exist.) No banner
-    copy — the logo and the form speak for themselves (this is the admin's own login, not a consent)."""
+def admin_login_body_html(error: str = "", provider: str | None = None) -> str:
+    """The admin sign-in page: the admin's pinned social provider (when configured) above the password
+    form — matching the MCP login's options. Only the admin's *one* pinned provider is offered, since
+    that's the only one that can resolve to the admin (a second button would just say "not an admin").
+    No banner copy — the logo and the form speak for themselves (this is the admin's own login)."""
+    button = (
+        ui.provider_button(provider, f"/admin/oidc/start?provider={provider}") if provider else ""
+    )
+    social = f'<div class="providers">{button}</div><div class="divider">or</div>' if button else ""
     alert = f'<div class="alert error">{ui.esc(error)}</div>' if error else ""
-    body = f"""{alert}
+    body = f"""{alert}{social}
 <form method="post">
 <label for="u">Email</label>
 <input id="u" name="username" type="email" autocomplete="email" placeholder="you@example.com">
@@ -241,6 +247,17 @@ def _admin_username() -> str | None:
     return name or None
 
 
+def _admin_provider() -> str | None:
+    """The admin's pinned OIDC provider (`AGAMI_ADMIN_PROVIDER`), or None — only returned when it's a
+    provider that's actually configured, so the login page never shows a button that can't work."""
+    key = os.environ.get("AGAMI_ADMIN_PROVIDER", "").strip().lower()
+    if not key:
+        return None
+    import oidc  # lazy: the egress module, server-only
+
+    return key if key in oidc.available_providers() else None
+
+
 def issue_session(username: str) -> str:
     """A short-TTL HS256 session JWT (sub=username, purpose=admin_session) for the cookie."""
     now = datetime.now(timezone.utc)
@@ -369,12 +386,24 @@ def _admin_chrome(store: Any, admin_username: str) -> dict[str, str]:
     }
 
 
+def complete_admin_oidc_login(username: str | None) -> Response:
+    """Finish an admin OIDC login (called by the shared OIDC callback for an `admin_login` state): a
+    verified identity that resolves to THE configured admin gets an admin session; anyone else — an
+    unresolved identity, or a valid but non-admin user — is refused with the branded page, no session.
+    The provider-pin + subject binding were already enforced upstream by `_resolve_oidc_user`."""
+    if username is not None and username == _admin_username():
+        resp: Response = RedirectResponse("/admin", status_code=302)
+        _set_session(resp, issue_session(username))
+        return resp
+    return HTMLResponse(not_admin_body_html(_base_url()), status_code=403)
+
+
 async def admin_login(request: Request) -> Response:
     """GET → the admin sign-in page; POST → authenticate, gate on the admin-username, mint a session."""
     if request.method == "GET":
         if current_admin(request) is not None:
             return RedirectResponse("/admin", status_code=302)
-        return HTMLResponse(admin_login_body_html())
+        return HTMLResponse(admin_login_body_html(provider=_admin_provider()))
 
     form = await _form(request)
     # Email is the identity: normalize the typed address (trim + lowercase) so login is
@@ -521,9 +550,19 @@ def routes() -> list:
         Route("/admin", admin_home, methods=["GET"]),
         Route("/admin/login", admin_login, methods=["GET", "POST"]),
         Route("/admin/logout", admin_logout, methods=["GET"]),
+        # The admin OIDC start (handler lives in oauth_server, with the OIDC machinery). The IdP
+        # redirects back to the shared /oauth/oidc/callback, which branches on the state's purpose.
+        Route("/admin/oidc/start", admin_oidc_start, methods=["GET"]),
         Route("/admin/users", admin_create_user, methods=["POST"]),
         Route("/admin/users/status", admin_set_status, methods=["POST"]),
     ]
 
 
-ADMIN_PATHS = ("/admin", "/admin/login", "/admin/logout", "/admin/users", "/admin/users/status")
+ADMIN_PATHS = (
+    "/admin",
+    "/admin/login",
+    "/admin/logout",
+    "/admin/oidc/start",
+    "/admin/users",
+    "/admin/users/status",
+)

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -248,14 +248,33 @@ def _admin_username() -> str | None:
 
 
 def _admin_provider() -> str | None:
-    """The admin's pinned OIDC provider (`AGAMI_ADMIN_PROVIDER`), or None — only returned when it's a
-    provider that's actually configured, so the login page never shows a button that can't work."""
+    """The admin's pinned OIDC provider (`AGAMI_ADMIN_PROVIDER`), or None — only when it's a provider
+    that's actually configured (client id/secret present)."""
     key = os.environ.get("AGAMI_ADMIN_PROVIDER", "").strip().lower()
     if not key:
         return None
     import oidc  # lazy: the egress module, server-only
 
     return key if key in oidc.available_providers() else None
+
+
+def _admin_login_provider() -> str | None:
+    """The provider button to render on the admin login: the pinned, configured provider, but ONLY
+    when the admin's stored row is actually bound to it. This avoids a dead button — e.g. if
+    `AGAMI_ADMIN_PROVIDER` is set after the admin was seeded password-only (the seed is idempotent and
+    won't backfill `oidc_provider`), the button would otherwise show but dead-end at "not an admin"."""
+    provider = _admin_provider()
+    admin = _admin_username()
+    if provider is None or admin is None:
+        return None
+    store = _open_store()
+    if store is None:
+        return None
+    try:
+        row = user_store.get_user(store, admin)
+    finally:
+        store.close()
+    return provider if row is not None and row.get("oidc_provider") == provider else None
 
 
 def issue_session(username: str) -> str:
@@ -403,7 +422,7 @@ async def admin_login(request: Request) -> Response:
     if request.method == "GET":
         if current_admin(request) is not None:
             return RedirectResponse("/admin", status_code=302)
-        return HTMLResponse(admin_login_body_html(provider=_admin_provider()))
+        return HTMLResponse(admin_login_body_html(provider=_admin_login_provider()))
 
     form = await _form(request)
     # Email is the identity: normalize the typed address (trim + lowercase) so login is
@@ -423,7 +442,7 @@ async def admin_login(request: Request) -> Response:
         # Same generic message for wrong password, unknown user, or disabled — no enumeration oracle.
         # Keep the social button on the re-render so a failed password attempt doesn't hide it.
         return HTMLResponse(
-            admin_login_body_html(error="Invalid email or password.", provider=_admin_provider()),
+            admin_login_body_html(error="Invalid email or password.", provider=_admin_login_provider()),
             status_code=401,
         )
     if principal.subject != _admin_username():

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -493,10 +493,38 @@ async def oidc_start(request: Request) -> Response:
     return resp
 
 
+async def admin_oidc_start(request: Request) -> Response:
+    """Begin an OIDC flow for **admin** login: redirect to the IdP with a signed state marked
+    `purpose=admin_login` so the shared callback mints an admin **session** (not a bearer code).
+    Carries no OAuth client context (this isn't a connector flow) and reuses the one registered
+    callback URI, so a deployer registers a single redirect URI for both flows."""
+    import oidc  # noqa: F401  (lazy: the egress module)
+
+    p = _safe_provider(request.query_params.get("provider", ""))
+    if p is None:
+        return _oauth_error("invalid_request", "unknown or unconfigured provider")
+    nonce = secrets.token_urlsafe(16)
+    csrf = secrets.token_urlsafe(16)
+    state = _mint_oidc_state({"purpose": "admin_login", "provider": p.key, "nonce": nonce}, csrf)
+    url = oidc.authorize_url(p, state=state, nonce=nonce, redirect_uri=_oidc_callback_uri())
+    resp = RedirectResponse(url, status_code=302)
+    resp.set_cookie(
+        _CSRF_COOKIE,
+        csrf,
+        max_age=int(_OIDC_STATE_TTL.total_seconds()),
+        httponly=True,
+        secure=True,
+        samesite="lax",
+    )
+    return resp
+
+
 async def oidc_callback(request: Request) -> Response:
     """Complete OIDC: verify state + CSRF, exchange the code, verify the ID token, resolve the user
-    **onboarded-only**, then resume the OAuth code mint. Any verification failure is a generic
-    403 — never an auto-created account."""
+    **onboarded-only**, then either mint an **admin session** (when the state's `purpose=admin_login`)
+    or resume the OAuth code mint. Any verification failure is a generic 403 — never an auto-created
+    account. The `purpose` marker keeps the two flows from crossing: an admin-login state can only mint
+    a session, a connector state can only mint a bearer code."""
     import oidc
 
     q = request.query_params
@@ -520,16 +548,24 @@ async def oidc_callback(request: Request) -> Response:
         return _oauth_error("server_error", "no datastore configured", status=500)
     try:
         username = _resolve_oidc_user(store, p.key, identity)
-        if username is None:
+        if claims.get("purpose") == "admin_login":
+            # Admin login: a verified identity that resolves to THE configured admin gets a session;
+            # anyone else (unresolved, or a non-admin user) is refused. The provider-pin + subject bind
+            # are already enforced by `_resolve_oidc_user`, so this only adds the "is it the admin?" gate.
+            import admin
+
+            resp = admin.complete_admin_oidc_login(username)
+        elif username is None:
             return _oauth_error("access_denied", "this account is not authorized", status=403)
-        resp = _issue_authorization_code(
-            store,
-            client_id=claims.get("client_id", ""),
-            redirect_uri=claims.get("redirect_uri", ""),
-            code_challenge=claims.get("code_challenge", ""),
-            username=username,
-            client_state=claims.get("client_state", ""),
-        )
+        else:
+            resp = _issue_authorization_code(
+                store,
+                client_id=claims.get("client_id", ""),
+                redirect_uri=claims.get("redirect_uri", ""),
+                code_challenge=claims.get("code_challenge", ""),
+                username=username,
+                client_state=claims.get("client_state", ""),
+            )
     finally:
         store.close()
     resp.delete_cookie(_CSRF_COOKIE)

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -498,7 +498,7 @@ async def admin_oidc_start(request: Request) -> Response:
     `purpose=admin_login` so the shared callback mints an admin **session** (not a bearer code).
     Carries no OAuth client context (this isn't a connector flow) and reuses the one registered
     callback URI, so a deployer registers a single redirect URI for both flows."""
-    import oidc  # noqa: F401  (lazy: the egress module)
+    import oidc  # lazy: the egress module (server-only), like oidc_start
 
     p = _safe_provider(request.query_params.get("provider", ""))
     if p is None:
@@ -546,12 +546,15 @@ async def oidc_callback(request: Request) -> Response:
     store = _open_store()
     if store is None:
         return _oauth_error("server_error", "no datastore configured", status=500)
+    is_admin_login = claims.get("purpose") == "admin_login"
     try:
-        username = _resolve_oidc_user(store, p.key, identity)
-        if claims.get("purpose") == "admin_login":
-            # Admin login: a verified identity that resolves to THE configured admin gets a session;
-            # anyone else (unresolved, or a non-admin user) is refused. The provider-pin + subject bind
-            # are already enforced by `_resolve_oidc_user`, so this only adds the "is it the admin?" gate.
+        # Admin login is strictly onboarded-only — never self-provision a user as a side effect of an
+        # admin sign-in attempt (even on a public-signup demo instance).
+        username = _resolve_oidc_user(store, p.key, identity, allow_signup=not is_admin_login)
+        if is_admin_login:
+            # A verified identity that resolves to THE configured admin gets a session; anyone else
+            # (unresolved, or a non-admin user) is refused. The provider-pin + subject bind are already
+            # enforced by `_resolve_oidc_user`, so this only adds the "is it the admin?" gate.
             import admin
 
             resp = admin.complete_admin_oidc_login(username)
@@ -577,9 +580,13 @@ async def oidc_callback(request: Request) -> Response:
 _LOGIN_STATUSES = {"active", "demo"}
 
 
-def _resolve_oidc_user(store: Store, provider_key: str, identity: Identity) -> str | None:
+def _resolve_oidc_user(
+    store: Store, provider_key: str, identity: Identity, *, allow_signup: bool = True
+) -> str | None:
     """Map a verified OIDC identity to a username, or None to reject. Onboarded-only by default; with
-    public signup enabled an unknown email self-provisions a demo user.
+    public signup enabled (and `allow_signup`) an unknown email self-provisions a demo user.
+    `allow_signup=False` forces strict onboarded-only — the admin-login path passes it so an admin
+    sign-in attempt can never create a user as a side effect.
 
     Provider-binding closes IdP confusion: an existing user must be bound to THIS provider, and (once
     set) THIS subject — so an attacker with the same email at another IdP, or a different account at
@@ -603,8 +610,9 @@ def _resolve_oidc_user(store: Store, provider_key: str, identity: Identity) -> s
             return None
         return user["username"]
 
-    # Unknown email: only a public-demo instance may self-provision (fail-closed default).
-    if not oidc.public_signup_enabled():
+    # Unknown email: only a public-demo instance may self-provision (fail-closed default), and never
+    # on an admin-login attempt (allow_signup=False) — that route must not create users.
+    if not allow_signup or not oidc.public_signup_enabled():
         return None
     try:
         create_user(

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -173,10 +173,14 @@ def seed_admin_from_env(store: Store) -> str | None:
 
     Create-if-absent and idempotent: a redeploy never duplicates the admin or clobbers changes the
     admin has since made. (Switching an existing admin's auth method is a manual re-seed — out of scope.)"""
-    email = _normalize_email(os.environ.get("AGAMI_ADMIN_USERNAME", ""))
+    raw = os.environ.get("AGAMI_ADMIN_USERNAME", "").strip()
+    email = _normalize_email(raw)
     if email is None:
         return None
-    password = os.environ.get("AGAMI_ADMIN_PASSWORD", "") or None
+    # A whitespace-only password is a misconfig — treat it as unset (so it falls back to the provider,
+    # or no-ops) rather than letting create_user raise and crash startup.
+    pw_env = os.environ.get("AGAMI_ADMIN_PASSWORD", "")
+    password = pw_env if pw_env.strip() else None
     provider = os.environ.get("AGAMI_ADMIN_PROVIDER", "").strip().lower() or None
     # An unknown provider key is a misconfig — ignore it (fall back to the password if present) rather
     # than seed an admin pinned to a provider that can never resolve.
@@ -184,7 +188,9 @@ def seed_admin_from_env(store: Store) -> str | None:
         provider = None
     if password is None and provider is None:
         return None  # no usable credential → nothing to seed
-    if get_user(store, email) is not None:
+    # Idempotent across an upgrade: skip if an admin already exists under the normalized email OR under
+    # a pre-existing (possibly mixed-case) raw username — so a redeploy never creates a duplicate row.
+    if get_user(store, email) is not None or (raw != email and get_user(store, raw) is not None):
         return None
     create_user(
         store,

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -23,6 +23,10 @@ from store import Store
 
 _ACTIVE = "active"
 
+# The OIDC provider keys a deploy may pin the admin to. Mirrors `oidc._PROVIDERS`, duplicated here on
+# purpose: `oidc` is the one egress module (httpx), and `user_store` must stay import-light + egress-free.
+_KNOWN_OIDC_PROVIDERS = ("google", "microsoft")
+
 # A throwaway argon2id hash that no password verifies against. `authenticate` verifies against it on
 # the user-absent path so every code path pays the same KDF cost — without it, a missing username
 # returns far faster than a wrong password and leaks which usernames exist (an enumeration oracle).
@@ -158,16 +162,38 @@ def authenticate(store: Store, username: str, password: str) -> Principal | None
 
 
 def seed_admin_from_env(store: Store) -> str | None:
-    """Seed the initial admin from AGAMI_ADMIN_USERNAME / AGAMI_ADMIN_PASSWORD if both are set.
+    """Seed the initial admin from the AGAMI_ADMIN_* env. Returns the seeded username (the email), or
+    None if there's nothing to seed / the admin already exists.
 
-    Create-if-absent and idempotent: a redeploy never duplicates the admin or clobbers a
-    password the admin has since changed. Returns the username seeded, or None if unset/already
-    present. (Rotating the seed password is out of scope — that's a later reset path.)"""
-    username = os.environ.get("AGAMI_ADMIN_USERNAME", "").strip()
-    password = os.environ.get("AGAMI_ADMIN_PASSWORD", "")
-    if not username or not password:
+    The admin is keyed by **email** (`AGAMI_ADMIN_USERNAME` = the email; `username` = the normalized
+    email, so login is by the address they know). Auth method is whatever the deploy supplies — a
+    password (`AGAMI_ADMIN_PASSWORD`) and/or a pinned OIDC provider (`AGAMI_ADMIN_PROVIDER`,
+    google|microsoft); **at least one is required**, and both is fine (the provider is the primary path,
+    the password a fallback). `AGAMI_ADMIN_FIRST_NAME`/`LAST_NAME` are display-only.
+
+    Create-if-absent and idempotent: a redeploy never duplicates the admin or clobbers changes the
+    admin has since made. (Switching an existing admin's auth method is a manual re-seed — out of scope.)"""
+    email = _normalize_email(os.environ.get("AGAMI_ADMIN_USERNAME", ""))
+    if email is None:
         return None
-    if get_user(store, username) is not None:
+    password = os.environ.get("AGAMI_ADMIN_PASSWORD", "") or None
+    provider = os.environ.get("AGAMI_ADMIN_PROVIDER", "").strip().lower() or None
+    # An unknown provider key is a misconfig — ignore it (fall back to the password if present) rather
+    # than seed an admin pinned to a provider that can never resolve.
+    if provider is not None and provider not in _KNOWN_OIDC_PROVIDERS:
+        provider = None
+    if password is None and provider is None:
+        return None  # no usable credential → nothing to seed
+    if get_user(store, email) is not None:
         return None
-    create_user(store, username, password, status=_ACTIVE)
-    return username
+    create_user(
+        store,
+        username=email,
+        password=password,
+        email=email,
+        status=_ACTIVE,
+        oidc_provider=provider,
+        first_name=os.environ.get("AGAMI_ADMIN_FIRST_NAME", ""),
+        last_name=os.environ.get("AGAMI_ADMIN_LAST_NAME", ""),
+    )
+    return email

--- a/render_previews.py
+++ b/render_previews.py
@@ -57,7 +57,7 @@ write(
     "03-login-error.html",
     oauth_server.login_body_html(OAUTH, error="Invalid email or password.", providers=("google", "microsoft"), wrap=True),
 )
-write("04-admin-login.html", admin.admin_login_body_html())
+write("04-admin-login.html", admin.admin_login_body_html(provider="google"))
 write("05-admin-users.html", admin.users_tab_html(USERS, csrf="t0ken", ok="User added.", **ADMIN))
 write("06-admin-dashboard.html", admin.dashboard_tab_html(**CHROME))
 write("07-admin-sessions.html", admin.sessions_tab_html(**CHROME))

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -194,6 +194,16 @@ def test_valid_non_admin_is_refused_with_no_session(client):
     assert client.get("/admin", follow_redirects=False).status_code == 302
 
 
+def test_admin_login_is_case_insensitive_on_the_email(client):
+    # Email is the identity — a differently-cased address still authenticates as the admin.
+    r = client.post(
+        "/admin/login",
+        data={"username": "ADMIN@Example.COM", "password": ADMIN_PW},
+        follow_redirects=False,
+    )
+    assert r.status_code == 302 and r.headers["location"] == "/admin"
+
+
 def test_admin_login_sets_a_hardened_session_cookie(client):
     r = client.post(
         "/admin/login", data={"username": ADMIN_USER, "password": ADMIN_PW}, follow_redirects=False

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -254,6 +254,104 @@ def test_callback_rejects_tampered_state_or_missing_cookie(env, monkeypatch):
     assert cb.status_code == 400
 
 
+# --- admin social login (OIDC → admin SESSION, provider-pinned) --------------
+
+ADMIN_EMAIL = "admin@example.com"
+
+
+def _seed_admin(db_url, monkeypatch, *, provider="google"):
+    """Make the configured admin a provider-bound user (username == email), as the seed would."""
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", ADMIN_EMAIL)
+    monkeypatch.setenv("AGAMI_ADMIN_PROVIDER", provider)
+    s = Store.connect(db_url)
+    user_store.create_user(
+        s, username=ADMIN_EMAIL, password=None, email=ADMIN_EMAIL, oidc_provider=provider
+    )
+    s.close()
+
+
+def _admin_start(c: TestClient, provider: str = "google"):
+    r = c.get("/admin/oidc/start", params={"provider": provider}, follow_redirects=False)
+    assert r.status_code == 302
+    q = parse_qs(urlparse(r.headers["location"]).query)
+    return q["state"][0], q["nonce"][0]
+
+
+def test_admin_oidc_login_mints_a_session(env, monkeypatch):
+    _seed_admin(env, monkeypatch)
+    c = _client()
+    state, nonce = _admin_start(c)
+    monkeypatch.setattr(
+        oidc,
+        "exchange_code",
+        lambda p, *, code, redirect_uri: _id_token(nonce=nonce, email=ADMIN_EMAIL, sub="admin-sub"),
+    )
+    cb = c.get("/oauth/oidc/callback", params={"code": "x", "state": state}, follow_redirects=False)
+    # An admin session (not a bearer code): 302 straight to /admin + a hardened session cookie.
+    assert cb.status_code == 302 and cb.headers["location"] == "/admin"
+    sc = cb.headers["set-cookie"]
+    assert "agami_admin_session=" in sc and "HttpOnly" in sc and "Secure" in sc
+
+
+def test_admin_oidc_refuses_a_non_admin_identity(env, monkeypatch):
+    _seed_admin(env, monkeypatch)
+    c = _client()
+    state, nonce = _admin_start(c)
+    # alice (you@example.com) is an onboarded NON-admin OIDC user (from the env fixture).
+    monkeypatch.setattr(
+        oidc,
+        "exchange_code",
+        lambda p, *, code, redirect_uri: _id_token(nonce=nonce, email="you@example.com"),
+    )
+    cb = c.get("/oauth/oidc/callback", params={"code": "x", "state": state}, follow_redirects=False)
+    assert cb.status_code == 403
+    assert "agami_admin_session" not in cb.headers.get("set-cookie", "")  # no session minted
+
+
+def test_admin_oidc_refuses_an_unknown_identity(env, monkeypatch):
+    _seed_admin(env, monkeypatch)
+    c = _client()
+    state, nonce = _admin_start(c)
+    monkeypatch.setattr(
+        oidc,
+        "exchange_code",
+        lambda p, *, code, redirect_uri: _id_token(nonce=nonce, email="stranger@example.com"),
+    )
+    cb = c.get("/oauth/oidc/callback", params={"code": "x", "state": state}, follow_redirects=False)
+    assert cb.status_code == 403
+
+
+def test_admin_oidc_idp_confusion_is_closed_by_the_pin(env, monkeypatch):
+    # Admin pinned to Google. Configure Microsoft too; an admin-login attempt for the admin email via
+    # Microsoft (an attacker controlling that email at another IdP) must be refused — the pin holds.
+    _seed_admin(env, monkeypatch, provider="google")
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_CLIENT_ID", CLIENT_ID)
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_CLIENT_SECRET", "ms-secret")
+    monkeypatch.setenv("AGAMI_OIDC_MICROSOFT_TENANT", MS_TENANT)
+    c = _client()
+    state, nonce = _admin_start(c, provider="microsoft")
+    monkeypatch.setattr(
+        oidc,
+        "exchange_code",
+        lambda p, *, code, redirect_uri: _id_token(nonce=nonce, email=ADMIN_EMAIL, sub="ms-sub"),
+    )
+    cb = c.get("/oauth/oidc/callback", params={"code": "x", "state": state}, follow_redirects=False)
+    assert cb.status_code == 403  # bound to google ⇒ a microsoft identity for the email is not the admin
+
+
+def test_admin_login_page_shows_only_the_pinned_provider(env, monkeypatch):
+    _seed_admin(env, monkeypatch)  # pinned google; microsoft not configured
+    html = _client().get("/admin/login").text
+    assert "Continue with Google" in html and "/admin/oidc/start?provider=google" in html
+    assert "Continue with Microsoft" not in html
+
+
+def test_admin_oidc_start_rejects_an_unconfigured_provider(env, monkeypatch):
+    _seed_admin(env, monkeypatch)
+    r = _client().get("/admin/oidc/start", params={"provider": "microsoft"}, follow_redirects=False)
+    assert r.status_code == 400  # microsoft isn't configured → clean 400, no redirect
+
+
 def test_provider_option_hidden_when_unconfigured(monkeypatch, tmp_path):
     monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
     monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -377,6 +377,18 @@ def test_admin_login_keeps_the_provider_button_after_a_bad_password(env, monkeyp
     assert "Continue with Google" in html  # a failed password attempt doesn't hide the social option
 
 
+def test_admin_login_hides_button_when_admin_row_is_not_pinned_to_the_provider(env, monkeypatch):
+    # Config drift: admin was seeded password-only; AGAMI_ADMIN_PROVIDER added later (the idempotent
+    # seed won't backfill oidc_provider). The button must NOT show — it would dead-end at "not an admin".
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", ADMIN_EMAIL)
+    monkeypatch.setenv("AGAMI_ADMIN_PROVIDER", "google")  # configured, but the admin isn't bound to it
+    s = Store.connect(env)
+    user_store.create_user(s, username=ADMIN_EMAIL, password="admin-pw", email=ADMIN_EMAIL)
+    s.close()
+    html = _client().get("/admin/login").text
+    assert "Continue with Google" not in html
+
+
 def test_provider_option_hidden_when_unconfigured(monkeypatch, tmp_path):
     monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
     monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -352,6 +352,31 @@ def test_admin_oidc_start_rejects_an_unconfigured_provider(env, monkeypatch):
     assert r.status_code == 400  # microsoft isn't configured → clean 400, no redirect
 
 
+def test_admin_oidc_never_self_provisions_even_with_public_signup(env, monkeypatch):
+    # An admin sign-in attempt by an unknown email must NOT create a user, even on a public-signup
+    # demo instance — the admin route is strictly onboarded-only.
+    _seed_admin(env, monkeypatch)
+    monkeypatch.setenv("AGAMI_PUBLIC_SIGNUP", "1")
+    c = _client()
+    state, nonce = _admin_start(c)
+    monkeypatch.setattr(
+        oidc,
+        "exchange_code",
+        lambda p, *, code, redirect_uri: _id_token(nonce=nonce, email="stranger@example.com", sub="x"),
+    )
+    cb = c.get("/oauth/oidc/callback", params={"code": "x", "state": state}, follow_redirects=False)
+    assert cb.status_code == 403
+    s = Store.connect(env)
+    assert user_store.get_user_by_email(s, "stranger@example.com") is None  # no row created
+    s.close()
+
+
+def test_admin_login_keeps_the_provider_button_after_a_bad_password(env, monkeypatch):
+    _seed_admin(env, monkeypatch)  # pinned google
+    html = _client().post("/admin/login", data={"username": ADMIN_EMAIL, "password": "wrong"}).text
+    assert "Continue with Google" in html  # a failed password attempt doesn't hide the social option
+
+
 def test_provider_option_hidden_when_unconfigured(monkeypatch, tmp_path):
     monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
     monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -202,6 +202,31 @@ def test_seed_admin_hybrid_password_and_provider(monkeypatch):
     s.close()
 
 
+def test_seed_admin_whitespace_password_is_treated_as_unset(monkeypatch):
+    s = _store()
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", "owner@example.com")
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", "   ")  # whitespace-only ⇒ unset, must not crash
+    monkeypatch.setenv("AGAMI_ADMIN_PROVIDER", "google")
+    assert user_store.seed_admin_from_env(s) == "owner@example.com"
+    row = user_store.get_user(s, "owner@example.com")
+    assert row["password_hash"] is None and row["oidc_provider"] == "google"
+    s.close()
+
+
+def test_seed_admin_is_idempotent_against_a_prior_mixed_case_username(monkeypatch):
+    s = _store()
+    # Simulate a legacy seed: an admin row created with the verbatim (mixed-case) username.
+    user_store.create_user(
+        s, username="Owner@Example.com", password="old-pw", email="owner@example.com"
+    )
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", "Owner@Example.com")
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", "seed-pw")
+    monkeypatch.delenv("AGAMI_ADMIN_PROVIDER", raising=False)
+    assert user_store.seed_admin_from_env(s) is None  # already present ⇒ no duplicate admin row
+    assert len(user_store.list_users(s)) == 1
+    s.close()
+
+
 def test_needs_rehash_upgrade_path(monkeypatch):
     # Simulate a stored hash made with a weaker profile: authenticate should re-store an upgraded
     # hash in place (the cross-tier cost-bump path) without changing the verified password.

--- a/tests/test_user_store.py
+++ b/tests/test_user_store.py
@@ -147,10 +147,58 @@ def test_seed_admin_from_env_creates_and_is_idempotent(monkeypatch):
 
 def test_seed_admin_noop_when_env_unset(monkeypatch):
     s = _store()
-    monkeypatch.delenv("AGAMI_ADMIN_USERNAME", raising=False)
-    monkeypatch.delenv("AGAMI_ADMIN_PASSWORD", raising=False)
+    for var in ("AGAMI_ADMIN_USERNAME", "AGAMI_ADMIN_PASSWORD", "AGAMI_ADMIN_PROVIDER"):
+        monkeypatch.delenv(var, raising=False)
     assert user_store.seed_admin_from_env(s) is None
     assert user_store.list_users(s) == []
+    s.close()
+
+
+def test_seed_admin_provider_only_is_passwordless_and_named(monkeypatch):
+    s = _store()
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", "Owner@Example.com")
+    monkeypatch.delenv("AGAMI_ADMIN_PASSWORD", raising=False)
+    monkeypatch.setenv("AGAMI_ADMIN_PROVIDER", "google")
+    monkeypatch.setenv("AGAMI_ADMIN_FIRST_NAME", "Alex")
+    monkeypatch.setenv("AGAMI_ADMIN_LAST_NAME", "Kim")
+    assert user_store.seed_admin_from_env(s) == "owner@example.com"  # email is the identity, normalized
+    row = user_store.get_user(s, "owner@example.com")
+    assert row["oidc_provider"] == "google" and row["password_hash"] is None
+    assert row["first_name"] == "Alex" and row["last_name"] == "Kim"
+    # passwordless ⇒ no password login
+    assert user_store.authenticate(s, "owner@example.com", "anything") is None
+    s.close()
+
+
+def test_seed_admin_requires_at_least_one_credential(monkeypatch):
+    s = _store()
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", "owner@example.com")
+    monkeypatch.delenv("AGAMI_ADMIN_PASSWORD", raising=False)
+    monkeypatch.delenv("AGAMI_ADMIN_PROVIDER", raising=False)
+    assert user_store.seed_admin_from_env(s) is None  # email alone is not a credential
+    assert user_store.list_users(s) == []
+    s.close()
+
+
+def test_seed_admin_ignores_an_unknown_provider(monkeypatch):
+    s = _store()
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", "owner@example.com")
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", "seed-pw")
+    monkeypatch.setenv("AGAMI_ADMIN_PROVIDER", "bogus")  # typo / unsupported → ignored, not pinned
+    assert user_store.seed_admin_from_env(s) == "owner@example.com"
+    assert user_store.get_user(s, "owner@example.com")["oidc_provider"] is None
+    s.close()
+
+
+def test_seed_admin_hybrid_password_and_provider(monkeypatch):
+    s = _store()
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", "owner@example.com")
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", "seed-pw")
+    monkeypatch.setenv("AGAMI_ADMIN_PROVIDER", "microsoft")
+    assert user_store.seed_admin_from_env(s) == "owner@example.com"
+    row = user_store.get_user(s, "owner@example.com")
+    assert row["oidc_provider"] == "microsoft" and row["password_hash"] is not None
+    assert user_store.authenticate(s, "owner@example.com", "seed-pw") is not None  # password still works
     s.close()
 
 


### PR DESCRIPTION
## Summary

Adds **admin social login** — signing in to the `/admin` console with Google/Microsoft, so the admin
login offers the **same options as the MCP login** (most users authenticate with a social provider).

The MCP buttons run the OIDC flow and mint a **bearer JWT** for `/mcp`; the admin needs the same IdP
flow but ending in an **admin session cookie**. The key reuse: the admin flow goes through the **one
registered OIDC callback** (`/oauth/oidc/callback`) and branches on a `purpose` marker in the *signed*
state — so an admin-login state can only mint a session and a connector state can only mint a bearer,
and the deployer registers a single redirect URI.

**Provider-pinned** admin (owner decision): the admin is identified by **email**
(`AGAMI_ADMIN_USERNAME`) and pinned to one provider (`AGAMI_ADMIN_PROVIDER`). Admin login reuses
ACE-006's hardened `_resolve_oidc_user` (provider + subject binding), then requires the resolved
identity == the configured admin before minting a session — so IdP-confusion (the admin email
controlled at a *different* IdP) is closed for free.

## Changes

- **`oauth_server.py`** — `admin_oidc_start` (purpose-marked state, CSRF cookie, redirect to the IdP via
  the shared callback) + a `purpose` branch in `oidc_callback` that mints an admin session via
  `admin.complete_admin_oidc_login`. Admin login is strictly onboarded-only (`allow_signup=False`), so
  an admin sign-in attempt never self-provisions a user.
- **`admin.py`** — `complete_admin_oidc_login` (mints a session only for the configured admin, else a
  403 page, no session), `_admin_provider()`, the pinned-provider button on the admin login, and
  email-normalized admin identity (case-insensitive login + gate).
- **`user_store.py`** — `seed_admin_from_env` keys the admin by **email**, accepts `AGAMI_ADMIN_PROVIDER`
  + `AGAMI_ADMIN_FIRST_NAME/LAST_NAME`, and makes the password optional (a provider-only admin) —
  requiring at least one credential.
- **Docs/previews** — README documents the admin identity, the pinned provider, and the single
  redirect URI; `render_previews.py` shows the admin login with the provider button.

## Test plan

- `tests/test_oidc.py` — admin login mints a session (302 `/admin` + hardened cookie); a non-admin and an
  unknown identity are refused (403, **no session**); **IdP-confusion** via a different provider is
  refused; the login page shows only the pinned provider; an unconfigured provider is a clean 400; admin
  login **never self-provisions** even with public signup on; the social button survives a bad password.
- `tests/test_user_store.py` — seed: provider-only (passwordless), hybrid, unknown-provider ignored,
  requires-a-credential, email normalized.
- `tests/test_admin.py` — case-insensitive admin email login.
- Gate green: ruff + ruff-format + full pytest (871) + gitleaks; patch coverage 100%.
- Reviewed with `/code-review` + `/security-review` (new credential-minting path); findings addressed.

## Checklist

- [x] Tests added and passing; gate green
- [x] No real customer names / data / credentials — neutral placeholders only
- [x] No new network egress (reuses `oidc.py`, the existing single egress module)
- [x] Flat access preserved (no role/permission column)
- [ ] Manual end-to-end smoke behind a Cloudflare tunnel with a real Google client (reviewer's machine)

Spec: ACE-012
