### PR TITLE
Teammate self-onboarding (deployment-wide auth method)

### DIFF
--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -94,6 +94,10 @@ the deployment's **single auth method** — uniform for everyone, set by what yo
 The login surfaces show only the configured method (the admin keeps a password **break-glass** fallback
 on `/admin/login`).
 
+> **Trust note.** OIDC onboarding binds the account to whoever first proves the teammate's email at the
+> configured IdP — so add a teammate by an email the *right* person controls there. The setup link and
+> the other pre-auth endpoints aren't rate-limited in-process; put them behind your proxy/LB if exposed.
+
 ### Local end-to-end test (HTTPS via a tunnel)
 
 OAuth and the `Secure` admin cookie need HTTPS, so expose the local server through a tunnel:

--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -79,9 +79,20 @@ A deployment is one host (`PUBLIC_BASE_URL`). Everything lives under it:
   refused — the pin closes IdP-confusion). An `/mcp` bearer token is useless here (different
   credential). Unset `AGAMI_ADMIN_USERNAME` ⇒ the admin console is disabled entirely.
 
-The admin adds a teammate by **email + name**; the teammate then signs in at the connector. (Letting
-that teammate choose their own sign-in method on first login — Google/Microsoft or a self-set
-password — is the next increment.)
+### Onboarding a teammate
+
+The admin adds a teammate by **email + name** (a *pending* user). How they finish setting up follows
+the deployment's **single auth method** — uniform for everyone, set by what you configured:
+
+- **OIDC deployment** (a Google/Microsoft client is configured): the teammate just adds `{base}/mcp` to
+  Claude and signs in with that provider — the IdP verifies their email and binds the account on first
+  login. No link to share.
+- **Password deployment** (no OIDC configured): the admin **copies the teammate's setup link** from the
+  Users tab and shares it out-of-band; the teammate opens it and sets their own password. The link is a
+  signed, time-boxed token and is single-use (it stops working once the account is set up).
+
+The login surfaces show only the configured method (the admin keeps a password **break-glass** fallback
+on `/admin/login`).
 
 ### Local end-to-end test (HTTPS via a tunnel)
 

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -44,7 +44,7 @@ server = [
 package-dir = { "" = "src" }
 # Flat top-level modules (not under a parent package) — listed explicitly so the import
 # names stay flat regardless of disk layout.
-py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui"]
+py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
 packages = ["semantic_model"]
 
 [tool.setuptools.package-data]

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -114,6 +114,21 @@ or a password they set the first time — and can then use this agami server fro
 </div>"""
 
 
+def _signin_cell(user: dict[str, Any], setup_links: dict[str, str]) -> str:
+    """The Sign-in column: the user's method, plus — for a *pending* user in a password deployment —
+    a copy-able setup link the admin shares out-of-band (the page is session-gated, admin-only)."""
+    sign_in = user.get("oidc_provider") or ("password" if user.get("has_password") else "not set yet")
+    link = setup_links.get(user.get("username", ""))
+    extra = (
+        f'<details class="setup"><summary>Setup link</summary>'
+        f'<input class="code" readonly value="{ui.esc(link)}" style="width:100%;margin-top:6px">'
+        f"</details>"
+        if link
+        else ""
+    )
+    return f'<td class="muted">{ui.esc(sign_in)}{extra}</td>'
+
+
 def users_tab_html(
     users: list[dict[str, Any]],
     csrf: str,
@@ -121,18 +136,20 @@ def users_tab_html(
     admin_username: str = "",
     admin_email: str = "",
     admin_label: str = "",
+    setup_links: dict[str, str] | None = None,
     error: str = "",
     ok: str = "",
 ) -> str:
-    """The Users tab: a roster table + an 'Add user' button that opens the drawer."""
+    """The Users tab: a roster table + an 'Add user' button that opens the drawer. `setup_links`
+    (username → URL) attaches a copy-able setup link to each pending row (password deployments)."""
+    setup_links = setup_links or {}
     rows = ""
     for u in users:
-        sign_in = u.get("oidc_provider") or ("password" if u.get("has_password") else "not set yet")
         rows += (
             "<tr>"
             f'<td><strong>{ui.esc(_full_name(u))}</strong></td>'
             f'<td class="muted">{ui.esc(u.get("email") or "—")}</td>'
-            f'<td class="muted">{ui.esc(sign_in)}</td>'
+            f"{_signin_cell(u, setup_links)}"
             f"<td>{_status_pill(u['status'])}</td>"
             f'<td style="text-align:right">{_row_action(u, csrf, admin_username)}</td>'
             "</tr>"
@@ -482,8 +499,27 @@ async def admin_home(request: Request) -> Response:
     ok = _OK_FLASH.get(request.query_params.get("ok", ""), "")
     err = _ERR_FLASH.get(request.query_params.get("err", ""), "")
     return HTMLResponse(
-        users_tab_html(users, csrf, admin_username=admin, ok=ok, error=err, **chrome)
+        users_tab_html(
+            users, csrf, admin_username=admin, setup_links=_setup_links(users), ok=ok, error=err, **chrome
+        )
     )
+
+
+def _setup_links(users: list[dict[str, Any]]) -> dict[str, str]:
+    """Per-pending-user setup links — but only in a **password** deployment (no OIDC configured). When
+    an OIDC provider is configured, teammates onboard by signing in with it, so no link is offered."""
+    import oidc  # lazy: the egress module, server-only
+
+    if oidc.available_providers():
+        return {}
+    import onboarding
+
+    base = _base_url()
+    return {
+        u["username"]: f"{base}/claim?token={onboarding.mint_setup_token(u['username'])}"
+        for u in users
+        if onboarding.is_pending(u)
+    }
 
 
 def _valid_email(email: str) -> bool:

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -22,6 +22,7 @@ import os
 from pathlib import Path
 
 import admin
+import onboarding
 from oss_adapters import PresenceAuthProvider, SingleTenantOrgResolver
 from ports import AuthProvider, Org
 from starlette.applications import Starlette
@@ -131,7 +132,7 @@ def _is_public_path(path: str) -> bool:
         return True
     if path == "/":
         return True
-    return path in _OAUTH_PATHS or path in admin.ADMIN_PATHS
+    return path in _OAUTH_PATHS or path in admin.ADMIN_PATHS or path in onboarding.PUBLIC_PATHS
 
 
 class _AuthMiddleware(BaseHTTPMiddleware):
@@ -265,6 +266,7 @@ def build_app() -> Starlette:
         Route("/oauth/oidc/start", oidc_start, methods=["GET"]),
         Route("/oauth/oidc/callback", oidc_callback, methods=["GET"]),
         *admin.routes(),
+        *onboarding.routes(),
         Mount("/static", app=StaticFiles(directory=_STATIC_DIR), name="static"),
         Mount("/mcp", app=handle_mcp),
     ]

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -33,6 +33,7 @@ from store import Store
 from user_store import (
     authenticate,
     bind_oidc_subject,
+    claim_pending_oidc,
     create_user,
     get_user,
     get_user_by_email,
@@ -597,6 +598,20 @@ def _resolve_oidc_user(
     if user is not None:
         if user["status"] not in _LOGIN_STATUSES:
             return None
+        # Pending user (deployment-wide OIDC onboarding, ACE-011): a row with no password and no
+        # provider adopts THIS provider + subject on first login, then we re-read and require both are
+        # ours. The guard makes a concurrent or already-claimed case (e.g. a password set first) a
+        # no-op → we reject rather than log in against an unexpected binding.
+        if user["oidc_provider"] is None and user["password_hash"] is None:
+            claim_pending_oidc(store, user["username"], provider_key, identity.subject)
+            bound = get_user(store, user["username"])
+            if (
+                bound is None
+                or bound["oidc_provider"] != provider_key
+                or bound["oidc_subject"] != identity.subject
+            ):
+                return None
+            return user["username"]
         if user["oidc_provider"] != provider_key:
             return None  # bound to a different IdP (or password-only) → not an OIDC login for this provider
         # Bind the subject on first login (a no-clobber UPDATE that only sets it when NULL), then

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -226,10 +226,6 @@ def login_body_html(
     """The sign-in page HTML (the inner body, or the full page when `wrap`). Split out so previews can
     render it with sample values without going through a request."""
     carried = {k: params.get(k, "") for k in _OAUTH_CONTEXT_KEYS}
-    hidden = "".join(
-        f'<input type="hidden" name="{k}" value="{ui.esc(params.get(k, ""))}">'
-        for k in _OAUTH_CONTEXT_KEYS
-    )
     alert = f'<div class="alert error">{ui.esc(error)}</div>' if error else ""
     client = _client_label(params.get("redirect_uri", ""))
     # Consent banner mirrors the web app: a quiet "Allow <client> to access your data". When the
@@ -251,6 +247,10 @@ def login_body_html(
         methods = f'<div class="providers">{buttons}</div>'
     else:
         # Password deployment — the email/password form (the OAuth context rides as hidden fields).
+        hidden = "".join(
+            f'<input type="hidden" name="{k}" value="{ui.esc(params.get(k, ""))}">'
+            for k in _OAUTH_CONTEXT_KEYS
+        )
         methods = f"""<form method="post">{hidden}
 <label for="u">Email</label>
 <input id="u" name="username" type="email" autocomplete="email" placeholder="you@example.com">
@@ -290,6 +290,12 @@ async def authorize(request: Request) -> Response:
         code_challenge = form.get("code_challenge", "")
         if not code_challenge:
             return _oauth_error("invalid_request", "code_challenge is required (PKCE)")
+
+        # Deployment-wide method: in an OIDC deployment the connector is provider-only — refuse a
+        # (crafted) password POST server-side, not just by hiding the form. The admin's password
+        # break-glass lives on the separate /admin/login surface, not here.
+        if providers:
+            return _login_form(form, providers=providers)
 
         principal = authenticate(store, form.get("username", ""), form.get("password", ""))
         if principal is None:

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -230,12 +230,6 @@ def login_body_html(
         f'<input type="hidden" name="{k}" value="{ui.esc(params.get(k, ""))}">'
         for k in _OAUTH_CONTEXT_KEYS
     )
-    # OIDC buttons carry the same OAuth context to /oauth/oidc/start so the flow resumes after the IdP.
-    buttons = "".join(
-        ui.provider_button(key, f"/oauth/oidc/start?{urlencode({**carried, 'provider': key})}")
-        for key in providers
-    )
-    social = f'<div class="providers">{buttons}</div><div class="divider">or</div>' if buttons else ""
     alert = f'<div class="alert error">{ui.esc(error)}</div>' if error else ""
     client = _client_label(params.get("redirect_uri", ""))
     # Consent banner mirrors the web app: a quiet "Allow <client> to access your data". When the
@@ -247,15 +241,24 @@ def login_body_html(
         if client
         else ""
     )
-    body = f"""{consent}
-{alert}{social}
-<form method="post">{hidden}
+    if providers:
+        # OIDC deployment — the auth method is the configured provider(s) for everyone; no password
+        # surface (the OIDC buttons carry the OAuth context to /oauth/oidc/start to resume after the IdP).
+        buttons = "".join(
+            ui.provider_button(key, f"/oauth/oidc/start?{urlencode({**carried, 'provider': key})}")
+            for key in providers
+        )
+        methods = f'<div class="providers">{buttons}</div>'
+    else:
+        # Password deployment — the email/password form (the OAuth context rides as hidden fields).
+        methods = f"""<form method="post">{hidden}
 <label for="u">Email</label>
 <input id="u" name="username" type="email" autocomplete="email" placeholder="you@example.com">
 <label for="p">Password</label>
 <input id="p" name="password" type="password" autocomplete="current-password" placeholder="••••••••">
 <button class="btn" type="submit" style="margin-top:22px">Sign in</button>
 </form>"""
+    body = f"{consent}\n{alert}{methods}"
     return ui.auth_page("Sign in", body) if wrap else body
 
 
@@ -598,8 +601,8 @@ def _resolve_oidc_user(
     if user is not None:
         if user["status"] not in _LOGIN_STATUSES:
             return None
-        # Pending user (deployment-wide OIDC onboarding, ACE-011): a row with no password and no
-        # provider adopts THIS provider + subject on first login, then we re-read and require both are
+        # Pending user (deployment-wide OIDC onboarding): a row with no password and no provider
+        # adopts THIS provider + subject on first login, then we re-read and require both are
         # ours. The guard makes a concurrent or already-claimed case (e.g. a password set first) a
         # no-op → we reject rather than log in against an unexpected binding.
         if user["oidc_provider"] is None and user["password_hash"] is None:

--- a/packages/agami-core/src/onboarding.py
+++ b/packages/agami-core/src/onboarding.py
@@ -29,6 +29,7 @@ from starlette.responses import HTMLResponse, Response
 _SETUP_TTL = timedelta(days=14)
 _SETUP_PURPOSE = "setup"  # marks this token apart from the OAuth bearer + the admin session JWT
 _MIN_PASSWORD_LEN = 8
+_MAX_PASSWORD_LEN = 256  # cap the input (a sane bound; argon2's cost is fixed, this just rejects junk)
 
 
 def mint_setup_token(username: str) -> str:
@@ -126,7 +127,10 @@ def _pending_user(username: str) -> dict[str, Any] | None:
 async def claim(request: Request) -> Response:
     """GET → the set-password page for a valid link to a still-pending user; POST → set the password.
     Every failure (bad token, already-claimed, weak password, lost race) is a generic page — no
-    credential overwrite of a claimed account, no enumeration."""
+    credential overwrite of a claimed account, no enumeration. Both the token check and the pending
+    re-read run BEFORE any argon2 hash, so an attacker can't drive hashing without a valid (signed,
+    admin-minted) token for a still-pending user. This endpoint is **not** rate-limited in-process —
+    rely on the deployment's proxy/LB for that (a documented gap, like the other public endpoints)."""
     if request.method == "GET":
         username = verify_setup_token(request.query_params.get("token", ""))
         if username is None or _pending_user(username) is None:
@@ -139,7 +143,7 @@ async def claim(request: Request) -> Response:
     if username is None or _pending_user(username) is None:
         return HTMLResponse(setup_invalid_html(), status_code=400)
     password = form.get("password", "")
-    if len(password) < _MIN_PASSWORD_LEN:
+    if not _MIN_PASSWORD_LEN <= len(password) <= _MAX_PASSWORD_LEN:
         return HTMLResponse(
             setup_page_html(token, error=f"Use at least {_MIN_PASSWORD_LEN} characters."),
             status_code=400,

--- a/packages/agami-core/src/onboarding.py
+++ b/packages/agami-core/src/onboarding.py
@@ -1,0 +1,168 @@
+"""Teammate self-onboarding — the **setup link** path for a password deployment.
+
+When a deployment has no OIDC configured, a teammate the admin created is a *pending* user (no
+password, no provider) and there's no email to send an invite to. The admin copies a **setup link**
+from the console (a signed, time-boxed token — no new table) and shares it out-of-band; the teammate
+opens it and sets their own password. The token is single-use by construction: claiming flips the user
+out of the *pending* state, so the guarded `claim_pending_password` UPDATE no-ops any replay. (OIDC
+deployments don't use this — teammates bind on first OIDC login at the connector; see `oauth_server`.)
+
+This is a public surface (the teammate has no session yet), so it self-checks: a bad/expired/used
+token, or an already-claimed user, yields a generic page — never a credential-overwrite of a claimed
+account, and no email-enumeration (the token is opaque; we don't echo who it was for).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import jwt
+import ui
+import user_store
+from oauth_server import _open_store, _signing_secret
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, Response
+
+# A generous TTL — the admin shares the link out-of-band and the teammate may take a while. The token
+# is still single-use (the pending guard), so the window only bounds an unused link, not a claimed one.
+_SETUP_TTL = timedelta(days=14)
+_SETUP_PURPOSE = "setup"  # marks this token apart from the OAuth bearer + the admin session JWT
+_MIN_PASSWORD_LEN = 8
+
+
+def mint_setup_token(username: str) -> str:
+    """A signed, time-boxed setup token for `username` — the body of the admin's copy-able setup link."""
+    now = datetime.now(timezone.utc)
+    return jwt.encode(
+        {
+            "sub": username,
+            "purpose": _SETUP_PURPOSE,
+            "iat": int(now.timestamp()),
+            "exp": int((now + _SETUP_TTL).timestamp()),
+        },
+        _signing_secret(),
+        algorithm="HS256",
+    )
+
+
+def verify_setup_token(token: str) -> str | None:
+    """The username a valid setup token names, or None (bad signature / expired / wrong purpose)."""
+    try:
+        claims = jwt.decode(
+            token, _signing_secret(), algorithms=["HS256"], options={"require": ["exp", "sub"]}
+        )
+    except Exception:
+        return None
+    if claims.get("purpose") != _SETUP_PURPOSE:
+        return None
+    sub = claims.get("sub")
+    return sub if isinstance(sub, str) and sub else None
+
+
+def is_pending(user: dict[str, Any]) -> bool:
+    """A user who hasn't claimed a credential yet: no password AND no OIDC provider. Works for both row
+    shapes — `get_user` (carries `password_hash`) and `list_users` (carries the derived `has_password`)."""
+    has_password = user.get("password_hash") is not None or bool(user.get("has_password"))
+    return not has_password and user.get("oidc_provider") is None
+
+
+# ---------------------------------------------------------------------------
+# Pages
+# ---------------------------------------------------------------------------
+
+
+def setup_page_html(token: str, error: str = "") -> str:
+    """The set-your-password page reached from a valid setup link."""
+    alert = f'<div class="alert error">{ui.esc(error)}</div>' if error else ""
+    body = f"""<div class="consent"><p class="who">Set up your account</p>
+<p class="small">Choose a password to finish setting up.</p></div>
+{alert}
+<form method="post" action="/claim">
+<input type="hidden" name="token" value="{ui.esc(token)}">
+<label for="p">Password</label>
+<input id="p" name="password" type="password" autocomplete="new-password" placeholder="••••••••">
+<button class="btn" type="submit" style="margin-top:22px">Set password</button>
+</form>"""
+    return ui.auth_page("Set up your account", body)
+
+
+def setup_done_html(base_url: str) -> str:
+    body = f"""<div class="consent"><p class="who">You're all set</p>
+<p class="small">Your password is set. Add this server to Claude as a custom connector:</p></div>
+<p><span class="code">{ui.esc(base_url)}/mcp</span></p>"""
+    return ui.auth_page("All set", body)
+
+
+def setup_invalid_html() -> str:
+    body = """<div class="consent"><p class="who">This link isn't valid</p>
+<p class="small">It may have expired or already been used. Ask your administrator for a new setup
+link.</p></div>"""
+    return ui.auth_page("Invalid link", body)
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+async def _form(request: Request) -> dict[str, str]:
+    data = await request.form()
+    return {k: (v if isinstance(v, str) else "") for k, v in data.items()}
+
+
+def _pending_user(username: str) -> dict[str, Any] | None:
+    """The pending user a token names, or None (unknown / already claimed / no store)."""
+    store = _open_store()
+    if store is None:
+        return None
+    try:
+        user = user_store.get_user(store, username)
+    finally:
+        store.close()
+    return user if (user is not None and is_pending(user)) else None
+
+
+async def claim(request: Request) -> Response:
+    """GET → the set-password page for a valid link to a still-pending user; POST → set the password.
+    Every failure (bad token, already-claimed, weak password, lost race) is a generic page — no
+    credential overwrite of a claimed account, no enumeration."""
+    if request.method == "GET":
+        username = verify_setup_token(request.query_params.get("token", ""))
+        if username is None or _pending_user(username) is None:
+            return HTMLResponse(setup_invalid_html(), status_code=400)
+        return HTMLResponse(setup_page_html(request.query_params.get("token", "")))
+
+    form = await _form(request)
+    token = form.get("token", "")
+    username = verify_setup_token(token)
+    if username is None or _pending_user(username) is None:
+        return HTMLResponse(setup_invalid_html(), status_code=400)
+    password = form.get("password", "")
+    if len(password) < _MIN_PASSWORD_LEN:
+        return HTMLResponse(
+            setup_page_html(token, error=f"Use at least {_MIN_PASSWORD_LEN} characters."),
+            status_code=400,
+        )
+    store = _open_store()
+    if store is None:
+        return HTMLResponse(setup_invalid_html(), status_code=400)
+    try:
+        # Guarded: the UPDATE only fires while still pending — a concurrent claim makes it a no-op.
+        changed = user_store.claim_pending_password(store, username, password)
+    finally:
+        store.close()
+    if not changed:
+        return HTMLResponse(setup_invalid_html(), status_code=400)
+    from mcp_http import public_base_url
+
+    return HTMLResponse(setup_done_html(public_base_url()))
+
+
+def routes() -> list:
+    from starlette.routing import Route
+
+    return [Route("/claim", claim, methods=["GET", "POST"])]
+
+
+PUBLIC_PATHS = ("/claim",)

--- a/packages/agami-core/src/onboarding.py
+++ b/packages/agami-core/src/onboarding.py
@@ -9,7 +9,9 @@ deployments don't use this — teammates bind on first OIDC login at the connect
 
 This is a public surface (the teammate has no session yet), so it self-checks: a bad/expired/used
 token, or an already-claimed user, yields a generic page — never a credential-overwrite of a claimed
-account, and no email-enumeration (the token is opaque; we don't echo who it was for).
+account, and no email-enumeration. (The token is a signed JWT — unforgeable, though its `sub` is
+base64url-readable by whoever holds the link; the no-enumeration property comes from the handler
+returning the same generic page regardless, not from the token being secret.)
 """
 
 from __future__ import annotations

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -99,6 +99,34 @@ def bind_oidc_subject(store: Store, username: str, subject: str) -> None:
     store.commit()
 
 
+def claim_pending_oidc(store: Store, username: str, provider: str, subject: str) -> int:
+    """A **pending** user (no password, no provider) adopts an OIDC provider + subject on first login.
+    Guarded so it fires ONLY while still pending — if a password was set (a password deployment) or
+    another provider already bound, the WHERE matches nothing and this no-ops; the caller re-reads and
+    rejects rather than logging in against an unexpected binding. Returns the row count (0 ⇒ not
+    pending / not claimable)."""
+    cur = store.execute(
+        "UPDATE users SET oidc_provider = ?, oidc_subject = ? "
+        "WHERE username = ? AND oidc_provider IS NULL AND password_hash IS NULL",
+        (provider, subject, username),
+    )
+    store.commit()
+    return cur.rowcount
+
+
+def claim_pending_password(store: Store, username: str, password: str) -> int:
+    """A **pending** user sets their own password (a password deployment, via the admin setup link).
+    Guarded so it fires ONLY while still pending — if an OIDC provider already bound (or a password was
+    already set), the WHERE matches nothing and this no-ops. Returns the row count (0 ⇒ not claimable)."""
+    cur = store.execute(
+        "UPDATE users SET password_hash = ? "
+        "WHERE username = ? AND password_hash IS NULL AND oidc_provider IS NULL",
+        (hash_password(password), username),
+    )
+    store.commit()
+    return cur.rowcount
+
+
 def get_user_by_email(store: Store, email: str) -> dict[str, Any] | None:
     """Look up a user by email — the onboarded-only lookup OIDC uses. Case-insensitive (emails are
     stored lowercased) and one-to-one (the email index is UNIQUE)."""

--- a/render_previews.py
+++ b/render_previews.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(PKG))
 
 import admin  # noqa: E402
 import oauth_server  # noqa: E402
+import onboarding  # noqa: E402
 
 OUT = ROOT / "previews"
 OUT.mkdir(exist_ok=True)
@@ -58,13 +59,23 @@ write(
     oauth_server.login_body_html(OAUTH, error="Invalid email or password.", providers=("google", "microsoft"), wrap=True),
 )
 write("04-admin-login.html", admin.admin_login_body_html(provider="google"))
-write("05-admin-users.html", admin.users_tab_html(USERS, csrf="t0ken", ok="User added.", **ADMIN))
+# In a password deployment the roster shows a copy-able setup link per pending user.
+SETUP_LINKS = {
+    u["username"]: f"{BASE}/claim?token=eyJhbGciOi.SAMPLE-SETUP-TOKEN.xyz"
+    for u in USERS
+    if onboarding.is_pending(u)
+}
+write("05-admin-users.html",
+      admin.users_tab_html(USERS, csrf="t0ken", ok="User added.", setup_links=SETUP_LINKS, **ADMIN))
 write("06-admin-dashboard.html", admin.dashboard_tab_html(**CHROME))
 write("07-admin-sessions.html", admin.sessions_tab_html(**CHROME))
 write("08-not-admin.html", admin.not_admin_body_html(BASE))
 write("09-landing.html", admin.landing_body_html(BASE))
 write("10-mcp-in-browser.html", admin.mcp_landing_body_html(BASE))
 write("11-not-authorized.html", admin.not_authorized_body_html("morgan@example.com"))
+write("12-setup-password.html", onboarding.setup_page_html("eyJhbGciOi.SAMPLE.xyz"))
+write("13-setup-done.html", onboarding.setup_done_html(BASE))
+write("14-setup-invalid.html", onboarding.setup_invalid_html())
 
 print(f"Wrote {len(list(OUT.glob('*.html')))} previews to {OUT}/")
 for p in sorted(OUT.glob("*.html")):

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -486,6 +486,30 @@ def test_connector_login_shows_only_the_configured_method(env, monkeypatch):
     assert 'name="password"' in html2 and "Continue with Google" not in html2
 
 
+def test_connector_password_post_is_refused_in_an_oidc_deployment(env):
+    # The method-gating is enforced server-side, not just hidden: a *correct* password POST issues no
+    # code when an OIDC provider is configured (the gate fires before authenticate).
+    s = Store.from_env()
+    user_store.create_user(s, username="pat@example.com", email="pat@example.com", password="pat-pw-123456")
+    s.close()
+    r = _client().post(
+        "/oauth/authorize",
+        data={"username": "pat@example.com", "password": "pat-pw-123456", "redirect_uri": REDIRECT,
+              "client_id": CLIENT_ID, "code_challenge": CHALLENGE, "state": "x"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 200 and "Continue with Google" in r.text  # re-rendered login, no auth code
+
+
+def test_oidc_bound_user_cannot_then_set_a_password(env):
+    # First-claim-locks the other direction: once OIDC-bound, the password claim guard no-ops.
+    s = Store.from_env()
+    user_store.create_user(s, username="newbie@example.com", email="newbie@example.com", password=None)
+    assert _resolve_oidc_user(s, "google", Identity("newbie@example.com", "sub-1")) == "newbie@example.com"
+    assert user_store.claim_pending_password(s, "newbie@example.com", "late-pw-12345") == 0
+    s.close()
+
+
 def test_pending_user_binds_on_first_oidc_login(env):
     # A pending teammate (no password, no provider) adopts the provider + subject on first OIDC login.
     s = Store.from_env()

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -474,6 +474,29 @@ def test_subject_tofu_binds_then_enforces(env):
     s.close()
 
 
+def test_pending_user_binds_on_first_oidc_login(env):
+    # A pending teammate (no password, no provider) adopts the provider + subject on first OIDC login.
+    s = Store.from_env()
+    user_store.create_user(s, username="newbie@example.com", email="newbie@example.com", password=None)
+    assert _resolve_oidc_user(s, "google", Identity("newbie@example.com", "sub-1")) == "newbie@example.com"
+    row = user_store.get_user(s, "newbie@example.com")
+    assert row["oidc_provider"] == "google" and row["oidc_subject"] == "sub-1"
+    # bound now: same provider+subject still resolves; a different provider for the email is refused
+    assert _resolve_oidc_user(s, "google", Identity("newbie@example.com", "sub-1")) == "newbie@example.com"
+    assert _resolve_oidc_user(s, "microsoft", Identity("newbie@example.com", "ms-sub")) is None
+    s.close()
+
+
+def test_password_user_is_not_a_pending_oidc_claim(env):
+    # A password user (a password deployment) is NOT pending — an OIDC login for that email is refused,
+    # never silently binds a provider onto a password account.
+    s = Store.from_env()
+    user_store.create_user(s, username="pat@example.com", email="pat@example.com", password="pat-pw-1234")
+    assert _resolve_oidc_user(s, "google", Identity("pat@example.com", "sub-1")) is None
+    assert user_store.get_user(s, "pat@example.com")["oidc_provider"] is None  # unchanged
+    s.close()
+
+
 def test_demo_signup_off_rejects_unknown_email(env):
     s = Store.from_env()  # AGAMI_PUBLIC_SIGNUP unset → fail-closed
     assert _resolve_oidc_user(s, "google", Identity("stranger@example.com", "s")) is None

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -474,6 +474,18 @@ def test_subject_tofu_binds_then_enforces(env):
     s.close()
 
 
+def test_connector_login_shows_only_the_configured_method(env, monkeypatch):
+    p = {"client_id": CLIENT_ID, "redirect_uri": REDIRECT, "code_challenge": CHALLENGE, "state": "x"}
+    # OIDC deployment (google configured by the fixture): providers only, no password surface.
+    html = _client().get("/oauth/authorize", params=p).text
+    assert "Continue with Google" in html and 'name="password"' not in html
+    # Password deployment: clear OIDC → the password form, no provider buttons.
+    monkeypatch.delenv("AGAMI_OIDC_GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("AGAMI_OIDC_GOOGLE_CLIENT_SECRET", raising=False)
+    html2 = _client().get("/oauth/authorize", params=p).text
+    assert 'name="password"' in html2 and "Continue with Google" not in html2
+
+
 def test_pending_user_binds_on_first_oidc_login(env):
     # A pending teammate (no password, no provider) adopts the provider + subject on first OIDC login.
     s = Store.from_env()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,157 @@
+"""Teammate self-onboarding via the admin setup link (the password-deployment path).
+
+Proves the setup token is unforgeable + single-use, the /claim flow sets a password for a pending user
+only, and the admin roster surfaces a copy-able setup link for pending users — but only when the
+deployment has no OIDC configured. SQLite-backed; https base so the Secure admin cookie round-trips.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("starlette")
+pytest.importorskip("mcp")
+pytest.importorskip("jwt")
+pytest.importorskip("argon2")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import jwt  # noqa: E402
+import mcp_http  # noqa: E402
+import onboarding  # noqa: E402
+import user_store  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+from store import Store  # noqa: E402
+
+BASE = "https://your-host.example.com"
+SECRET = "x" * 40
+ADMIN_USER = "admin@example.com"
+ADMIN_PW = "admin-password-localtest"
+PENDING = "newbie@example.com"
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    db_url = "sqlite://" + str(tmp_path / "onboard.db")
+    monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    monkeypatch.setenv("AGAMI_DB_URL", db_url)
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", ADMIN_USER)
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", ADMIN_PW)
+    # A password deployment — no OIDC configured.
+    for var in ("AGAMI_OIDC_GOOGLE_CLIENT_ID", "AGAMI_OIDC_GOOGLE_CLIENT_SECRET",
+                "AGAMI_OIDC_MICROSOFT_CLIENT_ID", "AGAMI_OIDC_MICROSOFT_CLIENT_SECRET"):
+        monkeypatch.delenv(var, raising=False)
+    s = Store.connect(db_url)
+    s.run_migrations()
+    user_store.seed_admin_from_env(s)
+    user_store.create_user(s, username=PENDING, email=PENDING, password=None)  # pending teammate
+    s.close()
+    return db_url
+
+
+@pytest.fixture
+def client(env):
+    return TestClient(mcp_http.build_app(), base_url=BASE)
+
+
+# --- the token in isolation --------------------------------------------------
+
+
+def test_setup_token_round_trips(env):
+    token = onboarding.mint_setup_token(PENDING)
+    assert onboarding.verify_setup_token(token) == PENDING
+
+
+def test_setup_token_rejects_forged_expired_and_wrong_purpose(env):
+    assert onboarding.verify_setup_token("not-a-jwt") is None
+    # signed with a different key → bad signature
+    forged = jwt.encode({"sub": PENDING, "purpose": "setup", "exp": 9_999_999_999}, "y" * 40, algorithm="HS256")
+    assert onboarding.verify_setup_token(forged) is None
+    # expired
+    expired = jwt.encode(
+        {"sub": PENDING, "purpose": "setup", "exp": int(datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp())},
+        SECRET, algorithm="HS256",
+    )
+    assert onboarding.verify_setup_token(expired) is None
+    # right key, wrong purpose (e.g. a bearer/admin-session token replayed as a setup link)
+    wrong = jwt.encode({"sub": PENDING, "purpose": "admin_session", "exp": 9_999_999_999}, SECRET, algorithm="HS256")
+    assert onboarding.verify_setup_token(wrong) is None
+
+
+# --- the /claim flow ---------------------------------------------------------
+
+
+def test_claim_sets_a_password_for_a_pending_user(client, env):
+    token = onboarding.mint_setup_token(PENDING)
+    assert "Set up your account" in client.get("/claim", params={"token": token}).text
+    r = client.post("/claim", data={"token": token, "password": "teammate-pw-123"})
+    assert r.status_code == 200 and f"{BASE}/mcp" in r.text
+    s = Store.connect(env)
+    assert user_store.authenticate(s, PENDING, "teammate-pw-123") is not None
+    s.close()
+
+
+def test_claim_link_is_single_use(client, env):
+    token = onboarding.mint_setup_token(PENDING)
+    client.post("/claim", data={"token": token, "password": "teammate-pw-123"})
+    # replay: the user is no longer pending → generic invalid page, password unchanged
+    r = client.post("/claim", data={"token": token, "password": "attacker-pw-999"})
+    assert r.status_code == 400 and "isn't valid" in r.text
+    s = Store.connect(env)
+    assert user_store.authenticate(s, PENDING, "teammate-pw-123") is not None  # original still works
+    assert user_store.authenticate(s, PENDING, "attacker-pw-999") is None
+    s.close()
+
+
+def test_claim_rejects_a_bad_token(client):
+    assert client.get("/claim", params={"token": "nope"}, follow_redirects=False).status_code == 400
+    assert client.post("/claim", data={"token": "nope", "password": "whatever-123"}).status_code == 400
+
+
+def test_claim_rejects_a_short_password(client, env):
+    token = onboarding.mint_setup_token(PENDING)
+    r = client.post("/claim", data={"token": token, "password": "short"})
+    assert r.status_code == 400 and "at least" in r.text
+    s = Store.connect(env)
+    assert onboarding.is_pending(user_store.get_user(s, PENDING))  # still pending — nothing set
+    s.close()
+
+
+def test_claim_for_an_already_password_user_is_refused(client, env):
+    # The admin (a password user) isn't pending; a token for them can't overwrite their password.
+    token = onboarding.mint_setup_token(ADMIN_USER)
+    assert client.get("/claim", params={"token": token}).status_code == 400
+
+
+# --- the admin roster setup link ---------------------------------------------
+
+
+def _login(client):
+    client.post("/admin/login", data={"username": ADMIN_USER, "password": ADMIN_PW})
+
+
+def test_admin_roster_shows_a_setup_link_for_pending_users(client):
+    _login(client)
+    html = client.get("/admin").text
+    assert "Setup link" in html
+    m = re.search(r'/claim\?token=([\w.\-]+)', html)
+    assert m and onboarding.verify_setup_token(m.group(1)) == PENDING
+    # the admin's own (password) row offers no setup link
+    admin_row = next(r for r in html.split("<tr>") if ADMIN_USER in r and "<td" in r)
+    assert "Setup link" not in admin_row
+
+
+def test_admin_roster_hides_setup_links_in_an_oidc_deployment(client, monkeypatch):
+    # Configure an OIDC provider → it's no longer a password deployment → no setup links.
+    monkeypatch.setenv("AGAMI_OIDC_GOOGLE_CLIENT_ID", "cid")
+    monkeypatch.setenv("AGAMI_OIDC_GOOGLE_CLIENT_SECRET", "secret")
+    _login(client)
+    assert "Setup link" not in client.get("/admin").text


### PR DESCRIPTION
## Summary

Completes teammate onboarding. An admin creates a teammate by **email + name** (a *pending* user who
can't yet sign in); this lets them finish setting up — following a **deployment-wide auth method**,
uniform for everyone, set by what's configured:

- **OIDC deployment** (a Google/Microsoft client is configured): a pending teammate signs in with that
  provider at the connector — the IdP verifies their email and **binds the account on first login**. No
  link to share.
- **Password deployment** (no OIDC): the admin **copies a setup link** from the Users tab and shares it
  out-of-band; the teammate opens it and **sets their own password**. The link is a signed, time-boxed
  token (no new table) and is **single-use** — it stops working once the account is set up.

Because a deployment offers one method, a user can never hold two credentials — so there's no per-user
choice and no lock-juggling. Login surfaces show **only the configured method** (the admin keeps a
password **break-glass** fallback on `/admin/login`).

## Changes

- **`user_store.py`** — `claim_pending_oidc` / `claim_pending_password`: guarded
  `UPDATE … WHERE password_hash IS NULL AND oidc_provider IS NULL` (race-safe, mirrors the ACE-006 bind).
- **`oauth_server.py`** — `_resolve_oidc_user` gains a *pending* branch (bind on first OIDC login, then
  re-read and require the binding is ours); `login_body_html` renders only the configured method, and
  `/oauth/authorize` **refuses a password POST server-side** in an OIDC deployment.
- **`onboarding.py`** (NEW) — the setup token (purpose-marked HS256, no new table) + the `/claim` setup
  page/handler. Unforgeable, single-use, never overwrites a claimed account; hashes only after the token
  + pending checks.
- **`admin.py`** — the Users tab shows a copy-able **setup link** for pending users, **only** in a
  password deployment (the page is session-gated).
- **`mcp_http.py`** — `/claim` routes + the bearer public-skip (boundary-matched). Docs + previews.

## Test plan

- `tests/test_onboarding.py` — token round-trip + forged/expired/wrong-purpose rejection; `/claim` sets a
  password for a pending user; **single-use** (replay refused, original password still works, attacker's
  rejected); short/bad-token refused; can't overwrite a claimed/admin account; roster shows the setup
  link for pending users **only** in a password deployment.
- `tests/test_oidc.py` — pending user binds on first OIDC login; a password user is never a pending OIDC
  claim; **first-claim-locks** both directions; connector login shows only the configured method; a
  password POST is refused server-side in an OIDC deployment.
- Gate green: ruff + ruff-format + full pytest (890) + gitleaks; patch coverage 100% (onboarding 96% — the
  3 uncovered lines are defensive store-unavailable guards).
- Reviewed with `/code-review` + `/security-review` (new public credential surface); findings addressed.

## Checklist

- [x] Tests added and passing; gate green
- [x] No real customer names / data / credentials — neutral placeholders only
- [x] No new network egress (OIDC reuses `oidc.py`, the existing single egress module)
- [x] Flat access preserved (no role/permission column)
- [ ] Manual end-to-end smoke behind a Cloudflare tunnel — OIDC bind + the setup-link password path

Spec: ACE-011
