### PR TITLE
Admin read-only Model explorer (catalog idiom)

### DIFF
--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -115,6 +115,24 @@ The admin console also has two read-only activity tabs:
 The `tool_calls` log grows one row per call and has **no automatic retention** — it's your local store,
 so prune it on your own schedule if it gets large.
 
+### Model view
+
+The **Model** tab (`{base}/admin/model`) is a **read-only** explorer of the semantic model you've
+deployed — the same tree the MCP tools serve, so it can't drift from what Claude actually reads. It's a
+catalog: a browse rail (datasource → subject area → table) and one page at a time —
+
+- a **datasource overview** (description, glossary, storage-connection names/types, the subject areas),
+- a **subject-area landing** (its tables, metrics, entities),
+- a **table page** — the schema, with each column's type and description, and flags only where they
+  carry signal (**PK / FK / sensitive / unit / enum / caveat**). Trust is shown as a single table-level
+  **confidence** badge; **caveats** (the domain gotchas) are elevated to a callout; wide tables collapse
+  behind "show all N", and tables that author `column_groups` render those as collapsible sections,
+- a **domain-context** page (your `ORGANIZATION.md`, rendered as safe markdown).
+
+It is **read-only by construction** — a single GET endpoint, no write path. Editing the model stays
+conversational in Claude (the in-app editor is a Hosted feature); connection **credentials are never
+rendered** (names and types only). Deploy a change in Claude and it shows up here on the next deploy.
+
 ### Local end-to-end test (HTTPS via a tunnel)
 
 OAuth and the `Secure` admin cookie need HTTPS, so expose the local server through a tunnel:

--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -127,6 +127,8 @@ catalog: a browse rail (datasource → subject area → table) and one page at a
   carry signal (**PK / FK / sensitive / unit / enum / caveat**). Trust is shown as a single table-level
   **confidence** badge; **caveats** (the domain gotchas) are elevated to a callout; wide tables collapse
   behind "show all N", and tables that author `column_groups` render those as collapsible sections,
+- a **Relationships** page (when the model has cross-area joins) — the org-level relationships that
+  span subject areas, **grouped by area-pair**, so the cross-area topology is readable in one place,
 - a **domain-context** page (your `ORGANIZATION.md`, rendered as safe markdown).
 
 It is **read-only by construction** — a single GET endpoint, no write path. Editing the model stays

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -928,6 +928,14 @@ def model_overview_html(org: Any, version: str | None, datasource: str, datasour
         f'<h2 class="sec">Subject areas <span class="c">{len(org.subject_areas)}</span></h2>'
         f'<div class="tlist">{areas}</div>'
     )
+    # Org-level (cross-area) metrics/entities belong to no single area — surface them here so they
+    # aren't silently dropped.
+    if org.cross_subject_area_metrics:
+        cards = "".join(_metric_card_html(m) for m in org.cross_subject_area_metrics)
+        content += f'<h2 class="sec">Cross-area metrics</h2><div class="grid">{cards}</div>'
+    if org.cross_subject_area_entities:
+        cards = "".join(_entity_card_html(e) for e in org.cross_subject_area_entities)
+        content += f'<h2 class="sec">Cross-area entities</h2><div class="grid">{cards}</div>'
     return _model_shell(content, tree, **chrome)
 
 
@@ -1174,6 +1182,25 @@ def model_table_html(org: Any, area: Any, table: Any, datasource: str, datasourc
     return _model_shell(content, tree, **chrome)
 
 
+def model_context_html(org: Any, memory: dict[str, str], datasource: str, datasources: list[str],
+                       **chrome: str) -> str:
+    """The Domain-context page — the deployed ORGANIZATION.md rendered as (safe) markdown."""
+    tree = _model_tree_html(org, datasource, datasources, active_view="context")
+    org_md = memory.get("organization")
+    doc = (
+        f'<div class="context">{ui.md(org_md)}</div>'
+        if org_md
+        else '<p class="lead">No domain context (ORGANIZATION.md) deployed for this datasource.</p>'
+    )
+    content = (
+        f'<div class="crumbs"><a href="{_model_url(datasource)}">{ui.esc(datasource)}</a>'
+        '<span class="sep">/</span>Domain context</div><h1>Domain context</h1>'
+        '<p class="lead">The deployed ORGANIZATION.md — the domain notes Claude reads as context. '
+        f'Read-only.</p>{doc}'
+    )
+    return _model_shell(content, tree, **chrome)
+
+
 async def admin_model(request: Request) -> Response:
     """The read-only Model explorer. Session-gated; a pure GET projection of the served model. Query:
     `?datasource=` (defaults to the first served), `?area=`, `?view=context`."""
@@ -1194,6 +1221,9 @@ async def admin_model(request: Request) -> Response:
         org = model_store.load_organization(store, datasource)
         if org is None:
             return HTMLResponse(model_empty_html(datasource, datasources, **chrome))
+        if request.query_params.get("view") == "context":
+            memory = model_store.load_memory(store, datasource)
+            return HTMLResponse(model_context_html(org, memory, datasource, datasources, **chrome))
         area_name = request.query_params.get("area")
         if area_name:
             area = next((a for a in org.subject_areas if a.name == area_name), None)

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -16,6 +16,7 @@ import hmac
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from urllib.parse import quote
 
 import jwt
 import ui
@@ -744,6 +745,274 @@ async def admin_set_status(request: Request) -> Response:
     )
 
 
+# ---------------------------------------------------------------------------
+# Admin console — Model tab (read-only model explorer)
+#
+# A pure projection of the served model (`model_store.load_organization`) + the domain docs
+# (`load_memory`) — the SAME tree every MCP tool reads, so there is zero drift and no second store.
+# Read-only by construction: the only route is a GET (see `routes()`), there is no write path, and
+# `storage_connections[].storage_config` (hosts/credentials) is NEVER rendered. The catalog idiom (a
+# browse tree + one page at a time) keeps a wide model — real tables run to dozens of columns —
+# legible. Builders are split from the handler so previews can render them with sample data.
+# ---------------------------------------------------------------------------
+
+# Trust posture is surfaced as an honest read-only badge (agami's differentiator: the model says how
+# much to trust each piece), never as a clickable review control — that editor is Hosted.
+_CONF_LABEL = {"confirmed": "✓ confirmed", "inferred": "~ inferred", "proposed": "⋯ proposed"}
+
+
+def _conf_badge(confidence: str | None) -> str:
+    c = (confidence or "").lower()
+    if c not in _CONF_LABEL:
+        return ""
+    return f'<span class="badge b-{c}">{_CONF_LABEL[c]}</span>'
+
+
+def _human_count(n: int | None) -> str:
+    """A compact row-count, e.g. 6591 -> '≈ 6.6k', 612000 -> '≈ 612k'. None -> '' (unknown)."""
+    if n is None:
+        return ""
+    if n < 1000:
+        return f"≈ {n}"
+    if n < 1_000_000:
+        return f"≈ {n / 1000:.1f}k".replace(".0k", "k")
+    return f"≈ {n / 1_000_000:.1f}M".replace(".0M", "M")
+
+
+def _model_url(datasource: str, *, area: str | None = None, table: str | None = None,
+               view: str | None = None) -> str:
+    """An attribute-safe `/admin/model` href. Values are %-encoded (names may contain spaces); the
+    `&` separators are written as `&amp;` so the whole string is safe in an HTML attribute."""
+    parts = [f"datasource={quote(datasource)}"]
+    if area is not None:
+        parts.append(f"area={quote(area)}")
+    if table is not None:
+        parts.append(f"table={quote(table)}")
+    if view is not None:
+        parts.append(f"view={quote(view)}")
+    return "/admin/model?" + "&amp;".join(parts)
+
+
+def _model_tree_html(org: Any, datasource: str, datasources: list[str], *,
+                     active_area: str | None = None, active_view: str | None = None) -> str:
+    """The left browse rail: a datasource picker (only when more than one is served), an Overview
+    link, the subject areas, and the Domain-context node."""
+    if len(datasources) > 1:
+        opts = "".join(
+            f'<option value="{ui.esc(d)}"{" selected" if d == datasource else ""}>{ui.esc(d)}'
+            "</option>"
+            for d in datasources
+        )
+        picker = (
+            '<form class="ds" method="get" action="/admin/model">'
+            '<span class="muted">Datasource</span>'
+            f'<select name="datasource" onchange="this.form.submit()">{opts}</select></form>'
+        )
+    else:
+        picker = (
+            f'<div class="ds"><span class="muted">Datasource</span>'
+            f'<b>{ui.esc(datasource)}</b></div>'
+        )
+    overview_cls = "navitem" + (" active" if active_area is None and active_view is None else "")
+    areas = "".join(
+        f'<a class="navitem{" active" if a.name == active_area else ""}" '
+        f'href="{_model_url(datasource, area=a.name)}">{ui.esc(a.name)} '
+        f'<span class="n">{len(a.tables_defined)}</span></a>'
+        for a in org.subject_areas
+    )
+    context_cls = "navitem" + (" active" if active_view == "context" else "")
+    return (
+        f'<aside class="tree">{picker}'
+        f'<a class="{overview_cls}" href="{_model_url(datasource)}">Overview</a>'
+        f'<h4>Subject areas</h4>{areas}'
+        f'<h4>Browse</h4>'
+        f'<a class="{context_cls}" href="{_model_url(datasource, view="context")}">Domain context</a>'
+        "</aside>"
+    )
+
+
+def _model_shell(content: str, tree: str, *, admin_label: str = "", admin_email: str = "") -> str:
+    """Wrap the browse tree + a content pane in the admin shell with the Model tab active."""
+    body = f'<div class="explorer">{tree}<main class="content">{content}</main></div>'
+    return ui.admin_shell("Model · agami admin", "model", body,
+                          admin_label=admin_label, admin_email=admin_email)
+
+
+def model_empty_html(datasource: str, datasources: list[str], **chrome: str) -> str:
+    """The clean state when nothing is deployed yet (no served model rows)."""
+    content = (
+        '<div class="crumbs">Model</div><h1>Model</h1>'
+        '<p class="lead">No model deployed yet. Author your semantic model in Claude with the agami '
+        "plugin and deploy it — the served subject areas, tables, and metrics will show up here, "
+        "read-only.</p>"
+    )
+    label = datasource or (datasources[0] if datasources else "")
+    tree = (
+        f'<aside class="tree"><div class="ds"><span class="muted">Datasource</span>'
+        f'<b>{ui.esc(label) or "—"}</b></div></aside>'
+    )
+    return _model_shell(content, tree, **chrome)
+
+
+def _glossary_html(key_terminology: dict[str, str]) -> str:
+    if not key_terminology:
+        return ""
+    terms = "".join(
+        f'<span class="term"><b>{ui.esc(k)}</b> {ui.esc(v)}</span>'
+        for k, v in key_terminology.items()
+    )
+    return f'<h2 class="sec">Glossary</h2><div class="gloss">{terms}</div>'
+
+
+def _storage_html(connections: list[Any]) -> str:
+    # Names + types only — storage_config (hosts/credentials) is deliberately never rendered.
+    if not connections:
+        return ""
+    rows = "".join(
+        f'<span class="term"><b>{ui.esc(c.name)}</b> '
+        f'{ui.esc(getattr(c, "storage_type", "") or "")}</span>'
+        for c in connections
+    )
+    return f'<h2 class="sec">Storage connections</h2><div class="gloss">{rows}</div>'
+
+
+def model_overview_html(org: Any, version: str | None, datasource: str, datasources: list[str],
+                        **chrome: str) -> str:
+    """The datasource landing: org header + glossary + storage + the subject-area list."""
+    tree = _model_tree_html(org, datasource, datasources)
+    table_total = sum(len(a.tables_defined) for a in org.subject_areas)
+    ver = ui.esc(version[:8]) if version else f"v{org.version}"
+    stats = (
+        f'<div class="stat"><div class="k">Subject areas</div>'
+        f'<div class="v">{len(org.subject_areas)}</div></div>'
+        f'<div class="stat"><div class="k">Tables</div><div class="v">{table_total}</div></div>'
+        f'<div class="stat"><div class="k">Version</div>'
+        f'<div class="v mono" style="font-size:14px">{ver}</div></div>'
+        f'<div class="stat"><div class="k">Fiscal year</div>'
+        f'<div class="v" style="font-size:14px">Starts month {org.fiscal_year_start_month}</div></div>'
+    )
+    areas = "".join(
+        f'<a class="trow" href="{_model_url(datasource, area=a.name)}">'
+        f'<span class="nm">{ui.esc(a.name)}</span>'
+        f'<span class="d">{ui.esc(a.description or "")}</span>'
+        f'<span class="meta">{len(a.tables_defined)} tables · {len(a.metrics)} metrics</span>'
+        '<span class="chev">›</span></a>'
+        for a in org.subject_areas
+    )
+    content = (
+        '<div class="crumbs">Model</div>'
+        f'<div class="h1row"><h1>{ui.esc(org.organization)}</h1>'
+        '<span class="readonly-pill">Read-only · edit in Claude</span></div>'
+        f'<p class="lead">{ui.esc(org.description or "The deployed semantic model.")}</p>'
+        f'<div class="statrow">{stats}</div>'
+        f'{_glossary_html(org.key_terminology)}'
+        f'{_storage_html(org.storage_connections)}'
+        f'<h2 class="sec">Subject areas <span class="c">{len(org.subject_areas)}</span></h2>'
+        f'<div class="tlist">{areas}</div>'
+    )
+    return _model_shell(content, tree, **chrome)
+
+
+def _metric_card_html(m: Any) -> str:
+    aliases = ", ".join(m.other_names) if m.other_names else ""
+    alias_html = f' <span class="al">· {ui.esc(aliases)}</span>' if aliases else ""
+    unit = f' <span class="al">· {ui.esc(m.unit)}</span>' if m.unit else ""
+    calc = ui.esc(m.calculation or "")
+    return (
+        f'<div class="mcard"><div class="nm">{ui.esc(m.name)}{alias_html}{unit}</div>'
+        f'<div class="muted" style="font-size:13px">{ui.esc(m.description or "")}</div>'
+        f'<span class="calc">{calc}</span></div>'
+    )
+
+
+def _entity_card_html(e: Any) -> str:
+    aliases = ", ".join(e.other_names) if e.other_names else ""
+    alias_html = f' <span class="al">· {ui.esc(aliases)}</span>' if aliases else ""
+    pattern = (
+        f' <span class="muted mono" style="font-size:12px">{ui.esc(e.value_pattern)}</span>'
+        if e.value_pattern else ""
+    )
+    return (
+        f'<div class="mcard"><div class="nm">{ui.esc(e.name)}{alias_html} '
+        f'{_conf_badge(e.confidence)}</div>'
+        f'<div class="muted" style="font-size:13px">{ui.esc(e.description or "")}{pattern}</div></div>'
+    )
+
+
+def model_area_html(org: Any, area: Any, datasource: str, datasources: list[str],
+                    **chrome: str) -> str:
+    """A subject-area landing: its tables (scannable), then metrics + entities as cards."""
+    tree = _model_tree_html(org, datasource, datasources, active_area=area.name)
+    tables = "".join(
+        f'<div class="trow"><span class="nm">{ui.esc(t.name)}</span>'
+        f'<span class="d">{ui.esc(t.description or "")}</span>'
+        f'<span class="meta">{len(t.columns)} cols · '
+        f'{ui.esc(_human_count(_est_rows_obj(t)))}</span>{_conf_badge(t.confidence)}</div>'
+        for t in area.tables_defined
+    )
+    metrics = "".join(_metric_card_html(m) for m in area.metrics)
+    entities = "".join(_entity_card_html(e) for e in area.entities)
+    window = (
+        f'<span>default window · <b>{ui.esc(area.default_time_window)}</b></span>'
+        if area.default_time_window else ""
+    )
+    content = (
+        f'<div class="crumbs"><a href="{_model_url(datasource)}">{ui.esc(datasource)}</a>'
+        f'<span class="sep">/</span>{ui.esc(area.name)}</div>'
+        f'<h1>{ui.esc(area.name)}</h1>'
+        f'<div class="subline"><span><b>{len(area.tables_defined)}</b> tables</span>'
+        f'<span><b>{len(area.metrics)}</b> metrics</span>'
+        f'<span><b>{len(area.entities)}</b> entities</span>{window}</div>'
+        f'<p class="lead">{ui.esc(area.description or "")}</p>'
+        f'<h2 class="sec">Tables <span class="c">{len(area.tables_defined)}</span></h2>'
+        f'<div class="tlist">{tables}</div>'
+    )
+    if metrics:
+        content += f'<h2 class="sec">Metrics</h2><div class="grid">{metrics}</div>'
+    if entities:
+        content += f'<h2 class="sec">Entities</h2><div class="grid">{entities}</div>'
+    return _model_shell(content, tree, **chrome)
+
+
+def _est_rows_obj(table: Any) -> int | None:
+    ph = getattr(table, "performance_hints", None)
+    return getattr(ph, "estimated_row_count", None) if ph is not None else None
+
+
+async def admin_model(request: Request) -> Response:
+    """The read-only Model explorer. Session-gated; a pure GET projection of the served model. Query:
+    `?datasource=` (defaults to the first served), `?area=`, `?view=context`."""
+    import model_store
+
+    admin = current_admin(request)
+    if admin is None:
+        return RedirectResponse("/admin/login", status_code=302)
+    store = _open_store()
+    try:
+        chrome = _admin_chrome(store, admin)
+        datasources = model_store.list_datasources(store) if store is not None else []
+        if not datasources:
+            return HTMLResponse(model_empty_html("", [], **chrome))
+        datasource = request.query_params.get("datasource") or datasources[0]
+        if datasource not in datasources:  # an unknown/stale datasource param → the first served
+            datasource = datasources[0]
+        org = model_store.load_organization(store, datasource)
+        if org is None:
+            return HTMLResponse(model_empty_html(datasource, datasources, **chrome))
+        area_name = request.query_params.get("area")
+        if area_name:
+            area = next((a for a in org.subject_areas if a.name == area_name), None)
+            if area is not None:
+                return HTMLResponse(model_area_html(org, area, datasource, datasources, **chrome))
+        version = model_store.newest_model_version(store, datasource)
+        return HTMLResponse(
+            model_overview_html(org, version, datasource, datasources, **chrome)
+        )
+    finally:
+        if store is not None:
+            store.close()
+
+
 def routes() -> list:
     """The `/admin/*` routes, for the transport to mount. Each is session-gated in the handler (the
     transport adds these paths to the bearer public-skip — they do their own auth, not the MCP one)."""
@@ -751,6 +1020,8 @@ def routes() -> list:
 
     return [
         Route("/admin", admin_home, methods=["GET"]),
+        # Read-only model explorer — GET only, by design (no write path can hide behind /admin/model).
+        Route("/admin/model", admin_model, methods=["GET"]),
         Route("/admin/login", admin_login, methods=["GET", "POST"]),
         Route("/admin/logout", admin_logout, methods=["GET"]),
         # The admin OIDC start (handler lives in oauth_server, with the OIDC machinery). The IdP
@@ -763,6 +1034,7 @@ def routes() -> list:
 
 ADMIN_PATHS = (
     "/admin",
+    "/admin/model",
     "/admin/login",
     "/admin/logout",
     "/admin/oidc/start",

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -793,10 +793,29 @@ def _model_url(datasource: str, *, area: str | None = None, table: str | None = 
     return "/admin/model?" + "&amp;".join(parts)
 
 
+def _area_nav_html(a: Any, datasource: str, active_area: str | None,
+                   active_table: str | None) -> str:
+    """One area node; when it's the active area it expands into links to its tables."""
+    head = (
+        f'<a class="navitem{" active" if a.name == active_area else ""}" '
+        f'href="{_model_url(datasource, area=a.name)}">{ui.esc(a.name)} '
+        f'<span class="n">{len(a.tables_defined)}</span></a>'
+    )
+    if a.name != active_area:
+        return head
+    leaves = "".join(
+        f'<a class="leaf{" active" if t.name == active_table else ""}" '
+        f'href="{_model_url(datasource, area=a.name, table=t.name)}">{ui.esc(t.name)}</a>'
+        for t in a.tables_defined
+    )
+    return head + f'<div class="children">{leaves}</div>' if leaves else head
+
+
 def _model_tree_html(org: Any, datasource: str, datasources: list[str], *,
-                     active_area: str | None = None, active_view: str | None = None) -> str:
+                     active_area: str | None = None, active_table: str | None = None,
+                     active_view: str | None = None) -> str:
     """The left browse rail: a datasource picker (only when more than one is served), an Overview
-    link, the subject areas, and the Domain-context node."""
+    link, the subject areas (the active one expands to its tables), and the Domain-context node."""
     if len(datasources) > 1:
         opts = "".join(
             f'<option value="{ui.esc(d)}"{" selected" if d == datasource else ""}>{ui.esc(d)}'
@@ -813,12 +832,11 @@ def _model_tree_html(org: Any, datasource: str, datasources: list[str], *,
             f'<div class="ds"><span class="muted">Datasource</span>'
             f'<b>{ui.esc(datasource)}</b></div>'
         )
-    overview_cls = "navitem" + (" active" if active_area is None and active_view is None else "")
+    overview_cls = "navitem" + (
+        " active" if active_area is None and active_view is None else ""
+    )
     areas = "".join(
-        f'<a class="navitem{" active" if a.name == active_area else ""}" '
-        f'href="{_model_url(datasource, area=a.name)}">{ui.esc(a.name)} '
-        f'<span class="n">{len(a.tables_defined)}</span></a>'
-        for a in org.subject_areas
+        _area_nav_html(a, datasource, active_area, active_table) for a in org.subject_areas
     )
     context_cls = "navitem" + (" active" if active_view == "context" else "")
     return (
@@ -944,10 +962,12 @@ def model_area_html(org: Any, area: Any, datasource: str, datasources: list[str]
     """A subject-area landing: its tables (scannable), then metrics + entities as cards."""
     tree = _model_tree_html(org, datasource, datasources, active_area=area.name)
     tables = "".join(
-        f'<div class="trow"><span class="nm">{ui.esc(t.name)}</span>'
+        f'<a class="trow" href="{_model_url(datasource, area=area.name, table=t.name)}">'
+        f'<span class="nm">{ui.esc(t.name)}</span>'
         f'<span class="d">{ui.esc(t.description or "")}</span>'
         f'<span class="meta">{len(t.columns)} cols · '
-        f'{ui.esc(_human_count(_est_rows_obj(t)))}</span>{_conf_badge(t.confidence)}</div>'
+        f'{ui.esc(_human_count(_est_rows_obj(t)))}</span>{_conf_badge(t.confidence)}'
+        '<span class="chev">›</span></a>'
         for t in area.tables_defined
     )
     metrics = "".join(_metric_card_html(m) for m in area.metrics)
@@ -979,6 +999,181 @@ def _est_rows_obj(table: Any) -> int | None:
     return getattr(ph, "estimated_row_count", None) if ph is not None else None
 
 
+# --- the table (dataset) page ------------------------------------------------
+
+_COL_THEAD = (
+    '<thead><tr><th style="width:210px">Column</th><th style="width:120px">Type</th>'
+    '<th>Description</th><th style="width:170px" class="flags">Flags</th></tr></thead>'
+)
+
+
+def _col_flags_html(col: Any) -> str:
+    """Per-column flags — only what carries signal (PK / FK / enum / unit / sensitive / caveat); the
+    redundant per-column 'confirmed/approved' the old view repeated on every row is left out."""
+    flags = []
+    if col.primary_key:
+        flags.append('<span class="badge b-pk">PK</span>')
+    fk = getattr(col, "foreign_key", None)
+    if fk is not None and getattr(fk, "table", None):
+        flags.append(f'<span class="badge b-fk">FK → {ui.esc(fk.table)}</span>')
+    if getattr(col, "choice_field", None):
+        flags.append('<span class="badge b-soft">enum</span>')
+    if col.unit:
+        flags.append(f'<span class="badge b-soft">{ui.esc(str(col.unit))}</span>')
+    if col.sensitive:
+        flags.append('<span class="badge b-sensitive">● sensitive</span>')
+    if col.caveats:
+        flags.append('<span class="badge b-proposed">⚠ caveat</span>')
+    return " ".join(flags)
+
+
+def _col_rows_html(columns: list[Any]) -> str:
+    """The <tr>s for a set of columns; a column with caveats gets an inline note row beneath it."""
+    out = ""
+    for col in columns:
+        if col.description:
+            desc = ui.esc(col.description)
+            if getattr(col, "description_source", None) == "ai_unvalidated":
+                desc += ' <span class="aichip" title="AI-described, unvalidated">AI</span>'
+        else:
+            desc = '<span class="dash">—</span>'
+        out += (
+            '<tr class="crow">'
+            f'<td class="cn">{ui.esc(col.name)}</td>'
+            f'<td><span class="ct">{ui.esc(str(col.type))}</span></td>'
+            f'<td class="cd">{desc}</td>'
+            f'<td class="flags">{_col_flags_html(col)}</td></tr>'
+        )
+        if col.caveats:
+            note = "<br>".join(ui.esc(c) for c in col.caveats)
+            out += f'<tr class="noterow"><td colspan="4"><div class="note">{note}</div></td></tr>'
+    return out
+
+
+def _columns_flat_html(columns: list[Any]) -> str:
+    """A flat schema table. Narrow tables show in full; wide ones show the first 8 and tuck the rest
+    behind a JS-free 'show all N' <details> — the default stays short without hiding anything."""
+    if len(columns) <= 12:
+        return f'<table class="cols">{_COL_THEAD}<tbody>{_col_rows_html(columns)}</tbody></table>'
+    head = _col_rows_html(columns[:8])
+    rest = _col_rows_html(columns[8:])
+    return (
+        f'<table class="cols">{_COL_THEAD}<tbody>{head}</tbody></table>'
+        f'<details class="showmore"><summary>Show all {len(columns)} columns</summary>'
+        f'<table class="cols"><tbody>{rest}</tbody></table></details>'
+    )
+
+
+def _columns_grouped_html(table: Any) -> str:
+    """Collapsible groups from the table's authored `column_groups` (labelled by
+    `column_group_descriptions`); columns in no authored group fall into a trailing 'Other'."""
+    descs = getattr(table, "column_group_descriptions", {}) or {}
+    by_name = {c.name: c for c in table.columns}
+    seen: set[str] = set()
+    blocks = ""
+    for i, (gname, colnames) in enumerate(table.column_groups.items()):
+        cols = [by_name[n] for n in colnames if n in by_name]
+        seen.update(colnames)
+        gloss = ui.esc(descs.get(gname, ""))
+        gloss_html = f'<span class="gdesc">{gloss}</span>' if gloss else ""
+        blocks += (
+            f'<details class="grp"{" open" if i < 2 else ""}><summary>'
+            f'<span class="gname">{ui.esc(gname)}</span>{gloss_html}'
+            f'<span class="gn">{len(cols)}</span></summary>'
+            f'<table class="cols"><tbody>{_col_rows_html(cols)}</tbody></table></details>'
+        )
+    other = [c for c in table.columns if c.name not in seen]
+    if other:
+        blocks += (
+            '<details class="grp"><summary><span class="gname">Other</span>'
+            f'<span class="gn">{len(other)}</span></summary>'
+            f'<table class="cols"><tbody>{_col_rows_html(other)}</tbody></table></details>'
+        )
+    return blocks
+
+
+def _caveat_callout(caveats: list[str]) -> str:
+    if not caveats:
+        return ""
+    body = "<br>".join(ui.esc(c) for c in caveats)
+    return f'<div class="caveat"><span class="ic">⚠</span><div class="t">{body}</div></div>'
+
+
+def _table_rels_html(org: Any, area: Any, table_name: str) -> str:
+    """Relationships touching this table — within-area + the org-level cross-area ones."""
+    rels = list(area.relationships) + list(org.cross_subject_area_relationships)
+    rows = "".join(
+        f'<div class="rel"><span class="mono">{ui.esc(r.from_table)}</span>'
+        f'<span class="arr">→</span><span class="mono">{ui.esc(r.to_table)}</span>'
+        f'<span class="badge b-soft">{ui.esc(str(r.relationship))}</span>'
+        f'<span class="ro">{ui.esc(str(r.join_type))} · {ui.esc(str(r.confidence))}</span></div>'
+        for r in rels
+        if r.from_table == table_name or r.to_table == table_name
+    )
+    if not rows:
+        return ""
+    return f'<h2 class="sec">Relationships</h2><div class="card">{rows}</div>'
+
+
+def _table_metrics_html(area: Any, table_name: str) -> str:
+    """Metrics whose `source_tables` include this table."""
+    using = [m for m in area.metrics if table_name in (m.source_tables or [])]
+    if not using:
+        return ""
+    cards = "".join(_metric_card_html(m) for m in using)
+    return f'<h2 class="sec">Used by metrics</h2><div class="grid">{cards}</div>'
+
+
+def model_table_html(org: Any, area: Any, table: Any, datasource: str, datasources: list[str],
+                     **chrome: str) -> str:
+    """A table (dataset) page — the heart of the explorer: header, caveats, columns
+    (grouped-when-authored else flat), then relationships + metrics that use it."""
+    tree = _model_tree_html(org, datasource, datasources,
+                            active_area=area.name, active_table=table.name)
+    schema = f'<span class="schema">{ui.esc(table.schema_name)}.</span>' if table.schema_name else ""
+    rows = _human_count(_est_rows_obj(table))
+    grain = ", ".join(table.grain) if table.grain else ""
+    aichip = (
+        ' <span class="descsrc">AI-described · unvalidated</span>'
+        if getattr(table, "description_source", None) == "ai_unvalidated" else ""
+    )
+    sql_block = ""
+    if getattr(table, "source_type", None) == "sql" and table.sql:
+        sql_block = (
+            '<h2 class="sec">Defining SQL</h2>'
+            f'<pre class="code" style="white-space:pre-wrap;display:block;padding:12px">'
+            f'{ui.esc(table.sql)}</pre>'
+        )
+    subline = "".join(
+        f"<span>{s}</span>"
+        for s in (
+            f"<b>{len(table.columns)}</b> columns",
+            f"<b>{ui.esc(rows)}</b> rows" if rows else "",
+            f'grain · <b class="mono">{ui.esc(grain)}</b>' if grain else "",
+            ui.esc(table.storage_connection or ""),
+        )
+        if s
+    )
+    columns = _columns_grouped_html(table) if table.column_groups else _columns_flat_html(table.columns)
+    content = (
+        f'<div class="crumbs"><a href="{_model_url(datasource)}">{ui.esc(datasource)}</a>'
+        f'<span class="sep">/</span>'
+        f'<a href="{_model_url(datasource, area=area.name)}">{ui.esc(area.name)}</a>'
+        f'<span class="sep">/</span>{ui.esc(table.name)}</div>'
+        f'<div class="h1row"><h1>{schema}{ui.esc(table.name)}</h1>'
+        f'{_conf_badge(table.confidence)}'
+        '<span class="readonly-pill">Read-only · edit in Claude</span></div>'
+        f'<div class="subline">{subline}</div>'
+        f'<p class="desc">{ui.esc(table.description or "")}{aichip}</p>'
+        f'{_caveat_callout(table.caveats)}'
+        f'<h2 class="sec">Columns <span class="c">{len(table.columns)}</span></h2>'
+        f'{columns}{sql_block}'
+        f'{_table_rels_html(org, area, table.name)}'
+        f'{_table_metrics_html(area, table.name)}'
+    )
+    return _model_shell(content, tree, **chrome)
+
+
 async def admin_model(request: Request) -> Response:
     """The read-only Model explorer. Session-gated; a pure GET projection of the served model. Query:
     `?datasource=` (defaults to the first served), `?area=`, `?view=context`."""
@@ -1003,6 +1198,13 @@ async def admin_model(request: Request) -> Response:
         if area_name:
             area = next((a for a in org.subject_areas if a.name == area_name), None)
             if area is not None:
+                table_name = request.query_params.get("table")
+                if table_name:
+                    table = next((t for t in area.tables_defined if t.name == table_name), None)
+                    if table is not None:
+                        return HTMLResponse(
+                            model_table_html(org, area, table, datasource, datasources, **chrome)
+                        )
                 return HTMLResponse(model_area_html(org, area, datasource, datasources, **chrome))
         version = model_store.newest_model_version(store, datasource)
         return HTMLResponse(

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -858,10 +858,13 @@ def _model_tree_html(
             "</option>"
             for d in datasources
         )
+        # onchange auto-submits for JS users; the Go button is the no-JS fallback (the rest of the
+        # admin UI is JS-free, so the picker keeps a working control without JavaScript too).
         picker = (
             '<form class="ds" method="get" action="/admin/model">'
             '<span class="muted">Datasource</span>'
-            f'<select name="datasource" onchange="this.form.submit()">{opts}</select></form>'
+            f'<select name="datasource" onchange="this.form.submit()">{opts}</select>'
+            '<button type="submit" class="ds-go">Go</button></form>'
         )
     else:
         picker = (

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -78,7 +78,9 @@ def _row_action(user: dict[str, Any], csrf: str, admin_username: str) -> str:
     if user.get("username") == admin_username:
         return '<span class="muted">—</span>'
     active = user["status"] == "active"
-    target, label, cls = ("disabled", "Disable", "danger") if active else ("active", "Enable", "secondary")
+    target, label, cls = (
+        ("disabled", "Disable", "danger") if active else ("active", "Enable", "secondary")
+    )
     return (
         '<form method="post" action="/admin/users/status" style="display:inline">'
         f'<input type="hidden" name="csrf" value="{ui.esc(csrf)}">'
@@ -118,7 +120,9 @@ or a password they set the first time — and can then use this agami server fro
 def _signin_cell(user: dict[str, Any], setup_links: dict[str, str]) -> str:
     """The Sign-in column: the user's method, plus — for a *pending* user in a password deployment —
     a copy-able setup link the admin shares out-of-band (the page is session-gated, admin-only)."""
-    sign_in = user.get("oidc_provider") or ("password" if user.get("has_password") else "not set yet")
+    sign_in = user.get("oidc_provider") or (
+        "password" if user.get("has_password") else "not set yet"
+    )
     link = setup_links.get(user.get("username", ""))
     extra = (
         f'<details class="setup"><summary>Setup link</summary>'
@@ -148,7 +152,7 @@ def users_tab_html(
     for u in users:
         rows += (
             "<tr>"
-            f'<td><strong>{ui.esc(_full_name(u))}</strong></td>'
+            f"<td><strong>{ui.esc(_full_name(u))}</strong></td>"
             f'<td class="muted">{ui.esc(u.get("email") or "—")}</td>'
             f"{_signin_cell(u, setup_links)}"
             f"<td>{_status_pill(u['status'])}</td>"
@@ -220,7 +224,7 @@ def _call_drawer(r: dict[str, Any], idx: int) -> str:
     )
     sql = (
         f'<label>SQL</label><pre class="code" style="white-space:pre-wrap;padding:12px;display:block">'
-        f'{ui.esc(r["sql"])}</pre>'
+        f"{ui.esc(r['sql'])}</pre>"
         if r.get("sql")
         else ""
     )
@@ -239,7 +243,9 @@ def _call_drawer(r: dict[str, Any], idx: int) -> str:
 </div></aside></div>"""
 
 
-def calls_tab_html(rows: list[dict[str, Any]], *, admin_label: str = "", admin_email: str = "") -> str:
+def calls_tab_html(
+    rows: list[dict[str, Any]], *, admin_label: str = "", admin_email: str = ""
+) -> str:
     """The Tool calls tab: every MCP call, newest first, each with a detail drawer."""
     body_rows, drawers = "", ""
     for i, r in enumerate(rows):
@@ -250,7 +256,7 @@ def calls_tab_html(rows: list[dict[str, Any]], *, admin_label: str = "", admin_e
         body_rows += (
             "<tr>"
             f"<td>{_utc(r['ts'])}</td>"
-            f'<td><strong>{ui.esc(r.get("actor") or "—")}</strong></td>'
+            f"<td><strong>{ui.esc(r.get('actor') or '—')}</strong></td>"
             f'<td><span class="pill" style="background:var(--chip);color:var(--ink)">{ui.esc(r["tool_name"])}</span></td>'
             f'<td class="muted">{ui.esc(r.get("datasource") or "—")}</td>'
             f'<td class="muted">{r.get("row_count") if r.get("row_count") is not None else "—"}</td>'
@@ -266,8 +272,14 @@ def calls_tab_html(rows: list[dict[str, Any]], *, admin_label: str = "", admin_e
 <div class="table-wrap"><table>
 <thead><tr><th>Time</th><th>User</th><th>Tool</th><th>Datasource</th><th>Rows</th><th>Latency</th><th>Status</th><th></th></tr></thead>
 <tbody>{body_rows}</tbody></table></div>"""
-    return ui.admin_shell("Tool calls · agami admin", "calls", panel, admin_label=admin_label,
-                          admin_email=admin_email, extra=drawers)
+    return ui.admin_shell(
+        "Tool calls · agami admin",
+        "calls",
+        panel,
+        admin_label=admin_label,
+        admin_email=admin_email,
+        extra=drawers,
+    )
 
 
 def _session_drawer(s: dict[str, Any], idx: int) -> str:
@@ -278,19 +290,21 @@ def _session_drawer(s: dict[str, Any], idx: int) -> str:
         sub = (
             f'<div class="muted" style="margin:2px 0 8px">↳ {ui.esc(q["agent_query"])} '
             f'<span class="muted">· self-reported</span></div>'
-            if q.get("agent_query") else ""
+            if q.get("agent_query")
+            else ""
         )
         sql = (
             f'<pre class="code" style="white-space:pre-wrap;padding:12px;display:block;margin-top:6px">'
-            f'{ui.esc(q["sql"])}</pre>'
-            if q.get("sql") else ""
+            f"{ui.esc(q['sql'])}</pre>"
+            if q.get("sql")
+            else ""
         )
         lat = (str(q["execution_ms"]) + " ms") if q.get("execution_ms") is not None else ""
         cards += (
             '<div style="border-top:1px solid var(--line);padding:14px 0">'
             f'<div style="display:flex;justify-content:space-between"><strong>{ui.esc(question)}</strong>'
             f'<span class="muted" style="font-size:13px">{_utc(q["ts"])} · {lat} {_ok_pill(q["success"])}</span></div>'
-            f'{sub}{sql}'
+            f"{sub}{sql}"
             f'<div class="muted" style="font-size:13px;margin-top:6px">{q.get("row_count") if q.get("row_count") is not None else "—"} rows</div></div>'
         )
     return f"""<input type="checkbox" id="{sid}" class="drawer-toggle">
@@ -313,7 +327,7 @@ def sessions_tab_html(
         body_rows += (
             "<tr>"
             f'<td><label for="sess-{i}" style="cursor:pointer;color:var(--brand)">{_utc(s["started"])}</label></td>'
-            f'<td><strong>{ui.esc(s.get("actor") or "—")}</strong></td>'
+            f"<td><strong>{ui.esc(s.get('actor') or '—')}</strong></td>"
             f'<td class="muted">{ui.esc(s.get("datasource") or "—")}</td>'
             f'<td class="muted">{s["query_count"]}</td>'
             f'<td class="muted">{s["error_count"] or "—"}</td>'
@@ -328,8 +342,14 @@ def sessions_tab_html(
 <div class="table-wrap"><table>
 <thead><tr><th>Started</th><th>User</th><th>Datasource</th><th>Queries</th><th>Errors</th><th>Avg time</th><th>Last activity</th><th></th></tr></thead>
 <tbody>{body_rows}</tbody></table></div>"""
-    return ui.admin_shell("Sessions · agami admin", "sessions", panel, admin_label=admin_label,
-                          admin_email=admin_email, extra=drawers)
+    return ui.admin_shell(
+        "Sessions · agami admin",
+        "sessions",
+        panel,
+        admin_label=admin_label,
+        admin_email=admin_email,
+        extra=drawers,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -600,7 +620,9 @@ async def admin_login(request: Request) -> Response:
         # Same generic message for wrong password, unknown user, or disabled — no enumeration oracle.
         # Keep the social button on the re-render so a failed password attempt doesn't hide it.
         return HTMLResponse(
-            admin_login_body_html(error="Invalid email or password.", provider=_admin_login_provider()),
+            admin_login_body_html(
+                error="Invalid email or password.", provider=_admin_login_provider()
+            ),
             status_code=401,
         )
     if principal.subject != _admin_username():
@@ -647,7 +669,13 @@ async def admin_home(request: Request) -> Response:
     err = _ERR_FLASH.get(request.query_params.get("err", ""), "")
     return HTMLResponse(
         users_tab_html(
-            users, csrf, admin_username=admin, setup_links=_setup_links(users), ok=ok, error=err, **chrome
+            users,
+            csrf,
+            admin_username=admin,
+            setup_links=_setup_links(users),
+            ok=ok,
+            error=err,
+            **chrome,
         )
     )
 
@@ -779,8 +807,9 @@ def _human_count(n: int | None) -> str:
     return f"≈ {n / 1_000_000:.1f}M".replace(".0M", "M")
 
 
-def _model_url(datasource: str, *, area: str | None = None, table: str | None = None,
-               view: str | None = None) -> str:
+def _model_url(
+    datasource: str, *, area: str | None = None, table: str | None = None, view: str | None = None
+) -> str:
     """An attribute-safe `/admin/model` href. Values are %-encoded (names may contain spaces); the
     `&` separators are written as `&amp;` so the whole string is safe in an HTML attribute."""
     parts = [f"datasource={quote(datasource)}"]
@@ -793,8 +822,9 @@ def _model_url(datasource: str, *, area: str | None = None, table: str | None = 
     return "/admin/model?" + "&amp;".join(parts)
 
 
-def _area_nav_html(a: Any, datasource: str, active_area: str | None,
-                   active_table: str | None) -> str:
+def _area_nav_html(
+    a: Any, datasource: str, active_area: str | None, active_table: str | None
+) -> str:
     """One area node; when it's the active area it expands into links to its tables."""
     head = (
         f'<a class="navitem{" active" if a.name == active_area else ""}" '
@@ -811,9 +841,15 @@ def _area_nav_html(a: Any, datasource: str, active_area: str | None,
     return head + f'<div class="children">{leaves}</div>' if leaves else head
 
 
-def _model_tree_html(org: Any, datasource: str, datasources: list[str], *,
-                     active_area: str | None = None, active_table: str | None = None,
-                     active_view: str | None = None) -> str:
+def _model_tree_html(
+    org: Any,
+    datasource: str,
+    datasources: list[str],
+    *,
+    active_area: str | None = None,
+    active_table: str | None = None,
+    active_view: str | None = None,
+) -> str:
     """The left browse rail: a datasource picker (only when more than one is served), an Overview
     link, the subject areas (the active one expands to its tables), and the Domain-context node."""
     if len(datasources) > 1:
@@ -830,20 +866,27 @@ def _model_tree_html(org: Any, datasource: str, datasources: list[str], *,
     else:
         picker = (
             f'<div class="ds"><span class="muted">Datasource</span>'
-            f'<b>{ui.esc(datasource)}</b></div>'
+            f"<b>{ui.esc(datasource)}</b></div>"
         )
-    overview_cls = "navitem" + (
-        " active" if active_area is None and active_view is None else ""
-    )
+    overview_cls = "navitem" + (" active" if active_area is None and active_view is None else "")
     areas = "".join(
         _area_nav_html(a, datasource, active_area, active_table) for a in org.subject_areas
     )
+    # The cross-area Relationships node only appears when the model actually has org-level
+    # (cross-subject-area) relationships — no dead node for a single-area model.
+    rel_node = ""
+    if org.cross_subject_area_relationships:
+        rel_cls = "navitem" + (" active" if active_view == "relationships" else "")
+        rel_node = (
+            f'<a class="{rel_cls}" href="{_model_url(datasource, view="relationships")}">'
+            f'Relationships <span class="n">{len(org.cross_subject_area_relationships)}</span></a>'
+        )
     context_cls = "navitem" + (" active" if active_view == "context" else "")
     return (
         f'<aside class="tree">{picker}'
         f'<a class="{overview_cls}" href="{_model_url(datasource)}">Overview</a>'
-        f'<h4>Subject areas</h4>{areas}'
-        f'<h4>Browse</h4>'
+        f"<h4>Subject areas</h4>{areas}"
+        f"<h4>Browse</h4>{rel_node}"
         f'<a class="{context_cls}" href="{_model_url(datasource, view="context")}">Domain context</a>'
         "</aside>"
     )
@@ -852,8 +895,9 @@ def _model_tree_html(org: Any, datasource: str, datasources: list[str], *,
 def _model_shell(content: str, tree: str, *, admin_label: str = "", admin_email: str = "") -> str:
     """Wrap the browse tree + a content pane in the admin shell with the Model tab active."""
     body = f'<div class="explorer">{tree}<main class="content">{content}</main></div>'
-    return ui.admin_shell("Model · agami admin", "model", body,
-                          admin_label=admin_label, admin_email=admin_email)
+    return ui.admin_shell(
+        "Model · agami admin", "model", body, admin_label=admin_label, admin_email=admin_email
+    )
 
 
 def model_empty_html(datasource: str, datasources: list[str], **chrome: str) -> str:
@@ -867,7 +911,7 @@ def model_empty_html(datasource: str, datasources: list[str], **chrome: str) -> 
     label = datasource or (datasources[0] if datasources else "")
     tree = (
         f'<aside class="tree"><div class="ds"><span class="muted">Datasource</span>'
-        f'<b>{ui.esc(label) or "—"}</b></div></aside>'
+        f"<b>{ui.esc(label) or '—'}</b></div></aside>"
     )
     return _model_shell(content, tree, **chrome)
 
@@ -888,14 +932,15 @@ def _storage_html(connections: list[Any]) -> str:
         return ""
     rows = "".join(
         f'<span class="term"><b>{ui.esc(c.name)}</b> '
-        f'{ui.esc(getattr(c, "storage_type", "") or "")}</span>'
+        f"{ui.esc(getattr(c, 'storage_type', '') or '')}</span>"
         for c in connections
     )
     return f'<h2 class="sec">Storage connections</h2><div class="gloss">{rows}</div>'
 
 
-def model_overview_html(org: Any, version: str | None, datasource: str, datasources: list[str],
-                        **chrome: str) -> str:
+def model_overview_html(
+    org: Any, version: str | None, datasource: str, datasources: list[str], **chrome: str
+) -> str:
     """The datasource landing: org header + glossary + storage + the subject-area list."""
     tree = _model_tree_html(org, datasource, datasources)
     table_total = sum(len(a.tables_defined) for a in org.subject_areas)
@@ -923,8 +968,8 @@ def model_overview_html(org: Any, version: str | None, datasource: str, datasour
         '<span class="readonly-pill">Read-only · edit in Claude</span></div>'
         f'<p class="lead">{ui.esc(org.description or "The deployed semantic model.")}</p>'
         f'<div class="statrow">{stats}</div>'
-        f'{_glossary_html(org.key_terminology)}'
-        f'{_storage_html(org.storage_connections)}'
+        f"{_glossary_html(org.key_terminology)}"
+        f"{_storage_html(org.storage_connections)}"
         f'<h2 class="sec">Subject areas <span class="c">{len(org.subject_areas)}</span></h2>'
         f'<div class="tlist">{areas}</div>'
     )
@@ -956,17 +1001,19 @@ def _entity_card_html(e: Any) -> str:
     alias_html = f' <span class="al">· {ui.esc(aliases)}</span>' if aliases else ""
     pattern = (
         f' <span class="muted mono" style="font-size:12px">{ui.esc(e.value_pattern)}</span>'
-        if e.value_pattern else ""
+        if e.value_pattern
+        else ""
     )
     return (
         f'<div class="mcard"><div class="nm">{ui.esc(e.name)}{alias_html} '
-        f'{_conf_badge(e.confidence)}</div>'
+        f"{_conf_badge(e.confidence)}</div>"
         f'<div class="muted" style="font-size:13px">{ui.esc(e.description or "")}{pattern}</div></div>'
     )
 
 
-def model_area_html(org: Any, area: Any, datasource: str, datasources: list[str],
-                    **chrome: str) -> str:
+def model_area_html(
+    org: Any, area: Any, datasource: str, datasources: list[str], **chrome: str
+) -> str:
     """A subject-area landing: its tables (scannable), then metrics + entities as cards."""
     tree = _model_tree_html(org, datasource, datasources, active_area=area.name)
     tables = "".join(
@@ -974,23 +1021,24 @@ def model_area_html(org: Any, area: Any, datasource: str, datasources: list[str]
         f'<span class="nm">{ui.esc(t.name)}</span>'
         f'<span class="d">{ui.esc(t.description or "")}</span>'
         f'<span class="meta">{len(t.columns)} cols · '
-        f'{ui.esc(_human_count(_est_rows_obj(t)))}</span>{_conf_badge(t.confidence)}'
+        f"{ui.esc(_human_count(_est_rows_obj(t)))}</span>{_conf_badge(t.confidence)}"
         '<span class="chev">›</span></a>'
         for t in area.tables_defined
     )
     metrics = "".join(_metric_card_html(m) for m in area.metrics)
     entities = "".join(_entity_card_html(e) for e in area.entities)
     window = (
-        f'<span>default window · <b>{ui.esc(area.default_time_window)}</b></span>'
-        if area.default_time_window else ""
+        f"<span>default window · <b>{ui.esc(area.default_time_window)}</b></span>"
+        if area.default_time_window
+        else ""
     )
     content = (
         f'<div class="crumbs"><a href="{_model_url(datasource)}">{ui.esc(datasource)}</a>'
         f'<span class="sep">/</span>{ui.esc(area.name)}</div>'
-        f'<h1>{ui.esc(area.name)}</h1>'
+        f"<h1>{ui.esc(area.name)}</h1>"
         f'<div class="subline"><span><b>{len(area.tables_defined)}</b> tables</span>'
-        f'<span><b>{len(area.metrics)}</b> metrics</span>'
-        f'<span><b>{len(area.entities)}</b> entities</span>{window}</div>'
+        f"<span><b>{len(area.metrics)}</b> metrics</span>"
+        f"<span><b>{len(area.entities)}</b> entities</span>{window}</div>"
         f'<p class="lead">{ui.esc(area.description or "")}</p>'
         f'<h2 class="sec">Tables <span class="c">{len(area.tables_defined)}</span></h2>'
         f'<div class="tlist">{tables}</div>'
@@ -1132,25 +1180,30 @@ def _table_metrics_html(area: Any, table_name: str) -> str:
     return f'<h2 class="sec">Used by metrics</h2><div class="grid">{cards}</div>'
 
 
-def model_table_html(org: Any, area: Any, table: Any, datasource: str, datasources: list[str],
-                     **chrome: str) -> str:
+def model_table_html(
+    org: Any, area: Any, table: Any, datasource: str, datasources: list[str], **chrome: str
+) -> str:
     """A table (dataset) page — the heart of the explorer: header, caveats, columns
     (grouped-when-authored else flat), then relationships + metrics that use it."""
-    tree = _model_tree_html(org, datasource, datasources,
-                            active_area=area.name, active_table=table.name)
-    schema = f'<span class="schema">{ui.esc(table.schema_name)}.</span>' if table.schema_name else ""
+    tree = _model_tree_html(
+        org, datasource, datasources, active_area=area.name, active_table=table.name
+    )
+    schema = (
+        f'<span class="schema">{ui.esc(table.schema_name)}.</span>' if table.schema_name else ""
+    )
     rows = _human_count(_est_rows_obj(table))
     grain = ", ".join(table.grain) if table.grain else ""
     aichip = (
         ' <span class="descsrc">AI-described · unvalidated</span>'
-        if getattr(table, "description_source", None) == "ai_unvalidated" else ""
+        if getattr(table, "description_source", None) == "ai_unvalidated"
+        else ""
     )
     sql_block = ""
     if getattr(table, "source_type", None) == "sql" and table.sql:
         sql_block = (
             '<h2 class="sec">Defining SQL</h2>'
             f'<pre class="code" style="white-space:pre-wrap;display:block;padding:12px">'
-            f'{ui.esc(table.sql)}</pre>'
+            f"{ui.esc(table.sql)}</pre>"
         )
     subline = "".join(
         f"<span>{s}</span>"
@@ -1162,28 +1215,79 @@ def model_table_html(org: Any, area: Any, table: Any, datasource: str, datasourc
         )
         if s
     )
-    columns = _columns_grouped_html(table) if table.column_groups else _columns_flat_html(table.columns)
+    columns = (
+        _columns_grouped_html(table) if table.column_groups else _columns_flat_html(table.columns)
+    )
     content = (
         f'<div class="crumbs"><a href="{_model_url(datasource)}">{ui.esc(datasource)}</a>'
         f'<span class="sep">/</span>'
         f'<a href="{_model_url(datasource, area=area.name)}">{ui.esc(area.name)}</a>'
         f'<span class="sep">/</span>{ui.esc(table.name)}</div>'
         f'<div class="h1row"><h1>{schema}{ui.esc(table.name)}</h1>'
-        f'{_conf_badge(table.confidence)}'
+        f"{_conf_badge(table.confidence)}"
         '<span class="readonly-pill">Read-only · edit in Claude</span></div>'
         f'<div class="subline">{subline}</div>'
         f'<p class="desc">{ui.esc(table.description or "")}{aichip}</p>'
-        f'{_caveat_callout(table.caveats)}'
+        f"{_caveat_callout(table.caveats)}"
         f'<h2 class="sec">Columns <span class="c">{len(table.columns)}</span></h2>'
-        f'{columns}{sql_block}'
-        f'{_table_rels_html(org, area, table.name)}'
-        f'{_table_metrics_html(area, table.name)}'
+        f"{columns}{sql_block}"
+        f"{_table_rels_html(org, area, table.name)}"
+        f"{_table_metrics_html(area, table.name)}"
     )
     return _model_shell(content, tree, **chrome)
 
 
-def model_context_html(org: Any, memory: dict[str, str], datasource: str, datasources: list[str],
-                       **chrome: str) -> str:
+def _qualified(schema: str | None, table: str) -> str:
+    return f"{ui.esc(schema)}.{ui.esc(table)}" if schema else ui.esc(table)
+
+
+def _cross_rel_row_html(r: Any) -> str:
+    """One cross-area relationship: schema-qualified from→to, the join columns, cardinality, trust."""
+    on = f"{ui.esc(r.from_column)} = {ui.esc(r.to_column)}" if r.from_column and r.to_column else ""
+    meta = " · ".join(p for p in (on, ui.esc(str(r.join_type)), ui.esc(str(r.confidence))) if p)
+    return (
+        f'<div class="rel"><span class="mono">{_qualified(r.from_schema, r.from_table)}</span>'
+        f'<span class="arr">→</span>'
+        f'<span class="mono">{_qualified(r.to_schema, r.to_table)}</span>'
+        f'<span class="badge b-soft">{ui.esc(str(r.relationship))}</span>'
+        f'<span class="ro">{meta}</span></div>'
+    )
+
+
+def model_relationships_html(
+    org: Any, datasource: str, datasources: list[str], **chrome: str
+) -> str:
+    """The cross-area relationships — the org-level joins that span subject areas — grouped by
+    area-pair, so the model's cross-area topology is readable in one place (within-area joins stay
+    on each table page)."""
+    tree = _model_tree_html(org, datasource, datasources, active_view="relationships")
+    rels = org.cross_subject_area_relationships
+    groups: dict[tuple[str, str], list[Any]] = {}
+    for r in rels:
+        groups.setdefault((r.from_subject_area, r.to_subject_area), []).append(r)
+    # Most-connected area-pairs first, then alphabetical — the same ordering as the topology view.
+    blocks = ""
+    for (fa, ta), items in sorted(groups.items(), key=lambda kv: (-len(kv[1]), kv[0])):
+        rows = "".join(_cross_rel_row_html(r) for r in items)
+        blocks += (
+            f'<details class="grp" open><summary>'
+            f'<span class="gname">{ui.esc(fa)} <span class="arr">→</span> {ui.esc(ta)}</span>'
+            f'<span class="gn">{len(items)}</span></summary>{rows}</details>'
+        )
+    body = blocks if rels else '<p class="lead">No cross-area relationships in this model.</p>'
+    content = (
+        f'<div class="crumbs"><a href="{_model_url(datasource)}">{ui.esc(datasource)}</a>'
+        '<span class="sep">/</span>Relationships</div><h1>Cross-area relationships</h1>'
+        f'<p class="lead">The <b>{len(rels)}</b> org-level joins that span subject areas, grouped by '
+        "area-pair. (Joins within a single area show on each table page.)</p>"
+        f"{body}"
+    )
+    return _model_shell(content, tree, **chrome)
+
+
+def model_context_html(
+    org: Any, memory: dict[str, str], datasource: str, datasources: list[str], **chrome: str
+) -> str:
     """The Domain-context page — the deployed ORGANIZATION.md rendered as (safe) markdown."""
     tree = _model_tree_html(org, datasource, datasources, active_view="context")
     org_md = memory.get("organization")
@@ -1196,7 +1300,7 @@ def model_context_html(org: Any, memory: dict[str, str], datasource: str, dataso
         f'<div class="crumbs"><a href="{_model_url(datasource)}">{ui.esc(datasource)}</a>'
         '<span class="sep">/</span>Domain context</div><h1>Domain context</h1>'
         '<p class="lead">The deployed ORGANIZATION.md — the domain notes Claude reads as context. '
-        f'Read-only.</p>{doc}'
+        f"Read-only.</p>{doc}"
     )
     return _model_shell(content, tree, **chrome)
 
@@ -1221,7 +1325,10 @@ async def admin_model(request: Request) -> Response:
         org = model_store.load_organization(store, datasource)
         if org is None:
             return HTMLResponse(model_empty_html(datasource, datasources, **chrome))
-        if request.query_params.get("view") == "context":
+        view = request.query_params.get("view")
+        if view == "relationships":
+            return HTMLResponse(model_relationships_html(org, datasource, datasources, **chrome))
+        if view == "context":
             memory = model_store.load_memory(store, datasource)
             return HTMLResponse(model_context_html(org, memory, datasource, datasources, **chrome))
         area_name = request.query_params.get("area")
@@ -1237,9 +1344,7 @@ async def admin_model(request: Request) -> Response:
                         )
                 return HTMLResponse(model_area_html(org, area, datasource, datasources, **chrome))
         version = model_store.newest_model_version(store, datasource)
-        return HTMLResponse(
-            model_overview_html(org, version, datasource, datasources, **chrome)
-        )
+        return HTMLResponse(model_overview_html(org, version, datasource, datasources, **chrome))
     finally:
         if store is not None:
             store.close()

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -137,6 +137,13 @@ def load_organization(store: Store, datasource: str) -> Organization | None:
     return Organization.model_validate(org_doc)
 
 
+def list_datasources(store: Store) -> list[str]:
+    """The datasources that have a served model, sorted. The admin model view picks among these; one
+    deployment can serve several (single-tenant per datasource)."""
+    rows = store.query("SELECT datasource FROM organization ORDER BY datasource")
+    return [r["datasource"] for r in rows]
+
+
 # ---------------------------------------------------------------------------
 # Memory (ORGANIZATION.md / USER_MEMORY.md) + model_version — served from the DB too, so a DB-only
 # deploy reads NO files at runtime (get_datasource_schema's domain context + the receipt's version

--- a/packages/agami-core/src/ui.py
+++ b/packages/agami-core/src/ui.py
@@ -173,6 +173,8 @@ time{font-variant-numeric:tabular-nums}
 .tree h4{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#8a94a8;margin:16px 8px 6px}
 .ds{display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--line);border-radius:9px;background:#f7f9fc;font-weight:600;margin-bottom:8px}
 .ds select{border:0;background:transparent;font:inherit;font-weight:600;color:var(--ink);outline:none;width:100%;height:auto}
+.ds-go{flex:none;font:inherit;font-size:12px;font-weight:600;color:var(--brand-600);background:#fff;border:1px solid var(--line);border-radius:7px;padding:3px 9px;cursor:pointer}
+.ds-go:hover{background:#eef3fe;border-color:#cfe0fb}
 .navitem{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 10px;border-radius:8px;color:var(--ink);text-decoration:none;font-weight:550}
 .navitem:hover{background:#f1f5fd;text-decoration:none}
 .navitem.active{background:#eef3fe;color:var(--brand-600)}
@@ -274,8 +276,16 @@ def esc(value: str | None) -> str:
 
 def _md_inline(s: str) -> str:
     """Inline markdown on an ALREADY-escaped string: inline code, bold, italic, and scheme-checked
-    links. Code is substituted first so `**` inside backticks is left literal."""
-    s = re.sub(r"`([^`]+)`", r"<code>\1</code>", s)
+    links. Inline-code spans are pulled out FIRST and restored LAST, so their contents stay literal —
+    a `[x](url)` or `**y**` inside backticks is never re-parsed into a live link / bold."""
+    spans: list[str] = []
+
+    def _stash(m: "re.Match[str]") -> str:
+        spans.append(m.group(1))
+        # NUL can't appear in html.escape'd text, so the placeholder can't collide with real content.
+        return f"\x00{len(spans) - 1}\x00"
+
+    s = re.sub(r"`([^`]+)`", _stash, s)
     s = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", s)
     s = re.sub(r"(?<![*\w])\*([^*]+)\*(?![*\w])", r"<em>\1</em>", s)
 
@@ -287,7 +297,8 @@ def _md_inline(s: str) -> str:
             return f'<a href="{url}" rel="noopener noreferrer" target="_blank">{text}</a>'
         return text
 
-    return re.sub(r"\[([^\]]+)\]\(([^)\s]+)\)", _link, s)
+    s = re.sub(r"\[([^\]]+)\]\(([^)\s]+)\)", _link, s)
+    return re.sub(r"\x00(\d+)\x00", lambda m: f"<code>{spans[int(m.group(1))]}</code>", s)
 
 
 def md(text: str) -> str:

--- a/packages/agami-core/src/ui.py
+++ b/packages/agami-core/src/ui.py
@@ -166,6 +166,103 @@ input:focus,select:focus{border-color:var(--brand);box-shadow:0 0 0 4px var(--ri
 .drawer{box-shadow:-26px 0 70px rgba(13,20,38,.20);border-left:1px solid var(--line)}
 time{font-variant-numeric:tabular-nums}
 @media (max-width:680px){.main{padding:18px 16px 48px}.topbar{padding:0 16px}.drawer{width:94vw!important}}
+
+/* ---- read-only model explorer (catalog idiom: browse tree + one page at a time) ---- */
+.explorer{display:grid;grid-template-columns:248px 1fr;align-items:start;margin:-4px 0 0}
+.tree{border-right:1px solid var(--line);padding:6px 14px 24px;font-size:13.5px}
+.tree h4{font-size:11px;letter-spacing:.06em;text-transform:uppercase;color:#8a94a8;margin:16px 8px 6px}
+.ds{display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--line);border-radius:9px;background:#f7f9fc;font-weight:600;margin-bottom:8px}
+.ds select{border:0;background:transparent;font:inherit;font-weight:600;color:var(--ink);outline:none;width:100%;height:auto}
+.navitem{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 10px;border-radius:8px;color:var(--ink);text-decoration:none;font-weight:550}
+.navitem:hover{background:#f1f5fd;text-decoration:none}
+.navitem.active{background:#eef3fe;color:var(--brand-600)}
+.navitem .n{font-size:11px;color:#8a94a8;background:#eef1f7;border-radius:20px;padding:1px 8px;font-weight:600}
+.navitem.active .n{background:#dde9fd;color:var(--brand-600)}
+.children{margin:1px 0 6px 14px;border-left:1px solid var(--line);padding-left:6px;display:flex;flex-direction:column}
+.leaf{padding:6px 9px;border-radius:7px;color:var(--muted);text-decoration:none;font-size:13px}
+.leaf:hover{background:#f1f5fd;color:var(--ink);text-decoration:none}
+.leaf.active{background:#eef3fe;color:var(--brand-600);font-weight:600}
+.content{padding:6px 4px 40px 30px;min-width:0}
+.content .crumbs{font-size:12.5px;color:var(--muted);margin-bottom:8px}
+.content .crumbs a{color:var(--muted)}
+.content .crumbs a:hover{color:var(--brand)}
+.content .sep{color:#c2cadb;margin:0 7px}
+.h1row{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.h1row h1{font-family:ui-monospace,Menlo,monospace;font-size:21px;font-weight:680}
+.h1row h1 .schema{color:#9aa6bd;font-weight:500}
+.lead{color:var(--muted);max-width:760px;margin:6px 0 0}
+.readonly-pill{margin-left:auto;font-size:11px;font-weight:600;color:var(--muted);background:#f1f3f9;border:1px solid var(--line);border-radius:20px;padding:4px 11px}
+.subline{display:flex;gap:18px;flex-wrap:wrap;color:var(--muted);font-size:13px;margin:10px 0 0}
+.subline b{color:var(--ink);font-weight:600}
+.desc{margin:14px 0 0;color:#33415c;max-width:760px}
+.descsrc{font-size:11px;color:#b45309;background:#fffbeb;border:1px solid #fde68a;border-radius:20px;padding:1px 8px;font-weight:600;margin-left:6px}
+h2.sec{font-size:12px;letter-spacing:.06em;text-transform:uppercase;color:#8a94a8;margin:30px 0 12px;font-weight:650}
+h2.sec .c{background:#eef1f7;color:#8a94a8;border-radius:20px;padding:1px 9px;font-size:12px;margin-left:6px}
+.statrow{display:flex;flex-wrap:wrap;gap:26px;align-items:center;margin:16px 0 0;padding:14px 18px;background:#fff;border:1px solid var(--line);border-radius:12px}
+.stat .k{font-size:11px;letter-spacing:.04em;text-transform:uppercase;color:#8a94a8}
+.stat .v{font-size:20px;font-weight:680}
+.gloss{display:flex;flex-wrap:wrap;gap:8px;margin-top:6px}
+.term{background:#f4f6fb;border:1px solid var(--line);border-radius:8px;padding:5px 10px;font-size:12.5px}
+.tlist{background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
+.trow{display:flex;align-items:center;gap:14px;padding:13px 16px;border-bottom:1px solid var(--line);text-decoration:none;color:inherit}
+.trow:last-child{border-bottom:0}
+.trow:hover{background:#f6f9ff;text-decoration:none}
+.trow .nm{font-weight:600;font-family:ui-monospace,Menlo,monospace;font-size:13.5px;min-width:150px}
+.trow .d{color:var(--muted);flex:1;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.trow .meta{color:#9aa6bd;font-size:12px;white-space:nowrap}
+.trow .chev{color:#c2cadb}
+.grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+.mcard{background:#fff;border:1px solid var(--line);border-radius:11px;padding:13px 15px}
+.mcard .nm{font-weight:600}
+.mcard .al{color:#9aa6bd;font-weight:500;font-size:12px}
+.calc{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:#0b3b8c;background:#f5f8ff;border:1px solid var(--line);border-radius:7px;padding:4px 8px;display:inline-block;margin-top:7px}
+.badge{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;padding:2px 8px;border-radius:20px;border:1px solid transparent;white-space:nowrap}
+.b-confirmed{color:#047857;background:#ecfdf5;border-color:#a7f3d0}
+.b-inferred{color:var(--brand-600);background:#eef3fe;border-color:#cfe0fb}
+.b-proposed{color:#b45309;background:#fffbeb;border-color:#fde68a}
+.b-sensitive{color:#b42318;background:#fef3f2;border-color:#fecdca}
+.b-pk{color:#6d28d9;background:#f5f3ff;border-color:#ddd6fe}
+.b-fk{color:#0369a1;background:#f0f9ff;border-color:#bae6fd}
+.b-soft{color:var(--muted);background:#f1f3f9;border-color:var(--line)}
+.aichip{font-size:10px;font-weight:700;color:#b45309;background:#fffbeb;border:1px solid #fde68a;border-radius:5px;padding:0 4px;vertical-align:middle}
+.caveat{display:flex;gap:11px;background:#fffbeb;border:1px solid #fde68a;border-radius:11px;padding:13px 15px;margin:18px 0}
+.caveat .ic{color:#b45309;font-weight:700;flex:none}
+.caveat .t{color:#7c4a02;font-size:13px}
+.caveat .t b{color:#5c3700}
+table.cols{width:100%;border-collapse:collapse;font-size:13.5px;margin:0}
+.cols th{text-align:left;font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:#8a94a8;font-weight:600;padding:11px 12px;border-top:0;border-bottom:1px solid var(--line)}
+.cols td{padding:11px 12px;border-top:0;border-bottom:1px solid var(--line);vertical-align:top}
+.cols tr:last-child td{border-bottom:0}
+.cols tbody tr:hover{background:#f8fafe}
+.cols .noterow td{border-bottom:0;padding-top:0}
+.cn{font-weight:600;font-family:ui-monospace,Menlo,monospace;font-size:12.5px}
+.ct{display:inline-block;color:var(--muted);font-family:ui-monospace,Menlo,monospace;font-size:11.5px;background:#f7f9fc;border:1px solid var(--line);border-radius:6px;padding:1px 7px}
+.cd{color:#445}
+.cd .dash{color:#c2cadb}
+.note{font-size:12.5px;color:#7c4a02;background:#fffbeb;border-left:3px solid #fde68a;padding:8px 12px;border-radius:0 7px 7px 0}
+details.grp{background:#fff;border:1px solid var(--line);border-radius:11px;margin:12px 0;overflow:hidden}
+details.grp>summary{list-style:none;cursor:pointer;padding:12px 16px;display:flex;align-items:center;gap:10px}
+details.grp>summary::-webkit-details-marker{display:none}
+details.grp>summary:hover{background:#f7f9fc}
+details.grp .gname{font-weight:680;font-size:13.5px}
+details.grp .gdesc{color:var(--muted);font-size:12.5px}
+details.grp .gn{margin-left:auto;font-size:11px;color:#8a94a8;background:#eef1f7;border:1px solid var(--line);border-radius:20px;padding:1px 9px}
+details.grp .cols{border-top:1px solid var(--line)}
+details.showmore>summary{cursor:pointer;color:var(--brand);font-size:12.5px;font-weight:600;padding:11px 12px;list-style:none}
+details.showmore>summary::-webkit-details-marker{display:none}
+.rel{display:flex;align-items:center;gap:10px;padding:12px 16px;border-bottom:1px solid var(--line)}
+.rel:last-child{border-bottom:0}
+.rel .arr{color:var(--brand);font-weight:700}
+.rel .ro{margin-left:auto;color:#9aa6bd;font-size:12px}
+.card{background:#fff;border:1px solid var(--line);border-radius:12px;overflow:hidden}
+.context{background:#fff;border:1px solid var(--line);border-radius:12px;padding:6px 24px 20px;margin-top:8px}
+.context h1{font-size:18px;margin:18px 0 6px}
+.context h2{font-size:15px;margin:16px 0 6px}
+.context h3{font-size:13.5px;margin:14px 0 6px}
+.context p,.context li{color:#33415c;font-size:14px}
+.context code{font-family:ui-monospace,Menlo,monospace;background:#f1f3f9;border:1px solid var(--line);border-radius:6px;padding:1px 6px;font-size:12.5px}
+.context pre.code{padding:12px 14px;white-space:pre-wrap}
+@media (max-width:820px){.explorer{grid-template-columns:1fr}.tree{border-right:0;border-bottom:1px solid var(--line)}.content{padding:16px 0 40px}.grid{grid-template-columns:1fr}}
 """
 
 

--- a/packages/agami-core/src/ui.py
+++ b/packages/agami-core/src/ui.py
@@ -11,6 +11,7 @@ Pure strings; no template engine; a tiny CSS-only drawer + a native `<details>` 
 from __future__ import annotations
 
 import html
+import re
 
 # Palette + components mirror the agami web app (brand #0b57d0, line #D2DBF1, chip #f4f5fb). Embedded
 # so pages are self-contained — no build step, no asset pipeline. Layout is responsive: the media
@@ -171,6 +172,89 @@ time{font-variant-numeric:tabular-nums}
 def esc(value: str | None) -> str:
     """HTML-escape (attribute-safe) any interpolated value. Use for EVERYTHING user-influenced."""
     return html.escape(value or "", quote=True)
+
+
+def _md_inline(s: str) -> str:
+    """Inline markdown on an ALREADY-escaped string: inline code, bold, italic, and scheme-checked
+    links. Code is substituted first so `**` inside backticks is left literal."""
+    s = re.sub(r"`([^`]+)`", r"<code>\1</code>", s)
+    s = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", s)
+    s = re.sub(r"(?<![*\w])\*([^*]+)\*(?![*\w])", r"<em>\1</em>", s)
+
+    def _link(m: "re.Match[str]") -> str:
+        text, url = m.group(1), m.group(2)
+        # Only http(s) links — the text is already escaped, so a `javascript:`/`data:` URL renders as
+        # plain text (never a live href). This is the one place a URL becomes an attribute.
+        if url.startswith(("http://", "https://")):
+            return f'<a href="{url}" rel="noopener noreferrer" target="_blank">{text}</a>'
+        return text
+
+    return re.sub(r"\[([^\]]+)\]\(([^)\s]+)\)", _link, s)
+
+
+def md(text: str) -> str:
+    """A tiny, SAFE markdown subset for the domain-context doc — **escape-first**, so any raw HTML in
+    the source is inert. Supports headings, bold/italic, inline + fenced code, bullet/numbered lists,
+    and http(s) links. Not a full renderer; just enough for an ORGANIZATION.md."""
+    if not text:
+        return ""
+    out: list[str] = []
+    lst: str | None = None  # the open list tag ("ul"/"ol"), or None
+    para: list[str] = []
+    code: list[str] | None = None  # accumulating fenced-code lines, or None
+
+    def _flush_para() -> None:
+        if para:
+            out.append(f"<p>{_md_inline(' '.join(para))}</p>")
+            para.clear()
+
+    def _close_list() -> None:
+        nonlocal lst
+        if lst:
+            out.append(f"</{lst}>")
+            lst = None
+
+    for raw in text.splitlines():
+        line = html.escape(raw)
+        if line.strip() == "```" or line.strip().startswith("```"):
+            if code is None:  # opening a fence
+                _flush_para()
+                _close_list()
+                code = []
+            else:  # closing it
+                out.append(f'<pre class="code">{chr(10).join(code)}</pre>')
+                code = None
+            continue
+        if code is not None:
+            code.append(line)
+            continue
+        h = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if h:
+            _flush_para()
+            _close_list()
+            lvl = len(h.group(1))
+            out.append(f"<h{lvl}>{_md_inline(h.group(2))}</h{lvl}>")
+            continue
+        m = re.match(r"^\s*([-*]|\d+\.)\s+(.*)$", line)
+        if m:
+            _flush_para()
+            want = "ol" if m.group(1)[0].isdigit() else "ul"
+            if lst != want:
+                _close_list()
+                out.append(f"<{want}>")
+                lst = want
+            out.append(f"<li>{_md_inline(m.group(2))}</li>")
+            continue
+        if not line.strip():
+            _flush_para()
+            _close_list()
+            continue
+        para.append(line.strip())
+    if code is not None:  # an unterminated fence still renders (no data dropped)
+        out.append(f'<pre class="code">{chr(10).join(code)}</pre>')
+    _flush_para()
+    _close_list()
+    return "\n".join(out)
 
 
 def initials(name: str) -> str:

--- a/packages/agami-core/src/ui.py
+++ b/packages/agami-core/src/ui.py
@@ -228,7 +228,16 @@ _TABS = (
     ("users", "Users"),
     ("sessions", "Sessions"),
     ("calls", "Tool calls"),
+    ("model", "Model"),
 )
+
+# Most tabs hang off `/admin?tab=`; the read-only Model view has its own contract-named GET endpoint
+# (`/admin/model`) so it's the *only* model surface — no write route can hide behind a shared handler.
+_TAB_HREFS = {"model": "/admin/model"}
+
+
+def _tab_href(key: str) -> str:
+    return _TAB_HREFS.get(key, f"/admin?tab={esc(key)}")
 
 
 def _account_menu(label: str, email: str) -> str:
@@ -254,7 +263,7 @@ def admin_shell(
     `extra` is emitted at the body root before the bar — used for the CSS-only drawer (whose toggle
     checkbox must be a sibling of `.drawer-wrap`)."""
     tabs = "".join(
-        f'<a href="/admin?tab={esc(key)}" class="{"active" if key == active else ""}">{esc(label)}</a>'
+        f'<a href="{_tab_href(key)}" class="{"active" if key == active else ""}">{esc(label)}</a>'
         for key, label in _TABS
     )
     body_html = f"""{extra}<div class="topbar">

--- a/packages/agami-core/src/ui.py
+++ b/packages/agami-core/src/ui.py
@@ -247,7 +247,8 @@ details.grp>summary:hover{background:#f7f9fc}
 details.grp .gname{font-weight:680;font-size:13.5px}
 details.grp .gdesc{color:var(--muted);font-size:12.5px}
 details.grp .gn{margin-left:auto;font-size:11px;color:#8a94a8;background:#eef1f7;border:1px solid var(--line);border-radius:20px;padding:1px 9px}
-details.grp .cols{border-top:1px solid var(--line)}
+details.grp .cols,details.grp>.rel:first-of-type{border-top:1px solid var(--line)}
+details.grp>.rel{padding-left:18px;padding-right:18px}
 details.showmore>summary{cursor:pointer;color:var(--brand);font-size:12.5px;font-weight:600;padding:11px 12px;list-style:none}
 details.showmore>summary::-webkit-details-marker{display:none}
 .rel{display:flex;align-items:center;gap:10px;padding:12px 16px;border-bottom:1px solid var(--line)}

--- a/render_previews.py
+++ b/render_previews.py
@@ -217,6 +217,18 @@ _MODEL_ORG = {
             "relationships": [],
         },
     ],
+    # Cross-area joins (Sales → Catalog) — surfaced in the Relationships browse view, grouped by pair.
+    "cross_subject_area_relationships": [
+        {"from_table": "orders", "to_table": "products", "from_column": "product_id",
+         "to_column": "id", "from_schema": "public", "to_schema": "public", "join_type": "LEFT",
+         "relationship": "many_to_one", "confidence": "inferred", "review_state": "unreviewed",
+         "from_subject_area": "Sales", "to_subject_area": "Catalog"},
+        {"from_table": "orders", "to_table": "inventory", "from_column": "warehouse_id",
+         "to_column": "location_id", "from_schema": "public", "to_schema": "public",
+         "join_type": "LEFT", "relationship": "many_to_one", "confidence": "proposed",
+         "review_state": "unreviewed",
+         "from_subject_area": "Sales", "to_subject_area": "Catalog"},
+    ],
 }
 _ORG_MD = (
     "# About Acme Commerce\n\n"
@@ -246,6 +258,8 @@ write("19-model-table-grouped.html",
 write("20-model-context.html",
       admin.model_context_html(_org, model_store.load_memory(_s, "SALES_DATA"), "SALES_DATA", _dss,
                                **CHROME))
+write("21-model-relationships.html",
+      admin.model_relationships_html(_org, "SALES_DATA", _dss, **CHROME))
 _s.close()
 write("08-not-admin.html", admin.not_admin_body_html(BASE))
 write("09-landing.html", admin.landing_body_html(BASE))

--- a/render_previews.py
+++ b/render_previews.py
@@ -104,6 +104,148 @@ for _c in _SAMPLE_CALLS:
     _sink.record_tool_call(ToolCallRecord(**_c))
 write("07-admin-sessions.html", admin.sessions_tab_html(model_store.list_sessions(_s), **CHROME))
 write("15-tool-calls.html", admin.calls_tab_html(model_store.list_tool_calls(_s), **CHROME))
+
+# The read-only model explorer — rendered from the REAL builders over the SAME served tree the MCP
+# tools read (load_organization), so the previews can't drift from production. Neutral demo data only.
+from semantic_model.models import Organization  # noqa: E402
+
+_MODEL_ORG = {
+    "organization": "acme",
+    "version": 1,
+    "description": "Acme Commerce — the deployed semantic model.",
+    "fiscal_year_start_month": 1,
+    "key_terminology": {"AOV": "average order value", "Net revenue": "sales minus refunds"},
+    "storage_connections": [
+        {"name": "warehouse", "storage_type": "PostgreSQL",
+         "storage_config": {"host": "never-rendered"}}
+    ],
+    "subject_areas": [
+        {
+            "name": "Catalog", "description": "Products, pricing and stock.",
+            "default_time_window": "last_90_days",
+            "tables": [{"storage_connection": "warehouse", "schema": "public", "table": "products"}],
+            "tables_defined": [
+                {
+                    "name": "products", "schema": "public", "storage_connection": "warehouse",
+                    "grain": ["id"], "description": "Master product catalog.",
+                    "description_source": "ai_unvalidated", "confidence": "proposed",
+                    "review_state": "unreviewed",
+                    "caveats": ["\"Coffee\" = category='cafe' AND name ILIKE '%coffee%','%latte%'…"],
+                    "columns": [
+                        {"name": "id", "type": "uuid", "primary_key": True},
+                        {"name": "sku", "type": "string"},
+                        {"name": "name", "type": "string"},
+                        {"name": "category", "type": "string",
+                         "description": "Product type: 'book', 'cafe', 'merchandise', or 'other'.",
+                         "description_source": "ai_unvalidated",
+                         "choice_field": {"book": "Book", "cafe": "Cafe"}},
+                        {"name": "price", "type": "decimal", "unit": "USD"},
+                        {"name": "cost_price", "type": "decimal", "unit": "USD",
+                         "caveats": ["~20% of rows have cost_price > price (data-entry errors). "
+                                     "Treat as valid only when cost_price <= price."]},
+                        {"name": "supplier_email", "type": "string", "sensitive": True,
+                         "description": "Distributor contact."},
+                        {"name": "category_id", "type": "uuid",
+                         "foreign_key": {"table": "categories", "column": "id"}},
+                        {"name": "stock_qty", "type": "integer"},
+                        {"name": "is_active", "type": "boolean"},
+                        {"name": "created_at", "type": "timestamp"},
+                        {"name": "author", "type": "string"},
+                        {"name": "publisher", "type": "string"},
+                        {"name": "barcode", "type": "string"},
+                    ],
+                    "performance_hints": {"estimated_row_count": 6591},
+                },
+                {
+                    "name": "inventory", "schema": "public", "storage_connection": "warehouse",
+                    "grain": ["id"], "description": "Per-location stock levels.",
+                    "confidence": "confirmed", "review_state": "approved",
+                    "column_groups": {"Identifiers": ["id", "product_id", "location_id"],
+                                      "Levels": ["on_hand", "reserved"]},
+                    "column_group_descriptions": {"Identifiers": "keys & references",
+                                                  "Levels": "stock counts"},
+                    "columns": [
+                        {"name": "id", "type": "uuid", "primary_key": True},
+                        {"name": "product_id", "type": "uuid",
+                         "foreign_key": {"table": "products", "column": "id"}},
+                        {"name": "location_id", "type": "uuid"},
+                        {"name": "on_hand", "type": "integer"},
+                        {"name": "reserved", "type": "integer"},
+                        {"name": "counted_at", "type": "timestamp"},  # in no group → "Other"
+                    ],
+                    "performance_hints": {"estimated_row_count": 41000},
+                },
+            ],
+            "metrics": [
+                {"name": "active products", "calculation": "COUNT(*) FILTER (WHERE is_active)",
+                 "other_names": ["live items"]}
+            ],
+            "entities": [
+                {"name": "product", "other_names": ["sku", "item"],
+                 "description": "A sellable catalog item.", "value_pattern": "SKU-[0-9]{6}",
+                 "confidence": "inferred"}
+            ],
+            "relationships": [
+                {"from_table": "products", "to_table": "categories", "from_column": "category_id",
+                 "to_column": "id", "relationship": "many_to_one", "confidence": "confirmed",
+                 "review_state": "approved"}
+            ],
+        },
+        {
+            "name": "Sales", "description": "Orders, line items and revenue.",
+            "tables": [{"storage_connection": "warehouse", "schema": "public", "table": "orders"}],
+            "tables_defined": [
+                {
+                    "name": "orders", "schema": "public", "storage_connection": "warehouse",
+                    "grain": ["id"], "description": "One row per placed order.",
+                    "confidence": "confirmed", "review_state": "approved",
+                    "columns": [
+                        {"name": "id", "type": "integer", "primary_key": True},
+                        {"name": "customer_id", "type": "integer",
+                         "foreign_key": {"table": "customers", "column": "id"}},
+                        {"name": "amount", "type": "decimal", "unit": "USD"},
+                        {"name": "placed_at", "type": "timestamp"},
+                    ],
+                    "performance_hints": {"estimated_row_count": 184000},
+                }
+            ],
+            "metrics": [
+                {"name": "revenue", "calculation": "SUM(amount)", "unit": "USD",
+                 "other_names": ["sales"], "source_tables": ["orders"]}
+            ],
+            "entities": [],
+            "relationships": [],
+        },
+    ],
+}
+_ORG_MD = (
+    "# About Acme Commerce\n\n"
+    "Acme sells direct-to-consumer goods online. Every checkout writes an **orders** row.\n\n"
+    "## Key terms\n\n"
+    "- **Net revenue** excludes cancelled orders and nets refunds.\n"
+    "- A **member** has a row in the loyalty table — not just anyone who checked out.\n"
+)
+model_store.write_organization(_s, "SALES_DATA", Organization.model_validate(_MODEL_ORG))
+model_store.write_organization(_s, "MARKETING", Organization.model_validate(_MODEL_ORG))  # → picker
+model_store.write_memory(_s, "SALES_DATA", organization=_ORG_MD)
+model_store.write_model_version(_s, "SALES_DATA", "a1f4c39c0b2e", created_at="2026-06-27T09:00:00Z")
+_dss = model_store.list_datasources(_s)
+_org = model_store.load_organization(_s, "SALES_DATA")
+_ver = model_store.newest_model_version(_s, "SALES_DATA")
+_catalog = next(a for a in _org.subject_areas if a.name == "Catalog")
+_products = next(t for t in _catalog.tables_defined if t.name == "products")
+_inventory = next(t for t in _catalog.tables_defined if t.name == "inventory")
+write("16-model-overview.html",
+      admin.model_overview_html(_org, _ver, "SALES_DATA", _dss, **CHROME))
+write("17-model-area.html",
+      admin.model_area_html(_org, _catalog, "SALES_DATA", _dss, **CHROME))
+write("18-model-table-flat.html",
+      admin.model_table_html(_org, _catalog, _products, "SALES_DATA", _dss, **CHROME))
+write("19-model-table-grouped.html",
+      admin.model_table_html(_org, _catalog, _inventory, "SALES_DATA", _dss, **CHROME))
+write("20-model-context.html",
+      admin.model_context_html(_org, model_store.load_memory(_s, "SALES_DATA"), "SALES_DATA", _dss,
+                               **CHROME))
 _s.close()
 write("08-not-admin.html", admin.not_admin_body_html(BASE))
 write("09-landing.html", admin.landing_body_html(BASE))

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -21,6 +21,7 @@ PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "
 if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
+import admin  # noqa: E402
 import mcp_http  # noqa: E402
 import model_store  # noqa: E402
 import ui  # noqa: E402
@@ -117,6 +118,21 @@ ORG = {
                         {"name": "language", "type": "string"},
                     ],
                     "performance_hints": {"estimated_row_count": 6591},
+                },
+                {
+                    # A SQL-backed (view) table — exercises the "Defining SQL" block.
+                    "name": "monthly_revenue",
+                    "schema": "public",
+                    "storage_connection": "warehouse",
+                    "source_type": "sql",
+                    "sql": "SELECT date_trunc('month', placed_at) AS m, SUM(amount) FROM orders "
+                    "GROUP BY 1",
+                    "grain": ["m"],
+                    "description": "Monthly revenue rollup.",
+                    "columns": [
+                        {"name": "m", "type": "date"},
+                        {"name": "revenue", "type": "decimal", "unit": "USD"},
+                    ],
                 },
             ],
             "metrics": [
@@ -419,3 +435,29 @@ def test_cross_area_objects_surface_on_overview(client, env):
     html = client.get("/admin/model?datasource=X").text
     assert "Cross-area metrics" in html and "global_rev" in html
     assert "Cross-area entities" in html and "company" in html
+
+
+# --- odds and ends -----------------------------------------------------------
+
+
+def test_human_count_branches():
+    assert admin._human_count(None) == ""
+    assert admin._human_count(42) == "≈ 42"
+    assert admin._human_count(6591) == "≈ 6.6k"
+    assert admin._human_count(184000) == "≈ 184k"
+    assert admin._human_count(2_400_000) == "≈ 2.4M"
+
+
+def test_sql_backed_table_shows_defining_sql(client, env):
+    _seed(env)
+    _login(client)
+    html = client.get("/admin/model?datasource=SALES_DATA&area=Sales&table=monthly_revenue").text
+    assert "Defining SQL" in html and "date_trunc" in html
+
+
+def test_stale_datasource_param_falls_back_to_first(client, env):
+    _seed(env, "SALES_DATA")
+    _login(client)
+    # An unknown datasource param degrades to the first served one, not a 500.
+    html = client.get("/admin/model?datasource=DOES_NOT_EXIST").text
+    assert "acme" in html and "Subject areas" in html

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -261,9 +261,9 @@ def test_overview_renders_org_and_areas(client, env):
     _login(client)
     html = client.get("/admin/model").text
     assert "acme" in html and "Sales" in html
+    assert "Acme Commerce" in html  # the org description renders
     assert "AOV" in html and "average order value" in html  # glossary
     assert "warehouse" in html and "PostgreSQL" in html  # storage names/types
-    assert "Model" in html  # the tab is present in the shell
 
 
 def test_overview_never_leaks_storage_config(client, env):
@@ -296,8 +296,9 @@ def test_unknown_area_falls_back_to_overview(client, env):
     _seed(env)
     _login(client)
     # A stale/unknown area param must not 500 — it degrades to the datasource overview.
-    html = client.get("/admin/model?datasource=SALES_DATA&area=Nope").text
-    assert "acme" in html and "Subject areas" in html
+    r = client.get("/admin/model?datasource=SALES_DATA&area=Nope")
+    assert r.status_code == 200
+    assert "acme" in r.text and "Subject areas" in r.text
 
 
 # --- table (dataset) page ----------------------------------------------------
@@ -346,13 +347,30 @@ def test_table_page_shows_relationships_and_metrics(client, env):
     _login(client)
     html = client.get("/admin/model?datasource=SALES_DATA&area=Sales&table=orders").text
     assert "Relationships" in html and "customers" in html  # a relationship touching orders
+    assert "many_to_one" in html  # the cardinality renders, not just the table name
     assert "Used by metrics" in html and "revenue" in html  # a metric whose source is orders
+    assert 'class="caveat"' not in html  # orders has no caveats → no stray callout
+
+
+def test_table_with_no_relationships_omits_the_section(client, env):
+    _seed(env)
+    _login(client)
+    # products is in no relationship → the filter must omit the section, not show every relationship.
+    assert "Relationships" not in _products(client)
+
+
+def test_empty_description_renders_a_dash(client, env):
+    _seed(env)
+    _login(client)
+    assert 'class="dash"' in _products(client)  # description-less columns (sku, barcode…) show "—"
 
 
 def test_flat_columns_when_no_authored_groups(client, env):
     _seed(env)
     _login(client)
-    assert 'class="grp"' not in _products(client)  # products authors no column_groups → flat
+    html = _products(client)
+    assert 'class="grp"' not in html  # products authors no column_groups → flat
+    assert 'class="cols"' in html and "supplier_email" in html  # …and the columns actually render
 
 
 def test_grouped_columns_when_authored(client, env):
@@ -369,8 +387,9 @@ def test_unknown_table_falls_back_to_area(client, env):
     _seed(env)
     _login(client)
     # A stale/unknown table param degrades to the area landing, not a 500.
-    html = client.get("/admin/model?datasource=SALES_DATA&area=Sales&table=nope").text
-    assert "Tables" in html and "orders" in html
+    r = client.get("/admin/model?datasource=SALES_DATA&area=Sales&table=nope")
+    assert r.status_code == 200
+    assert "Tables" in r.text and "orders" in r.text
 
 
 # --- domain context (markdown) ----------------------------------------------
@@ -467,5 +486,6 @@ def test_stale_datasource_param_falls_back_to_first(client, env):
     _seed(env, "SALES_DATA")
     _login(client)
     # An unknown datasource param degrades to the first served one, not a 500.
-    html = client.get("/admin/model?datasource=DOES_NOT_EXIST").text
-    assert "acme" in html and "Subject areas" in html
+    r = client.get("/admin/model?datasource=DOES_NOT_EXIST")
+    assert r.status_code == 200
+    assert "acme" in r.text and "Subject areas" in r.text

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -391,6 +391,14 @@ def test_md_fenced_code_and_link_scheme_check():
     assert "javascript:" not in out  # a non-http link degrades to plain text, never a live href
 
 
+def test_md_empty_and_unterminated_fence():
+    assert ui.md("") == ""
+    out = ui.md(
+        "```\nopen fence never closed"
+    )  # an unterminated fence still renders, dropping nothing
+    assert "open fence never closed" in out
+
+
 def test_context_page_renders_org_md(client, env):
     _seed(env)
     s = Store.connect(env)

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -23,6 +23,7 @@ if str(PKG_SRC) not in sys.path:
 
 import mcp_http  # noqa: E402
 import model_store  # noqa: E402
+import ui  # noqa: E402
 import user_store  # noqa: E402
 from semantic_model.models import Organization  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
@@ -354,3 +355,67 @@ def test_unknown_table_falls_back_to_area(client, env):
     # A stale/unknown table param degrades to the area landing, not a 500.
     html = client.get("/admin/model?datasource=SALES_DATA&area=Sales&table=nope").text
     assert "Tables" in html and "orders" in html
+
+
+# --- domain context (markdown) ----------------------------------------------
+
+
+def test_md_renders_subset_and_escapes_raw_html():
+    out = ui.md("# Title\n\nHello **bold** and `c`.\n\n- one\n- two\n\n<script>alert(1)</script>")
+    assert "<h1>Title</h1>" in out
+    assert "<strong>bold</strong>" in out and "<code>c</code>" in out
+    assert "<ul>" in out and "<li>one</li>" in out
+    assert "<script>alert(1)" not in out and "&lt;script&gt;" in out
+
+
+def test_md_fenced_code_and_link_scheme_check():
+    out = ui.md("```\nSELECT 1\n```\n\n[ok](https://example.com) [bad](javascript:alert(1))")
+    assert "<pre" in out and "SELECT 1" in out
+    assert 'href="https://example.com"' in out
+    assert "javascript:" not in out  # a non-http link degrades to plain text, never a live href
+
+
+def test_context_page_renders_org_md(client, env):
+    _seed(env)
+    s = Store.connect(env)
+    model_store.write_memory(s, "SALES_DATA", organization="# About\n\nAcme **notes**.")
+    s.close()
+    _login(client)
+    html = client.get("/admin/model?datasource=SALES_DATA&view=context").text
+    assert "<h1>About</h1>" in html and "<strong>notes</strong>" in html
+
+
+def test_context_page_escapes_doc(client, env):
+    _seed(env)
+    s = Store.connect(env)
+    model_store.write_memory(s, "SALES_DATA", organization="<script>alert(1)</script>")
+    s.close()
+    _login(client)
+    html = client.get("/admin/model?datasource=SALES_DATA&view=context").text
+    assert "<script>alert(1)" not in html and "&lt;script&gt;" in html
+
+
+def test_context_page_empty_when_no_doc(client, env):
+    _seed(env)
+    _login(client)
+    html = client.get("/admin/model?datasource=SALES_DATA&view=context").text
+    assert "No domain context" in html
+
+
+# --- cross-area (org-level) objects are not dropped --------------------------
+
+CROSS_ORG = {
+    "organization": "acme",
+    "storage_connections": [{"name": "c", "storage_type": "PostgreSQL"}],
+    "subject_areas": [{"name": "A", "tables": [], "tables_defined": []}],
+    "cross_subject_area_metrics": [{"name": "global_rev", "calculation": "sum all"}],
+    "cross_subject_area_entities": [{"name": "company"}],
+}
+
+
+def test_cross_area_objects_surface_on_overview(client, env):
+    _seed(env, "X", CROSS_ORG)
+    _login(client)
+    html = client.get("/admin/model?datasource=X").text
+    assert "Cross-area metrics" in html and "global_rev" in html
+    assert "Cross-area entities" in html and "company" in html

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -65,7 +65,58 @@ ORG = {
                         {"name": "amount", "type": "decimal", "unit": "USD"},
                     ],
                     "performance_hints": {"estimated_row_count": 184000},
-                }
+                },
+                {
+                    # A wide, low-trust table exercising every flag + truncation + escaping.
+                    "name": "products",
+                    "schema": "public",
+                    "storage_connection": "warehouse",
+                    "grain": ["id"],
+                    "description": "Master product catalog.",
+                    "description_source": "ai_unvalidated",
+                    "confidence": "proposed",
+                    "review_state": "unreviewed",
+                    "caveats": ["Coffee = category='cafe'. danger <script>alert(1)</script>"],
+                    "columns": [
+                        {"name": "id", "type": "uuid", "primary_key": True},
+                        {"name": "sku", "type": "string"},
+                        {
+                            "name": "category",
+                            "type": "string",
+                            "description": "Type.",
+                            "description_source": "ai_unvalidated",
+                            "choice_field": {"book": "Book", "cafe": "Cafe"},
+                        },
+                        {"name": "price", "type": "decimal", "unit": "INR"},
+                        {
+                            "name": "cost_price",
+                            "type": "decimal",
+                            "unit": "INR",
+                            "caveats": [
+                                "~20% of rows have cost_price > price — exclude for margins."
+                            ],
+                        },
+                        {
+                            "name": "supplier_email",
+                            "type": "string",
+                            "sensitive": True,
+                            "description": "Distributor contact.",
+                        },
+                        {
+                            "name": "added_by_user_id",
+                            "type": "uuid",
+                            "foreign_key": {"table": "users", "column": "id"},
+                        },
+                        {"name": "created_at", "type": "timestamp"},
+                        {"name": "is_active", "type": "boolean"},
+                        {"name": "stock_qty", "type": "integer"},
+                        {"name": "genre", "type": "string"},
+                        {"name": "publisher", "type": "string"},
+                        {"name": "barcode", "type": "string"},
+                        {"name": "language", "type": "string"},
+                    ],
+                    "performance_hints": {"estimated_row_count": 6591},
+                },
             ],
             "metrics": [
                 {
@@ -73,10 +124,50 @@ ORG = {
                     "calculation": "sum of amount",
                     "other_names": ["sales"],
                     "unit": "USD",
+                    "source_tables": ["orders"],
                 }
             ],
             "entities": [{"name": "customer", "value_pattern": "^C[0-9]+$"}],
-            "relationships": [],
+            "relationships": [
+                {
+                    "from_table": "orders",
+                    "from_column": "customer_id",
+                    "to_table": "customers",
+                    "to_column": "id",
+                    "relationship": "many_to_one",
+                    "confidence": "inferred",
+                    "review_state": "unreviewed",
+                }
+            ],
+        }
+    ],
+}
+
+# A model whose table authors `column_groups` — the grouped column view (the other 12%).
+GROUPED_ORG = {
+    "organization": "acme",
+    "storage_connections": [{"name": "c", "storage_type": "PostgreSQL"}],
+    "subject_areas": [
+        {
+            "name": "Catalog",
+            "tables": [{"storage_connection": "c", "schema": "public", "table": "items"}],
+            "tables_defined": [
+                {
+                    "name": "items",
+                    "schema": "public",
+                    "storage_connection": "c",
+                    "grain": ["id"],
+                    "description": "Items.",
+                    "column_groups": {"Identity": ["id", "sku"], "Pricing": ["price"]},
+                    "column_group_descriptions": {"Identity": "keys & codes", "Pricing": "money"},
+                    "columns": [
+                        {"name": "id", "type": "uuid", "primary_key": True},
+                        {"name": "sku", "type": "string"},
+                        {"name": "price", "type": "decimal", "unit": "USD"},
+                        {"name": "notes", "type": "string"},  # in no group → trailing "Other"
+                    ],
+                }
+            ],
         }
     ],
 }
@@ -190,3 +281,76 @@ def test_unknown_area_falls_back_to_overview(client, env):
     # A stale/unknown area param must not 500 — it degrades to the datasource overview.
     html = client.get("/admin/model?datasource=SALES_DATA&area=Nope").text
     assert "acme" in html and "Subject areas" in html
+
+
+# --- table (dataset) page ----------------------------------------------------
+
+
+def _products(client):
+    return client.get("/admin/model?datasource=SALES_DATA&area=Sales&table=products").text
+
+
+def test_table_page_shows_every_flag(client, env):
+    _seed(env)
+    _login(client)
+    html = _products(client)
+    assert ">PK<" in html  # primary key
+    assert "FK → users" in html  # foreign key → target
+    assert ">enum<" in html  # choice_field
+    assert ">INR<" in html  # unit
+    assert "sensitive" in html  # sensitive column flag
+    assert "caveat" in html  # a column with caveats is flagged
+    assert "AI-described" in html  # ai_unvalidated table description
+    assert "proposed" in html  # the table-level (low) confidence badge
+
+
+def test_wide_table_collapses_extra_columns(client, env):
+    _seed(env)
+    _login(client)
+    assert "Show all 14 columns" in _products(client)
+
+
+def test_table_page_escapes_caveat(client, env):
+    _seed(env)
+    _login(client)
+    html = _products(client)
+    assert "<script>alert(1)" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_table_page_never_leaks_storage_config(client, env):
+    _seed(env)
+    _login(client)
+    assert "host-should-not-render" not in _products(client)
+
+
+def test_table_page_shows_relationships_and_metrics(client, env):
+    _seed(env)
+    _login(client)
+    html = client.get("/admin/model?datasource=SALES_DATA&area=Sales&table=orders").text
+    assert "Relationships" in html and "customers" in html  # a relationship touching orders
+    assert "Used by metrics" in html and "revenue" in html  # a metric whose source is orders
+
+
+def test_flat_columns_when_no_authored_groups(client, env):
+    _seed(env)
+    _login(client)
+    assert 'class="grp"' not in _products(client)  # products authors no column_groups → flat
+
+
+def test_grouped_columns_when_authored(client, env):
+    _seed(env, "CATALOG", GROUPED_ORG)
+    _login(client)
+    html = client.get("/admin/model?datasource=CATALOG&area=Catalog&table=items").text
+    assert 'class="grp"' in html  # collapsible groups
+    assert "Identity" in html and "keys &amp; codes" in html  # group label + gloss
+    assert "Pricing" in html
+    assert "Other" in html  # a column in no authored group falls into a trailing group
+
+
+def test_unknown_table_falls_back_to_area(client, env):
+    _seed(env)
+    _login(client)
+    # A stale/unknown table param degrades to the area landing, not a 500.
+    html = client.get("/admin/model?datasource=SALES_DATA&area=Sales&table=nope").text
+    assert "Tables" in html and "orders" in html

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -464,6 +464,92 @@ def test_cross_area_objects_surface_on_overview(client, env):
     assert "Cross-area entities" in html and "company" in html
 
 
+# --- cross-area relationships view -------------------------------------------
+
+XREL_ORG = {
+    "organization": "acme",
+    "storage_connections": [{"name": "c", "storage_type": "PostgreSQL"}],
+    "subject_areas": [
+        {"name": "finance", "tables": [], "tables_defined": []},
+        {"name": "billing", "tables": [], "tables_defined": []},
+        {"name": "crm", "tables": [], "tables_defined": []},
+    ],
+    "cross_subject_area_relationships": [
+        {
+            "from_table": "revenue",
+            "to_table": "subscriptions",
+            "from_column": "sub_id",
+            "to_column": "id",
+            "from_schema": "finance",
+            "to_schema": "billing",
+            "join_type": "LEFT",
+            "relationship": "many_to_one",
+            "confidence": "proposed",
+            "review_state": "approved",
+            "from_subject_area": "finance",
+            "to_subject_area": "billing",
+        },
+        {
+            "from_table": "revenue",
+            "to_table": "customers",
+            "from_column": "cust_id",
+            "to_column": "id",
+            "from_schema": "finance",
+            "to_schema": "billing",
+            "join_type": "LEFT",
+            "relationship": "many_to_one",
+            "confidence": "proposed",
+            "review_state": "approved",
+            "from_subject_area": "finance",
+            "to_subject_area": "billing",
+        },
+        {
+            "from_table": "invoice",
+            "to_table": "account",
+            "from_column": "acct_id",
+            "to_column": "id",
+            "from_schema": "billing",
+            "to_schema": "crm",
+            "join_type": "LEFT",
+            "relationship": "many_to_one",
+            "confidence": "confirmed",
+            "review_state": "approved",
+            "from_subject_area": "billing",
+            "to_subject_area": "crm",
+        },
+    ],
+}
+
+
+def test_relationships_node_only_when_cross_rels_exist(client, env):
+    _seed(env)  # the demo ORG has no cross-area relationships
+    _login(client)
+    assert "view=relationships" not in client.get("/admin/model").text  # no dead node
+    _seed(env, "XR", XREL_ORG)
+    assert "view=relationships" in client.get("/admin/model?datasource=XR").text  # node appears
+
+
+def test_relationships_view_groups_by_area_pair(client, env):
+    _seed(env, "XR", XREL_ORG)
+    _login(client)
+    html = client.get("/admin/model?datasource=XR&view=relationships").text
+    assert "Cross-area relationships" in html
+    assert "finance" in html and "billing" in html and "crm" in html  # the area-pairs
+    assert "revenue" in html and "subscriptions" in html  # a schema-qualified endpoint pair
+    assert "many_to_one" in html  # the cardinality
+    # finance→billing has 2 rels, billing→crm has 1 → grouped (3 total, 2 groups)
+    assert html.count('class="grp"') == 2
+    assert html.count('class="rel"') == 3
+
+
+def test_relationships_view_empty_when_none(client, env):
+    _seed(env)  # demo: no cross-area rels — reachable by direct URL, must not 500
+    _login(client)
+    r = client.get("/admin/model?datasource=SALES_DATA&view=relationships")
+    assert r.status_code == 200
+    assert "No cross-area relationships" in r.text
+
+
 # --- odds and ends -----------------------------------------------------------
 
 

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -277,7 +277,10 @@ def test_picker_only_when_multiple_datasources(client, env):
     _login(client)
     assert 'name="datasource"' not in client.get("/admin/model").text  # one → no picker
     _seed(env, "MARKETING")
-    assert 'name="datasource"' in client.get("/admin/model").text  # two → picker
+    html = client.get("/admin/model").text
+    assert 'name="datasource"' in html  # two → picker
+    # The picker form must have a real submit control (no-JS fallback, not only onchange JS).
+    assert 'class="ds-go"' in html and 'type="submit"' in html
 
 
 # --- area landing ------------------------------------------------------------
@@ -416,6 +419,15 @@ def test_md_empty_and_unterminated_fence():
         "```\nopen fence never closed"
     )  # an unterminated fence still renders, dropping nothing
     assert "open fence never closed" in out
+
+
+def test_md_inline_code_is_literal_not_reparsed():
+    # A link or bold inside backticks must stay literal text in a <code> span — not become a live
+    # <a>/<strong> (Copilot finding: code spans were re-parsed after substitution).
+    out = ui.md("Use the syntax `[label](https://example.com)` and `**not bold**`.")
+    assert "<code>[label](https://example.com)</code>" in out
+    assert "<a href" not in out  # the link inside backticks did NOT become live
+    assert "<code>**not bold**</code>" in out and "<strong>" not in out
 
 
 def test_context_page_renders_org_md(client, env):

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -1,0 +1,192 @@
+"""The admin read-only Model explorer.
+
+A pure projection of the served model (`load_organization`) + domain docs (`load_memory`): the
+overview / area landing / table page render the served tree; it is admin-gated, read-only (a GET
+only), never leaks `storage_config`, and escapes operator-authored text.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("starlette")
+pytest.importorskip("mcp")
+pytest.importorskip("argon2")
+pytest.importorskip("pydantic")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import mcp_http  # noqa: E402
+import model_store  # noqa: E402
+import user_store  # noqa: E402
+from semantic_model.models import Organization  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+from store import Store  # noqa: E402
+
+BASE = "https://your-host.example.com"
+SECRET = "x" * 40
+ADMIN_USER = "admin@example.com"
+ADMIN_PW = "admin-password-localtest"
+
+# A neutral served model — `storage_config` carries a sentinel that must NEVER reach the rendered page.
+ORG = {
+    "organization": "acme",
+    "version": 1,
+    "description": "Acme Commerce — the deployed model.",
+    "fiscal_year_start_month": 1,
+    "key_terminology": {"AOV": "average order value"},
+    "storage_connections": [
+        {
+            "name": "warehouse",
+            "storage_type": "PostgreSQL",
+            "storage_config": {"host": "host-should-not-render"},
+        }
+    ],
+    "subject_areas": [
+        {
+            "name": "Sales",
+            "description": "Orders and revenue.",
+            "default_time_window": "last_90_days",
+            "tables": [{"storage_connection": "warehouse", "schema": "public", "table": "orders"}],
+            "tables_defined": [
+                {
+                    "name": "orders",
+                    "schema": "public",
+                    "storage_connection": "warehouse",
+                    "grain": ["id"],
+                    "description": "One row per order.",
+                    "columns": [
+                        {"name": "id", "type": "integer", "primary_key": True},
+                        {"name": "amount", "type": "decimal", "unit": "USD"},
+                    ],
+                    "performance_hints": {"estimated_row_count": 184000},
+                }
+            ],
+            "metrics": [
+                {
+                    "name": "revenue",
+                    "calculation": "sum of amount",
+                    "other_names": ["sales"],
+                    "unit": "USD",
+                }
+            ],
+            "entities": [{"name": "customer", "value_pattern": "^C[0-9]+$"}],
+            "relationships": [],
+        }
+    ],
+}
+
+
+def _seed(url, datasource="SALES_DATA", org=ORG):
+    s = Store.connect(url)
+    s.run_migrations()
+    model_store.write_organization(s, datasource, Organization.model_validate(org))
+    s.close()
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    url = "sqlite://" + str(tmp_path / "model.db")
+    monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", ADMIN_USER)
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", ADMIN_PW)
+    for v in ("AGAMI_OIDC_GOOGLE_CLIENT_ID", "AGAMI_OIDC_GOOGLE_CLIENT_SECRET"):
+        monkeypatch.delenv(v, raising=False)
+    s = Store.connect(url)
+    s.run_migrations()
+    user_store.seed_admin_from_env(s)
+    s.close()
+    return url
+
+
+@pytest.fixture
+def client(env):
+    return TestClient(mcp_http.build_app(), base_url=BASE)
+
+
+def _login(c):
+    c.post("/admin/login", data={"username": ADMIN_USER, "password": ADMIN_PW})
+
+
+# --- read helper -------------------------------------------------------------
+
+
+def test_list_datasources_is_sorted(env):
+    _seed(env, "ZED")
+    _seed(env, "ACME")
+    s = Store.connect(env)
+    assert model_store.list_datasources(s) == ["ACME", "ZED"]
+    s.close()
+
+
+# --- gating + empty state ----------------------------------------------------
+
+
+def test_model_requires_a_session(client):
+    assert client.get("/admin/model", follow_redirects=False).status_code == 302
+
+
+def test_model_route_is_get_only(client, env):
+    # Read-only by construction: no write verb is mounted at /admin/model.
+    _login(client)
+    assert client.post("/admin/model", follow_redirects=False).status_code == 405
+
+
+def test_empty_state_when_no_model(client, env):
+    _login(client)
+    html = client.get("/admin/model").text
+    assert "No model deployed yet" in html
+
+
+# --- overview ----------------------------------------------------------------
+
+
+def test_overview_renders_org_and_areas(client, env):
+    _seed(env)
+    _login(client)
+    html = client.get("/admin/model").text
+    assert "acme" in html and "Sales" in html
+    assert "AOV" in html and "average order value" in html  # glossary
+    assert "warehouse" in html and "PostgreSQL" in html  # storage names/types
+    assert "Model" in html  # the tab is present in the shell
+
+
+def test_overview_never_leaks_storage_config(client, env):
+    _seed(env)
+    _login(client)
+    assert "host-should-not-render" not in client.get("/admin/model").text
+
+
+def test_picker_only_when_multiple_datasources(client, env):
+    _seed(env, "SALES_DATA")
+    _login(client)
+    assert 'name="datasource"' not in client.get("/admin/model").text  # one → no picker
+    _seed(env, "MARKETING")
+    assert 'name="datasource"' in client.get("/admin/model").text  # two → picker
+
+
+# --- area landing ------------------------------------------------------------
+
+
+def test_area_landing_renders_tables_metrics_entities(client, env):
+    _seed(env)
+    _login(client)
+    html = client.get("/admin/model?datasource=SALES_DATA&area=Sales").text
+    assert "orders" in html  # its table
+    assert "revenue" in html and "sum of amount" in html  # a metric + its calculation
+    assert "customer" in html  # an entity
+
+
+def test_unknown_area_falls_back_to_overview(client, env):
+    _seed(env)
+    _login(client)
+    # A stale/unknown area param must not 500 — it degrades to the datasource overview.
+    html = client.get("/admin/model?datasource=SALES_DATA&area=Nope").text
+    assert "acme" in html and "Subject areas" in html


### PR DESCRIPTION
**Spec: ACE-014**

## Summary
Adds the admin **Model** tab — a read-only **Model explorer** for the deployed semantic model. It's a pure projection of `model_store.load_organization` (the *same* tree the MCP tools serve, so it can't drift) + `load_memory` for the domain doc. Replaces the cognitively-heavy "dump every column of every table with full per-column trust metadata" approach with a **DataHub/Sundial-style catalog**: a browse rail (datasource → subject area → table) and one page at a time.

## Changes
- **`GET /admin/model`** (session-gated, **GET-only** — read-only by construction; no write path) with `?datasource=`, `?area=`, `?table=`, `?view=context`.
- **Three+1 screens** (builders split for previewing): a datasource **overview** (glossary, storage-connection *names/types*, subject areas, cross-area metrics/entities), a **subject-area landing** (tables + metric/entity cards), a **table (dataset) page**, and a **domain-context** page.
- **Table page** — calm schema table; **trust as exceptions** (one table-level `confidence` badge; per-column flags only where they carry signal: PK / FK→target / `sensitive` / unit / enum / caveat); **caveats elevated** to an amber callout + inline note; `ai_unvalidated` marked; relationships + metrics that use the table. **Columns grouped** when the table authors `column_groups` (collapsible, labelled), else a flat **"show all N"** list (wide tables stay short).
- **`ui.md`** — a tiny **escape-first** markdown subset (headings, bold/italic, inline + fenced code, lists, **http(s)-only** links) for `ORGANIZATION.md`; raw HTML in the doc is inert.
- `model_store.list_datasources`; `_TABS` gains a **Model** tab (its own `/admin/model` href); the catalog design folded into `ui._CSS` (light rail, full-width, mobile); `render_previews.py` renders the model pages from the real builders over neutral seeded data; README documents the view.

## Safety
- **Read-only**: a single GET route, no POST/PATCH/DELETE under `/admin/model`. Editing stays conversational in Claude (the in-app editor is Hosted).
- **No secret leak**: connection **names + types only** — `storage_config` (hosts/credentials) is never rendered. Verified by a security pass.
- **Escaping**: every model field goes through `ui.esc`; the markdown renderer is escape-first with an http(s) link allowlist that fails closed. No new egress.

## Test plan
`tests/test_admin_model.py` (27 tests): gating + GET-only (405 on POST); empty state; datasource picker (present >1, absent =1) + stale-param fallback; overview (glossary, storage names, **never `storage_config`**); area landing; the table page's every flag (PK/FK/enum/unit/sensitive/caveat/`ai_unvalidated`/low-confidence); wide-table "show all 14"; grouped-vs-flat columns; SQL-backed table; relationships + metrics; `ui.md` subset + **escaping** (a `<script>` in the doc is inert) + http(s)-only links; cross-area objects; markdown empty/unterminated-fence guards.

## Checklist
- [x] `uv run dev.py check` green — **937 tests**, ruff lint, gitleaks
- [x] Patch coverage **98%** (`uv run dev.py cover`)
- [x] `/code-review` + security review — **0 must-fix**; XSS/secret surface verified clean
- [x] Read-only + admin-gated; no `storage_config`/secrets; no new egress
- [x] Neutral placeholders only (`acme` / `SALES_DATA` / `you@example.com`) — no customer data
- [x] Decisions recorded in the spec; previews regenerate via `render_previews.py`
