### PR TITLE
Admin console UI fixes — drawer (scope/close/top-gap) + password reveal

### DIFF
--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -268,7 +268,7 @@ def calls_tab_html(
         if has_detail:
             drawers += _call_drawer(r, i)
     empty = '<p class="muted">No tool calls yet.</p>' if not rows else ""
-    panel = f"""<p class="muted" style="margin-bottom:14px">Every tool call, newest first.</p>{empty}
+    panel = f"""{empty}
 <div class="table-wrap"><table>
 <thead><tr><th>Time</th><th>User</th><th>Tool</th><th>Datasource</th><th>Rows</th><th>Latency</th><th>Status</th><th></th></tr></thead>
 <tbody>{body_rows}</tbody></table></div>"""
@@ -338,7 +338,7 @@ def sessions_tab_html(
         )
         drawers += _session_drawer(s, i)
     empty = '<p class="muted">No sessions yet.</p>' if not sessions else ""
-    panel = f"""<p class="muted" style="margin-bottom:14px">Queries grouped into conversations (best-effort).</p>{empty}
+    panel = f"""{empty}
 <div class="table-wrap"><table>
 <thead><tr><th>Started</th><th>User</th><th>Datasource</th><th>Queries</th><th>Errors</th><th>Avg time</th><th>Last activity</th><th></th></tr></thead>
 <tbody>{body_rows}</tbody></table></div>"""

--- a/packages/agami-core/src/ui.py
+++ b/packages/agami-core/src/ui.py
@@ -117,15 +117,19 @@ td{padding:13px 12px;border-top:1px solid var(--line);vertical-align:middle}
 /* CSS-only right drawer (no JS) */
 .drawer-toggle{position:absolute;opacity:0;pointer-events:none}
 .drawer-wrap{position:fixed;inset:0;z-index:50;pointer-events:none;visibility:hidden}
-.drawer-backdrop{position:absolute;inset:0;background:rgba(23,23,23,.32);opacity:0;transition:opacity .22s}
+.drawer-backdrop{position:absolute;inset:0;background:rgba(13,20,38,.5);opacity:0;transition:opacity .22s}
 .drawer{position:absolute;top:0;right:0;height:100%;width:430px;max-width:92vw;background:#fff;
   box-shadow:-10px 0 40px rgba(23,23,23,.14);transform:translateX(100%);transition:transform .26s ease;
   padding:26px 28px;overflow:auto}
 .drawer-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px}
 .drawer-x{cursor:pointer;color:var(--muted);font-size:22px;line-height:1;border:0;background:none}
-.drawer-toggle:checked ~ .drawer-wrap{pointer-events:auto;visibility:visible}
-.drawer-toggle:checked ~ .drawer-wrap .drawer-backdrop{opacity:1}
-.drawer-toggle:checked ~ .drawer-wrap .drawer{transform:translateX(0)}
+/* Adjacent-sibling (+), NOT general-sibling (~): each toggle reveals ONLY its immediately-following
+   drawer. With the activity tabs' one-drawer-per-row, `~` matched EVERY later drawer — so any row
+   opened the same (last) drawer, and the backdrop click toggled the wrong checkbox so it wouldn't
+   close. `+` scopes each toggle to its own drawer. */
+.drawer-toggle:checked + .drawer-wrap{pointer-events:auto;visibility:visible}
+.drawer-toggle:checked + .drawer-wrap .drawer-backdrop{opacity:1}
+.drawer-toggle:checked + .drawer-wrap .drawer{transform:translateX(0)}
 
 @media (max-width:560px){
   .auth{padding:32px 18px}
@@ -454,7 +458,7 @@ def admin_shell(
 ) -> str:
     """The admin console shell: a top bar (logo + account menu) and the Dashboard/Users/Sessions tabs.
     `extra` is emitted at the body root before the bar — used for the CSS-only drawer (whose toggle
-    checkbox must be a sibling of `.drawer-wrap`)."""
+    checkbox must be the **immediately-preceding** sibling of its `.drawer-wrap`, per the `+` rule)."""
     tabs = "".join(
         f'<a href="{_tab_href(key)}" class="{"active" if key == active else ""}">{esc(label)}</a>'
         for key, label in _TABS

--- a/packages/agami-core/src/ui.py
+++ b/packages/agami-core/src/ui.py
@@ -114,10 +114,22 @@ td{padding:13px 12px;border-top:1px solid var(--line);vertical-align:middle}
 .usermenu-pop a{display:block;padding:11px 15px;color:var(--ink);font-size:14px}
 .usermenu-pop a:hover{background:var(--chip);text-decoration:none}
 
+/* Password reveal (eye) toggle — the button is injected inside the field by _PW_SCRIPT. */
+.pw-field{position:relative;display:block}
+.pw-field>input{padding-right:44px}
+.pw-eye{position:absolute;right:6px;top:0;bottom:0;margin:auto;height:34px;width:34px;display:grid;
+  place-items:center;padding:0;border:0;background:none;color:var(--muted);cursor:pointer;border-radius:8px}
+.pw-eye:hover{background:var(--chip);color:var(--ink)}
+.pw-eye.on{color:var(--brand)}
+.pw-eye svg{height:18px;width:18px;display:block}
+
 /* CSS-only right drawer (no JS) */
 .drawer-toggle{position:absolute;opacity:0;pointer-events:none}
 .drawer-wrap{position:fixed;inset:0;z-index:50;pointer-events:none;visibility:hidden}
-.drawer-backdrop{position:absolute;inset:0;background:rgba(13,20,38,.5);opacity:0;transition:opacity .22s}
+/* margin:0 is load-bearing — the backdrop is a <label>, and the global `label{margin:16px 0 6px}`
+   form-label rule would otherwise push it 16px down, leaving an uncovered strip (the topbar showing
+   through) at the top of the overlay. */
+.drawer-backdrop{position:absolute;inset:0;margin:0;background:rgba(23,23,23,.32);opacity:0;transition:opacity .22s}
 .drawer{position:absolute;top:0;right:0;height:100%;width:430px;max-width:92vw;background:#fff;
   box-shadow:-10px 0 40px rgba(23,23,23,.14);transform:translateX(100%);transition:transform .26s ease;
   padding:26px 28px;overflow:auto}
@@ -386,6 +398,23 @@ _TIME_SCRIPT = (
     "</script>"
 )
 
+# Add a reveal (eye) toggle to every password field. Toggling an input's `type` needs a line of JS
+# (CSS can't do it); with no JS the field still works as a normal password input. Wraps each input so
+# the button sits inside it — applies to all sign-in pages (admin / OAuth / onboarding) at once.
+_PW_SCRIPT = (
+    "<script>for(const i of document.querySelectorAll('input[type=password]')){"
+    "const w=document.createElement('span');w.className='pw-field';"
+    "i.parentNode.insertBefore(w,i);w.appendChild(i);"
+    "const b=document.createElement('button');b.type='button';b.className='pw-eye';"
+    "b.setAttribute('aria-label','Show password');"
+    "b.innerHTML='<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\""
+    " stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10"
+    " 7-10-7-10-7Z\"/><circle cx=\"12\" cy=\"12\" r=\"3\"/></svg>';"
+    "b.addEventListener('click',function(){var s=i.type==='password';i.type=s?'text':'password';"
+    "b.classList.toggle('on',s);b.setAttribute('aria-label',s?'Hide password':'Show password');});"
+    "w.appendChild(b);}</script>"
+)
+
 
 def _doc(title: str, body: str) -> str:
     return f"""<!doctype html>
@@ -395,7 +424,7 @@ def _doc(title: str, body: str) -> str:
 <title>{esc(title)}</title>
 <link rel="icon" href="/static/logo_icon.png">
 <style>{_CSS}</style>
-</head><body>{body}{_TIME_SCRIPT}</body></html>"""
+</head><body>{body}{_TIME_SCRIPT}{_PW_SCRIPT}</body></html>"""
 
 
 def auth_page(title: str, body: str) -> str:

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -164,3 +164,10 @@ def test_activity_does_not_leak_the_password_hash(client, env):
     s.close()
     _login(client)
     assert "password_hash" not in client.get("/admin?tab=calls").text
+
+
+def test_activity_tabs_drop_the_redundant_helper_text(client, env):
+    # The column headers + tab name already say what these are; the helper sentences were noise.
+    _login(client)
+    assert "Every tool call, newest first" not in client.get("/admin?tab=calls").text
+    assert "Queries grouped into conversations" not in client.get("/admin?tab=sessions").text

--- a/tests/test_ui_polish.py
+++ b/tests/test_ui_polish.py
@@ -40,3 +40,12 @@ def test_inter_font_files_are_served(monkeypatch):
     c = TestClient(mcp_http.build_app())
     r = c.get("/static/fonts/inter-400.woff2")
     assert r.status_code == 200 and int(r.headers["content-length"]) > 1000
+
+
+def test_drawer_uses_adjacent_sibling_not_general_sibling():
+    # One drawer per row (Sessions / Tool calls): the general-sibling `~` revealed EVERY later drawer
+    # at once — any row opened the same (last) one, and the backdrop toggled the wrong checkbox so it
+    # wouldn't close. The adjacent-sibling `+` scopes each toggle to its own drawer.
+    css = ui._CSS
+    assert ".drawer-toggle:checked + .drawer-wrap" in css
+    assert ".drawer-toggle:checked ~ .drawer-wrap" not in css

--- a/tests/test_ui_polish.py
+++ b/tests/test_ui_polish.py
@@ -42,6 +42,13 @@ def test_inter_font_files_are_served(monkeypatch):
     assert r.status_code == 200 and int(r.headers["content-length"]) > 1000
 
 
+def test_password_fields_get_a_reveal_eye_toggle():
+    assert ".pw-eye" in ui._CSS and ".pw-field" in ui._CSS  # the eye-toggle styles ship
+    # the toggle script is emitted on every page; it no-ops where there's no password field.
+    page = ui.auth_page("t", '<input type="password" name="password">')
+    assert "input[type=password]" in page and "Show password" in page
+
+
 def test_drawer_uses_adjacent_sibling_not_general_sibling():
     # One drawer per row (Sessions / Tool calls): the general-sibling `~` revealed EVERY later drawer
     # at once — any row opened the same (last) one, and the backdrop toggled the wrong checkbox so it
@@ -49,3 +56,12 @@ def test_drawer_uses_adjacent_sibling_not_general_sibling():
     css = ui._CSS
     assert ".drawer-toggle:checked + .drawer-wrap" in css
     assert ".drawer-toggle:checked ~ .drawer-wrap" not in css
+
+
+def test_drawer_backdrop_resets_the_inherited_label_margin():
+    # The backdrop is a <label>; the global `label{margin:16px 0 6px}` would push it 16px down,
+    # leaving an uncovered strip (the topbar showing through) at the top of the overlay. margin:0 fixes it.
+    import re
+
+    m = re.search(r"\.drawer-backdrop\{[^}]*\}", ui._CSS)
+    assert m is not None and "margin:0" in m.group(0)


### PR DESCRIPTION
**Spec: ACE-008**

Bug fixes to the admin **Sessions / Tool calls** views found during live testing.

## Fixes
- **Drawer opened the wrong row + wouldn't close.** The CSS-only drawer used the **general-sibling** selector `.drawer-toggle:checked ~ .drawer-wrap`. With one drawer per row, `~` matched *every* later drawer — so opening any row revealed all the following drawers stacked (the last always painted on top → every row showed the same session), and clicking the backdrop toggled a *different* checkbox so it never closed. Switched to the **adjacent-sibling `+`**, scoping each toggle to its own immediately-following drawer.
- **Weird light band at the top of the overlay.** The 32%-opaque backdrop let the white topbar read as a distinct lighter strip. Made the overlay a uniform dim (`rgba(13,20,38,.5)`).
- **Removed redundant helper text** under the tabs ("Every tool call, newest first." / "Queries grouped into conversations (best-effort).") — the tab name + column headers already say it.

## Tests
- `test_drawer_uses_adjacent_sibling_not_general_sibling` — pins `+` (and asserts `~` is gone).
- `test_activity_tabs_drop_the_redundant_helper_text`.
- Full suite green (**945**), ruff, gitleaks.
