### PR TITLE
Unified Activity view — every tool call folded into the conversation

### DIFF
--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -105,8 +105,10 @@ it belongs to — **thread (conversation) ▸ turn (one user question) ▸ call*
 see its whole arc, *not just the queries*: the `list_datasources` / `get_datasource_schema` calls that
 scoped the work sit alongside the `execute_sql`s that answered it (*"User asked what datasources →
 `list_datasources`; user asked revenue by region → `get_datasource_schema`, then `execute_sql` ×2"*). A
-query call shows its SQL, row count, latency, and status; a non-query call shows its tool name and
-datasource.
+query call shows its SQL, row count, latency, and status; a non-query call shows its tool name. Every
+call carries its **own** datasource, because a conversation — or even a single turn — can span several:
+the user switches datasource mid-session, or asks something that runs one query per datasource. The
+conversation row lists the full set it touched.
 
 The split is deliberate: it is **audit-grade for *what* ran** — the server observes every call directly,
 so nothing is dropped — and **best-effort for *how* it's grouped**. The MCP protocol carries neither the

--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -98,21 +98,27 @@ on `/admin/login`).
 > configured IdP — so add a teammate by an email the *right* person controls there. The setup link and
 > the other pre-auth endpoints aren't rate-limited in-process; put them behind your proxy/LB if exposed.
 
-### Activity views
+### Activity view
 
-The admin console also has two read-only activity tabs:
+The admin console has one read-only **Activity** tab: every MCP tool call, folded into the conversation
+it belongs to — **thread (conversation) ▸ turn (one user question) ▸ call**. Open a conversation and you
+see its whole arc, *not just the queries*: the `list_datasources` / `get_datasource_schema` calls that
+scoped the work sit alongside the `execute_sql`s that answered it (*"User asked what datasources →
+`list_datasources`; user asked revenue by region → `get_datasource_schema`, then `execute_sql` ×2"*). A
+query call shows its SQL, row count, latency, and status; a non-query call shows its tool name and
+datasource.
 
-- **Tool calls** — *every* MCP tool call, newest first: who (the authenticated user), the tool,
-  datasource, and for a query the SQL, row count, latency, and status. This is **audit-grade** — the
-  server observes it directly, so it's always accurate.
-- **Sessions** — those queries grouped into a conversation, and *within* it into **turns**: each turn
-  is one user question and the **N agent queries** Claude ran to answer it (*"User asked X → 2
-  queries"*). This is **best-effort** — the MCP protocol carries neither the user's question, a
-  conversation id, nor a turn boundary, so Claude self-reports them: a `user_question` (kept verbatim),
-  a `thread_id` (per conversation), and a `correlation_id` (per turn). The turn's question is taken from
-  the **first** call in the turn (the model sometimes drifts it on later refinements). When Claude
-  doesn't supply a `correlation_id`, each query simply shows as its own turn — the view degrades, never
-  errors. Treat the self-reported fields as a hint, not a record.
+The split is deliberate: it is **audit-grade for *what* ran** — the server observes every call directly,
+so nothing is dropped — and **best-effort for *how* it's grouped**. The MCP protocol carries neither the
+user's question, a conversation id, nor a turn boundary, so Claude self-reports them on every call: a
+`user_question` (kept verbatim), a `thread_id` (per conversation), and a `correlation_id` (per turn). The
+turn's question is taken from the **first** call in the turn (the model sometimes drifts it on later
+refinements). When Claude doesn't supply the ids, a call simply shows as its own singleton conversation —
+the view degrades, never drops a call. Treat the self-reported grouping as a hint, not a record.
+
+> **Free-tier limit.** A turn that produces **no** tool call — Claude answering "let's continue" from
+> context — never reaches the server and so can't appear here; this is an audit of what ran against your
+> data, not a chat transcript.
 
 The `tool_calls` log grows one row per call and has **no automatic retention** — it's your local store,
 so prune it on your own schedule if it gets large.

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -63,7 +63,7 @@ def admin_login_body_html(error: str = "", provider: str | None = None) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Admin console — Users tab (+ Dashboard / Sessions placeholders)
+# Admin console — Users tab (+ Dashboard / Activity placeholders)
 # ---------------------------------------------------------------------------
 
 
@@ -193,7 +193,7 @@ def dashboard_tab_html(*, admin_label: str = "", admin_email: str = "") -> str:
 
 
 # ---------------------------------------------------------------------------
-# Activity views — Tool calls (audit-grade) + Sessions (best-effort grouping)
+# Activity view — every tool call, folded into its conversation (thread ▸ turn ▸ call)
 # ---------------------------------------------------------------------------
 
 
@@ -208,112 +208,50 @@ def _utc(ts: str | None) -> str:
     return f'<time data-utc="{ui.esc(ts)}">{ui.esc(ts)}</time>'
 
 
-def _call_drawer(r: dict[str, Any], idx: int) -> str:
-    """A per-call detail drawer (toggled by the row's Open). The question/agent-query are self-reported,
-    so they're labelled as such; SQL/question are attacker-influenceable → escaped. The DOM id is the
-    row index (never user data), so a crafted value can't break the toggle."""
-    cid = f"call-{idx}"
-    rows = [
-        ("User question", r.get("user_question"), "self-reported"),
-        ("Agent query", r.get("agent_query"), "self-reported"),
-    ]
-    fields = "".join(
-        f'<label>{lbl} <span class="muted">— {note}</span></label><div class="muted">{ui.esc(v)}</div>'
-        for lbl, v, note in rows
-        if v
-    )
-    sql = (
-        f'<label>SQL</label><pre class="code" style="white-space:pre-wrap;padding:12px;display:block">'
-        f"{ui.esc(r['sql'])}</pre>"
-        if r.get("sql")
-        else ""
-    )
-    return f"""<input type="checkbox" id="{cid}" class="drawer-toggle">
-<div class="drawer-wrap"><label for="{cid}" class="drawer-backdrop"></label>
-<aside class="drawer" style="width:560px">
-<div class="drawer-head"><h1 style="font-size:17px">Tool call</h1>
-<label for="{cid}" class="drawer-x" aria-label="Close">&times;</label></div>
-<p class="sub" style="margin-bottom:14px">{ui.esc(r["tool_name"])} · {ui.esc(r.get("actor") or "—")} · {_utc(r["ts"])}</p>
-{fields}{sql}
-<div class="grid2" style="margin-top:16px">
-<div><label>Rows</label><div class="muted">{r.get("row_count") if r.get("row_count") is not None else "—"}</div></div>
-<div><label>Latency</label><div class="muted">{(str(r["execution_ms"]) + " ms") if r.get("execution_ms") is not None else "—"}</div></div>
-<div><label>Status</label><div>{_ok_pill(r["success"])}</div></div>
-<div><label>Datasource</label><div class="muted">{ui.esc(r.get("datasource") or "—")}</div></div>
-</div></aside></div>"""
-
-
-def calls_tab_html(
-    rows: list[dict[str, Any]], *, admin_label: str = "", admin_email: str = ""
-) -> str:
-    """The Tool calls tab: every MCP call, newest first, each with a detail drawer."""
-    body_rows, drawers = "", ""
-    for i, r in enumerate(rows):
-        has_detail = bool(r.get("sql") or r.get("user_question") or r.get("agent_query"))
-        open_ = (
-            f'<label for="call-{i}" class="btn tiny secondary">Open</label>' if has_detail else ""
+def _call_card(c: dict[str, Any]) -> str:
+    """One call inside a turn. A **query** call (has `sql`) shows its agent-framing + SQL; a **non-query**
+    call (list_datasources, get_datasource_schema, …) has no SQL, so it shows its tool name + datasource —
+    so every call in the conversation is visible, not just the queries. SQL/framing are self-reported and
+    attacker-influenceable → escaped; rows shown only when the call recorded a count."""
+    if c.get("sql"):
+        head = (
+            f'<div class="muted" style="margin:0 0 6px">↳ {ui.esc(c["agent_query"])} '
+            f'<span class="muted">· agent-reported</span></div>'
+            if c.get("agent_query")
+            else ""
         )
-        body_rows += (
-            "<tr>"
-            f"<td>{_utc(r['ts'])}</td>"
-            f"<td><strong>{ui.esc(r.get('actor') or '—')}</strong></td>"
-            f'<td><span class="pill" style="background:var(--chip);color:var(--ink)">{ui.esc(r["tool_name"])}</span></td>'
-            f'<td class="muted">{ui.esc(r.get("datasource") or "—")}</td>'
-            f'<td class="muted">{r.get("row_count") if r.get("row_count") is not None else "—"}</td>'
-            f'<td class="muted">{(str(r["execution_ms"]) + " ms") if r.get("execution_ms") is not None else "—"}</td>'
-            f"<td>{_ok_pill(r['success'])}</td>"
-            f'<td style="text-align:right">{open_}</td>'
-            "</tr>"
+        body = (
+            f'<pre class="code" style="white-space:pre-wrap;padding:12px;display:block;margin-top:4px">'
+            f"{ui.esc(c['sql'])}</pre>"
         )
-        if has_detail:
-            drawers += _call_drawer(r, i)
-    empty = '<p class="muted">No tool calls yet.</p>' if not rows else ""
-    panel = f"""{empty}
-<div class="table-wrap"><table>
-<thead><tr><th>Time</th><th>User</th><th>Tool</th><th>Datasource</th><th>Rows</th><th>Latency</th><th>Status</th><th></th></tr></thead>
-<tbody>{body_rows}</tbody></table></div>"""
-    return ui.admin_shell(
-        "Tool calls · agami admin",
-        "calls",
-        panel,
-        admin_label=admin_label,
-        admin_email=admin_email,
-        extra=drawers,
+    else:
+        head = (
+            '<div style="margin:0 0 6px">'
+            f'<span class="pill" style="background:var(--chip);color:var(--ink)">{ui.esc(c["tool_name"])}</span> '
+            f'<span class="muted">{ui.esc(c.get("datasource") or "—")}</span></div>'
+        )
+        body = ""
+    lat = (str(c["execution_ms"]) + " ms") if c.get("execution_ms") is not None else ""
+    rows_bit = f' · {c["row_count"]} rows' if c.get("row_count") is not None else ""
+    return (
+        '<div style="border-top:1px solid var(--line);padding:9px 0 11px">'
+        f"{head}{body}"
+        f'<div class="muted" style="font-size:13px;margin-top:6px">{_utc(c["ts"])} · '
+        f"{lat} {_ok_pill(c['success'])}{rows_bit}</div></div>"
     )
 
 
 def _session_drawer(s: dict[str, Any], idx: int) -> str:
     sid = f"sess-{idx}"  # DOM id is the row index, never the (self-reported, attacker-influenceable) key
-    # Render the session as **turns** (one user question -> N agent queries), grouped on correlation_id
-    # by list_sessions. The turn header shows the verbatim question once; each agent refinement (its
-    # `agent_query` + SQL) lists beneath it. Degrades cleanly: a call with no correlation_id is its own
-    # one-query turn, so this reads like the old flat list when Claude doesn't self-report.
+    # Render the conversation as **turns** (one user question -> the N calls answering it), grouped on
+    # correlation_id by list_sessions. The turn header shows the verbatim question once; each call (a
+    # query's SQL, or a non-query tool's name) lists beneath it. Degrades cleanly: a call with no
+    # correlation_id is its own one-call turn, so this reads like a flat list when Claude doesn't self-report.
     cards = ""
     for t in s["turns"]:
         question = t.get("question") or "(no question reported)"
-        n = len(t["queries"])
-        qrows = ""
-        for q in t["queries"]:
-            sub = (
-                f'<div class="muted" style="margin:0 0 6px">↳ {ui.esc(q["agent_query"])} '
-                f'<span class="muted">· agent-reported</span></div>'
-                if q.get("agent_query")
-                else ""
-            )
-            sql = (
-                f'<pre class="code" style="white-space:pre-wrap;padding:12px;display:block;margin-top:4px">'
-                f"{ui.esc(q['sql'])}</pre>"
-                if q.get("sql")
-                else ""
-            )
-            lat = (str(q["execution_ms"]) + " ms") if q.get("execution_ms") is not None else ""
-            rc = q.get("row_count") if q.get("row_count") is not None else "—"
-            qrows += (
-                '<div style="border-top:1px solid var(--line);padding:9px 0 11px">'
-                f"{sub}{sql}"
-                f'<div class="muted" style="font-size:13px;margin-top:6px">{_utc(q["ts"])} · '
-                f"{lat} {_ok_pill(q['success'])} · {rc} rows</div></div>"
-            )
+        n = len(t["calls"])
+        call_cards = "".join(_call_card(c) for c in t["calls"])
         # The question is Claude-self-reported (best-effort, attacker-influenceable) — mark it so, like
         # the rest of the activity log; "User asked" is the framing, "· self-reported" the provenance.
         asked = (
@@ -325,23 +263,24 @@ def _session_drawer(s: dict[str, Any], idx: int) -> str:
         cards += (
             '<div style="border-top:2px solid var(--line);padding:14px 0 2px;margin-top:8px">'
             f'<div style="margin-bottom:4px">{asked} '
-            f'<span class="muted" style="font-size:13px">· {n} {"query" if n == 1 else "queries"}</span>'
-            f"</div>{qrows}</div>"
+            f'<span class="muted" style="font-size:13px">· {n} {"call" if n == 1 else "calls"}</span>'
+            f"</div>{call_cards}</div>"
         )
     return f"""<input type="checkbox" id="{sid}" class="drawer-toggle">
 <div class="drawer-wrap"><label for="{sid}" class="drawer-backdrop"></label>
 <aside class="drawer" style="width:560px">
-<div class="drawer-head"><h1 style="font-size:17px">Session</h1>
+<div class="drawer-head"><h1 style="font-size:17px">Conversation</h1>
 <label for="{sid}" class="drawer-x" aria-label="Close">&times;</label></div>
-<p class="sub" style="margin-bottom:8px">{ui.esc(s.get("actor") or "—")} · {ui.esc(s.get("datasource") or "—")} · {s["query_count"]} queries · started {_utc(s["started"])}</p>
+<p class="sub" style="margin-bottom:8px">{ui.esc(s.get("actor") or "—")} · {ui.esc(s.get("datasource") or "—")} · {s["call_count"]} calls · started {_utc(s["started"])}</p>
 {cards}</aside></div>"""
 
 
-def sessions_tab_html(
+def activity_tab_html(
     sessions: list[dict[str, Any]] | None = None, *, admin_label: str = "", admin_email: str = ""
 ) -> str:
-    """The Sessions tab: query calls grouped into conversations (best-effort via the self-reported
-    `thread_id`; ungrouped singletons otherwise). Each row opens to its queries + their NL questions."""
+    """The Activity tab: **every** tool call grouped into conversations (best-effort via the self-reported
+    `thread_id`; ungrouped singletons otherwise — so it stays audit-complete). Each row opens to the
+    conversation's turns, and within them every call (query or not)."""
     sessions = sessions or []
     body_rows, drawers = "", ""
     for i, s in enumerate(sessions):
@@ -350,7 +289,7 @@ def sessions_tab_html(
             f'<td><label for="sess-{i}" style="cursor:pointer;color:var(--brand)">{_utc(s["started"])}</label></td>'
             f"<td><strong>{ui.esc(s.get('actor') or '—')}</strong></td>"
             f'<td class="muted">{ui.esc(s.get("datasource") or "—")}</td>'
-            f'<td class="muted">{s["query_count"]}</td>'
+            f'<td class="muted">{s["call_count"]}</td>'
             f'<td class="muted">{s["error_count"] or "—"}</td>'
             f'<td class="muted">{(str(s["avg_ms"]) + " ms") if s.get("avg_ms") is not None else "—"}</td>'
             f"<td>{_utc(s['last_activity'])}</td>"
@@ -358,14 +297,14 @@ def sessions_tab_html(
             "</tr>"
         )
         drawers += _session_drawer(s, i)
-    empty = '<p class="muted">No sessions yet.</p>' if not sessions else ""
+    empty = '<p class="muted">No activity yet.</p>' if not sessions else ""
     panel = f"""{empty}
 <div class="table-wrap"><table>
-<thead><tr><th>Started</th><th>User</th><th>Datasource</th><th>Queries</th><th>Errors</th><th>Avg time</th><th>Last activity</th><th></th></tr></thead>
+<thead><tr><th>Started</th><th>User</th><th>Datasource</th><th>Calls</th><th>Errors</th><th>Avg time</th><th>Last activity</th><th></th></tr></thead>
 <tbody>{body_rows}</tbody></table></div>"""
     return ui.admin_shell(
-        "Sessions · agami admin",
-        "sessions",
+        "Activity · agami admin",
+        "activity",
         panel,
         admin_label=admin_label,
         admin_email=admin_email,
@@ -661,7 +600,7 @@ async def admin_logout(request: Request) -> Response:
 
 
 async def admin_home(request: Request) -> Response:
-    """The console. `?tab=` picks Dashboard / Users (default) / Sessions / Tool calls. Session-gated."""
+    """The console. `?tab=` picks Dashboard / Users (default) / Activity. Session-gated."""
     import model_store
 
     admin = current_admin(request)
@@ -673,12 +612,9 @@ async def admin_home(request: Request) -> Response:
         tab = request.query_params.get("tab", "users")
         if tab == "dashboard":
             return HTMLResponse(dashboard_tab_html(**chrome))
-        if tab == "sessions":
+        if tab == "activity":
             sessions = model_store.list_sessions(store) if store is not None else []
-            return HTMLResponse(sessions_tab_html(sessions, **chrome))
-        if tab == "calls":
-            calls = model_store.list_tool_calls(store) if store is not None else []
-            return HTMLResponse(calls_tab_html(calls, **chrome))
+            return HTMLResponse(activity_tab_html(sessions, **chrome))
         users = user_store.list_users(store) if store is not None else []
     finally:
         if store is not None:

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -210,9 +210,11 @@ def _utc(ts: str | None) -> str:
 
 def _call_card(c: dict[str, Any]) -> str:
     """One call inside a turn. A **query** call (has `sql`) shows its agent-framing + SQL; a **non-query**
-    call (list_datasources, get_datasource_schema, …) has no SQL, so it shows its tool name + datasource —
-    so every call in the conversation is visible, not just the queries. SQL/framing are self-reported and
-    attacker-influenceable → escaped; rows shown only when the call recorded a count."""
+    call (list_datasources, get_datasource_schema, …) has no SQL, so it shows its tool name — so every call
+    in the conversation is visible, not just the queries. Every card's meta line carries the call's OWN
+    datasource (a turn can span datasources — a cross-datasource question runs one execute_sql each — so
+    per-call attribution matters). SQL/framing are self-reported + attacker-influenceable → escaped; rows
+    shown only when the call recorded a count."""
     if c.get("sql"):
         head = (
             f'<div class="muted" style="margin:0 0 6px">↳ {ui.esc(c["agent_query"])} '
@@ -227,16 +229,17 @@ def _call_card(c: dict[str, Any]) -> str:
     else:
         head = (
             '<div style="margin:0 0 6px">'
-            f'<span class="pill" style="background:var(--chip);color:var(--ink)">{ui.esc(c["tool_name"])}</span> '
-            f'<span class="muted">{ui.esc(c.get("datasource") or "—")}</span></div>'
+            f'<span class="pill" style="background:var(--chip);color:var(--ink)">{ui.esc(c["tool_name"])}</span>'
+            "</div>"
         )
         body = ""
+    ds = ui.esc(c.get("datasource") or "—")
     lat = (str(c["execution_ms"]) + " ms") if c.get("execution_ms") is not None else ""
     rows_bit = f' · {c["row_count"]} rows' if c.get("row_count") is not None else ""
     return (
         '<div style="border-top:1px solid var(--line);padding:9px 0 11px">'
         f"{head}{body}"
-        f'<div class="muted" style="font-size:13px;margin-top:6px">{_utc(c["ts"])} · '
+        f'<div class="muted" style="font-size:13px;margin-top:6px">{_utc(c["ts"])} · {ds} · '
         f"{lat} {_ok_pill(c['success'])}{rows_bit}</div></div>"
     )
 
@@ -271,7 +274,7 @@ def _session_drawer(s: dict[str, Any], idx: int) -> str:
 <aside class="drawer" style="width:560px">
 <div class="drawer-head"><h1 style="font-size:17px">Conversation</h1>
 <label for="{sid}" class="drawer-x" aria-label="Close">&times;</label></div>
-<p class="sub" style="margin-bottom:8px">{ui.esc(s.get("actor") or "—")} · {ui.esc(s.get("datasource") or "—")} · {s["call_count"]} calls · started {_utc(s["started"])}</p>
+<p class="sub" style="margin-bottom:8px">{ui.esc(s.get("actor") or "—")} · {ui.esc(", ".join(s["datasources"]) or "—")} · {s["call_count"]} calls · started {_utc(s["started"])}</p>
 {cards}</aside></div>"""
 
 
@@ -288,7 +291,7 @@ def activity_tab_html(
             "<tr>"
             f'<td><label for="sess-{i}" style="cursor:pointer;color:var(--brand)">{_utc(s["started"])}</label></td>'
             f"<td><strong>{ui.esc(s.get('actor') or '—')}</strong></td>"
-            f'<td class="muted">{ui.esc(s.get("datasource") or "—")}</td>'
+            f'<td class="muted">{ui.esc(", ".join(s["datasources"]) or "—")}</td>'
             f'<td class="muted">{s["call_count"]}</td>'
             f'<td class="muted">{s["error_count"] or "—"}</td>'
             f'<td class="muted">{(str(s["avg_ms"]) + " ms") if s.get("avg_ms") is not None else "—"}</td>'
@@ -300,7 +303,7 @@ def activity_tab_html(
     empty = '<p class="muted">No activity yet.</p>' if not sessions else ""
     panel = f"""{empty}
 <div class="table-wrap"><table>
-<thead><tr><th>Started</th><th>User</th><th>Datasource</th><th>Calls</th><th>Errors</th><th>Avg time</th><th>Last activity</th><th></th></tr></thead>
+<thead><tr><th>Started</th><th>User</th><th>Datasources</th><th>Calls</th><th>Errors</th><th>Avg time</th><th>Last activity</th><th></th></tr></thead>
 <tbody>{body_rows}</tbody></table></div>"""
     return ui.admin_shell(
         "Activity · agami admin",

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -432,11 +432,15 @@ def list_sessions(store: Store, *, limit: int = 500) -> list[dict[str, Any]]:
         ms = [c["execution_ms"] for c in cs if c["execution_ms"] is not None]
         s["started"] = min(ts_all)
         s["last_activity"] = max(ts_all)
-        # The conversation's datasource = the EARLIEST call that has one set. A conversation now often
-        # opens with list_datasources (no datasource), so the first row's would show "—" even though the
-        # conversation queried a real datasource. `cs` is ts-DESC, so scan it chronologically (min ts).
-        with_ds = [c for c in cs if c["datasource"]]
-        s["datasource"] = min(with_ds, key=lambda c: c["ts"])["datasource"] if with_ds else None
+        # A conversation — or even one turn — can touch SEVERAL datasources: the user switches mid-session,
+        # or asks something spanning two (the agent runs one execute_sql per datasource). Surface the full
+        # distinct set in first-seen (chronological) order, not just one; `cs` is ts-DESC, so walk it
+        # reversed. Empty when only datasource-less calls (e.g. list_datasources) ran.
+        seen_ds: list[str] = []
+        for c in reversed(cs):
+            if c["datasource"] and c["datasource"] not in seen_ds:
+                seen_ds.append(c["datasource"])
+        s["datasources"] = seen_ds
         s["call_count"] = len(cs)
         s["error_count"] = sum(1 for c in cs if not c["success"])
         s["avg_ms"] = round(sum(ms) / len(ms)) if ms else None  # over calls that recorded latency

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -386,8 +386,13 @@ def _group_turns(calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
     turns: list[dict[str, Any]] = []
     for ck in turn_order:
         tc = sorted(turns_map[ck], key=lambda x: x["ts"])  # chronological within the turn
+        # The turn's question = the EARLIEST call that actually reported one. Not literally tc[0]: the
+        # setup calls that now fold into a turn (list_datasources, get_datasource_schema) carry no
+        # user_question, so they'd mask the real question that the execute_sql did report. Earliest-with-
+        # one stays drift-proof (a later call's drifted question can't win over the first real one).
+        question = next((c["user_question"] for c in tc if c.get("user_question")), None)
         turns.append({
-            "question": tc[0].get("user_question"),  # earliest call's question (drift-proof)
+            "question": question,
             "started": tc[0]["ts"],
             "calls": tc,
         })

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -427,6 +427,10 @@ def list_sessions(store: Store, *, limit: int = 500) -> list[dict[str, Any]]:
         ms = [c["execution_ms"] for c in cs if c["execution_ms"] is not None]
         s["started"] = min(ts_all)
         s["last_activity"] = max(ts_all)
+        # The conversation's datasource = its first call with one set. A conversation now often opens
+        # with list_datasources (no datasource), so taking the first row's would show "—" even though
+        # the conversation queried a real datasource.
+        s["datasource"] = next((c["datasource"] for c in cs if c["datasource"]), None)
         s["call_count"] = len(cs)
         s["error_count"] = sum(1 for c in cs if not c["success"])
         s["avg_ms"] = round(sum(ms) / len(ms)) if ms else None  # over calls that recorded latency

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -368,46 +368,41 @@ _TOOL_CALL_COLS = (
 )
 
 
-def list_tool_calls(store: Store, *, limit: int = 200) -> list[dict[str, Any]]:
-    """Recent tool calls, newest first — the audit-grade flat activity view."""
-    return store.query(
-        f"SELECT {_TOOL_CALL_COLS} FROM tool_calls ORDER BY ts DESC LIMIT ?", (limit,)
-    )
-
-
-def _group_turns(queries: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Group a session's query calls into **turns** by the self-reported `correlation_id` (one user
-    question -> N agent sub-queries). A query with no `correlation_id` is its own singleton turn (so
-    the view degrades to the per-call list). The turn's `question` is the **earliest** call's
-    `user_question` — Claude drifts `user_question` onto later refinements, so the first is the reliable
-    one. Turns keep newest-first order (queries arrive ts-DESC); each turn's queries read chronologically."""
+def _group_turns(calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group a conversation's calls into **turns** by the self-reported `correlation_id` (one user
+    question -> the N calls the agent made answering it). A call with no `correlation_id` is its own
+    singleton turn (so the view degrades to the per-call list). The turn's `question` is the **earliest**
+    call's `user_question` — Claude drifts `user_question` onto later refinements, so the first is the
+    reliable one. Turns keep newest-first order (calls arrive ts-DESC); each turn's calls read
+    chronologically."""
     turns_map: dict[Any, list[dict[str, Any]]] = {}
     turn_order: list[Any] = []
-    for q in queries:
-        ck = q["correlation_id"] or q["id"]  # no correlation_id -> singleton keyed on the row id
+    for c in calls:
+        ck = c["correlation_id"] or c["id"]  # no correlation_id -> singleton keyed on the row id
         if ck not in turns_map:
             turns_map[ck] = []
             turn_order.append(ck)
-        turns_map[ck].append(q)
+        turns_map[ck].append(c)
     turns: list[dict[str, Any]] = []
     for ck in turn_order:
-        tq = sorted(turns_map[ck], key=lambda x: x["ts"])  # chronological within the turn
+        tc = sorted(turns_map[ck], key=lambda x: x["ts"])  # chronological within the turn
         turns.append({
-            "question": tq[0].get("user_question"),  # earliest call's question (drift-proof)
-            "started": tq[0]["ts"],
-            "queries": tq,
+            "question": tc[0].get("user_question"),  # earliest call's question (drift-proof)
+            "started": tc[0]["ts"],
+            "calls": tc,
         })
     return turns
 
 
 def list_sessions(store: Store, *, limit: int = 500) -> list[dict[str, Any]]:
-    """Group the **query** calls (execute_sql) into sessions for the best-effort Sessions view: same
-    `thread_id` = one session; a call with no `thread_id` (Claude didn't self-report) becomes its own
-    singleton session (grouped on its id), so the view degrades gracefully to ungrouped. Grouping +
-    aggregation are done in Python (portable, no dialect-specific GROUP BY)."""
+    """Group **all** tool calls into conversations for the best-effort Activity view: same `thread_id`
+    = one conversation; a call with no `thread_id` (Claude didn't self-report) becomes its own singleton
+    (grouped on its id), so the view degrades gracefully to ungrouped — and stays **audit-complete**:
+    every call appears, query or not (the non-query tools — list_datasources, get_datasource_schema, …
+    — fold into the conversation alongside the execute_sql calls). Grouping + aggregation are done in
+    Python (portable, no dialect-specific GROUP BY)."""
     rows = store.query(
-        f"SELECT {_TOOL_CALL_COLS} FROM tool_calls WHERE tool_name = 'execute_sql' "
-        "ORDER BY ts DESC LIMIT ?",
+        f"SELECT {_TOOL_CALL_COLS} FROM tool_calls ORDER BY ts DESC LIMIT ?",
         (limit,),
     )
     sessions: dict[Any, dict[str, Any]] = {}
@@ -415,26 +410,26 @@ def list_sessions(store: Store, *, limit: int = 500) -> list[dict[str, Any]]:
     for r in rows:
         # Scope the group by the (audit-grade) actor as well as the (self-reported, untrusted) thread_id:
         # two different users colliding on one thread_id must NOT blend into a single, misattributed
-        # session. A call with no thread_id stays its own singleton (grouped on its id).
+        # conversation. A call with no thread_id stays its own singleton (grouped on its id).
         key = (r["actor"], r["thread_id"]) if r["thread_id"] else r["id"]
         s = sessions.get(key)
         if s is None:
             s = {"key": key, "thread_id": r["thread_id"], "actor": r["actor"],
-                 "datasource": r["datasource"], "queries": []}
+                 "datasource": r["datasource"], "calls": []}
             sessions[key] = s
             order.append(key)
-        s["queries"].append(r)
+        s["calls"].append(r)
     out: list[dict[str, Any]] = []
     for key in order:
         s = sessions[key]
-        qs = s["queries"]
-        ts_all = [q["ts"] for q in qs]
-        ms = [q["execution_ms"] for q in qs if q["execution_ms"] is not None]
+        cs = s["calls"]
+        ts_all = [c["ts"] for c in cs]
+        ms = [c["execution_ms"] for c in cs if c["execution_ms"] is not None]
         s["started"] = min(ts_all)
         s["last_activity"] = max(ts_all)
-        s["query_count"] = len(qs)
-        s["error_count"] = sum(1 for q in qs if not q["success"])
-        s["avg_ms"] = round(sum(ms) / len(ms)) if ms else None
-        s["turns"] = _group_turns(qs)  # the within-session turn level (ACE-015)
+        s["call_count"] = len(cs)
+        s["error_count"] = sum(1 for c in cs if not c["success"])
+        s["avg_ms"] = round(sum(ms) / len(ms)) if ms else None  # over calls that recorded latency
+        s["turns"] = _group_turns(cs)  # the within-conversation turn level (ACE-015)
         out.append(s)
     return out

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -427,10 +427,11 @@ def list_sessions(store: Store, *, limit: int = 500) -> list[dict[str, Any]]:
         ms = [c["execution_ms"] for c in cs if c["execution_ms"] is not None]
         s["started"] = min(ts_all)
         s["last_activity"] = max(ts_all)
-        # The conversation's datasource = its first call with one set. A conversation now often opens
-        # with list_datasources (no datasource), so taking the first row's would show "—" even though
-        # the conversation queried a real datasource.
-        s["datasource"] = next((c["datasource"] for c in cs if c["datasource"]), None)
+        # The conversation's datasource = the EARLIEST call that has one set. A conversation now often
+        # opens with list_datasources (no datasource), so the first row's would show "—" even though the
+        # conversation queried a real datasource. `cs` is ts-DESC, so scan it chronologically (min ts).
+        with_ds = [c for c in cs if c["datasource"]]
+        s["datasource"] = min(with_ds, key=lambda c: c["ts"])["datasource"] if with_ds else None
         s["call_count"] = len(cs)
         s["error_count"] = sum(1 for c in cs if not c["success"])
         s["avg_ms"] = round(sum(ms) / len(ms)) if ms else None  # over calls that recorded latency

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -77,12 +77,12 @@ SERVER_INSTRUCTIONS = (
     "COUNT/COUNT(DISTINCT)/filter/GROUP BY/JOIN on it, but never SELECT its raw per-row values. "
     "'unique emails' → COUNT(DISTINCT email). To disambiguate identical labels, project the "
     "non-sensitive id. (execute_sql enforces this and errors on a raw sensitive projection.)\n"
-    "Activity log: on execute_sql, pass `user_question` (the user's question VERBATIM — keep it the "
-    "SAME across every query answering that one question; put your own refinement in `raw_query`, never "
-    "in `user_question`), a `thread_id` (one per conversation), and a `correlation_id` (one per user "
-    "question/turn, reused across the queries answering it, fresh when they ask something new) — so a "
-    "deployment admin sees the conversation, and within it 'user asked X → agent ran N queries'. "
-    "Best-effort; omit if unknown."
+    "Activity log: on EVERY tool call (not just execute_sql), pass a `thread_id` (one per conversation, "
+    "reused across all its calls) and a `correlation_id` (one per user question/turn, reused across the "
+    "calls answering it, fresh when they ask something new), plus `user_question` (the user's question "
+    "VERBATIM — keep it the SAME across the calls answering it; on execute_sql your own refinement goes "
+    "in `raw_query`, never in `user_question`) — so a deployment admin sees the whole conversation, and "
+    "within it 'user asked X → agent made N calls'. Best-effort; omit if unknown."
 )
 
 
@@ -1045,6 +1045,27 @@ def _record_tool_call(rec: dict[str, Any]) -> None:
 # Tool registry (name → (handler, description, inputSchema))
 # ---------------------------------------------------------------------------
 
+# The self-reported grouping ids — the same on EVERY tool, so the admin activity log can reconstruct
+# the conversation (thread ▸ turn ▸ call) the MCP server never sees. Defined once and spread into each
+# schema's `properties` so the wording can't drift between tools; SERVER_INSTRUCTIONS tells Claude to
+# pass them on every call. All best-effort (omit if unknown).
+_THREAD_ID_PROP = {
+    "type": "string",
+    "description": "A short id you generate ONCE per conversation and reuse on every tool call in it "
+    "— lets the admin group a conversation's calls into one session.",
+}
+_CORRELATION_ID_PROP = {
+    "type": "string",
+    "description": "A short id you generate ONCE per USER QUESTION (a turn) and reuse on every call "
+    "you make answering THAT question — lets the admin see 'user asked X → agent made N calls'. "
+    "Start a fresh one when the user asks something new.",
+}
+_USER_QUESTION_PROP = {
+    "type": "string",
+    "description": "The user's question, VERBATIM, that this call helps answer — recorded so an admin "
+    "sees what was actually asked. Keep it the SAME across the calls answering one question.",
+}
+
 TOOLS: dict[str, dict[str, Any]] = {
     "list_datasources": {
         "handler": tool_list_datasources,
@@ -1053,7 +1074,15 @@ TOOLS: dict[str, dict[str, Any]] = {
             "semantic model. Local analog of the hosted list_organizations. Call this first "
             "when the datasource is not yet known; the others accept an optional `datasource`."
         ),
-        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "user_question": _USER_QUESTION_PROP,
+                "thread_id": _THREAD_ID_PROP,
+                "correlation_id": _CORRELATION_ID_PROP,
+            },
+            "additionalProperties": False,
+        },
     },
     "get_datasource_schema": {
         "handler": tool_get_datasource_schema,
@@ -1092,6 +1121,9 @@ TOOLS: dict[str, dict[str, Any]] = {
                     "items": {"type": "string"},
                     "description": "Return full detail for these named metrics.",
                 },
+                "user_question": _USER_QUESTION_PROP,
+                "thread_id": _THREAD_ID_PROP,
+                "correlation_id": _CORRELATION_ID_PROP,
             },
             "additionalProperties": False,
         },
@@ -1118,6 +1150,9 @@ TOOLS: dict[str, dict[str, Any]] = {
                     "type": "integer",
                     "description": "Accepted for hosted-parity; not applied locally.",
                 },
+                "user_question": _USER_QUESTION_PROP,
+                "thread_id": _THREAD_ID_PROP,
+                "correlation_id": _CORRELATION_ID_PROP,
             },
             "additionalProperties": False,
         },
@@ -1153,17 +1188,8 @@ TOOLS: dict[str, dict[str, Any]] = {
                     "query you run to answer one question — do not replace it with your refinement (that "
                     "goes in raw_query). Recorded so an admin sees what was actually asked.",
                 },
-                "thread_id": {
-                    "type": "string",
-                    "description": "A short id you generate ONCE per conversation and reuse on every "
-                    "tool call in it — lets the admin group a conversation's queries into one session.",
-                },
-                "correlation_id": {
-                    "type": "string",
-                    "description": "A short id you generate ONCE per USER QUESTION (a turn) and reuse on "
-                    "every query you run to answer THAT question — lets the admin see 'user asked X → "
-                    "agent ran N queries'. Start a fresh one when the user asks something new.",
-                },
+                "thread_id": _THREAD_ID_PROP,
+                "correlation_id": _CORRELATION_ID_PROP,
                 "max_rows": {"type": "integer", "description": "Row cap (clamped 1–10000)."},
             },
             "required": ["sql"],
@@ -1189,6 +1215,9 @@ TOOLS: dict[str, dict[str, Any]] = {
                     "type": "string",
                     "description": "Profile name; defaults to the active profile.",
                 },
+                "user_question": _USER_QUESTION_PROP,
+                "thread_id": _THREAD_ID_PROP,
+                "correlation_id": _CORRELATION_ID_PROP,
             },
             "required": ["raw_query", "rating"],
             "additionalProperties": False,

--- a/packages/agami-core/src/ui.py
+++ b/packages/agami-core/src/ui.py
@@ -452,8 +452,7 @@ def provider_button(key: str, href: str) -> str:
 _TABS = (
     ("dashboard", "Dashboard"),
     ("users", "Users"),
-    ("sessions", "Sessions"),
-    ("calls", "Tool calls"),
+    ("activity", "Activity"),
     ("model", "Model"),
 )
 
@@ -485,7 +484,7 @@ def admin_shell(
     admin_email: str = "",
     extra: str = "",
 ) -> str:
-    """The admin console shell: a top bar (logo + account menu) and the Dashboard/Users/Sessions tabs.
+    """The admin console shell: a top bar (logo + account menu) and the Dashboard/Users/Activity tabs.
     `extra` is emitted at the body root before the bar — used for the CSS-only drawer (whose toggle
     checkbox must be the **immediately-preceding** sibling of its `.drawer-wrap`, per the `+` rule)."""
     tabs = "".join(

--- a/render_previews.py
+++ b/render_previews.py
@@ -105,6 +105,16 @@ _SAMPLE_CALLS = [
          datasource="SALES_DATA", sql="SELECT * FROM ordrs", execution_ms=31, success=False,
          error_kind="syntax", user_question="how many orders today?", agent_query="count today's orders",
          thread_id="t2", correlation_id="c3"),
+    # A cross-datasource turn (thread t3, one correlation): a question spanning two datasources runs one
+    # execute_sql per datasource — the row lists both, and each call card shows its own.
+    dict(ts="2026-06-27T10:55:10Z", tool_name="execute_sql", source="mcp_server", actor="jordan@example.com",
+         datasource="SALES_DATA", sql="SELECT region, SUM(amount) AS revenue\nFROM orders GROUP BY region",
+         row_count=5, execution_ms=72, success=True, user_question="revenue vs open support tickets by region",
+         agent_query="revenue by region", thread_id="t3", correlation_id="c4"),
+    dict(ts="2026-06-27T10:55:31Z", tool_name="execute_sql", source="mcp_server", actor="jordan@example.com",
+         datasource="SUPPORT_DATA", sql="SELECT region, COUNT(*) AS open_tickets\nFROM tickets WHERE status='open' GROUP BY region",
+         row_count=5, execution_ms=58, success=True, user_question="revenue vs open support tickets by region",
+         agent_query="open tickets by region", thread_id="t3", correlation_id="c4"),
     # A bare call with no self-reported ids → its own singleton conversation (audit-complete degradation).
     dict(ts="2026-06-27T10:40:03Z", tool_name="list_datasources", source="mcp_server",
          actor="morgan@example.com", execution_ms=3, success=True),

--- a/render_previews.py
+++ b/render_previews.py
@@ -69,7 +69,7 @@ write("05-admin-users.html",
       admin.users_tab_html(USERS, csrf="t0ken", ok="User added.", setup_links=SETUP_LINKS, **ADMIN))
 write("06-admin-dashboard.html", admin.dashboard_tab_html(**CHROME))
 
-# The activity views — rendered from the REAL builders + read helpers over a temp store (no drift).
+# The activity view — rendered from the REAL builders + read helpers over a temp store (no drift).
 import os  # noqa: E402
 import tempfile  # noqa: E402
 
@@ -84,29 +84,34 @@ _s = Store.connect("sqlite://" + _db_path)
 _s.run_migrations()
 _sink = DbActivitySink(_s)
 _SAMPLE_CALLS = [
-    # One turn (correlation c1): a single user question that the agent answered with TWO queries.
+    # One conversation (thread t1), two turns — and EVERY call folds in, not just the execute_sql ones:
+    # turn c1 scopes the datasource (list_datasources), turn c2 answers a question (schema + 2 queries).
+    dict(ts="2026-06-27T10:40:50Z", tool_name="list_datasources", source="mcp_server",
+         actor="jordan@example.com", execution_ms=3, success=True,
+         user_question="What datasources can I ask about?", thread_id="t1", correlation_id="c1"),
+    dict(ts="2026-06-27T10:41:05Z", tool_name="get_datasource_schema", source="mcp_server",
+         actor="jordan@example.com", datasource="SALES_DATA", execution_ms=12, success=True,
+         user_question="What's our revenue by region this quarter?", thread_id="t1", correlation_id="c2"),
     dict(ts="2026-06-27T10:42:17Z", tool_name="execute_sql", source="mcp_server", actor="jordan@example.com",
          datasource="SALES_DATA", sql="SELECT region, SUM(amount) AS revenue\nFROM orders\nGROUP BY region\nORDER BY revenue DESC",
          row_count=5, execution_ms=84, success=True, user_question="What's our revenue by region this quarter?",
-         agent_query="revenue by region", thread_id="t1", correlation_id="c1"),
+         agent_query="revenue by region", thread_id="t1", correlation_id="c2"),
     dict(ts="2026-06-27T10:42:41Z", tool_name="execute_sql", source="mcp_server", actor="jordan@example.com",
          datasource="SALES_DATA", sql="SELECT date_trunc('month', placed_at) AS month, SUM(amount)\nFROM orders\nWHERE region = 'West'\nGROUP BY 1\nORDER BY 1",
          row_count=3, execution_ms=61, success=True, user_question="What's our revenue by region this quarter?",
-         agent_query="monthly trend for the top region (West)", thread_id="t1", correlation_id="c1"),
-    dict(ts="2026-06-27T10:40:55Z", tool_name="get_datasource_schema", source="mcp_server",
-         actor="jordan@example.com", datasource="SALES_DATA", execution_ms=12, success=True),
-    # A separate one-query turn that errored (correlation c2).
+         agent_query="monthly trend for the top region (West)", thread_id="t1", correlation_id="c2"),
+    # A separate one-query turn that errored (thread t2).
     dict(ts="2026-06-27T10:41:50Z", tool_name="execute_sql", source="mcp_server", actor="sam@example.com",
          datasource="SALES_DATA", sql="SELECT * FROM ordrs", execution_ms=31, success=False,
          error_kind="syntax", user_question="how many orders today?", agent_query="count today's orders",
-         thread_id="t2", correlation_id="c2"),
+         thread_id="t2", correlation_id="c3"),
+    # A bare call with no self-reported ids → its own singleton conversation (audit-complete degradation).
     dict(ts="2026-06-27T10:40:03Z", tool_name="list_datasources", source="mcp_server",
-         actor="jordan@example.com", execution_ms=3, success=True),
+         actor="morgan@example.com", execution_ms=3, success=True),
 ]
 for _c in _SAMPLE_CALLS:
     _sink.record_tool_call(ToolCallRecord(**_c))
-write("07-admin-sessions.html", admin.sessions_tab_html(model_store.list_sessions(_s), **CHROME))
-write("15-tool-calls.html", admin.calls_tab_html(model_store.list_tool_calls(_s), **CHROME))
+write("07-admin-activity.html", admin.activity_tab_html(model_store.list_sessions(_s), **CHROME))
 
 # The read-only model explorer — rendered from the REAL builders over the SAME served tree the MCP
 # tools read (load_organization), so the previews can't drift from production. Neutral demo data only.

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -357,11 +357,10 @@ def test_admin_ui_is_disabled_when_no_admin_configured(env, monkeypatch):
 
 
 def test_dashboard_tab_is_a_placeholder(client):
-    # Dashboard is still a placeholder; Sessions + Tool calls are now real views.
+    # Dashboard is still a placeholder; Activity is the real (unified) view.
     _login(client)
     assert "Coming soon" in client.get("/admin?tab=dashboard").text
-    assert "No sessions yet" in client.get("/admin?tab=sessions").text
-    assert "No tool calls yet" in client.get("/admin?tab=calls").text
+    assert "No activity yet" in client.get("/admin?tab=activity").text
 
 
 def test_login_page_redirects_when_already_signed_in(client):

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -1,7 +1,7 @@
-"""The admin activity views — Tool calls (audit-grade flat) + Sessions (best-effort grouping).
+"""The admin Activity view — every tool call folded into its conversation (thread ▸ turn ▸ call).
 
-Covers the read helpers' grouping/degradation and the two rendered tabs (actor shown, SQL/question
-escaped, no secret leak, admin-gated).
+Covers the read helper's grouping/degradation (all call types, audit-complete) and the rendered tab
+(actor shown, SQL/question escaped, no secret leak, admin-gated).
 """
 
 from __future__ import annotations
@@ -74,14 +74,14 @@ def test_list_sessions_groups_by_thread_and_degrades(env):
     sessions = model_store.list_sessions(s)
     s.close()
     by_thread = {x["thread_id"]: x for x in sessions if x["thread_id"]}
-    assert by_thread["t1"]["query_count"] == 2 and by_thread["t1"]["error_count"] == 1
+    assert by_thread["t1"]["call_count"] == 2 and by_thread["t1"]["error_count"] == 1
     assert by_thread["t1"]["started"] == "2026-06-27T10:39:00Z"
     assert by_thread["t1"]["last_activity"] == "2026-06-27T10:42:00Z"
     assert by_thread["t1"]["avg_ms"] == 15
     assert by_thread["t3"]["avg_ms"] is None  # all-null latency degrades cleanly
-    assert by_thread["t2"]["query_count"] == 1
+    assert by_thread["t2"]["call_count"] == 1
     singletons = [x for x in sessions if x["thread_id"] is None]
-    assert len(singletons) == 1 and singletons[0]["query_count"] == 1  # degraded → ungrouped
+    assert len(singletons) == 1 and singletons[0]["call_count"] == 1  # degraded → ungrouped
 
 
 def test_list_sessions_does_not_blend_different_actors_on_a_colliding_thread(env):
@@ -93,16 +93,35 @@ def test_list_sessions_does_not_blend_different_actors_on_a_colliding_thread(env
     s.close()
     assert len(sessions) == 2
     assert {x["actor"] for x in sessions} == {"jordan@example.com", "sam@example.com"}
-    assert all(x["query_count"] == 1 for x in sessions)
+    assert all(x["call_count"] == 1 for x in sessions)
 
 
-def test_list_tool_calls_is_newest_first(env):
+def test_list_sessions_folds_non_query_calls_into_the_conversation(env):
+    # The point of the unified view: a non-execute_sql call sharing a thread_id groups into the SAME
+    # conversation as the query (not dropped, as it was when list_sessions filtered to execute_sql).
     s = Store.connect(env)
-    _call(s, ts="2026-06-27T10:00:00Z", tool_name="list_datasources", actor="a", success=True)
-    _call(s, ts="2026-06-27T11:00:00Z", tool_name="execute_sql", actor="b", sql="X", success=True)
-    rows = model_store.list_tool_calls(s)
+    _call(s, ts="2026-06-27T10:00:00Z", tool_name="list_datasources", actor="a", success=True,
+          thread_id="t1", user_question="what datasources do I have?", correlation_id="c0")
+    _call(s, ts="2026-06-27T10:01:00Z", tool_name="execute_sql", actor="a", sql="SELECT 1", success=True,
+          thread_id="t1", user_question="revenue?", correlation_id="c1")
+    sessions = model_store.list_sessions(s)
     s.close()
-    assert [r["tool_name"] for r in rows] == ["execute_sql", "list_datasources"]
+    assert len(sessions) == 1  # one conversation holding both calls
+    conv = sessions[0]
+    assert conv["call_count"] == 2
+    tool_names = {c["tool_name"] for t in conv["turns"] for c in t["calls"]}
+    assert tool_names == {"list_datasources", "execute_sql"}
+
+
+def test_list_sessions_keeps_a_thread_less_non_query_call_as_a_singleton(env):
+    # Audit-complete: a call with NO thread_id is never dropped — it shows as its own conversation,
+    # whatever the tool (here a non-query get_datasource_schema with no SQL).
+    s = Store.connect(env)
+    _call(s, ts="2026-06-27T10:00:00Z", tool_name="get_datasource_schema", actor="a", success=True)
+    sessions = model_store.list_sessions(s)
+    s.close()
+    assert len(sessions) == 1 and sessions[0]["call_count"] == 1
+    assert sessions[0]["turns"][0]["calls"][0]["tool_name"] == "get_datasource_schema"
 
 
 # --- the rendered tabs -------------------------------------------------------
@@ -117,16 +136,21 @@ def _login(c):
     c.post("/admin/login", data={"username": ADMIN_USER, "password": ADMIN_PW})
 
 
-def test_calls_tab_shows_actor_and_detail(client, env):
+def test_activity_tab_renders_query_and_non_query_calls(client, env):
+    # A conversation with both a non-query call (list_datasources — tool name, no SQL) and a query call
+    # (SQL + rows + latency). Both must render in the one Activity drawer.
     s = Store.connect(env)
+    _call(s, ts="2026-06-27T10:41:00Z", tool_name="list_datasources", actor="jordan@example.com",
+          success=True, thread_id="t1", correlation_id="c0", user_question="what can I ask about?")
     _call(s, ts="2026-06-27T10:42:00Z", actor="jordan@example.com", datasource="SALES_DATA",
           sql="SELECT region FROM orders", row_count=5, execution_ms=84, success=True,
-          user_question="revenue by region?")
+          thread_id="t1", correlation_id="c1", user_question="revenue by region?")
     s.close()
     _login(client)
-    html = client.get("/admin?tab=calls").text
-    assert "jordan@example.com" in html and "execute_sql" in html and "SALES_DATA" in html
-    assert "SELECT region FROM orders" in html and "revenue by region?" in html  # in the drawer
+    html = client.get("/admin?tab=activity").text
+    assert "jordan@example.com" in html and "SALES_DATA" in html
+    assert "list_datasources" in html  # the non-query call shows its tool name (no SQL)
+    assert "SELECT region FROM orders" in html and "revenue by region?" in html  # the query, in the drawer
 
 
 def test_activity_views_escape_sql_and_question(client, env):
@@ -135,27 +159,25 @@ def test_activity_views_escape_sql_and_question(client, env):
           user_question="<img src=x onerror=alert(1)>", success=True, thread_id="t1")
     s.close()
     _login(client)
-    for tab in ("calls", "sessions"):
-        html = client.get(f"/admin?tab={tab}").text
-        assert "<script>alert(1)" not in html and "<img src=x" not in html
-        assert "&lt;script&gt;" in html
+    html = client.get("/admin?tab=activity").text
+    assert "<script>alert(1)" not in html and "<img src=x" not in html
+    assert "&lt;script&gt;" in html
 
 
-def test_sessions_tab_groups_and_handles_missing_question(client, env):
+def test_activity_tab_groups_and_handles_missing_question(client, env):
     s = Store.connect(env)
     _call(s, ts="2026-06-27T10:42:00Z", actor="jordan@example.com", sql="A", success=True,
           thread_id="t1", user_question="what is the revenue by region")
     _call(s, ts="2026-06-27T10:30:00Z", actor="sam@example.com", sql="B", success=True, thread_id=None)
     s.close()
     _login(client)
-    html = client.get("/admin?tab=sessions").text
+    html = client.get("/admin?tab=activity").text
     assert "what is the revenue by region" in html  # the self-reported question
     assert "no question reported" in html  # graceful when Claude didn't supply one
 
 
 def test_activity_requires_a_session(client):
-    assert client.get("/admin?tab=calls", follow_redirects=False).status_code == 302
-    assert client.get("/admin?tab=sessions", follow_redirects=False).status_code == 302
+    assert client.get("/admin?tab=activity", follow_redirects=False).status_code == 302
 
 
 def test_activity_does_not_leak_the_password_hash(client, env):
@@ -163,14 +185,18 @@ def test_activity_does_not_leak_the_password_hash(client, env):
     _call(s, ts="2026-06-27T10:42:00Z", actor=ADMIN_USER, sql="SELECT 1", success=True)
     s.close()
     _login(client)
-    assert "password_hash" not in client.get("/admin?tab=calls").text
+    assert "password_hash" not in client.get("/admin?tab=activity").text
 
 
-def test_activity_tabs_drop_the_redundant_helper_text(client, env):
-    # The column headers + tab name already say what these are; the helper sentences were noise.
+def test_activity_tab_has_one_unified_tab_and_no_split_tabs(client, env):
+    # ACE-016: one Activity tab — the Tool-calls / Sessions split is gone from the rendered nav.
     _login(client)
-    assert "Every tool call, newest first" not in client.get("/admin?tab=calls").text
-    assert "Queries grouped into conversations" not in client.get("/admin?tab=sessions").text
+    html = client.get("/admin?tab=activity").text
+    assert ">Activity</a>" in html
+    assert ">Tool calls</a>" not in html and ">Sessions</a>" not in html
+    # And the old redundant helper sentences stay gone.
+    assert "Every tool call, newest first" not in html
+    assert "Queries grouped into conversations" not in html
 
 
 # --- ACE-015: the turn level (correlation_id) --------------------------------
@@ -187,9 +213,9 @@ def test_correlation_id_round_trips(env):
         thread_id="t1",
         correlation_id="turn-1",
     )
-    rows = model_store.list_tool_calls(s)
+    sessions = model_store.list_sessions(s)
     s.close()
-    assert rows[0]["correlation_id"] == "turn-1"
+    assert sessions[0]["turns"][0]["calls"][0]["correlation_id"] == "turn-1"
 
 
 def test_execute_sql_inputschema_exposes_correlation_id():
@@ -237,7 +263,7 @@ def test_turns_use_earliest_question_and_group_refinements(env):
     turns = sessions[0]["turns"]
     assert len(turns) == 1
     assert turns[0]["question"] == "feature adoption vs churn"  # earliest, not the drift
-    assert [q["sql"] for q in turns[0]["queries"]] == [
+    assert [c["sql"] for c in turns[0]["calls"]] == [
         "Q1",
         "Q2",
     ]  # chronological, both refinements
@@ -270,7 +296,7 @@ def test_turns_degrade_to_singletons_without_correlation_id(env):
     assert {t["question"] for t in turns} == {"q-a", "q-b"}
 
 
-def test_sessions_drawer_renders_turn_with_user_asked_and_agent_queries(client, env):
+def test_activity_drawer_renders_turn_with_user_asked_and_agent_queries(client, env):
     s = Store.connect(env)
     _call(
         s,
@@ -296,10 +322,30 @@ def test_sessions_drawer_renders_turn_with_user_asked_and_agent_queries(client, 
     )
     s.close()
     _login(client)
-    html = client.get("/admin?tab=sessions").text
+    html = client.get("/admin?tab=activity").text
     assert (
         "User asked" in html and "feature adoption vs churn" in html
     )  # the turn question (earliest)
     assert "drifted" not in html  # the drifted user_question is NOT shown
     assert "churn by adoption band" in html and "lost MRR" in html  # both agent refinements
-    assert "2 queries" in html
+    assert "2 calls" in html
+
+
+# --- ACE-016: every tool carries the grouping ids ----------------------------
+
+
+def test_all_tools_expose_thread_and_correlation_ids():
+    # The non-query tools must also accept thread_id/correlation_id so their calls can group into a
+    # conversation — without these, list_datasources/get_datasource_schema/... log with NULL ids.
+    import tools
+
+    for name in ("list_datasources", "get_datasource_schema", "get_prompt_examples",
+                 "execute_sql", "log_feedback"):
+        props = tools.TOOLS[name]["inputSchema"]["properties"]
+        assert "thread_id" in props and "correlation_id" in props, name
+
+
+def test_server_instructions_say_pass_ids_on_every_call():
+    import tools
+
+    assert "EVERY tool call" in tools.SERVER_INSTRUCTIONS

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -103,7 +103,7 @@ def test_list_sessions_folds_non_query_calls_into_the_conversation(env):
     _call(s, ts="2026-06-27T10:00:00Z", tool_name="list_datasources", actor="a", success=True,
           thread_id="t1", user_question="what datasources do I have?", correlation_id="c0")
     _call(s, ts="2026-06-27T10:01:00Z", tool_name="execute_sql", actor="a", sql="SELECT 1", success=True,
-          thread_id="t1", user_question="revenue?", correlation_id="c1")
+          datasource="SALES_DATA", thread_id="t1", user_question="revenue?", correlation_id="c1")
     sessions = model_store.list_sessions(s)
     s.close()
     assert len(sessions) == 1  # one conversation holding both calls
@@ -111,6 +111,9 @@ def test_list_sessions_folds_non_query_calls_into_the_conversation(env):
     assert conv["call_count"] == 2
     tool_names = {c["tool_name"] for t in conv["turns"] for c in t["calls"]}
     assert tool_names == {"list_datasources", "execute_sql"}
+    # The conversation opens with a datasource-less list_datasources; the row still shows the real
+    # datasource from the call that had one (not "—").
+    assert conv["datasource"] == "SALES_DATA"
 
 
 def test_list_sessions_keeps_a_thread_less_non_query_call_as_a_singleton(env):

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -116,6 +116,21 @@ def test_list_sessions_folds_non_query_calls_into_the_conversation(env):
     assert conv["datasource"] == "SALES_DATA"
 
 
+def test_conversation_datasource_is_the_earliest_call_that_has_one(env):
+    # Skip a datasource-less opener (list_datasources) and, when the datasource changes mid-thread,
+    # take the EARLIEST one — not the newest (the rows arrive ts-DESC, so order matters).
+    s = Store.connect(env)
+    _call(s, ts="2026-06-27T10:00:00Z", tool_name="list_datasources", actor="a", success=True,
+          thread_id="t1", correlation_id="c0")  # no datasource
+    _call(s, ts="2026-06-27T10:01:00Z", actor="a", sql="SELECT 1", success=True,
+          datasource="SALES_DATA", thread_id="t1", correlation_id="c1")
+    _call(s, ts="2026-06-27T10:02:00Z", actor="a", sql="SELECT 2", success=True,
+          datasource="OTHER_DATA", thread_id="t1", correlation_id="c2")
+    sessions = model_store.list_sessions(s)
+    s.close()
+    assert sessions[0]["datasource"] == "SALES_DATA"  # earliest with one set, not OTHER_DATA
+
+
 def test_list_sessions_keeps_a_thread_less_non_query_call_as_a_singleton(env):
     # Audit-complete: a call with NO thread_id is never dropped — it shows as its own conversation,
     # whatever the tool (here a non-query get_datasource_schema with no SQL).

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -287,6 +287,20 @@ def test_turns_use_earliest_question_and_group_refinements(env):
     ]  # chronological, both refinements
 
 
+def test_turn_question_comes_from_earliest_call_that_reported_one(env):
+    # A turn now folds in setup calls (get_datasource_schema) that carry no user_question; they lead the
+    # turn chronologically but must NOT mask the real question the execute_sql reported.
+    s = Store.connect(env)
+    _call(s, ts="2026-06-28T10:00:00Z", tool_name="get_datasource_schema", actor="a", success=True,
+          thread_id="t", correlation_id="c1")  # no user_question
+    _call(s, ts="2026-06-28T10:01:00Z", actor="a", sql="Q", success=True, datasource="SALES_DATA",
+          thread_id="t", correlation_id="c1", user_question="give me the incident trend")
+    sessions = model_store.list_sessions(s)
+    s.close()
+    turn = sessions[0]["turns"][0]
+    assert turn["question"] == "give me the incident trend"  # not None from the leading schema call
+
+
 def test_turns_degrade_to_singletons_without_correlation_id(env):
     s = Store.connect(env)
     _call(

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -113,22 +113,38 @@ def test_list_sessions_folds_non_query_calls_into_the_conversation(env):
     assert tool_names == {"list_datasources", "execute_sql"}
     # The conversation opens with a datasource-less list_datasources; the row still shows the real
     # datasource from the call that had one (not "—").
-    assert conv["datasource"] == "SALES_DATA"
+    assert conv["datasources"] == ["SALES_DATA"]
 
 
-def test_conversation_datasource_is_the_earliest_call_that_has_one(env):
-    # Skip a datasource-less opener (list_datasources) and, when the datasource changes mid-thread,
-    # take the EARLIEST one — not the newest (the rows arrive ts-DESC, so order matters).
+def test_conversation_lists_every_datasource_it_touched_in_order(env):
+    # A conversation can switch datasources mid-session (or a single turn can span two). The row shows
+    # the full distinct set in first-seen order, skipping datasource-less calls (list_datasources).
     s = Store.connect(env)
     _call(s, ts="2026-06-27T10:00:00Z", tool_name="list_datasources", actor="a", success=True,
-          thread_id="t1", correlation_id="c0")  # no datasource
+          thread_id="t1", correlation_id="c0")  # no datasource — contributes nothing
     _call(s, ts="2026-06-27T10:01:00Z", actor="a", sql="SELECT 1", success=True,
           datasource="SALES_DATA", thread_id="t1", correlation_id="c1")
     _call(s, ts="2026-06-27T10:02:00Z", actor="a", sql="SELECT 2", success=True,
-          datasource="OTHER_DATA", thread_id="t1", correlation_id="c2")
+          datasource="SUPPORT_DATA", thread_id="t1", correlation_id="c1")  # same turn, 2nd datasource
+    _call(s, ts="2026-06-27T10:03:00Z", actor="a", sql="SELECT 3", success=True,
+          datasource="SALES_DATA", thread_id="t1", correlation_id="c2")  # back to the first, no dupe
     sessions = model_store.list_sessions(s)
     s.close()
-    assert sessions[0]["datasource"] == "SALES_DATA"  # earliest with one set, not OTHER_DATA
+    assert sessions[0]["datasources"] == ["SALES_DATA", "SUPPORT_DATA"]  # distinct, first-seen order
+
+
+def test_activity_drawer_shows_each_call_datasource_for_a_spanning_turn(client, env):
+    # One turn (correlation_id="c1") spanning two datasources — each call card must show its OWN
+    # datasource, and the conversation row both.
+    s = Store.connect(env)
+    _call(s, ts="2026-06-27T10:01:00Z", actor="jordan@example.com", sql="SELECT a FROM x", success=True,
+          datasource="SALES_DATA", thread_id="t1", correlation_id="c1", user_question="compare sales vs support")
+    _call(s, ts="2026-06-27T10:01:30Z", actor="jordan@example.com", sql="SELECT b FROM y", success=True,
+          datasource="SUPPORT_DATA", thread_id="t1", correlation_id="c1", user_question="compare sales vs support")
+    s.close()
+    _login(client)
+    html = client.get("/admin?tab=activity").text
+    assert "SALES_DATA" in html and "SUPPORT_DATA" in html  # both datasources surfaced, per call
 
 
 def test_list_sessions_keeps_a_thread_less_non_query_call_as_a_singleton(env):


### PR DESCRIPTION
Spec: ACE-016

## Summary
The admin console had **two** activity tabs — **Tool calls** (every call, flat) and **Sessions** (`execute_sql`-only, grouped). A conversation's non-query work was invisible in the grouped view: you saw the `execute_sql` for a trend but not the `list_datasources` / `get_datasource_schema` that led there. This collapses them into **one conversation-centric Activity tab** where *every* tool call folds into its conversation: **thread ▸ turn (`correlation_id`) ▸ call**. Audit-complete for *what* ran (every call shown), best-effort for *how* it's grouped (self-reported ids; ungrouped calls degrade to singletons).

## Changes
- **All tools carry the grouping ids** (`tools.py`) — the four non-query inputSchemas (`list_datasources`, `get_datasource_schema`, `get_prompt_examples`, `log_feedback`) gain `thread_id`/`correlation_id` (+ `user_question`), defined once as shared property constants so the wording can't drift; `SERVER_INSTRUCTIONS` now says to pass them on **every** call. The record path already captured `args.get(...)` for all tools — no record-path change.
- **`list_sessions` over all calls** (`model_store.py`) — drops the `tool_name='execute_sql'` filter; groups every call by `(actor, thread_id)` ▸ turns (reuses ACE-015's `_group_turns`); aggregates become call-oriented (`call_count`); a conversation's datasource is its first call that has one.
- **The drawer renders every call type** (`admin.py`) — a query shows `agent_query` + SQL + rows/latency; a non-query shows its tool-name pill + datasource (no SQL).
- **One tab** (`ui.py`, `admin.py`) — the **Tool calls** + **Sessions** tabs become a single **Activity** tab; the now-dead flat surface (`calls_tab_html`, `_call_drawer`, `list_tool_calls`) is removed.
- Previews, README, and tests updated.

## Out of scope
Turns that produce **no** tool call (the MCP server only ever sees tool calls — stated as a Free-tier limit); tokens/cost/quality; the self-reported client model; model editing; server-side turn derivation.

## Checklist
- [x] `Spec: ACE-016` (decisions logged in the spec's `## Decisions`)
- [x] Gate green — `ruff check`, **956 tests**, gitleaks; **100%** patch coverage
- [x] Read-only + admin-session-gated; every self-reported field escaped (`ui.esc`); no new egress
- [x] Audit-complete — a thread-less call still renders as its own singleton conversation
- [x] No real customer data / names / credentials; neutral placeholders only