### PR TITLE
Auto-apply pending migrations on first DB open (multi-instance-safe, fail-closed)

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -18,6 +18,7 @@ reliably auto-detected behind a proxy/LB.
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import time
 from contextvars import ContextVar
@@ -34,6 +35,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
+from store import Store
 from tools import (
     SERVER_INSTRUCTIONS,
     SERVER_NAME,
@@ -42,6 +44,8 @@ from tools import (
     record_tool_call,
     server_version,
 )
+
+_log = logging.getLogger(__name__)
 
 # The authenticated user for the in-flight tool call. Set in `handle_mcp` (the raw-ASGI endpoint, which
 # runs in the request's task) so it propagates into the MCP dispatch — the tool handler `_call_tool`
@@ -308,6 +312,18 @@ def build_app() -> Starlette:
 
     @contextlib.asynccontextmanager
     async def lifespan(_app: Starlette):
+        # Heal the schema before serving: apply any pending migrations so freshly-deployed code never hits
+        # an old DB shape (a column a migration adds, selected before it's applied, 500s the admin). This
+        # is fail-closed — a failing migration propagates and aborts startup; a half-migrated DB never
+        # serves. File-mode (no DB configured) has nothing to migrate.
+        store = Store.from_env()
+        if store is not None:
+            try:
+                applied = store.run_migrations()
+                if applied:
+                    _log.info("applied migrations: %s", ", ".join(applied))
+            finally:
+                store.close()
         async with session_manager.run():
             yield
 

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -28,6 +28,10 @@ from typing import Any
 # or a checkout.
 MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "migrations" / "core"
 
+# A fixed (non-secret) key for the Postgres session advisory lock that serializes concurrent
+# migration runs — see run_migrations. The digits spell "AGAMI" in hex; any stable bigint works.
+_MIGRATION_LOCK_KEY = 0x4147414D49
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -105,25 +109,41 @@ class Store:
     # --- migrations ---------------------------------------------------------
 
     def run_migrations(self, migrations_dir: Path | None = None) -> list[str]:
-        """Apply un-applied `NNN_*.sql` in order; return the filenames newly applied. Idempotent."""
+        """Apply un-applied `NNN_*.sql` in order; return the filenames newly applied. Idempotent.
+
+        On Postgres a **session advisory lock** brackets the read-applied + apply so that when several
+        instances boot together (e.g. Cloud Run) exactly one migrates and the rest wait, then re-read the
+        applied set and skip what's done — otherwise two instances could both run a migration's DDL or
+        collide on the `schema_migrations` primary key. SQLite is single-writer, so the lock is a no-op.
+        A failing migration propagates (fail-closed: a half-migrated schema must not serve)."""
         migrations_dir = migrations_dir or MIGRATIONS_DIR
-        self.execute(
-            "CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT)"
-        )
-        self.commit()
-        applied = {r["id"] for r in self.query("SELECT id FROM schema_migrations")}
-        ran: list[str] = []
-        for path in sorted(migrations_dir.glob("*.sql")):
-            if path.name in applied:
-                continue
-            self._run_script(path.read_text())
+        # pg_advisory_lock (session-level, NOT released by commit) — must use the session variant so the
+        # per-migration commits in the loop below don't drop it mid-apply.
+        locked = self.dialect == "postgres"
+        if locked:
+            self.execute("SELECT pg_advisory_lock(?)", (_MIGRATION_LOCK_KEY,))
+        try:
             self.execute(
-                "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
-                (path.name, _now_iso()),
+                "CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT)"
             )
             self.commit()
-            ran.append(path.name)
-        return ran
+            applied = {r["id"] for r in self.query("SELECT id FROM schema_migrations")}
+            ran: list[str] = []
+            for path in sorted(migrations_dir.glob("*.sql")):
+                if path.name in applied:
+                    continue
+                self._run_script(path.read_text())
+                self.execute(
+                    "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+                    (path.name, _now_iso()),
+                )
+                self.commit()
+                ran.append(path.name)
+            return ran
+        finally:
+            if locked:
+                self.execute("SELECT pg_advisory_unlock(?)", (_MIGRATION_LOCK_KEY,))
+                self.commit()
 
     def _run_script(self, sql: str) -> None:
         """Run a multi-statement SQL script. SQLite needs executescript; psycopg2 runs a multi-

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -20,6 +20,7 @@ tracking table — re-running only applies new files.
 
 from __future__ import annotations
 
+import contextlib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -142,8 +143,14 @@ class Store:
             return ran
         finally:
             if locked:
-                self.execute("SELECT pg_advisory_unlock(?)", (_MIGRATION_LOCK_KEY,))
-                self.commit()
+                # A failed migration leaves the psycopg2 connection in an aborted-transaction state, so roll
+                # back FIRST — otherwise this unlock runs on the aborted connection, raises, masks the real
+                # migration error, and the lock would free only incidentally when the connection closes.
+                # Suppress any cleanup error so the in-flight migration exception is what propagates.
+                with contextlib.suppress(Exception):
+                    self.conn.rollback()
+                    self.execute("SELECT pg_advisory_unlock(?)", (_MIGRATION_LOCK_KEY,))
+                    self.commit()
 
     def _run_script(self, sql: str) -> None:
         """Run a multi-statement SQL script. SQLite needs executescript; psycopg2 runs a multi-

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -140,17 +140,22 @@ class Store:
                 )
                 self.commit()
                 ran.append(path.name)
-            return ran
-        finally:
+        except Exception:
             if locked:
                 # A failed migration leaves the psycopg2 connection in an aborted-transaction state, so roll
-                # back FIRST — otherwise this unlock runs on the aborted connection, raises, masks the real
-                # migration error, and the lock would free only incidentally when the connection closes.
-                # Suppress any cleanup error so the in-flight migration exception is what propagates.
+                # back FIRST so the unlock can run; suppress cleanup errors here so the REAL migration error
+                # is what propagates (the lock also frees on connection close as a backstop).
                 with contextlib.suppress(Exception):
                     self.conn.rollback()
                     self.execute("SELECT pg_advisory_unlock(?)", (_MIGRATION_LOCK_KEY,))
                     self.commit()
+            raise
+        if locked:
+            # Success: release the lock and let an unexpected unlock failure SURFACE — silently holding the
+            # lock would hang the next instance on pg_advisory_lock.
+            self.execute("SELECT pg_advisory_unlock(?)", (_MIGRATION_LOCK_KEY,))
+            self.commit()
+        return ran
 
     def _run_script(self, sql: str) -> None:
         """Run a multi-statement SQL script. SQLite needs executescript; psycopg2 runs a multi-

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -113,6 +113,7 @@ def test_postgres_brackets_the_apply_with_a_session_advisory_lock(tmp_path):
     assert "pg_advisory_xact_lock" not in " | ".join(rec.sql)
     assert rec.sql[-1] == "SELECT pg_advisory_unlock(?)"
     assert "pg_advisory_unlock" not in " | ".join(rec.sql[:-1])  # unlock only at the very end
+    assert not rec.conn.rolled_back  # success path doesn't roll back (only the error path does)
 
 
 def test_sqlite_takes_no_advisory_lock(tmp_path):

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -1,0 +1,149 @@
+"""ACE-019 — the server applies pending migrations on first DB open (idempotent, locked, fail-closed).
+
+Covers the read helper (`Store.run_migrations`: the Postgres advisory-lock bracketing, idempotency, and
+fail-closed-on-error) and the startup wiring (`mcp_http` lifespan applies them before serving + propagates).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("starlette")
+pytest.importorskip("mcp")
+pytest.importorskip("argon2")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import mcp_http  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+from store import Store  # noqa: E402
+
+BASE = "https://your-host.example.com"
+SECRET = "x" * 40
+ADMIN_USER = "admin@example.com"
+ADMIN_PW = "admin-password-localtest"
+
+
+def _write_migration(d: Path, name: str, sql: str) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(sql)
+
+
+# --- run_migrations: idempotency + fail-closed (real SQLite) ------------------
+
+
+def test_run_migrations_applies_then_is_idempotent(tmp_path):
+    mig = tmp_path / "m"
+    _write_migration(mig, "001_demo.sql", "CREATE TABLE demo_x (a INTEGER);")
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    first = s.run_migrations(mig)
+    second = s.run_migrations(mig)  # nothing pending now
+    rows = s.query("SELECT id FROM schema_migrations")
+    s.close()
+    assert first == ["001_demo.sql"]
+    assert second == []  # idempotent — a re-run applies nothing
+    assert [r["id"] for r in rows] == ["001_demo.sql"]
+
+
+def test_failing_migration_raises_and_is_not_recorded(tmp_path):
+    mig = tmp_path / "m"
+    _write_migration(mig, "001_bad.sql", "CREATE TABLE oops (")  # invalid SQL
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    with pytest.raises(Exception):  # noqa: B017 — backend raises its own error type; we only need "raised"
+        s.run_migrations(mig)
+    applied = {r["id"] for r in s.query("SELECT id FROM schema_migrations")}
+    s.close()
+    assert "001_bad.sql" not in applied  # fail-closed: a failed migration is never recorded
+
+
+# --- the advisory lock (dialect-branch, no real Postgres needed) -------------
+
+
+class _Recorder:
+    """A minimal stand-in for Store that records the SQL `run_migrations` issues, so we can assert the
+    advisory-lock bracketing per dialect without a live Postgres."""
+
+    def __init__(self, dialect: str) -> None:
+        self.dialect = dialect
+        self.sql: list[str] = []
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        self.sql.append(sql)
+
+    def query(self, sql: str, params: tuple = ()) -> list[dict]:
+        self.sql.append(sql)
+        return []  # nothing applied yet
+
+    def commit(self) -> None:
+        pass
+
+    def _run_script(self, sql: str) -> None:
+        pass
+
+
+def test_postgres_brackets_the_apply_with_a_session_advisory_lock(tmp_path):
+    mig = tmp_path / "m"
+    _write_migration(mig, "001_demo.sql", "CREATE TABLE demo_x (a INTEGER);")
+    rec = _Recorder("postgres")
+    Store.run_migrations(rec, mig)  # call the unbound method with our recorder as self
+    joined = " | ".join(rec.sql)
+    assert "pg_advisory_lock" in joined and "pg_advisory_unlock" in joined
+    # the lock is taken BEFORE the work and released AFTER it
+    assert rec.sql[0].startswith("SELECT pg_advisory_lock")
+    assert rec.sql[-1].startswith("SELECT pg_advisory_unlock")
+    assert "pg_advisory_unlock" not in " | ".join(rec.sql[:-1])  # unlock only at the very end
+
+
+def test_sqlite_takes_no_advisory_lock(tmp_path):
+    mig = tmp_path / "m"
+    _write_migration(mig, "001_demo.sql", "CREATE TABLE demo_x (a INTEGER);")
+    rec = _Recorder("sqlite")
+    Store.run_migrations(rec, mig)
+    assert not any("pg_advisory" in s for s in rec.sql)  # single-writer — no lock
+
+
+# --- the startup wiring (lifespan applies on open, fail-closed) --------------
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    url = "sqlite://" + str(tmp_path / "startup.db")  # FRESH, deliberately NOT pre-migrated
+    monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", ADMIN_USER)
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", ADMIN_PW)
+    for v in ("AGAMI_OIDC_GOOGLE_CLIENT_ID", "AGAMI_OIDC_GOOGLE_CLIENT_SECRET"):
+        monkeypatch.delenv(v, raising=False)
+    return url
+
+
+def test_startup_applies_pending_migrations(env):
+    # Entering the TestClient runs the lifespan = the server's startup. The DB starts EMPTY; after startup
+    # the real migrations must be applied (the footgun fix — no manual migrate step).
+    with TestClient(mcp_http.build_app()):
+        pass
+    s = Store.connect(env)
+    applied = s.query("SELECT id FROM schema_migrations")
+    has_tool_calls = s.query(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='tool_calls'"
+    )
+    s.close()
+    assert applied, "startup applied no migrations"  # at least one ran
+    assert has_tool_calls, "a migrated table is missing after startup"
+
+
+def test_startup_is_fail_closed_on_migration_error(env, monkeypatch):
+    # A failing migration must abort startup, not be swallowed — the lifespan propagates the error.
+    def _boom(self, migrations_dir=None):
+        raise RuntimeError("migration blew up")
+
+    monkeypatch.setattr(Store, "run_migrations", _boom)
+    with pytest.raises(RuntimeError, match="migration blew up"):
+        with TestClient(mcp_http.build_app()):
+            pass

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -51,26 +51,42 @@ def test_run_migrations_applies_then_is_idempotent(tmp_path):
 
 
 def test_failing_migration_raises_and_is_not_recorded(tmp_path):
+    import sqlite3
+
     mig = tmp_path / "m"
     _write_migration(mig, "001_bad.sql", "CREATE TABLE oops (")  # invalid SQL
     s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
-    with pytest.raises(Exception):  # noqa: B017 — backend raises its own error type; we only need "raised"
+    with pytest.raises(sqlite3.OperationalError):  # the raise comes from APPLYING the bad migration
         s.run_migrations(mig)
     applied = {r["id"] for r in s.query("SELECT id FROM schema_migrations")}
+    leaked = s.query("SELECT name FROM sqlite_master WHERE type='table' AND name='oops'")
     s.close()
     assert "001_bad.sql" not in applied  # fail-closed: a failed migration is never recorded
+    assert not leaked  # and no partial DDL leaked from the half-run script
 
 
 # --- the advisory lock (dialect-branch, no real Postgres needed) -------------
 
 
+class _Conn:
+    """Stub psycopg2 connection — records whether the failed-migration rollback ran."""
+
+    def __init__(self) -> None:
+        self.rolled_back = False
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
 class _Recorder:
     """A minimal stand-in for Store that records the SQL `run_migrations` issues, so we can assert the
-    advisory-lock bracketing per dialect without a live Postgres."""
+    advisory-lock bracketing per dialect (and the error-path cleanup) without a live Postgres."""
 
-    def __init__(self, dialect: str) -> None:
+    def __init__(self, dialect: str, *, fail_on_script: bool = False) -> None:
         self.dialect = dialect
         self.sql: list[str] = []
+        self.conn = _Conn()
+        self._fail = fail_on_script
 
     def execute(self, sql: str, params: tuple = ()) -> None:
         self.sql.append(sql)
@@ -83,7 +99,8 @@ class _Recorder:
         pass
 
     def _run_script(self, sql: str) -> None:
-        pass
+        if self._fail:
+            raise RuntimeError("bad migration")
 
 
 def test_postgres_brackets_the_apply_with_a_session_advisory_lock(tmp_path):
@@ -91,11 +108,10 @@ def test_postgres_brackets_the_apply_with_a_session_advisory_lock(tmp_path):
     _write_migration(mig, "001_demo.sql", "CREATE TABLE demo_x (a INTEGER);")
     rec = _Recorder("postgres")
     Store.run_migrations(rec, mig)  # call the unbound method with our recorder as self
-    joined = " | ".join(rec.sql)
-    assert "pg_advisory_lock" in joined and "pg_advisory_unlock" in joined
-    # the lock is taken BEFORE the work and released AFTER it
-    assert rec.sql[0].startswith("SELECT pg_advisory_lock")
-    assert rec.sql[-1].startswith("SELECT pg_advisory_unlock")
+    # SESSION lock (survives the per-migration commits), not the xact variant — taken first, freed last.
+    assert rec.sql[0] == "SELECT pg_advisory_lock(?)"
+    assert "pg_advisory_xact_lock" not in " | ".join(rec.sql)
+    assert rec.sql[-1] == "SELECT pg_advisory_unlock(?)"
     assert "pg_advisory_unlock" not in " | ".join(rec.sql[:-1])  # unlock only at the very end
 
 
@@ -105,6 +121,19 @@ def test_sqlite_takes_no_advisory_lock(tmp_path):
     rec = _Recorder("sqlite")
     Store.run_migrations(rec, mig)
     assert not any("pg_advisory" in s for s in rec.sql)  # single-writer — no lock
+    assert not rec.conn.rolled_back  # sqlite skips the whole locked-cleanup block
+
+
+def test_postgres_error_path_rolls_back_then_unlocks_without_masking(tmp_path):
+    # A failing migration must propagate the REAL error (not a masking "transaction aborted"), roll the
+    # aborted txn back, and still release the lock — see the run_migrations finally.
+    mig = tmp_path / "m"
+    _write_migration(mig, "001_demo.sql", "CREATE TABLE demo_x (a INTEGER);")
+    rec = _Recorder("postgres", fail_on_script=True)
+    with pytest.raises(RuntimeError, match="bad migration"):  # original error, not masked
+        Store.run_migrations(rec, mig)
+    assert rec.conn.rolled_back  # cleared the aborted state before unlocking
+    assert rec.sql[-1] == "SELECT pg_advisory_unlock(?)"  # lock still released on the error path
 
 
 # --- the startup wiring (lifespan applies on open, fail-closed) --------------


### PR DESCRIPTION
Spec: ACE-019

## Summary
Migrations were tracked idempotently but **nothing applied them at startup** — only `seed.py`/tests did. So deploying new code that reads a column a migration adds (e.g. `tool_calls.correlation_id`) 500s the admin until someone migrates by hand. This bit us twice during ACE-015/016. Now the server **heals its own schema on startup**, before serving.

## Changes
- **`store.py` `run_migrations`** — brackets the read-applied + apply loop with a Postgres **session** advisory lock (`pg_advisory_lock`/`unlock`, a fixed non-secret `_MIGRATION_LOCK_KEY`) so concurrent boots (Cloud Run) don't both apply a migration; SQLite is single-writer → no-op. On a migration failure it rolls the aborted transaction back before unlocking and suppresses cleanup errors, so the **real** error propagates and the lock is released deterministically.
- **`mcp_http.py` `lifespan`** — opens `Store.from_env()` and applies pending migrations **before** serving; **fail-closed** (a failing migration aborts startup — a half-migrated DB never serves); file-mode (no DB) skips; logs applied filenames only (no secrets).
- **`tests/test_auto_migrate.py`** (7) — idempotent; fail-closed (raises + not recorded + no partial DDL); session-lock bracketing; sqlite-no-lock; **error-path rollback + no-mask**; startup-applies-on-fresh-DB; startup-fail-closed.

## Out of scope
Authoring migrations / the file format; the deploy package/entrypoint that invokes startup (ACE-009); down-migrations.

## Checklist
- [x] `Spec: ACE-019` — decisions (session advisory lock; fail-closed) in the spec's `## Decisions`
- [x] Gate green — `ruff check`, **966 tests**, gitleaks; **100%** patch coverage
- [x] No secrets logged (applied = filenames only); the lock key is a non-secret constant
- [x] Both backends covered (SQLite real apply+startup; Postgres lock/error-path via a recorder)
- [ ] **Known gap:** the live-Postgres *concurrency* path isn't exercised in CI (sqlite-only) — bracketing + error-path are unit-tested; a testcontainers concurrency test is a tracked follow-up