### PR TITLE
Model-deploy command — load the local YAML model into serving Postgres

### DIFF
--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -44,7 +44,7 @@ server = [
 package-dir = { "" = "src" }
 # Flat top-level modules (not under a parent package) — listed explicitly so the import
 # names stay flat regardless of disk layout.
-py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
+py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "model_deploy", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
 packages = ["semantic_model"]
 
 [tool.setuptools.package-data]

--- a/packages/agami-core/src/model_deploy.py
+++ b/packages/agami-core/src/model_deploy.py
@@ -19,13 +19,15 @@ from store import Store
 
 
 def deploy_one(store: Store, datasource: str, profile_dir: Path) -> None:
-    """Load one datasource's model (org + examples + memory + version) from `profile_dir` into the store.
+    """Load one datasource's per-datasource model (org + examples + ORGANIZATION.md + version) from
+    `profile_dir` into the store. The install-global `USER_MEMORY.md` is handled once per run, separately
+    (`_deploy_user_memory`) — it lives at the artifacts ROOT, not per profile.
 
-    Reads + parses **everything first, then writes** — so a malformed model/examples fails *before* any DB
-    write rather than half-way through. Each model_store writer is individually idempotent (clear-then-
-    insert), so a clean re-run fully overwrites a datasource; the deploy entrypoint fail-closes on a non-zero
-    exit, so a partial write from a rare mid-write DB error is never served and self-heals on the next deploy.
-    (The writers commit individually, so this isn't one transaction — load-then-write is the practical guard.)"""
+    Reads + parses **everything first, then writes** — so a malformed model fails *before* any DB write
+    rather than half-way through. Each model_store writer is individually idempotent (clear-then-insert), so
+    a clean re-run fully overwrites a datasource; the entrypoint fail-closes on a non-zero exit, so a partial
+    write from a rare mid-write DB error is never served and self-heals on the next deploy. (The writers commit
+    individually, so this isn't one transaction — load-then-write is the practical guard.)"""
     from semantic_model import loader
     from semantic_model.snapshot import newest_version
 
@@ -44,26 +46,40 @@ def deploy_one(store: Store, datasource: str, profile_dir: Path) -> None:
             continue
         examples.extend({**ex, "area": ex.get("area") or sa.name} for ex in area_examples if isinstance(ex, dict))
     org_md = profile_dir / "ORGANIZATION.md"
-    user_md = profile_dir / "USER_MEMORY.md"
     org_text = org_md.read_text() if org_md.exists() else None
-    user_text = user_md.read_text() if user_md.exists() else None
     version = newest_version(profile_dir) or "deployed"
 
     # --- then write (version last, so its presence marks a completed deploy) ---
     model_store.write_organization(store, datasource, org)
-    if examples:
-        model_store.write_examples(store, datasource, examples)
-    model_store.write_memory(store, datasource, organization=org_text, user=user_text)
+    # Always write examples (even []) so a redeploy after REMOVING examples actually clears the stale rows —
+    # write_examples is clear-then-insert, so an empty list replaces the datasource's examples with none.
+    model_store.write_examples(store, datasource, examples)
+    model_store.write_memory(store, datasource, organization=org_text)  # per-datasource only
     model_store.write_model_version(store, datasource, version)
     store.commit()
 
 
+def _deploy_user_memory(store: Store, artifacts_dir: Path) -> None:
+    """USER_MEMORY.md is **install-global** (one shared row, keyed by the global sentinel inside
+    write_memory) and lives at the artifacts ROOT — not per profile — matching how the server reads it
+    (`tools._domain_memory` → `artifacts/USER_MEMORY.md`). Written once per run; absent ⇒ nothing to do."""
+    f = artifacts_dir / "USER_MEMORY.md"
+    if f.exists():
+        model_store.write_memory(store, "", user=f.read_text())  # datasource ignored for the global user row
+        store.commit()
+
+
 def deploy_models(store: Store, artifacts_dir: Path) -> list[str]:
-    """Load every datasource model under `artifacts_dir` (a subdir with an `org.yaml`) into the store.
-    Returns the datasources loaded. A non-model subdir (e.g. `local/`, which holds credentials) is skipped
-    because it has no `org.yaml`."""
+    """Load every datasource model under `artifacts_dir` (a *directory* with an `org.yaml`) into the store.
+    Returns the datasources loaded. The `local/` dir (gitignored secrets/state) and any non-directory or
+    org.yaml-less entry are skipped — `local/` explicitly, so a stray `local/org.yaml` can't deploy from the
+    secrets dir."""
     loaded: list[str] = []
-    for prof in sorted(p for p in artifacts_dir.iterdir() if (p / "org.yaml").exists()):
+    for prof in sorted(
+        p
+        for p in artifacts_dir.iterdir()
+        if p.is_dir() and p.name != agami_paths.LOCAL_SUBDIR and (p / "org.yaml").exists()
+    ):
         deploy_one(store, prof.name, prof)
         loaded.append(prof.name)
     return loaded
@@ -106,6 +122,10 @@ def main(argv: list[str] | None = None) -> int:
                     file=sys.stderr,
                 )
                 return 1
+        _deploy_user_memory(store, artifacts_dir)  # install-global USER_MEMORY.md, once
+    except Exception as e:  # noqa: BLE001 — any load/write failure is a clean fail-closed exit, not a traceback
+        print(f"model_deploy: failed: {e}", file=sys.stderr)
+        return 1
     finally:
         store.close()
     print(f"model_deploy: loaded model for: {', '.join(loaded)}")

--- a/packages/agami-core/src/model_deploy.py
+++ b/packages/agami-core/src/model_deploy.py
@@ -20,31 +20,41 @@ from store import Store
 
 def deploy_one(store: Store, datasource: str, profile_dir: Path) -> None:
     """Load one datasource's model (org + examples + memory + version) from `profile_dir` into the store.
-    Idempotent — the model_store writers clear each datasource's rows before re-inserting."""
+
+    Reads + parses **everything first, then writes** — so a malformed model/examples fails *before* any DB
+    write rather than half-way through. Each model_store writer is individually idempotent (clear-then-
+    insert), so a clean re-run fully overwrites a datasource; the deploy entrypoint fail-closes on a non-zero
+    exit, so a partial write from a rare mid-write DB error is never served and self-heals on the next deploy.
+    (The writers commit individually, so this isn't one transaction — load-then-write is the practical guard.)"""
     from semantic_model import loader
     from semantic_model.snapshot import newest_version
 
+    # --- read + parse everything first (where malformed input fails, before any write) ---
     org = loader.load_organization(profile_dir)
-    model_store.write_organization(store, datasource, org)
-
     # Examples live per subject area (prompt_examples/<area>/examples.yaml); tag each with its area so the
-    # served row carries it (write_examples reads ex["area"]).
+    # served row carries it (write_examples reads ex["area"]). A malformed examples file for one area is
+    # skipped with a warning, not fatal — examples are best-effort few-shots, not the model itself, and a bad
+    # one shouldn't block the team's model from deploying.
     examples: list[dict] = []
     for sa in org.subject_areas:
-        for ex in loader.list_prompt_examples(profile_dir, sa.name):
-            examples.append({**ex, "area": ex.get("area") or sa.name})
-    if examples:
-        model_store.write_examples(store, datasource, examples)
-
+        try:
+            area_examples = loader.list_prompt_examples(profile_dir, sa.name)
+        except Exception as e:  # noqa: BLE001 — a bad examples file mustn't abort the model deploy
+            print(f"model_deploy: skipping malformed examples for area {sa.name!r}: {e}", file=sys.stderr)
+            continue
+        examples.extend({**ex, "area": ex.get("area") or sa.name} for ex in area_examples if isinstance(ex, dict))
     org_md = profile_dir / "ORGANIZATION.md"
     user_md = profile_dir / "USER_MEMORY.md"
-    model_store.write_memory(
-        store,
-        datasource,
-        organization=org_md.read_text() if org_md.exists() else None,
-        user=user_md.read_text() if user_md.exists() else None,
-    )
-    model_store.write_model_version(store, datasource, newest_version(profile_dir) or "deployed")
+    org_text = org_md.read_text() if org_md.exists() else None
+    user_text = user_md.read_text() if user_md.exists() else None
+    version = newest_version(profile_dir) or "deployed"
+
+    # --- then write (version last, so its presence marks a completed deploy) ---
+    model_store.write_organization(store, datasource, org)
+    if examples:
+        model_store.write_examples(store, datasource, examples)
+    model_store.write_memory(store, datasource, organization=org_text, user=user_text)
+    model_store.write_model_version(store, datasource, version)
     store.commit()
 
 
@@ -70,6 +80,10 @@ def main(argv: list[str] | None = None) -> int:
     # run_migrations is idempotent, so the later lifespan pass is a harmless no-op.
     store.run_migrations()
     artifacts_dir = agami_paths.artifacts_dir()
+    if not artifacts_dir.is_dir():  # clean exit, not an uncaught FileNotFoundError from iterdir()
+        store.close()
+        print(f"model_deploy: artifacts dir not found: {artifacts_dir}", file=sys.stderr)
+        return 1
     try:
         if args:  # deploy only the named datasources
             loaded: list[str] = []

--- a/packages/agami-core/src/model_deploy.py
+++ b/packages/agami-core/src/model_deploy.py
@@ -1,0 +1,102 @@
+"""Load the local YAML semantic model into the serving Postgres — the deploy's `load model` step.
+
+The hosted server serves the model **from the database** (`tools._serve_model` reads the DB when one is
+configured), so a deploy has to push the YAML model into Postgres. The read→write primitives already exist
+and are idempotent; this is the orchestrator that wires them for every datasource under the artifacts dir.
+Run by the deploy entrypoint (ACE-009) and re-run on restart to pick up an edited model.
+
+    AGAMI_DB_URL=postgresql://…  AGAMI_ARTIFACTS_DIR=/…/agami-artifacts  python -m model_deploy [datasource …]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import agami_paths
+import model_store
+from store import Store
+
+
+def deploy_one(store: Store, datasource: str, profile_dir: Path) -> None:
+    """Load one datasource's model (org + examples + memory + version) from `profile_dir` into the store.
+    Idempotent — the model_store writers clear each datasource's rows before re-inserting."""
+    from semantic_model import loader
+    from semantic_model.snapshot import newest_version
+
+    org = loader.load_organization(profile_dir)
+    model_store.write_organization(store, datasource, org)
+
+    # Examples live per subject area (prompt_examples/<area>/examples.yaml); tag each with its area so the
+    # served row carries it (write_examples reads ex["area"]).
+    examples: list[dict] = []
+    for sa in org.subject_areas:
+        for ex in loader.list_prompt_examples(profile_dir, sa.name):
+            examples.append({**ex, "area": ex.get("area") or sa.name})
+    if examples:
+        model_store.write_examples(store, datasource, examples)
+
+    org_md = profile_dir / "ORGANIZATION.md"
+    user_md = profile_dir / "USER_MEMORY.md"
+    model_store.write_memory(
+        store,
+        datasource,
+        organization=org_md.read_text() if org_md.exists() else None,
+        user=user_md.read_text() if user_md.exists() else None,
+    )
+    model_store.write_model_version(store, datasource, newest_version(profile_dir) or "deployed")
+    store.commit()
+
+
+def deploy_models(store: Store, artifacts_dir: Path) -> list[str]:
+    """Load every datasource model under `artifacts_dir` (a subdir with an `org.yaml`) into the store.
+    Returns the datasources loaded. A non-model subdir (e.g. `local/`, which holds credentials) is skipped
+    because it has no `org.yaml`."""
+    loaded: list[str] = []
+    for prof in sorted(p for p in artifacts_dir.iterdir() if (p / "org.yaml").exists()):
+        deploy_one(store, prof.name, prof)
+        loaded.append(prof.name)
+    return loaded
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    store = Store.from_env()
+    if store is None:
+        print("model_deploy: no database configured (set AGAMI_DB_URL).", file=sys.stderr)
+        return 2
+    # Ensure the model tables exist before writing — this runs in the deploy entrypoint *before* the
+    # server (whose lifespan auto-migrates, ACE-019) is up, so the schema may not be applied yet.
+    # run_migrations is idempotent, so the later lifespan pass is a harmless no-op.
+    store.run_migrations()
+    artifacts_dir = agami_paths.artifacts_dir()
+    try:
+        if args:  # deploy only the named datasources
+            loaded: list[str] = []
+            for ds in args:
+                prof = artifacts_dir / ds
+                if not (prof / "org.yaml").exists():
+                    print(
+                        f"model_deploy: no model for datasource {ds!r} at {prof}/org.yaml",
+                        file=sys.stderr,
+                    )
+                    return 1
+                deploy_one(store, ds, prof)
+                loaded.append(ds)
+        else:  # deploy every model under the artifacts dir
+            loaded = deploy_models(store, artifacts_dir)
+            if not loaded:
+                print(
+                    f"model_deploy: no model found under {artifacts_dir} "
+                    "(a datasource is a subdir with an org.yaml).",
+                    file=sys.stderr,
+                )
+                return 1
+    finally:
+        store.close()
+    print(f"model_deploy: loaded model for: {', '.join(loaded)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_model_deploy.py
+++ b/tests/test_model_deploy.py
@@ -99,6 +99,44 @@ def test_examples_memory_and_version_are_loaded(tmp_path):
     assert version  # a model_version row was written
 
 
+def test_user_memory_is_loaded_from_the_artifacts_root(tmp_path, monkeypatch):
+    # USER_MEMORY.md is install-global — it lives at the artifacts ROOT (not per profile) and writes one
+    # shared row. main() handles it once (deploy_one does not).
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo")
+    (arts / "USER_MEMORY.md").write_text("# Preferences\nPrefer fiscal-year over calendar.\n")
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "m.db"))
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(arts))
+    assert model_deploy.main([]) == 0
+    store = Store.connect("sqlite://" + str(tmp_path / "m.db"))
+    user_rows = store.query("SELECT content FROM memory WHERE kind = 'user'")
+    store.close()
+    assert user_rows and "fiscal-year" in user_rows[0]["content"]  # the global user row was written
+
+
+def test_redeploy_clears_removed_examples(tmp_path):
+    # A redeploy after removing the examples file must clear the stale rows (write_examples always runs).
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo")
+    store = _store(tmp_path)
+    model_deploy.deploy_models(store, arts)
+    assert _count(store, "prompt_example", "demo") == 1
+    (arts / "demo" / "prompt_examples" / "Catalog" / "examples.yaml").unlink()  # remove the examples
+    model_deploy.deploy_models(store, arts)
+    after = _count(store, "prompt_example", "demo")
+    store.close()
+    assert after == 0  # stale examples cleared, not left behind
+
+
+def test_main_invalid_yaml_exits_one_not_traceback(tmp_path, monkeypatch):
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo")
+    (arts / "demo" / "org.yaml").write_text("organization: [unterminated\n")  # invalid YAML
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "m.db"))
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(arts))
+    assert model_deploy.main([]) == 1  # caught → clean exit, not an uncaught traceback
+
+
 def test_multiple_datasources_each_load(tmp_path):
     arts = tmp_path / "artifacts"
     _write_model(arts, "demo", org_name="acme")

--- a/tests/test_model_deploy.py
+++ b/tests/test_model_deploy.py
@@ -112,6 +112,27 @@ def test_multiple_datasources_each_load(tmp_path):
     assert loaded == ["demo", "demo2"]  # both models, 'local' skipped
 
 
+def test_main_deploys_all_then_a_named_datasource(tmp_path, monkeypatch):
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo")
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "m.db"))
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(arts))
+    assert model_deploy.main([]) == 0  # deploy every model under the dir (migrates first, then loads)
+    assert model_deploy.main(["demo"]) == 0  # deploy a named datasource
+    store = Store.connect("sqlite://" + str(tmp_path / "m.db"))
+    org = model_store.load_organization(store, "demo")
+    store.close()
+    assert org is not None and org.organization == "acme"
+
+
+def test_main_errors_when_no_model_found(tmp_path, monkeypatch):
+    arts = tmp_path / "artifacts"
+    arts.mkdir()  # exists but holds no model
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "m.db"))
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(arts))
+    assert model_deploy.main([]) == 1  # nothing to deploy → fail-closed
+
+
 def test_main_errors_when_no_database(monkeypatch):
     monkeypatch.delenv("AGAMI_DB_URL", raising=False)
     monkeypatch.delenv("APP_DATABASE_URL", raising=False)

--- a/tests/test_model_deploy.py
+++ b/tests/test_model_deploy.py
@@ -133,6 +133,29 @@ def test_main_errors_when_no_model_found(tmp_path, monkeypatch):
     assert model_deploy.main([]) == 1  # nothing to deploy → fail-closed
 
 
+def test_malformed_examples_file_is_skipped_not_fatal(tmp_path):
+    # A malformed examples file (a non-dict item) must not abort the deploy — the model still loads,
+    # that area's examples are just skipped (examples are best-effort).
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo")
+    (arts / "demo" / "prompt_examples" / "Catalog" / "examples.yaml").write_text(
+        "examples:\n  - just a bare string\n"  # invalid: a scalar where a mapping is expected
+    )
+    store = _store(tmp_path)
+    loaded = model_deploy.deploy_models(store, arts)  # must not raise
+    org = model_store.load_organization(store, "demo")
+    n_examples = _count(store, "prompt_example", "demo")
+    store.close()
+    assert loaded == ["demo"] and org is not None  # the model deployed despite the bad examples file
+    assert n_examples == 0  # the malformed area's examples were skipped, not partially written
+
+
+def test_main_errors_when_artifacts_dir_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "m.db"))
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "does-not-exist"))
+    assert model_deploy.main([]) == 1  # clean exit, not an uncaught FileNotFoundError
+
+
 def test_main_errors_when_no_database(monkeypatch):
     monkeypatch.delenv("AGAMI_DB_URL", raising=False)
     monkeypatch.delenv("APP_DATABASE_URL", raising=False)

--- a/tests/test_model_deploy.py
+++ b/tests/test_model_deploy.py
@@ -1,0 +1,127 @@
+"""ACE-022 — `model_deploy` loads the local YAML model into serving Postgres (idempotent, fail-closed).
+
+Builds a minimal NEUTRAL artifacts fixture in a tmp dir and runs the real loader → real DB writers (no
+mocking), then asserts the served model round-trips, re-running is idempotent, and the error paths exit non-zero.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("yaml")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import model_deploy  # noqa: E402
+import model_store  # noqa: E402
+from store import Store  # noqa: E402
+
+
+def _write_model(root: Path, datasource: str, org_name: str = "acme") -> None:
+    """A minimal but real v2 profile dir: org + one subject area + a table + examples + ORGANIZATION.md."""
+    d = root / datasource
+    (d / "subject_areas" / "Catalog" / "tables").mkdir(parents=True, exist_ok=True)
+    (d / "prompt_examples" / "Catalog").mkdir(parents=True, exist_ok=True)
+    (d / "org.yaml").write_text(
+        f"organization: {org_name}\nversion: 1\ndescription: A neutral demo model.\n"
+        "storage_connections:\n  - name: warehouse\n    storage_type: PostgreSQL\n"
+        "subject_areas:\n  - Catalog\n"
+    )
+    (d / "subject_areas" / "Catalog" / "subject_area.yaml").write_text(
+        "name: Catalog\ndescription: Products and pricing.\n"
+    )
+    (d / "subject_areas" / "Catalog" / "tables" / "products.yaml").write_text(
+        "name: products\ndescription: Master product catalog.\n"
+        "columns:\n  - name: id\n    type: uuid\n    primary_key: true\n  - name: sku\n    type: string\n"
+    )
+    (d / "prompt_examples" / "Catalog" / "examples.yaml").write_text(
+        "examples:\n  - question: how many products?\n    sql: SELECT COUNT(*) FROM products\n"
+    )
+    (d / "ORGANIZATION.md").write_text("# Acme\nNeutral demo domain notes.\n")
+
+
+def _store(tmp_path: Path) -> Store:
+    s = Store.connect("sqlite://" + str(tmp_path / "m.db"))
+    s.run_migrations()
+    return s
+
+
+def _count(store: Store, table: str, datasource: str) -> int:
+    return store.query(f"SELECT COUNT(*) AS n FROM {table} WHERE datasource = ?", (datasource,))[0]["n"]
+
+
+def test_deploy_loads_model_and_round_trips(tmp_path):
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo")
+    store = _store(tmp_path)
+    loaded = model_deploy.deploy_models(store, arts)
+    org = model_store.load_organization(store, "demo")
+    store.close()
+    assert loaded == ["demo"]
+    assert org is not None and org.organization == "acme"
+    assert [sa.name for sa in org.subject_areas] == ["Catalog"]
+    assert [t.name for sa in org.subject_areas for t in sa.tables_defined] == ["products"]
+
+
+def test_idempotent_reload_has_no_duplicates(tmp_path):
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo")
+    store = _store(tmp_path)
+    model_deploy.deploy_models(store, arts)
+    first = (_count(store, "subject_area", "demo"), _count(store, "model_table", "demo"),
+             _count(store, "prompt_example", "demo"))
+    model_deploy.deploy_models(store, arts)  # re-run (the model-update-on-restart path)
+    second = (_count(store, "subject_area", "demo"), _count(store, "model_table", "demo"),
+              _count(store, "prompt_example", "demo"))
+    store.close()
+    assert first == second == (1, 1, 1)  # clear-then-insert → stable, no dupes
+
+
+def test_examples_memory_and_version_are_loaded(tmp_path):
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo")
+    store = _store(tmp_path)
+    model_deploy.deploy_models(store, arts)
+    examples = store.query("SELECT question FROM prompt_example WHERE datasource = ?", ("demo",))
+    memory = store.query(
+        "SELECT content FROM memory WHERE datasource = ? AND kind = 'organization'", ("demo",)
+    )
+    version = store.query("SELECT version FROM model_version WHERE datasource = ?", ("demo",))
+    store.close()
+    assert any("how many products" in e["question"] for e in examples)
+    assert memory and "Neutral demo domain" in memory[0]["content"]
+    assert version  # a model_version row was written
+
+
+def test_multiple_datasources_each_load(tmp_path):
+    arts = tmp_path / "artifacts"
+    _write_model(arts, "demo", org_name="acme")
+    _write_model(arts, "demo2", org_name="beta")
+    # a non-model subdir (no org.yaml) must be skipped, not error
+    (arts / "local").mkdir(parents=True, exist_ok=True)
+    (arts / "local" / "credentials").write_text("[demo]\nhost=localhost\n")
+    store = _store(tmp_path)
+    loaded = model_deploy.deploy_models(store, arts)
+    store.close()
+    assert loaded == ["demo", "demo2"]  # both models, 'local' skipped
+
+
+def test_main_errors_when_no_database(monkeypatch):
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    assert model_deploy.main([]) == 2  # fail-closed, non-zero
+
+
+def test_main_errors_naming_a_missing_datasource(tmp_path, monkeypatch):
+    arts = tmp_path / "artifacts"
+    arts.mkdir()
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "m.db"))
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(arts))
+    rc = model_deploy.main(["nope"])  # no nope/org.yaml
+    assert rc == 1


### PR DESCRIPTION
Spec: ACE-022

## Summary
The hosted server serves the model **from Postgres** (`tools._serve_model` reads the DB when one is configured), but nothing packaged ever loaded it there — that wiring only lived in an ad-hoc local `seed.py`. So ACE-009's entrypoint `load model` step (and the model-update-on-restart story) had nothing to call. This adds **`model_deploy`** — the orchestrator over the existing idempotent pieces. Carved out of ACE-009 during its grounding.

## Changes
- **`packages/agami-core/src/model_deploy.py`** — `python -m model_deploy [datasource …]`. For every datasource under `AGAMI_ARTIFACTS_DIR` (a subdir with `org.yaml`; `local/` skipped), loads `loader.load_organization` → writes org + per-area examples + `ORGANIZATION.md`/`USER_MEMORY.md` + version via `model_store.write_*`. **Idempotent** (the writers clear-then-insert). Runs migrations first (it precedes the server's lifespan auto-migrate, ACE-019). **Fail-closed:** no DB → exit 2; no model / named profile missing `org.yaml` / missing artifacts dir → exit 1.
- **Load-then-write:** reads + parses everything before any DB write, so a malformed model fails before a partial write; a malformed examples file for one area is skipped with a warning (best-effort), not fatal.
- `pyproject.toml` — `model_deploy` added to `py-modules`.
- **`tests/test_model_deploy.py`** (10) — real loader→DB round-trip on a neutral tmp fixture; idempotent reload (no dupes); examples/memory/version loaded; multi-datasource + `local/` skipped; malformed-examples skipped; `main()` success + every error path.

## Out of scope
The Docker entrypoint that invokes this → ACE-009. Model authoring (`semantic_model.cli`). The push-from-Claude endpoint (parked). The write primitives (exist, ACE-002).

## Checklist
- [x] `Spec: ACE-022`
- [x] Gate green — `ruff check`, **978 tests**, gitleaks; **100%** patch coverage
- [x] Pure Python, fully unit-tested on SQLite (no Docker)
- [x] Neutral test fixture (`acme`/`Catalog`), no real customer data; logs datasource names only