### PR TITLE
Deploy package — secure-by-default compose (Caddy TLS) + entrypoint + preflight

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# The deploy image's build context is the repo root; keep it lean (only packages/ + migrations/ are COPYed).
+.git
+previews
+tests
+**/__pycache__
+**/*.pyc
+*.db
+.venv
+node_modules

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,34 @@
+# agami self-host config. Copy to `.env` and fill in. `deploy_preflight` validates it and APPENDS the rest
+# (AGAMI_SIGNING_SECRET, AGAMI_PUBLIC_HOST) — don't set those by hand.
+
+# Which parts of the stack to run (see docker-compose.yml). Default = the secure VM bundle.
+COMPOSE_PROFILES=bundled-db,edge
+
+# The public URL teammates connect to — a HOSTNAME, not a bare IP (TLS + OAuth need a DNS name).
+# Point a DNS A-record at this VM, or use the `tunnel` profile for a name without a public IP.
+PUBLIC_BASE_URL=https://agami.your-domain.example
+
+# The admin (identity = email; gates the /admin console). Set at least one auth method below.
+AGAMI_ADMIN_USERNAME=you@example.com
+AGAMI_ADMIN_FIRST_NAME=Alex
+AGAMI_ADMIN_LAST_NAME=Kim
+AGAMI_ADMIN_PASSWORD=choose-a-strong-password
+# AGAMI_ADMIN_PROVIDER=google            # or microsoft — also set the matching OIDC client:
+# AGAMI_OIDC_GOOGLE_CLIENT_ID=
+# AGAMI_OIDC_GOOGLE_CLIENT_SECRET=
+
+# The warehouse the model queries.
+DATASOURCE_URL=postgresql://user@your-warehouse.example/db
+
+# External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).
+# Use a PLAIN postgresql:// URL (e.g. a Cloud-SQL-like service via its IP + sslmode=require) — not a cloud connector.
+# APP_DATABASE_URL=postgresql://user@your-managed-pg.example:5432/agami?sslmode=require
+
+# Override the bundled-Postgres password if you like (it's never exposed, so the default is fine).
+# POSTGRES_PASSWORD=
+
+# Optional free registration key (best-effort; absent = full run).
+# AGAMI_LICENSE_KEY=
+
+# Only for the `tunnel` profile:
+# CLOUDFLARE_TUNNEL_TOKEN=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -17,8 +17,8 @@ AGAMI_ADMIN_PASSWORD=choose-a-strong-password
 # AGAMI_OIDC_GOOGLE_CLIENT_ID=
 # AGAMI_OIDC_GOOGLE_CLIENT_SECRET=
 
-# The warehouse the model queries.
-DATASOURCE_URL=postgresql://user@your-warehouse.example/db
+# NOTE: the WAREHOUSE the model queries is NOT configured here — its credentials travel in your mounted
+# artifacts at `<artifacts>/local/credentials` (an INI keyed by datasource), the same file agami uses locally.
 
 # External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).
 # Use a PLAIN postgresql:// URL (e.g. a Cloud-SQL-like service via its IP + sslmode=require) — not a cloud connector.

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,2 @@
+.env
+artifacts/

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,6 @@
+# Caddy terminates TLS for your hostname (automatic Let's Encrypt) and proxies to the internal agami
+# server. AGAMI_PUBLIC_HOST is the bare hostname (e.g. agami.example.com) — deploy_preflight derives it
+# from PUBLIC_BASE_URL. The host must resolve (a DNS A-record → this VM) for the certificate to issue.
+{$AGAMI_PUBLIC_HOST} {
+	reverse_proxy agami:8000
+}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,14 +1,19 @@
 # The agami MCP server image. Build context is the repo root (see docker-compose.yml `build.context: ..`).
 FROM python:3.12-slim
 
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 HOST=0.0.0.0 PORT=8000
+
 # An editable install keeps the package source at /app/packages/agami-core/src, so the package's relative
 # migrations path (store.py resolves parents[3]/migrations/core) points at /app/migrations.
 WORKDIR /app
 COPY packages/agami-core /app/packages/agami-core
 COPY migrations /app/migrations
 COPY deploy/entrypoint.sh /app/entrypoint.sh
+# Install as root, then run as a dedicated unprivileged user (smaller blast radius if the app is compromised).
 RUN pip install --no-cache-dir -e "/app/packages/agami-core[server,model]" \
- && chmod +x /app/entrypoint.sh
+ && chmod +x /app/entrypoint.sh \
+ && useradd --create-home --uid 10001 agami \
+ && chown -R agami:agami /app
+USER agami
 
-ENV HOST=0.0.0.0 PORT=8000
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,14 @@
+# The agami MCP server image. Build context is the repo root (see docker-compose.yml `build.context: ..`).
+FROM python:3.12-slim
+
+# An editable install keeps the package source at /app/packages/agami-core/src, so the package's relative
+# migrations path (store.py resolves parents[3]/migrations/core) points at /app/migrations.
+WORKDIR /app
+COPY packages/agami-core /app/packages/agami-core
+COPY migrations /app/migrations
+COPY deploy/entrypoint.sh /app/entrypoint.sh
+RUN pip install --no-cache-dir -e "/app/packages/agami-core[server,model]" \
+ && chmod +x /app/entrypoint.sh
+
+ENV HOST=0.0.0.0 PORT=8000
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,47 @@
+# Self-hosting agami (local → team)
+
+Stand up the agami MCP server on your own host so your team can query your semantic model in Claude. We
+ship Docker; you deploy it to your own VM/cloud. The default is **secure by construction**: Caddy gives you
+automatic HTTPS and is the *only* public service — agami and Postgres stay on the internal network with no
+exposed ports.
+
+## What you need
+- A host with Docker (a small cloud VM is plenty), with **only ports 80 and 443** open.
+- A **hostname** you control (e.g. `agami.acme.com`) with a DNS **A-record → your VM's IP**. (No domain? Use
+  the **Cloudflare Tunnel** profile below — no public IP or DNS needed.) TLS and OAuth require a name, not a
+  bare IP.
+- Your model — the local `agami-artifacts` folder you built with `agami-serve`.
+
+## Deploy (the secure VM bundle — the default)
+```bash
+git clone <this repo> && cd <repo>/deploy
+cp .env.example .env            # then edit: PUBLIC_BASE_URL (your hostname), admin email + password, DATASOURCE_URL
+ln -s /path/to/your/agami-artifacts ./artifacts   # or set AGAMI_ARTIFACTS_DIR in .env
+./deploy.sh                     # validates .env, generates the signing secret, builds + starts
+```
+That's it. `deploy.sh` runs the preflight (it generates and **persists** `AGAMI_SIGNING_SECRET` — keep `.env`,
+it's what keeps connected sessions valid across restarts) then `docker compose up`. The container migrates the
+database, loads your model into Postgres, and serves. Once Caddy issues the certificate (a few seconds):
+
+- **Your team:** add `https://<your-host>/mcp` as a custom connector in Claude and sign in.
+- **You:** manage who's allowed at `https://<your-host>/admin` (sign in with the admin email + password).
+
+## Updating the model
+Edit the model locally in Claude → refresh your `artifacts` → `docker compose restart agami`. The container
+re-ingests the model on boot. **No rebuild, no new VM, no database access** — the container does the load.
+
+## Variants (toggle `COMPOSE_PROFILES` in `.env`)
+| You want… | `.env` | command |
+|---|---|---|
+| **Secure VM** (default) | `COMPOSE_PROFILES=bundled-db,edge` | `docker compose up -d` |
+| **External / managed Postgres** (e.g. a Cloud-SQL-like service) | `COMPOSE_PROFILES=edge` + set `APP_DATABASE_URL` (a plain `postgresql://…?sslmode=require` URL — not a cloud connector) | `docker compose up -d` |
+| **No public IP** (Cloudflare Tunnel) | `COMPOSE_PROFILES=bundled-db,tunnel` + set `CLOUDFLARE_TUNNEL_TOKEN` | `docker compose up -d` |
+| **Cloud Run / serverless** (platform gives TLS) | set `APP_DATABASE_URL`; deploy the built image with these env vars | (your platform) |
+
+## Security notes
+- **Only Caddy is public** (80/443). agami and Postgres have no published ports — the DB is never reachable
+  from the internet. Lock down SSH separately.
+- The admin console is gated by the configured admin email + a session cookie; the `/mcp` query surface is
+  gated by per-user OAuth. Both need the HTTPS that Caddy provides.
+- `.env` holds the signing secret and DB creds — it stays on your host and is never committed. **No data ever
+  leaves your environment.**

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -45,3 +45,6 @@ re-ingests the model on boot. **No rebuild, no new VM, no database access** — 
   gated by per-user OAuth. Both need the HTTPS that Caddy provides.
 - `.env` holds the signing secret and DB creds — it stays on your host and is never committed. **No data ever
   leaves your environment.**
+- **Always deploy via `./deploy.sh`** (it runs the preflight). If you `docker compose up` directly without
+  having run the preflight, `AGAMI_PUBLIC_HOST` is unset and Caddy fails to start (loudly, never insecurely) —
+  run `python -m deploy_preflight .env` first.

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# One-shot deploy from this dir: validate/complete .env, then build + bring the stack up.
+# The preflight needs the agami-core package on PATH (the /agami-deploy skill runs it via uvx; manually:
+# `pip install -e ../packages/agami-core`).
+set -e
+cd "$(dirname "$0")"
+
+python -m deploy_preflight .env       # validate hard-floor inputs; generate+persist the signing secret; derive the host
+docker compose up -d --build
+
+echo "agami is starting. It's live at your PUBLIC_BASE_URL once Caddy issues the certificate (a few seconds)."
+echo "Share  \${PUBLIC_BASE_URL}/mcp  with your team; manage users at  \${PUBLIC_BASE_URL}/admin"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,71 @@
+# agami self-host stack. The default `docker compose up` (with COMPOSE_PROFILES=bundled-db,edge in .env)
+# brings up the secure VM deployment: Caddy terminates TLS and is the ONLY public service; agami and
+# Postgres live on the internal network with no published ports. Toggle the profiles for the variants:
+#   bundled-db,edge   (default)  — Caddy TLS + agami + bundled Postgres on a VM
+#   edge              + APP_DATABASE_URL — external/managed Postgres (e.g. Cloud SQL via a plain URL)
+#   tunnel            — Cloudflare Tunnel instead of a public IP (no inbound ports)
+#   (none)            — agami only, behind the platform's own TLS (e.g. Cloud Run); set APP_DATABASE_URL
+name: agami
+
+services:
+  caddy:
+    image: caddy:2
+    profiles: ["edge"]
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      AGAMI_PUBLIC_HOST: ${AGAMI_PUBLIC_HOST}  # the bare hostname; deploy_preflight derives it from PUBLIC_BASE_URL
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+  agami:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      # Bundled Postgres by default; set APP_DATABASE_URL in .env to point at managed Postgres instead.
+      AGAMI_DB_URL: ${APP_DATABASE_URL:-postgresql://agami:${POSTGRES_PASSWORD:-agami-bundled-local}@postgres:5432/agami}
+      AGAMI_ARTIFACTS_DIR: /artifacts
+      HOST: 0.0.0.0
+      PORT: "8000"
+    volumes:
+      - ${AGAMI_ARTIFACTS_DIR:-./artifacts}:/artifacts:ro  # your local agami-artifacts (the model), read-only
+    # No `ports:` and no `depends_on:` — agami is reached only via Caddy/the tunnel on the internal
+    # network, and the entrypoint waits for the DB itself (so the external-DB/cloud-run profiles work).
+
+  postgres:
+    image: postgres:16
+    profiles: ["bundled-db"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: agami
+      POSTGRES_USER: agami
+      # A bundled-local default — fine because the DB is never exposed; override it in .env if you like.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-agami-bundled-local}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agami -d agami"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    # No `ports:` — the database is never published to the host or the internet.
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    profiles: ["tunnel"]
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}  # from your Cloudflare Zero Trust tunnel
+
+volumes:
+  pgdata:
+  caddy_data:
+  caddy_config:

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# The container's boot sequence: wait for the DB, then migrate + load the model, then serve.
+# Fail-closed — a bad migration or model aborts the boot (set -e) rather than serving a broken state.
+set -e
+
+# The bundled Postgres may still be coming up; wait for it before model_deploy (which migrates + loads).
+# We don't use a compose `depends_on` so the external-DB / cloud-run profiles work without the bundled DB.
+python - <<'PY'
+import os, sys, time
+
+sys.path.insert(0, "/app/packages/agami-core/src")
+from store import Store
+
+url = os.environ.get("AGAMI_DB_URL") or os.environ.get("APP_DATABASE_URL") or ""
+for _ in range(60):
+    try:
+        Store.connect(url).close()
+        break
+    except Exception:
+        time.sleep(1)
+else:
+    sys.exit("entrypoint: database not reachable after 60s")
+PY
+
+python -m model_deploy      # migrate (ACE-019) + load the model into Postgres (ACE-022); fail-closed
+exec python -m mcp_http     # serve (also re-migrates + seeds the admin on startup; both idempotent)

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -16,6 +16,8 @@ for _ in range(60):
     try:
         Store.connect(url).close()
         break
+    except ValueError as e:
+        sys.exit(f"entrypoint: bad database URL — {e}")  # malformed scheme is permanent; don't wait 60s
     except Exception:
         time.sleep(1)
 else:

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -44,7 +44,7 @@ server = [
 package-dir = { "" = "src" }
 # Flat top-level modules (not under a parent package) — listed explicitly so the import
 # names stay flat regardless of disk layout.
-py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "model_deploy", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
+py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "model_deploy", "deploy_preflight", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
 packages = ["semantic_model"]
 
 [tool.setuptools.package-data]

--- a/packages/agami-core/src/deploy_preflight.py
+++ b/packages/agami-core/src/deploy_preflight.py
@@ -15,9 +15,10 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
-# The hard-floor inputs (see the ACE-009 `.env` contract). Auth needs at least one of the two methods.
-_REQUIRED = ("PUBLIC_BASE_URL", "AGAMI_ADMIN_USERNAME", "DATASOURCE_URL")
-_AUTH_ANY = ("AGAMI_ADMIN_PASSWORD", "AGAMI_ADMIN_PROVIDER")
+# The hard-floor inputs (see the ACE-009 `.env` contract). The warehouse credentials are NOT an env var —
+# they travel in the mounted artifacts (`<artifacts>/local/credentials`), so there's no DATASOURCE_URL here.
+_REQUIRED = ("PUBLIC_BASE_URL", "AGAMI_ADMIN_USERNAME")
+_OIDC_PROVIDERS = {"google": "GOOGLE", "microsoft": "MICROSOFT"}  # provider → AGAMI_OIDC_<PREFIX>_CLIENT_*
 
 
 def _parse_env(text: str) -> dict[str, str]:
@@ -58,20 +59,42 @@ def prepare_env(env_path: Path) -> list[str]:
     env = _parse_env(env_path.read_text())
 
     errors = [f"{k} is required" for k in _REQUIRED if not env.get(k)]
-    if not any(env.get(k) for k in _AUTH_ANY):
+
+    # TLS is mandatory — the server hard-fails on a non-https PUBLIC_BASE_URL, so catch it here with a clear
+    # message rather than a cryptic boot crash.
+    pub = env.get("PUBLIC_BASE_URL", "")
+    if pub and not pub.startswith("https://"):
+        errors.append("PUBLIC_BASE_URL must start with https:// (TLS is required for OAuth + the admin cookie)")
+
+    # Auth floor: a password and/or a pinned social provider — and a provider needs its OIDC client, or it
+    # would seed an admin who can't actually sign in.
+    provider = env.get("AGAMI_ADMIN_PROVIDER", "").lower()
+    if not env.get("AGAMI_ADMIN_PASSWORD") and not provider:
         errors.append("set AGAMI_ADMIN_PASSWORD and/or AGAMI_ADMIN_PROVIDER (at least one)")
+    if provider:
+        prefix = _OIDC_PROVIDERS.get(provider)
+        if prefix is None:
+            errors.append(f"AGAMI_ADMIN_PROVIDER must be one of: {', '.join(_OIDC_PROVIDERS)}")
+        elif not env.get(f"AGAMI_OIDC_{prefix}_CLIENT_ID") or not env.get(f"AGAMI_OIDC_{prefix}_CLIENT_SECRET"):
+            errors.append(
+                f"AGAMI_ADMIN_PROVIDER={provider} needs AGAMI_OIDC_{prefix}_CLIENT_ID + _CLIENT_SECRET"
+            )
 
-    # Generate-once-and-persist the signing secret — never regenerate (it would invalidate live tokens).
-    if not env.get("AGAMI_SIGNING_SECRET"):
-        _set_env(env_path, "AGAMI_SIGNING_SECRET", secrets.token_hex(32))
-
-    # Caddy's TLS site needs the bare hostname, not the full URL — derive it from PUBLIC_BASE_URL.
-    if not env.get("AGAMI_PUBLIC_HOST") and env.get("PUBLIC_BASE_URL"):
-        host = urlparse(env["PUBLIC_BASE_URL"]).hostname
-        if host:
-            _set_env(env_path, "AGAMI_PUBLIC_HOST", host)
-        else:
-            errors.append("PUBLIC_BASE_URL must be a URL like https://host (could not derive a hostname)")
+    # Generate/derive the values the operator shouldn't hand-set. Wrap the file writes so a permission error
+    # is a clean message, not a traceback.
+    try:
+        # Generate-once-and-persist the signing secret — never regenerate (it would invalidate live tokens).
+        if not env.get("AGAMI_SIGNING_SECRET"):
+            _set_env(env_path, "AGAMI_SIGNING_SECRET", secrets.token_hex(32))
+        # Caddy's TLS site needs the bare hostname — derive it from a valid https PUBLIC_BASE_URL.
+        if not env.get("AGAMI_PUBLIC_HOST") and pub.startswith("https://"):
+            host = urlparse(pub).hostname
+            if host:
+                _set_env(env_path, "AGAMI_PUBLIC_HOST", host)
+            else:
+                errors.append("PUBLIC_BASE_URL must be https://<host> (could not derive a hostname)")
+    except OSError as e:
+        errors.append(f"could not write {env_path}: {e}")
 
     return errors
 

--- a/packages/agami-core/src/deploy_preflight.py
+++ b/packages/agami-core/src/deploy_preflight.py
@@ -33,10 +33,21 @@ def _parse_env(text: str) -> dict[str, str]:
     return out
 
 
-def _append(env_path: Path, key: str, value: str) -> None:
-    with env_path.open("a") as f:
-        f.write(f"\n{key}={value}\n")
-    env_path.chmod(0o600)  # the file holds the signing secret + DB creds
+def _set_env(env_path: Path, key: str, value: str) -> None:
+    """Set `KEY=VALUE` in the `.env` — **replacing** an existing (even present-but-empty) line in place, else
+    appending. Replace-not-append avoids a confusing duplicate key when e.g. `AGAMI_SIGNING_SECRET=` is blank.
+    chmod 600 because the file holds the signing secret + DB creds."""
+    lines = env_path.read_text().splitlines()
+    new = f"{key}={value}"
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("#") and stripped.split("=", 1)[0].strip() == key:
+            lines[i] = new
+            break
+    else:
+        lines.append(new)
+    env_path.write_text("\n".join(lines) + "\n")
+    env_path.chmod(0o600)
 
 
 def prepare_env(env_path: Path) -> list[str]:
@@ -52,13 +63,13 @@ def prepare_env(env_path: Path) -> list[str]:
 
     # Generate-once-and-persist the signing secret — never regenerate (it would invalidate live tokens).
     if not env.get("AGAMI_SIGNING_SECRET"):
-        _append(env_path, "AGAMI_SIGNING_SECRET", secrets.token_hex(32))
+        _set_env(env_path, "AGAMI_SIGNING_SECRET", secrets.token_hex(32))
 
     # Caddy's TLS site needs the bare hostname, not the full URL — derive it from PUBLIC_BASE_URL.
     if not env.get("AGAMI_PUBLIC_HOST") and env.get("PUBLIC_BASE_URL"):
         host = urlparse(env["PUBLIC_BASE_URL"]).hostname
         if host:
-            _append(env_path, "AGAMI_PUBLIC_HOST", host)
+            _set_env(env_path, "AGAMI_PUBLIC_HOST", host)
         else:
             errors.append("PUBLIC_BASE_URL must be a URL like https://host (could not derive a hostname)")
 

--- a/packages/agami-core/src/deploy_preflight.py
+++ b/packages/agami-core/src/deploy_preflight.py
@@ -1,0 +1,82 @@
+"""Host-side deploy preflight — validate the `.env` and fill in what the operator shouldn't have to.
+
+Run before `docker compose up` (the `deploy.sh` wrapper / the `/agami-deploy` skill call it). It checks the
+hard-floor inputs are present, **generates and persists** `AGAMI_SIGNING_SECRET` once (an ephemeral secret
+would break every connected Claude on the next restart), and derives `AGAMI_PUBLIC_HOST` (the bare hostname
+Caddy needs for its TLS site) from `PUBLIC_BASE_URL`. Idempotent — a re-run reuses the persisted values.
+
+    python -m deploy_preflight [path/to/.env]   # default: ./.env
+"""
+
+from __future__ import annotations
+
+import secrets
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+# The hard-floor inputs (see the ACE-009 `.env` contract). Auth needs at least one of the two methods.
+_REQUIRED = ("PUBLIC_BASE_URL", "AGAMI_ADMIN_USERNAME", "DATASOURCE_URL")
+_AUTH_ANY = ("AGAMI_ADMIN_PASSWORD", "AGAMI_ADMIN_PROVIDER")
+
+
+def _parse_env(text: str) -> dict[str, str]:
+    """Parse a `.env` into {KEY: VALUE} — `KEY=VALUE` per line, `#` comments and blanks skipped. A value's
+    surrounding quotes are stripped; everything after the first `=` is the value (so URLs with `=` survive)."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        out[key.strip()] = val.strip().strip("'\"")
+    return out
+
+
+def _append(env_path: Path, key: str, value: str) -> None:
+    with env_path.open("a") as f:
+        f.write(f"\n{key}={value}\n")
+    env_path.chmod(0o600)  # the file holds the signing secret + DB creds
+
+
+def prepare_env(env_path: Path) -> list[str]:
+    """Validate + complete the `.env` in place. Returns a list of human-readable errors (empty = ready).
+    Generates `AGAMI_SIGNING_SECRET` and derives `AGAMI_PUBLIC_HOST` when absent — both idempotent."""
+    if not env_path.exists():
+        return [f"{env_path} not found — copy .env.example to .env and fill it in"]
+    env = _parse_env(env_path.read_text())
+
+    errors = [f"{k} is required" for k in _REQUIRED if not env.get(k)]
+    if not any(env.get(k) for k in _AUTH_ANY):
+        errors.append("set AGAMI_ADMIN_PASSWORD and/or AGAMI_ADMIN_PROVIDER (at least one)")
+
+    # Generate-once-and-persist the signing secret — never regenerate (it would invalidate live tokens).
+    if not env.get("AGAMI_SIGNING_SECRET"):
+        _append(env_path, "AGAMI_SIGNING_SECRET", secrets.token_hex(32))
+
+    # Caddy's TLS site needs the bare hostname, not the full URL — derive it from PUBLIC_BASE_URL.
+    if not env.get("AGAMI_PUBLIC_HOST") and env.get("PUBLIC_BASE_URL"):
+        host = urlparse(env["PUBLIC_BASE_URL"]).hostname
+        if host:
+            _append(env_path, "AGAMI_PUBLIC_HOST", host)
+        else:
+            errors.append("PUBLIC_BASE_URL must be a URL like https://host (could not derive a hostname)")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    env_path = Path(args[0]) if args else Path(".env")
+    errors = prepare_env(env_path)
+    if errors:
+        print("deploy_preflight: .env is not ready:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    print(f"deploy_preflight: {env_path} is ready.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import admin
 import onboarding
+import user_store
 from oss_adapters import PresenceAuthProvider, SingleTenantOrgResolver
 from ports import AuthProvider, Org
 from starlette.applications import Starlette
@@ -322,6 +323,13 @@ def build_app() -> Starlette:
                 applied = store.run_migrations()
                 if applied:
                     _log.info("applied migrations: %s", ", ".join(applied))
+                # Seed the configured admin (AGAMI_ADMIN_*) so a fresh deploy has someone who can sign in —
+                # nothing else creates it. Create-if-absent + idempotent, so a redeploy never duplicates or
+                # clobbers an admin who has since changed their own credentials.
+                seeded = user_store.seed_admin_from_env(store)
+                store.commit()
+                if seeded:
+                    _log.info("seeded admin: %s", seeded)
             finally:
                 store.close()
         async with session_manager.run():

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -329,7 +329,7 @@ def build_app() -> Starlette:
                 seeded = user_store.seed_admin_from_env(store)
                 store.commit()
                 if seeded:
-                    _log.info("seeded admin: %s", seeded)
+                    _log.info("seeded the configured admin")  # not the email — no PII in logs
             finally:
                 store.close()
         async with session_manager.run():

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -320,16 +320,20 @@ def build_app() -> Starlette:
         store = Store.from_env()
         if store is not None:
             try:
-                applied = store.run_migrations()
+                applied = store.run_migrations()  # fail-closed: a bad migration aborts startup
                 if applied:
                     _log.info("applied migrations: %s", ", ".join(applied))
                 # Seed the configured admin (AGAMI_ADMIN_*) so a fresh deploy has someone who can sign in —
-                # nothing else creates it. Create-if-absent + idempotent, so a redeploy never duplicates or
-                # clobbers an admin who has since changed their own credentials.
-                seeded = user_store.seed_admin_from_env(store)
-                store.commit()
-                if seeded:
-                    _log.info("seeded the configured admin")  # not the email — no PII in logs
+                # nothing else creates it. Create-if-absent + idempotent. BEST-EFFORT, unlike migrations: when
+                # several instances boot together they can race on the admin INSERT (a UNIQUE violation); the
+                # admin is seeded either way, so log + roll back + continue rather than aborting startup.
+                try:
+                    if user_store.seed_admin_from_env(store):
+                        _log.info("seeded the configured admin")  # not the email — no PII in logs
+                    store.commit()
+                except Exception:  # noqa: BLE001 — a concurrent boot won the seed; not fatal
+                    store.conn.rollback()
+                    _log.warning("admin seed skipped (already seeded or a concurrent boot won the race)")
             finally:
                 store.close()
         async with session_manager.run():

--- a/tests/test_admin_seed_on_startup.py
+++ b/tests/test_admin_seed_on_startup.py
@@ -64,6 +64,19 @@ def test_startup_admin_seed_is_idempotent(env):
     assert r.status_code == 302  # still exactly one working admin after a redeploy
 
 
+def test_startup_survives_a_seed_race(env, monkeypatch):
+    # If the admin seed raises (e.g. a concurrent boot won the INSERT — a UNIQUE violation), startup must
+    # NOT abort: the admin is seeded either way. Best-effort, unlike migrations.
+    import user_store
+
+    def _boom(_store):
+        raise RuntimeError("UNIQUE constraint failed: users.username")
+
+    monkeypatch.setattr(user_store, "seed_admin_from_env", _boom)
+    with TestClient(mcp_http.build_app()):  # entering runs the lifespan — must not raise
+        pass
+
+
 def test_startup_without_admin_env_seeds_nothing(env, monkeypatch):
     # No configured admin → startup still succeeds (no crash); there is just no admin to sign in as.
     monkeypatch.delenv("AGAMI_ADMIN_USERNAME", raising=False)

--- a/tests/test_admin_seed_on_startup.py
+++ b/tests/test_admin_seed_on_startup.py
@@ -1,0 +1,76 @@
+"""ACE-009 — the server seeds the configured admin on startup, so a fresh deploy can sign in.
+
+Nothing else creates the configured admin in a deployment (the local `seed.py` is test-only), so the
+`mcp_http` lifespan seeds it from `AGAMI_ADMIN_*` right after migrating — create-if-absent + idempotent.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("starlette")
+pytest.importorskip("mcp")
+pytest.importorskip("argon2")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import mcp_http  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+BASE = "https://your-host.example.com"
+SECRET = "x" * 40
+ADMIN_USER = "admin@example.com"
+ADMIN_PW = "admin-password-localtest"
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    # A FRESH DB, deliberately not seeded by anything other than startup.
+    monkeypatch.setenv("PUBLIC_BASE_URL", BASE)
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "seed.db"))
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", SECRET)
+    monkeypatch.setenv("AGAMI_ADMIN_USERNAME", ADMIN_USER)
+    monkeypatch.setenv("AGAMI_ADMIN_PASSWORD", ADMIN_PW)
+    for v in ("AGAMI_OIDC_GOOGLE_CLIENT_ID", "AGAMI_OIDC_GOOGLE_CLIENT_SECRET"):
+        monkeypatch.delenv(v, raising=False)
+
+
+def test_startup_seeds_the_configured_admin(env):
+    # Entering the TestClient runs the lifespan (startup) — which must seed the admin so the login works.
+    with TestClient(mcp_http.build_app()) as c:
+        r = c.post(
+            "/admin/login",
+            data={"username": ADMIN_USER, "password": ADMIN_PW},
+            follow_redirects=False,
+        )
+    assert r.status_code == 302  # the seeded admin can sign in (302 = success)
+
+
+def test_startup_admin_seed_is_idempotent(env):
+    # Two boots against the same DB must not duplicate or break the admin (redeploy is safe).
+    with TestClient(mcp_http.build_app()):
+        pass
+    with TestClient(mcp_http.build_app()) as c:
+        r = c.post(
+            "/admin/login",
+            data={"username": ADMIN_USER, "password": ADMIN_PW},
+            follow_redirects=False,
+        )
+    assert r.status_code == 302  # still exactly one working admin after a redeploy
+
+
+def test_startup_without_admin_env_seeds_nothing(env, monkeypatch):
+    # No configured admin → startup still succeeds (no crash); there is just no admin to sign in as.
+    monkeypatch.delenv("AGAMI_ADMIN_USERNAME", raising=False)
+    with TestClient(mcp_http.build_app()) as c:
+        r = c.post(
+            "/admin/login",
+            data={"username": ADMIN_USER, "password": ADMIN_PW},
+            follow_redirects=False,
+        )
+    assert r.status_code != 302  # nothing seeded → login does not succeed

--- a/tests/test_deploy_preflight.py
+++ b/tests/test_deploy_preflight.py
@@ -48,6 +48,14 @@ def test_signing_secret_is_generated_then_stable(tmp_path):
     assert first == second  # generated ONCE — never regenerated (would break live tokens)
 
 
+def test_present_but_empty_secret_is_filled_in_place_no_duplicate(tmp_path):
+    # A blank `AGAMI_SIGNING_SECRET=` must be filled in place, not appended as a second (duplicate) line.
+    p = _env(tmp_path, _COMPLETE + "AGAMI_SIGNING_SECRET=\n")
+    deploy_preflight.prepare_env(p)
+    lines = [ln for ln in p.read_text().splitlines() if ln.startswith("AGAMI_SIGNING_SECRET=")]
+    assert len(lines) == 1 and len(lines[0].split("=", 1)[1]) >= 32  # one line, now with a real value
+
+
 def test_public_host_is_derived_from_the_url(tmp_path):
     p = _env(tmp_path, _COMPLETE)
     deploy_preflight.prepare_env(p)

--- a/tests/test_deploy_preflight.py
+++ b/tests/test_deploy_preflight.py
@@ -15,7 +15,6 @@ _COMPLETE = (
     "PUBLIC_BASE_URL=https://agami.example.com\n"
     "AGAMI_ADMIN_USERNAME=you@example.com\n"
     "AGAMI_ADMIN_PASSWORD=choose-a-strong-one\n"
-    "DATASOURCE_URL=postgresql://you@warehouse/db\n"
 )
 
 
@@ -62,10 +61,20 @@ def test_public_host_is_derived_from_the_url(tmp_path):
     assert deploy_preflight._parse_env(p.read_text())["AGAMI_PUBLIC_HOST"] == "agami.example.com"
 
 
-def test_public_base_url_without_a_hostname_is_an_error(tmp_path):
-    p = _env(tmp_path, _COMPLETE.replace("https://agami.example.com", "not-a-real-url"))
+def test_non_https_public_base_url_is_an_error(tmp_path):
+    p = _env(tmp_path, _COMPLETE.replace("https://agami.example.com", "http://agami.example.com"))
     errors = deploy_preflight.prepare_env(p)
-    assert any("hostname" in e.lower() for e in errors)  # can't derive the Caddy host from a non-URL
+    assert any("https://" in e for e in errors)  # TLS is mandatory; catch plain http at the preflight
+
+
+def test_provider_without_its_oidc_client_is_an_error(tmp_path):
+    # A pinned provider with no OIDC client would seed an admin who can't sign in — block it.
+    p = _env(
+        tmp_path,
+        _COMPLETE.replace("AGAMI_ADMIN_PASSWORD=choose-a-strong-one\n", "AGAMI_ADMIN_PROVIDER=google\n"),
+    )
+    errors = deploy_preflight.prepare_env(p)
+    assert any("CLIENT_ID" in e for e in errors)
 
 
 def test_complete_env_passes(tmp_path):
@@ -73,12 +82,16 @@ def test_complete_env_passes(tmp_path):
     assert deploy_preflight.main([str(p)]) == 0  # ready → exit 0
 
 
-def test_provider_only_auth_is_accepted(tmp_path):
+def test_provider_with_its_oidc_client_is_accepted(tmp_path):
     p = _env(
         tmp_path,
-        _COMPLETE.replace("AGAMI_ADMIN_PASSWORD=choose-a-strong-one\n", "AGAMI_ADMIN_PROVIDER=google\n"),
+        _COMPLETE.replace(
+            "AGAMI_ADMIN_PASSWORD=choose-a-strong-one\n",
+            "AGAMI_ADMIN_PROVIDER=google\n"
+            "AGAMI_OIDC_GOOGLE_CLIENT_ID=id\nAGAMI_OIDC_GOOGLE_CLIENT_SECRET=secret\n",
+        ),
     )
-    assert deploy_preflight.prepare_env(p) == []  # a pinned provider alone satisfies the auth floor
+    assert deploy_preflight.prepare_env(p) == []  # a pinned provider + its OIDC client satisfies the auth floor
 
 
 def test_missing_env_file_is_a_clear_error(tmp_path):

--- a/tests/test_deploy_preflight.py
+++ b/tests/test_deploy_preflight.py
@@ -54,6 +54,12 @@ def test_public_host_is_derived_from_the_url(tmp_path):
     assert deploy_preflight._parse_env(p.read_text())["AGAMI_PUBLIC_HOST"] == "agami.example.com"
 
 
+def test_public_base_url_without_a_hostname_is_an_error(tmp_path):
+    p = _env(tmp_path, _COMPLETE.replace("https://agami.example.com", "not-a-real-url"))
+    errors = deploy_preflight.prepare_env(p)
+    assert any("hostname" in e.lower() for e in errors)  # can't derive the Caddy host from a non-URL
+
+
 def test_complete_env_passes(tmp_path):
     p = _env(tmp_path, _COMPLETE)
     assert deploy_preflight.main([str(p)]) == 0  # ready → exit 0

--- a/tests/test_deploy_preflight.py
+++ b/tests/test_deploy_preflight.py
@@ -1,0 +1,71 @@
+"""ACE-009 — the host-side deploy preflight: validate the `.env`, persist the signing secret, derive the host."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import deploy_preflight  # noqa: E402
+
+_COMPLETE = (
+    "PUBLIC_BASE_URL=https://agami.example.com\n"
+    "AGAMI_ADMIN_USERNAME=you@example.com\n"
+    "AGAMI_ADMIN_PASSWORD=choose-a-strong-one\n"
+    "DATASOURCE_URL=postgresql://you@warehouse/db\n"
+)
+
+
+def _env(tmp_path: Path, text: str) -> Path:
+    p = tmp_path / ".env"
+    p.write_text(text)
+    return p
+
+
+def test_missing_public_base_url_is_an_error(tmp_path):
+    p = _env(tmp_path, _COMPLETE.replace("PUBLIC_BASE_URL=https://agami.example.com\n", ""))
+    errors = deploy_preflight.prepare_env(p)
+    assert any("PUBLIC_BASE_URL" in e for e in errors)
+    assert deploy_preflight.main([str(p)]) == 1  # fails fast, non-zero
+
+
+def test_missing_auth_method_is_an_error(tmp_path):
+    p = _env(tmp_path, _COMPLETE.replace("AGAMI_ADMIN_PASSWORD=choose-a-strong-one\n", ""))
+    errors = deploy_preflight.prepare_env(p)
+    assert any("AGAMI_ADMIN_PASSWORD" in e for e in errors)  # neither password nor provider set
+
+
+def test_signing_secret_is_generated_then_stable(tmp_path):
+    p = _env(tmp_path, _COMPLETE)
+    assert deploy_preflight.prepare_env(p) == []  # complete .env → ready
+    first = deploy_preflight._parse_env(p.read_text())["AGAMI_SIGNING_SECRET"]
+    assert len(first) >= 32  # a real generated secret
+    deploy_preflight.prepare_env(p)  # re-run (a redeploy)
+    second = deploy_preflight._parse_env(p.read_text())["AGAMI_SIGNING_SECRET"]
+    assert first == second  # generated ONCE — never regenerated (would break live tokens)
+
+
+def test_public_host_is_derived_from_the_url(tmp_path):
+    p = _env(tmp_path, _COMPLETE)
+    deploy_preflight.prepare_env(p)
+    assert deploy_preflight._parse_env(p.read_text())["AGAMI_PUBLIC_HOST"] == "agami.example.com"
+
+
+def test_complete_env_passes(tmp_path):
+    p = _env(tmp_path, _COMPLETE)
+    assert deploy_preflight.main([str(p)]) == 0  # ready → exit 0
+
+
+def test_provider_only_auth_is_accepted(tmp_path):
+    p = _env(
+        tmp_path,
+        _COMPLETE.replace("AGAMI_ADMIN_PASSWORD=choose-a-strong-one\n", "AGAMI_ADMIN_PROVIDER=google\n"),
+    )
+    assert deploy_preflight.prepare_env(p) == []  # a pinned provider alone satisfies the auth floor
+
+
+def test_missing_env_file_is_a_clear_error(tmp_path):
+    assert deploy_preflight.main([str(tmp_path / "nope.env")]) == 1  # no .env → clean exit 1


### PR DESCRIPTION
Spec: ACE-009

## Summary
The free server had no packaging and no secure way to expose it. This is the self-contained deploy bundle: a Docker image + `docker-compose.yml` (Caddy auto-TLS as the **only** public service; agami + Postgres internal with **no published ports**), a container entrypoint that migrates + loads the model (ACE-019/022) then serves, and a host-side preflight that validates `.env` + persists the signing secret.

**Build-side grounding discovery:** the server never seeded the configured admin (`seed_admin_from_env` was only called by the local `seed.py`), so a fresh deploy had no one who could log in. Fixed by having the server self-seed on startup (idempotent), like ACE-019's auto-migrate.

## Changes
- **`mcp_http` lifespan** — seeds the configured admin (`AGAMI_ADMIN_*`) on startup after migrating; create-if-absent + idempotent; logs without the email.
- **`deploy_preflight.py`** (new, host-side) — validates hard-floor `.env` inputs (fail-fast), **generates + persists** `AGAMI_SIGNING_SECRET` once (an ephemeral secret breaks connected sessions on restart), derives `AGAMI_PUBLIC_HOST` for Caddy. Replace-in-place (no duplicate keys).
- **`deploy/`** — `Dockerfile` (editable install so the migrations path resolves), `entrypoint.sh` (wait-db → `model_deploy` → serve, fail-closed), `docker-compose.yml` (profiles: bundled-db / edge / tunnel; external Postgres via `APP_DATABASE_URL`), `Caddyfile`, `.env.example`, `deploy.sh`, `README.md` (self-host guide). Root `.dockerignore`.

## Verification
- **Gated (CI):** admin-seed-on-startup (3 tests), preflight validate/persist/derive (9 tests), 995 suite green, ruff + gitleaks clean, ~98% patch coverage.
- **Verified locally (not CI-gated):** the image **builds**; `docker compose config` parses + selects services per profile (**only Caddy publishes 80/443**); a real-container run smoke (sqlite + a mounted model) booted through migrate → load → serve → seed-admin and answered `/mcp` 401 + `/admin/login` 200.
- **Manual smoke (the operator, on a real host):** the Caddy/Let's-Encrypt **TLS path** needs a real domain + DNS — not CI-gatable. Two adversarial reviews (Python correctness + Docker security) confirmed the secure-by-default posture; findings fixed in-line.

## Out of scope
The `/agami-deploy` skill → ACE-010. Migration → ACE-019; model-load → ACE-022. License/telemetry → F5/F6 (parked/deferred). A GHCR pre-built image → fast-follow (compose `build:` for v1).

## Checklist
- [x] `Spec: ACE-009`; decisions in the spec's `## Decisions`
- [x] Gate green; ~98% patch coverage; no real secrets (`.env.example` placeholders; `.env` gitignored)
- [x] Secure-by-default: TLS-only public surface, DB never published, secret persisted-not-logged, no PII in logs, no data egress
- [ ] **Manual smoke required on a real host+domain** for the Caddy TLS / live-serving path (can't be CI-gated)