### PR TITLE
Publish the server image to GHCR on release (multi-arch)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,63 @@
+name: Release image
+
+# Builds and publishes the agami-core server image to GHCR so a self-host deploy can PULL it
+# (image: ghcr.io/agamiai/agami-core) instead of cloning the repo to build from source. The
+# migrations are baked into the image by deploy/Dockerfile, so the published image is self-contained.
+#
+# Manual prerequisite (ONE-TIME): after the first successful publish, set the `agami-core` GHCR
+# package visibility to PUBLIC (GitHub -> org Packages -> agami-core -> Package settings). The first
+# publish lands it private by default; anonymous `docker pull` needs it public. GHCR push uses the
+# per-run GITHUB_TOKEN below -- there is no PAT or registry secret to manage.
+
+on:
+  release:
+    types: [published]
+  # Manual test-publish (tags the image with the commit sha, no `latest`) so the workflow can be
+  # smoke-tested without cutting a formal release.
+  workflow_dispatch:
+
+permissions:
+  contents: read   # checkout
+  packages: write  # push to GHCR
+
+jobs:
+  publish:
+    name: build + push (multi-arch -> GHCR)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # arm64 emulation + buildx, so one job produces a linux/amd64 + linux/arm64 manifest.
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # `latest` only on a real release; semver tags from the release tag; a sha tag for dispatch
+      # test runs. metadata-action lowercases the image name, so the AgamiAI owner -> agamiai.
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/agami-core
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      # Build context is the repo root -- the Dockerfile COPYs packages/agami-core, migrations/, and
+      # deploy/entrypoint.sh (see deploy/docker-compose.yml `build.context: ..`).
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -16,14 +16,13 @@ on:
   # smoke-tested without cutting a formal release.
   workflow_dispatch:
 
-permissions:
-  contents: read   # checkout
-  packages: write  # push to GHCR
-
 jobs:
   publish:
     name: build + push (multi-arch -> GHCR)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read   # checkout
+      packages: write  # push to GHCR
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -37,15 +36,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # `latest` only on a real release; semver tags from the release tag; a sha tag for dispatch
-      # test runs. metadata-action lowercases the image name, so the AgamiAI owner -> agamiai.
+      # metadata-action lowercases the image name, so the AgamiAI owner -> agamiai.
       - id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/agami-core
+          # semver + latest only on a real release (so a workflow_dispatch from a tag ref can't mint or
+          # overwrite a released version); a sha tag for dispatch test runs.
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
 


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that builds the agami-core server image from `deploy/Dockerfile` and publishes it **multi-arch** to **GHCR** (`ghcr.io/<owner>/agami-core`). This lets a self-host deploy **pull** a pre-built image (`image: ghcr.io/agamiai/agami-core`) instead of cloning the repo to build from source — the prerequisite for a no-clone, one-command deploy. Migrations are already baked into the image by the Dockerfile, so it ships self-contained.

No application/Dockerfile/Python change — this is release infra only.

## Changes
- **New:** `.github/workflows/release-image.yml`
  - Triggers: `release: published` (the real path) + `workflow_dispatch` (manual test-publish, sha-tagged, no `latest`).
  - Job-level least-privilege `permissions: contents: read, packages: write`; GHCR auth via the per-run `GITHUB_TOKEN` (no PAT / registry secret).
  - All actions pinned to full commit SHAs (matching the `ci.yml` house style).
  - `docker/metadata-action` tags: **semver + `latest` only on a real release**; **sha tag on dispatch** — so a manual dispatch from a tag ref cannot mint or overwrite a released version.
  - `docker/build-push-action`: `context: .`, `file: deploy/Dockerfile`, `platforms: linux/amd64,linux/arm64`.

## Verification
- `actionlint` clean.
- Native build of `deploy/Dockerfile` succeeds; **multi-arch buildx** build succeeds for **both** `linux/amd64` and `linux/arm64`.
- Run-smoke of the built image (entrypoint migrate → load → serve): `/admin/login` → **200**, `/mcp` → **401**.
- No secrets baked into the image (`docker history` + filesystem scan clean; no `.env`/credentials in layers).
- **Honest caveat:** the actual publish + anonymous pull are **not CI-gated** (no Docker-push in CI) — they're a **manual release smoke** (trigger `workflow_dispatch` or cut a release, then `docker pull` from a clean machine), same posture as the deploy package's TLS path.

## Manual prerequisite (one-time)
After the first successful publish, set the `agami-core` GHCR package visibility to **public** (GitHub → org Packages → Package settings) — the first publish lands it private by default; anonymous pull needs it public. Documented in the workflow header.

## Checklist
- [x] One vertical slice, one reviewable file (63 lines)
- [x] Adversarial security review (GitHub Actions): permissions, token scope, action pinning, injection surface, trigger safety — one must-fix (semver/latest gating) fixed, one nit (job-level permissions) applied
- [x] No secrets; no real customer data in committed files
- [x] Decisions recorded in the spec (GHCR vs GCP/Docker Hub; build-from-source fallback retained)

Spec: ACE-025