### PR TITLE
The /agami-deploy skill — prepare a self-host bundle locally, deploy via the published image

### DIFF
--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -2,10 +2,12 @@
 """Scaffold an `/agami-deploy` bundle on the user's machine: copy the carried templates, stage the
 model artifacts, and write a `.env` with the NON-SECRET values the skill gathered.
 
-This helper never touches a secret. The admin password is typed by the user into the file afterwards
-(the agami-connect hand-off pattern), and `deploy_preflight` generates the signing secret. So that a
-re-run can't wipe a password the user already typed or a secret already generated, an EXISTING `.env`
-is preserved untouched — only the other bundle files (and the artifacts copy) are refreshed.
+This helper never touches a secret: the admin password is typed by the user into the file afterwards
+(the agami-connect hand-off pattern), `deploy_preflight` generates the signing secret, and an external
+`APP_DATABASE_URL` (itself a credential) is likewise edited into `.env` by the user — never passed here
+on the command line. So that a re-run can't wipe a password the user already typed or a secret already
+generated, an EXISTING `.env` is preserved untouched — only the other bundle files (and the artifacts
+copy) are refreshed.
 
 Stdout is a single status line (first token machine-readable); the skill reads it and acts. Stdlib only.
 
@@ -55,9 +57,8 @@ def _build_env(example: str, args: argparse.Namespace) -> str:
     text = _set_key(text, "AGAMI_ADMIN_USERNAME", args.admin_email)
     text = _set_key(text, "AGAMI_ADMIN_FIRST_NAME", args.admin_first)
     text = _set_key(text, "AGAMI_ADMIN_LAST_NAME", args.admin_last)
-    if args.app_database_url:
-        # External/managed Postgres: the template ships this commented; set it as a real line.
-        text = _set_key(text, "APP_DATABASE_URL", args.app_database_url)
+    # External/managed Postgres (APP_DATABASE_URL) is a credential, so it is NOT set here — the template
+    # ships it commented and the user edits it into .env by hand (the same hand-off as the password).
     return text
 
 
@@ -71,6 +72,9 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
     if not (artifacts / "local").is_dir():
         # No staged model/creds to ship — the deploy would have nothing to serve.
         return f"ERROR no artifacts (model + credentials) found at {artifacts} — run /agami-connect first", 1
+    if target == artifacts or target.is_relative_to(artifacts) or artifacts.is_relative_to(target):
+        # Else the copytree(artifacts -> target/artifacts) would recurse into the bundle it just created.
+        return f"ERROR --target must not be inside --artifacts-dir (or vice versa): {target}", 1
 
     try:
         target.mkdir(parents=True, exist_ok=True)
@@ -85,7 +89,9 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
 
         env_path = target / ".env"
         if env_path.exists():
-            # Never clobber a .env that may already hold a typed password / a generated signing secret.
+            # Never clobber a .env that may already hold a typed password / a generated signing secret —
+            # but do reassert chmod 600 in case an editor/umask loosened it (the file holds secrets).
+            env_path.chmod(0o600)
             return f"PREPARED_KEPT_ENV {target}", 0
         example = (_BUNDLE_SRC / ".env.example").read_text(encoding="utf-8")
         env_path.write_text(_build_env(example, args), encoding="utf-8")
@@ -105,9 +111,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--admin-first", required=True)
     p.add_argument("--admin-last", required=True)
     p.add_argument("--profiles", default="bundled-db,edge", help="COMPOSE_PROFILES (default: single-server)")
-    p.add_argument("--app-database-url", default="", help="external Postgres URL (omit for bundled)")
     p.add_argument("--image-tag", default="latest", help="ghcr.io/agamiai/agami-core tag to pull")
-    # Deliberately NO --password / secret args: secrets never travel on the command line.
+    # Deliberately NO --password / --app-database-url / secret args: a credential never travels on the
+    # command line (it would leak into chat logs / shell history). The user edits those into .env.
     args = p.parse_args(argv)
 
     status, code = prepare(args)

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -29,11 +29,13 @@ _BUNDLE_SRC = Path(__file__).resolve().parents[1] / "skills" / "agami-deploy" / 
 
 
 def _set_key(text: str, key: str, value: str) -> str:
-    """Replace the uncommented `KEY=...` line in-place, or append it if absent. Replace-not-append
-    avoids a confusing duplicate key (mirrors deploy_preflight._set_env)."""
+    """Set `KEY=value`, replacing the first matching line — whether it ships uncommented (`KEY=...`)
+    or commented as a hint (`# KEY=...`) — so e.g. `--app-database-url` uncomments the template's hint
+    rather than appending a confusing duplicate. Append only if the key is absent entirely. The `=`
+    guard prevents a prefix key (`AGAMI_IMAGE_TAG`) from matching a longer one (`AGAMI_IMAGE_TAG_X`)."""
     out, replaced = [], False
     for line in text.splitlines():
-        if line.startswith(f"{key}="):
+        if not replaced and line.lstrip("#").lstrip().startswith(f"{key}="):
             out.append(f"{key}={value}")
             replaced = True
         else:
@@ -77,8 +79,9 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
         (target / "deploy.sh").chmod(0o755)
 
         # Stage the model + warehouse credentials so the bundle is self-contained + shippable. copy2
-        # preserves the chmod-600 on local/credentials. dirs_exist_ok so a re-run refreshes in place.
-        shutil.copytree(artifacts, target / "artifacts", dirs_exist_ok=True)
+        # preserves the chmod-600 on local/credentials; symlinks=True keeps links as links rather than
+        # materializing their targets into the bundle. dirs_exist_ok so a re-run refreshes in place.
+        shutil.copytree(artifacts, target / "artifacts", symlinks=True, dirs_exist_ok=True)
 
         env_path = target / ".env"
         if env_path.exists():

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Scaffold an `/agami-deploy` bundle on the user's machine: copy the carried templates, stage the
+model artifacts, and write a `.env` with the NON-SECRET values the skill gathered.
+
+This helper never touches a secret. The admin password is typed by the user into the file afterwards
+(the agami-connect hand-off pattern), and `deploy_preflight` generates the signing secret. So that a
+re-run can't wipe a password the user already typed or a secret already generated, an EXISTING `.env`
+is preserved untouched — only the other bundle files (and the artifacts copy) are refreshed.
+
+Stdout is a single status line (first token machine-readable); the skill reads it and acts. Stdlib only.
+
+  PREPARED <target>           fresh bundle written; user must set AGAMI_ADMIN_PASSWORD next      [0]
+  PREPARED_KEPT_ENV <target>  bundle refreshed; an existing .env was preserved (not overwritten)  [0]
+  ERROR <message>             templates missing / artifacts missing / write failed                [1]
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+# The non-.env files copied verbatim into the bundle. `.env` is generated from `.env.example` (below),
+# never copied as-is, so the user gets a real config rather than a template full of placeholders.
+_VERBATIM = ("docker-compose.yml", "Caddyfile", "deploy.sh", "README.md")
+
+# The carried templates live next to the skill (scripts/ -> agami/ -> skills/agami-deploy/bundle/).
+_BUNDLE_SRC = Path(__file__).resolve().parents[1] / "skills" / "agami-deploy" / "bundle"
+
+
+def _set_key(text: str, key: str, value: str) -> str:
+    """Replace the uncommented `KEY=...` line in-place, or append it if absent. Replace-not-append
+    avoids a confusing duplicate key (mirrors deploy_preflight._set_env)."""
+    out, replaced = [], False
+    for line in text.splitlines():
+        if line.startswith(f"{key}="):
+            out.append(f"{key}={value}")
+            replaced = True
+        else:
+            out.append(line)
+    if not replaced:
+        out.append(f"{key}={value}")
+    return "\n".join(out) + "\n"
+
+
+def _build_env(example: str, args: argparse.Namespace) -> str:
+    """The `.env` for a fresh bundle: the non-secret answers written onto the template. The admin
+    password line is left blank (the user types it); the signing secret is left for deploy_preflight."""
+    text = example if example.endswith("\n") else example + "\n"
+    text = _set_key(text, "COMPOSE_PROFILES", args.profiles)
+    text = _set_key(text, "AGAMI_IMAGE_TAG", args.image_tag)
+    text = _set_key(text, "PUBLIC_BASE_URL", args.public_base_url)
+    text = _set_key(text, "AGAMI_ADMIN_USERNAME", args.admin_email)
+    text = _set_key(text, "AGAMI_ADMIN_FIRST_NAME", args.admin_first)
+    text = _set_key(text, "AGAMI_ADMIN_LAST_NAME", args.admin_last)
+    if args.app_database_url:
+        # External/managed Postgres: the template ships this commented; set it as a real line.
+        text = _set_key(text, "APP_DATABASE_URL", args.app_database_url)
+    return text
+
+
+def prepare(args: argparse.Namespace) -> tuple[str, int]:
+    """Returns (status_line, exit_code). The status line's first token is machine-readable."""
+    target = Path(args.target).expanduser().resolve()
+    artifacts = Path(args.artifacts_dir).expanduser().resolve()
+
+    if not _BUNDLE_SRC.is_dir():
+        return f"ERROR carried bundle templates not found at {_BUNDLE_SRC}", 1
+    if not (artifacts / "local").is_dir():
+        # No staged model/creds to ship — the deploy would have nothing to serve.
+        return f"ERROR no artifacts (model + credentials) found at {artifacts} — run /agami-connect first", 1
+
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+        for name in _VERBATIM:
+            shutil.copy2(_BUNDLE_SRC / name, target / name)
+        (target / "deploy.sh").chmod(0o755)
+
+        # Stage the model + warehouse credentials so the bundle is self-contained + shippable. copy2
+        # preserves the chmod-600 on local/credentials. dirs_exist_ok so a re-run refreshes in place.
+        shutil.copytree(artifacts, target / "artifacts", dirs_exist_ok=True)
+
+        env_path = target / ".env"
+        if env_path.exists():
+            # Never clobber a .env that may already hold a typed password / a generated signing secret.
+            return f"PREPARED_KEPT_ENV {target}", 0
+        example = (_BUNDLE_SRC / ".env.example").read_text(encoding="utf-8")
+        env_path.write_text(_build_env(example, args), encoding="utf-8")
+        env_path.chmod(0o600)
+    except OSError as e:
+        return f"ERROR {e}", 1
+
+    return f"PREPARED {target}", 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Scaffold an /agami-deploy bundle (non-secret values only).")
+    p.add_argument("--target", required=True, help="bundle output directory")
+    p.add_argument("--artifacts-dir", required=True, help="local agami-artifacts dir (model + credentials)")
+    p.add_argument("--public-base-url", required=True, help="https://<hostname> teammates connect to")
+    p.add_argument("--admin-email", required=True)
+    p.add_argument("--admin-first", required=True)
+    p.add_argument("--admin-last", required=True)
+    p.add_argument("--profiles", default="bundled-db,edge", help="COMPOSE_PROFILES (default: single-server)")
+    p.add_argument("--app-database-url", default="", help="external Postgres URL (omit for bundled)")
+    p.add_argument("--image-tag", default="latest", help="ghcr.io/agamiai/agami-core tag to pull")
+    # Deliberately NO --password / secret args: secrets never travel on the command line.
+    args = p.parse_args(argv)
+
+    status, code = prepare(args)
+    print(status)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/agami/skills/agami-deploy/SKILL.md
+++ b/plugins/agami/skills/agami-deploy/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: agami-deploy
+description: "Prepares a ready-to-run, self-hosted agami deploy bundle ON THE USER'S MACHINE so a team can stand up a shareable MCP server their Claude connects to. Conversationally gathers the hard-floor inputs (hostname, admin identity), auto-detects the local model, writes docker-compose.yml + Caddyfile + a filled .env (referencing the PUBLISHED image ghcr.io/agamiai/agami-core — no clone, no build), and stages the model artifacts. Generates the signing secret via deploy_preflight; the admin password is typed by the user into the file (never in chat). Then runs `docker compose up` if Docker is local, otherwise prints the exact VM steps + the shareable MCP URL. Username/password auth only on this paved path."
+when_to_use: "Use when the user says 'deploy agami', 'self-host agami', 'set up the agami server for my team', 'stand up a shared agami', 'host agami on a VM / in the cloud', '/agami-deploy', or otherwise wants the multi-user HTTP server (not the local single-player setup — that's agami-serve). Requires agami-connect to have run first (needs a semantic model + credentials). This is the TEAM path: it produces an internet-reachable server with OAuth + admin that claude.ai connects to."
+---
+
+# agami deploy — prepare a self-host bundle the user ships to their own host
+
+You are preparing a **deploy bundle** on the user's machine so they can stand up the multi-user agami
+server (the HTTP MCP server with OAuth + admin) that their team's Claude connects to. The bundle pulls
+the **published image** (`ghcr.io/agamiai/agami-core`) — there is **no repo to clone and nothing to
+build**. You gather a few inputs, write the bundle locally, and hand off the cloud steps you can't do.
+
+The local mirror of this (single-player, no network, no auth) is `agami-serve` — if the user only wants
+agami in their own Claude Desktop, point them there instead.
+
+## HARD RULES (load-bearing — a deploy handles secrets)
+
+1. **Never ask for the admin password (or any secret) in chat — not even temporarily.** The password is
+   typed by the **user** directly into the `.env` file (Phase 2 hand-off), exactly like `agami-connect`
+   does for DB credentials. You never see it.
+2. **Never put a secret on a Bash command line.** `prepare_deploy.py` takes only non-secret values;
+   `deploy_preflight` generates the signing secret *into the file*. Hosts render Bash calls in chat.
+3. **Username/password is the only auth this skill sets up.** Do **not** collect Google/Microsoft client
+   id/secret. Social login ships free but is a manual `.env` step — point the user at the in-repo deploy
+   README if they ask, and move on.
+4. **No signup, no license key, no LLM/embedding key.** None are required; don't ask for any.
+
+## Conversation style
+Tight and oriented. Print one-line progress markers (`✓ Bundle written to …`, `✓ .env validated`).
+Be honest about what's the user's clicks (provision the VM, point DNS) vs what you automate.
+
+## Phase −1: Plan-mode preflight
+Run the detection logic from [`shared/plan-mode-check.md`](../../shared/plan-mode-check.md). This skill
+writes files and may run Docker. If plan mode is active, refuse with: *"I can't prepare a deploy bundle
+in plan mode — it writes the bundle + your .env and may run Docker. Switch to **Auto** or **Edit
+Automatically** mode (Shift+Tab) and re-invoke me."* **DO NOT** write a plan file or call `ExitPlanMode`.
+
+## Phase 0: Preflight
+1. **Resolve the environment** — `python3 "$AGAMI_PLUGIN_ROOT/scripts/connect_resolve.py"` prints JSON;
+   read `data.artifacts_dir` (the local model dir) and `data.interpreter.python3` (call it `$PY` — the
+   interpreter that has the agami-core package; use it for `deploy_preflight`).
+2. **Model present** — `<artifacts_dir>/<active_profile>/org.yaml` must exist. If there's no model yet,
+   stop and invoke `/agami-connect` first — the deployed server has nothing to serve without one.
+
+## Phase 1: Gather the hard floor, then write the bundle
+Ask only these (everything else is defaulted or generated). Prefer one compact exchange:
+
+1. **Hostname** — "What address will your team connect to?" It must be a **hostname, not a bare IP**
+   (TLS + OAuth need a DNS name). → `PUBLIC_BASE_URL=https://<host>`.
+   - If they have **no domain / can't open ports**, offer the **Cloudflare tunnel** path (profiles
+     `bundled-db,tunnel`; they'll add `CLOUDFLARE_TUNNEL_TOKEN` to `.env`). The tunnel still needs a
+     domain on Cloudflare — it removes the public IP, not the name.
+2. **Admin** — first name, last name, work **email** (the email is the admin identity).
+3. *(only if they bring their own Postgres)* a managed `postgresql://…?sslmode=require` URL → profiles
+   `edge` + `--app-database-url`.
+
+Then write the bundle (default target `~/agami-deploy`; mention they can pick another):
+
+```bash
+python3 "$AGAMI_PLUGIN_ROOT/scripts/prepare_deploy.py" \
+  --target ~/agami-deploy \
+  --artifacts-dir "<data.artifacts_dir>" \
+  --public-base-url "https://<host>" \
+  --admin-email "<email>" --admin-first "<first>" --admin-last "<last>" \
+  --profiles "bundled-db,edge"
+```
+
+(Use `--profiles "bundled-db,tunnel"` for the tunnel, or `--profiles "edge" --app-database-url "<url>"`
+for managed Postgres.) Report the status line: `PREPARED <dir>` (fresh) or `PREPARED_KEPT_ENV <dir>`
+(an existing `.env` was preserved — tell the user to edit it directly to change values).
+
+## Phase 2: Hand off the password (then end the turn)
+Tell the user (do **not** proceed past this in the same turn):
+
+> Open `~/agami-deploy/.env`, set **`AGAMI_ADMIN_PASSWORD=`** to a strong password, and save. Then tell
+> me to continue. (I never see it — it stays in the file on your machine.)
+
+End the turn here. The user fills the password and re-invokes (or says "continue").
+
+## Phase 3: Finalize + deploy
+1. **Validate + generate the signing secret:** `$PY -m deploy_preflight ~/agami-deploy/.env`. If it
+   reports missing inputs (e.g. the password still blank, or a non-https URL), relay them and stop. On
+   success it has written `AGAMI_SIGNING_SECRET` + derived `AGAMI_PUBLIC_HOST` into the file.
+2. **Bring it up:**
+   - **Docker present here** (the user is on the target host, or testing locally) — run
+     `cd ~/agami-deploy && ./deploy.sh` (pulls the image + `docker compose up -d`).
+   - **No Docker / deploying to a remote VM** — hand off: have them copy `~/agami-deploy` to the host
+     (`scp -r` or a synced folder), then run `./deploy.sh` there. Give them the **cloud checklist** below.
+3. **Print the share lines:** the connector URL **`<PUBLIC_BASE_URL>/mcp`** (what teammates add in
+   claude.ai → Connectors), and the admin console **`<PUBLIC_BASE_URL>/admin`**.
+
+## The cloud steps you can't do (👤 — walk them through it)
+- **A VM** (~2 vCPU / 4 GB RAM / 20 GB disk), Ubuntu LTS, **only ports 80 + 443 open** (or the tunnel).
+- **DNS:** an **A-record** for their hostname → the VM's public IP. (Skip for the tunnel.)
+- **Docker** on the host: `curl -fsSL https://get.docker.com | sudo sh`.
+- Then `./deploy.sh` on the host → wait ~30s for Caddy to issue the cert → open `<PUBLIC_BASE_URL>/admin`.
+
+## Updating the model later
+They refresh the model locally → re-run `/agami-deploy` (re-stages `artifacts/`) → on the host
+`docker compose restart agami`. The server re-ingests the model on boot — no rebuild, no DB access.
+
+## Notes
+- This is the **team** path. For a quick local feel of the same tools, that's `agami-serve` (stdio, no
+  network). For a fully managed, governed, always-on server, that's the hosted product — see
+  `docs/open-vs-hosted.md`.
+- The bundle is self-contained and re-shippable: the generated signing secret lives in its `.env`, so a
+  VM rebuild that re-uses the same bundle keeps every connected Claude working (no reconnect).

--- a/plugins/agami/skills/agami-deploy/SKILL.md
+++ b/plugins/agami/skills/agami-deploy/SKILL.md
@@ -52,8 +52,9 @@ Ask only these (everything else is defaulted or generated). Prefer one compact e
      `bundled-db,tunnel`; they'll add `CLOUDFLARE_TUNNEL_TOKEN` to `.env`). The tunnel still needs a
      domain on Cloudflare — it removes the public IP, not the name.
 2. **Admin** — first name, last name, work **email** (the email is the admin identity).
-3. *(only if they bring their own Postgres)* a managed `postgresql://…?sslmode=require` URL → profiles
-   `edge` + `--app-database-url`.
+3. *(only if they bring their own Postgres)* note it → use profiles `edge` (drops the bundled DB). The
+   managed `postgresql://…` URL is a **credential**, so do **not** collect it in chat — after the bundle
+   is written, the user sets `APP_DATABASE_URL` in `.env` themselves (the same hand-off as the password).
 
 Then write the bundle (default target `~/agami-deploy`; mention they can pick another):
 
@@ -66,15 +67,17 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/prepare_deploy.py" \
   --profiles "bundled-db,edge"
 ```
 
-(Use `--profiles "bundled-db,tunnel"` for the tunnel, or `--profiles "edge" --app-database-url "<url>"`
-for managed Postgres.) Report the status line: `PREPARED <dir>` (fresh) or `PREPARED_KEPT_ENV <dir>`
-(an existing `.env` was preserved — tell the user to edit it directly to change values).
+(Use `--profiles "bundled-db,tunnel"` for the tunnel, or `--profiles "edge"` for managed Postgres — then
+have the user set `APP_DATABASE_URL` in `.env` by hand, never on the command line.) Report the status
+line: `PREPARED <dir>` (fresh) or `PREPARED_KEPT_ENV <dir>` (an existing `.env` was preserved — tell the
+user to edit it directly to change values).
 
 ## Phase 2: Hand off the password (then end the turn)
 Tell the user (do **not** proceed past this in the same turn):
 
-> Open `~/agami-deploy/.env`, set **`AGAMI_ADMIN_PASSWORD=`** to a strong password, and save. Then tell
-> me to continue. (I never see it — it stays in the file on your machine.)
+> Open `~/agami-deploy/.env`, set **`AGAMI_ADMIN_PASSWORD=`** to a strong password (and, if you chose
+> managed Postgres, set **`APP_DATABASE_URL=`** too), and save. Then tell me to continue. (I never see
+> them — they stay in the file on your machine.)
 
 End the turn here. The user fills the password and re-invokes (or says "continue").
 

--- a/plugins/agami/skills/agami-deploy/bundle/.env.example
+++ b/plugins/agami/skills/agami-deploy/bundle/.env.example
@@ -1,0 +1,33 @@
+# agami self-host config. `/agami-deploy` fills the non-secret values and runs `deploy_preflight`, which
+# generates AGAMI_SIGNING_SECRET + derives AGAMI_PUBLIC_HOST. You only type AGAMI_ADMIN_PASSWORD by hand.
+
+# Which parts of the stack to run (see docker-compose.yml). Default = the secure VM bundle.
+COMPOSE_PROFILES=bundled-db,edge
+
+# The published image tag to pull. `latest` tracks releases; pin a version (e.g. 0.3.0) for reproducibility.
+AGAMI_IMAGE_TAG=latest
+
+# The public URL teammates connect to — a HOSTNAME, not a bare IP (TLS + OAuth need a DNS name).
+# Point a DNS A-record at this VM, or use the `tunnel` profile for a name without a public IP.
+PUBLIC_BASE_URL=https://agami.your-domain.example
+
+# The admin (identity = email; gates the /admin console). Set the password below by hand.
+AGAMI_ADMIN_USERNAME=you@example.com
+AGAMI_ADMIN_FIRST_NAME=Alex
+AGAMI_ADMIN_LAST_NAME=Kim
+# Type a strong password here, then save. Never share it in chat. (OIDC-first orgs may leave this blank
+# and set AGAMI_ADMIN_PROVIDER + the matching AGAMI_OIDC_* vars instead — see the in-repo deploy README.)
+AGAMI_ADMIN_PASSWORD=
+
+# NOTE: the WAREHOUSE the model queries is NOT configured here — its credentials travel in your mounted
+# artifacts at `<artifacts>/local/credentials` (the same file agami uses locally).
+
+# External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).
+# Use a PLAIN postgresql:// URL (e.g. a Cloud-SQL-like service via its IP + sslmode=require) — not a cloud connector.
+# APP_DATABASE_URL=postgresql://user@your-managed-pg.example:5432/agami?sslmode=require
+
+# Override the bundled-Postgres password if you like (it's never exposed, so the default is fine).
+# POSTGRES_PASSWORD=
+
+# Only for the `tunnel` profile:
+# CLOUDFLARE_TUNNEL_TOKEN=

--- a/plugins/agami/skills/agami-deploy/bundle/Caddyfile
+++ b/plugins/agami/skills/agami-deploy/bundle/Caddyfile
@@ -1,0 +1,6 @@
+# Caddy terminates TLS for your hostname (automatic Let's Encrypt) and proxies to the internal agami
+# server. AGAMI_PUBLIC_HOST is the bare hostname (e.g. agami.example.com) — deploy_preflight derives it
+# from PUBLIC_BASE_URL. The host must resolve (a DNS A-record → this VM) for the certificate to issue.
+{$AGAMI_PUBLIC_HOST} {
+	reverse_proxy agami:8000
+}

--- a/plugins/agami/skills/agami-deploy/bundle/README.md
+++ b/plugins/agami/skills/agami-deploy/bundle/README.md
@@ -1,0 +1,28 @@
+# Your agami deploy bundle
+
+`/agami-deploy` prepared this folder. It's self-contained — it **pulls** the published image
+(`ghcr.io/agamiai/agami-core`), so there's nothing to build and no repo to clone.
+
+## What's here
+- `docker-compose.yml` — Caddy (auto-TLS, the only public service) + agami + bundled Postgres.
+- `Caddyfile` — TLS for your hostname.
+- `.env` — your config (filled by `/agami-deploy`; `deploy_preflight` generated the signing secret).
+- `artifacts/` — your semantic model + warehouse credentials (mounted read-only).
+- `deploy.sh` — pulls the image and brings the stack up.
+
+## Run it
+On a host with Docker + your hostname's DNS A-record pointed at it (or a Cloudflare tunnel):
+
+```sh
+./deploy.sh
+```
+
+Then open `<PUBLIC_BASE_URL>/admin` to sign in, and share `<PUBLIC_BASE_URL>/mcp` with your team.
+
+## Recommended VM size
+2 vCPU / 4 GB RAM / 20 GB disk runs the server + bundled Postgres comfortably for a small team. Open
+only ports 80 and 443 (or use the `tunnel` profile to expose nothing inbound).
+
+## Updating the model later
+Refresh your model locally, re-run `/agami-deploy` (or re-copy `artifacts/`), then on the host:
+`docker compose restart agami` — the server re-ingests the model on boot. No rebuild, no DB access.

--- a/plugins/agami/skills/agami-deploy/bundle/deploy.sh
+++ b/plugins/agami/skills/agami-deploy/bundle/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Bring up the agami stack from this prepared bundle. `/agami-deploy` already validated + filled your
+# .env locally (signing secret generated, host derived), so this just pulls the published image and runs.
+set -e
+cd "$(dirname "$0")"
+
+docker compose pull
+docker compose up -d
+
+echo "agami is starting. It's live at your PUBLIC_BASE_URL once Caddy issues the certificate (a few seconds)."
+echo "Share  \${PUBLIC_BASE_URL}/mcp  with your team; manage users at  \${PUBLIC_BASE_URL}/admin"

--- a/plugins/agami/skills/agami-deploy/bundle/docker-compose.yml
+++ b/plugins/agami/skills/agami-deploy/bundle/docker-compose.yml
@@ -1,0 +1,71 @@
+# agami self-host stack. The default `docker compose up` (with COMPOSE_PROFILES=bundled-db,edge in .env)
+# brings up the secure VM deployment: Caddy terminates TLS and is the ONLY public service; agami and
+# Postgres live on the internal network with no published ports. Toggle the profiles for the variants:
+#   bundled-db,edge   (default)  — Caddy TLS + agami + bundled Postgres on a VM
+#   edge              + APP_DATABASE_URL — external/managed Postgres (e.g. Cloud SQL via a plain URL)
+#   tunnel            — Cloudflare Tunnel instead of a public IP (no inbound ports)
+#   (none)            — agami only, behind the platform's own TLS (e.g. Cloud Run); set APP_DATABASE_URL
+#
+# Unlike the in-repo deploy/ stack, this bundle PULLS a pre-built image (no build context, no clone).
+name: agami
+
+services:
+  caddy:
+    image: caddy:2
+    profiles: ["edge"]
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      AGAMI_PUBLIC_HOST: ${AGAMI_PUBLIC_HOST}  # the bare hostname; deploy_preflight derives it from PUBLIC_BASE_URL
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+  agami:
+    image: ghcr.io/agamiai/agami-core:${AGAMI_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      # Bundled Postgres by default; set APP_DATABASE_URL in .env to point at managed Postgres instead.
+      AGAMI_DB_URL: ${APP_DATABASE_URL:-postgresql://agami:${POSTGRES_PASSWORD:-agami-bundled-local}@postgres:5432/agami}
+      AGAMI_ARTIFACTS_DIR: /artifacts
+      HOST: 0.0.0.0
+      PORT: "8000"
+    volumes:
+      - ${AGAMI_ARTIFACTS_DIR:-./artifacts}:/artifacts:ro  # your local agami-artifacts (the model), read-only
+    # No `ports:` and no `depends_on:` — agami is reached only via Caddy/the tunnel on the internal
+    # network, and the entrypoint waits for the DB itself (so the external-DB/cloud-run profiles work).
+
+  postgres:
+    image: postgres:16
+    profiles: ["bundled-db"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: agami
+      POSTGRES_USER: agami
+      # A bundled-local default — fine because the DB is never exposed; override it in .env if you like.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-agami-bundled-local}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agami -d agami"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    # No `ports:` — the database is never published to the host or the internet.
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    profiles: ["tunnel"]
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}  # from your Cloudflare Zero Trust tunnel
+
+volumes:
+  pgdata:
+  caddy_data:
+  caddy_config:

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -135,6 +135,20 @@ def test_existing_env_is_preserved(tmp_path):
     assert "AGAMI_SIGNING_SECRET=deadbeef" in kept
 
 
+def test_main_prints_status_and_returns_zero(tmp_path, capsys):
+    code = prepare_deploy.main(
+        [
+            "--target", str(tmp_path / "b"),
+            "--artifacts-dir", str(_artifacts(tmp_path)),
+            "--public-base-url", "https://h.example",
+            "--admin-email", "you@example.com",
+            "--admin-first", "A", "--admin-last", "K",
+        ]
+    )
+    assert code == 0
+    assert capsys.readouterr().out.startswith("PREPARED ")
+
+
 def test_no_artifacts_is_a_clean_error(tmp_path):
     target = tmp_path / "bundle"
     empty = tmp_path / "empty-artifacts"

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -105,6 +105,16 @@ def test_tier2_toggles_set_profiles(tmp_path, profiles, app_db, expect):
         assert f"APP_DATABASE_URL={app_db}" in env
 
 
+def test_set_key_uncomments_a_hint_and_avoids_duplicates_and_prefixes():
+    # A commented hint line is uncommented + set (no duplicate APP_DATABASE_URL appended).
+    out = prepare_deploy._set_key("# APP_DATABASE_URL=hint\nOTHER=1\n", "APP_DATABASE_URL", "real")
+    assert out.count("APP_DATABASE_URL=") == 1
+    assert "APP_DATABASE_URL=real" in out and "# APP_DATABASE_URL=hint" not in out
+    # A prefix key must not match a longer one.
+    out2 = prepare_deploy._set_key("AGAMI_IMAGE_TAG_X=keep\n", "AGAMI_IMAGE_TAG", "latest")
+    assert "AGAMI_IMAGE_TAG_X=keep" in out2 and "AGAMI_IMAGE_TAG=latest" in out2
+
+
 def test_helper_takes_no_password_argument(tmp_path):
     """Criterion: a secret never travels on the command line. Passing --password must be rejected."""
     with pytest.raises(SystemExit):

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -18,7 +18,9 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "packages" / "agami-core" / "src"))
 
+import deploy_preflight  # noqa: E402
 import prepare_deploy  # noqa: E402
 
 
@@ -43,7 +45,6 @@ def _args(target: Path, artifacts: Path, **over) -> argparse.Namespace:
         admin_first="Alex",
         admin_last="Kim",
         profiles="bundled-db,edge",
-        app_database_url="",
         image_tag="latest",
     )
     base.update(over)
@@ -89,20 +90,17 @@ def test_env_is_chmod_600(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "profiles,app_db,expect",
-    [
-        ("bundled-db,edge", "", "COMPOSE_PROFILES=bundled-db,edge"),
-        ("bundled-db,tunnel", "", "COMPOSE_PROFILES=bundled-db,tunnel"),
-        ("edge", "postgresql://u@mgd.example:5432/agami?sslmode=require", "COMPOSE_PROFILES=edge"),
-    ],
+    "profiles",
+    ["bundled-db,edge", "bundled-db,tunnel", "edge"],
 )
-def test_tier2_toggles_set_profiles(tmp_path, profiles, app_db, expect):
+def test_tier2_toggles_set_profiles(tmp_path, profiles):
     target = tmp_path / "bundle"
-    prepare_deploy.prepare(_args(target, _artifacts(tmp_path), profiles=profiles, app_database_url=app_db))
+    prepare_deploy.prepare(_args(target, _artifacts(tmp_path), profiles=profiles))
     env = (target / ".env").read_text()
-    assert expect in env
-    if app_db:
-        assert f"APP_DATABASE_URL={app_db}" in env
+    assert f"COMPOSE_PROFILES={profiles}" in env
+    # APP_DATABASE_URL is a credential — the helper never writes it (the user edits .env by hand); the
+    # external-DB case ships it only as the commented template hint.
+    assert "\nAPP_DATABASE_URL=" not in env
 
 
 def test_set_key_uncomments_a_hint_and_avoids_duplicates_and_prefixes():
@@ -167,9 +165,15 @@ def test_no_artifacts_is_a_clean_error(tmp_path):
     assert code == 1 and status.startswith("ERROR ") and "artifacts" in status
 
 
+def test_target_inside_artifacts_is_rejected(tmp_path):
+    """Else copytree(artifacts -> target/artifacts) would recurse into the bundle it just created."""
+    art = _artifacts(tmp_path)
+    status, code = prepare_deploy.prepare(_args(art / "nested-bundle", art))
+    assert code == 1 and status.startswith("ERROR ") and "must not be inside" in status
+
+
 def test_generated_env_passes_deploy_preflight(tmp_path):
     """The .env (once a password is set) satisfies deploy_preflight: secret generated, host derived."""
-    deploy_preflight = pytest.importorskip("deploy_preflight")
     target = tmp_path / "bundle"
     prepare_deploy.prepare(_args(target, _artifacts(tmp_path)))
     env_path = target / ".env"

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -1,0 +1,161 @@
+"""
+Tests for plugins/agami/scripts/prepare_deploy.py — the `/agami-deploy` bundle scaffolder.
+
+It copies the carried bundle templates, stages the model artifacts, and writes a `.env` with the
+NON-SECRET values only. The contract these tests pin: a complete bundle is produced, the right
+COMPOSE_PROFILES land per toggle, no password ever passes through the helper, an existing `.env` is
+preserved, and the generated `.env` passes deploy_preflight.
+"""
+
+from __future__ import annotations
+
+import argparse
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import prepare_deploy  # noqa: E402
+
+
+def _artifacts(tmp_path: Path) -> Path:
+    """A minimal local artifacts dir: a `local/credentials` (chmod 600) + one model profile."""
+    art = tmp_path / "agami-artifacts"
+    (art / "local").mkdir(parents=True)
+    creds = art / "local" / "credentials"
+    creds.write_text("[demo]\nhost = db.example\n", encoding="utf-8")
+    creds.chmod(0o600)
+    (art / "demo").mkdir()
+    (art / "demo" / "org.yaml").write_text("name: demo\n", encoding="utf-8")
+    return art
+
+
+def _args(target: Path, artifacts: Path, **over) -> argparse.Namespace:
+    base = dict(
+        target=str(target),
+        artifacts_dir=str(artifacts),
+        public_base_url="https://agami.acme.example",
+        admin_email="you@example.com",
+        admin_first="Alex",
+        admin_last="Kim",
+        profiles="bundled-db,edge",
+        app_database_url="",
+        image_tag="latest",
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def test_prepares_a_complete_bundle(tmp_path):
+    target = tmp_path / "bundle"
+    status, code = prepare_deploy.prepare(_args(target, _artifacts(tmp_path)))
+    assert code == 0 and status.startswith("PREPARED ")
+
+    # The carried templates are all present + the image-based compose pulls (no build context).
+    for name in ("docker-compose.yml", "Caddyfile", "deploy.sh", "README.md", ".env"):
+        assert (target / name).exists(), name
+    compose = (target / "docker-compose.yml").read_text()
+    assert "image: ghcr.io/agamiai/agami-core:" in compose
+    assert "build:" not in compose
+
+    # The model + credentials are staged so the bundle is self-contained + shippable.
+    assert (target / "artifacts" / "demo" / "org.yaml").exists()
+    assert (target / "artifacts" / "local" / "credentials").exists()
+
+
+def test_env_has_non_secrets_and_a_blank_password(tmp_path):
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, _artifacts(tmp_path)))
+    env = (target / ".env").read_text()
+    assert "PUBLIC_BASE_URL=https://agami.acme.example" in env
+    assert "AGAMI_ADMIN_USERNAME=you@example.com" in env
+    assert "AGAMI_ADMIN_FIRST_NAME=Alex" in env
+    assert "AGAMI_ADMIN_LAST_NAME=Kim" in env
+    # The password is left for the user to type into the file — never filled by the helper.
+    assert "AGAMI_ADMIN_PASSWORD=\n" in env or env.rstrip().endswith("AGAMI_ADMIN_PASSWORD=")
+    # And no signing secret yet — deploy_preflight generates that.
+    assert "AGAMI_SIGNING_SECRET=" not in env
+
+
+def test_env_is_chmod_600(tmp_path):
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, _artifacts(tmp_path)))
+    mode = stat.S_IMODE((target / ".env").stat().st_mode)
+    assert mode == 0o600, oct(mode)
+
+
+@pytest.mark.parametrize(
+    "profiles,app_db,expect",
+    [
+        ("bundled-db,edge", "", "COMPOSE_PROFILES=bundled-db,edge"),
+        ("bundled-db,tunnel", "", "COMPOSE_PROFILES=bundled-db,tunnel"),
+        ("edge", "postgresql://u@mgd.example:5432/agami?sslmode=require", "COMPOSE_PROFILES=edge"),
+    ],
+)
+def test_tier2_toggles_set_profiles(tmp_path, profiles, app_db, expect):
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, _artifacts(tmp_path), profiles=profiles, app_database_url=app_db))
+    env = (target / ".env").read_text()
+    assert expect in env
+    if app_db:
+        assert f"APP_DATABASE_URL={app_db}" in env
+
+
+def test_helper_takes_no_password_argument(tmp_path):
+    """Criterion: a secret never travels on the command line. Passing --password must be rejected."""
+    with pytest.raises(SystemExit):
+        prepare_deploy.main(
+            [
+                "--target", str(tmp_path / "b"),
+                "--artifacts-dir", str(_artifacts(tmp_path)),
+                "--public-base-url", "https://h.example",
+                "--admin-email", "you@example.com",
+                "--admin-first", "A", "--admin-last", "K",
+                "--password", "hunter2",  # not a real option — argparse must error out
+            ]
+        )
+
+
+def test_existing_env_is_preserved(tmp_path):
+    target = tmp_path / "bundle"
+    art = _artifacts(tmp_path)
+    prepare_deploy.prepare(_args(target, art))
+    # Simulate the user typing a password + a generated secret, then a re-run.
+    env_path = target / ".env"
+    env_path.write_text("AGAMI_ADMIN_PASSWORD=typed-by-user\nAGAMI_SIGNING_SECRET=deadbeef\n", encoding="utf-8")
+    status, code = prepare_deploy.prepare(_args(target, art))
+    assert code == 0 and status.startswith("PREPARED_KEPT_ENV ")
+    # The user's filled .env is untouched (no clobbered password / wiped secret).
+    kept = env_path.read_text()
+    assert "AGAMI_ADMIN_PASSWORD=typed-by-user" in kept
+    assert "AGAMI_SIGNING_SECRET=deadbeef" in kept
+
+
+def test_no_artifacts_is_a_clean_error(tmp_path):
+    target = tmp_path / "bundle"
+    empty = tmp_path / "empty-artifacts"
+    empty.mkdir()
+    status, code = prepare_deploy.prepare(_args(target, empty))
+    assert code == 1 and status.startswith("ERROR ") and "artifacts" in status
+
+
+def test_generated_env_passes_deploy_preflight(tmp_path):
+    """The .env (once a password is set) satisfies deploy_preflight: secret generated, host derived."""
+    deploy_preflight = pytest.importorskip("deploy_preflight")
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, _artifacts(tmp_path)))
+    env_path = target / ".env"
+    # The user supplies the password by editing the file (here, simulated).
+    env_path.write_text(
+        env_path.read_text().replace("AGAMI_ADMIN_PASSWORD=", "AGAMI_ADMIN_PASSWORD=a-strong-pw"),
+        encoding="utf-8",
+    )
+    errors = deploy_preflight.prepare_env(env_path)
+    assert errors == [], errors
+    after = env_path.read_text()
+    assert "AGAMI_SIGNING_SECRET=" in after
+    assert "AGAMI_PUBLIC_HOST=agami.acme.example" in after


### PR DESCRIPTION
## Summary
Adds the `/agami-deploy` skill — the conversational paved path for standing up the multi-user agami server. It prepares the whole deploy bundle **on the user's machine** (mirroring how `agami-connect` writes credentials — no secret ever in chat), writes a compose that **references the published image** (`ghcr.io/agamiai/agami-core:latest` — no clone, no build), stages the local model, and reduces the host to "receive a finished folder + run one command."

## Changes
- **`plugins/agami/skills/agami-deploy/SKILL.md`** — the skill: plan-mode preflight, model-present check (else `/agami-connect`), Tier-1 Q&A (hostname + IP/tunnel guidance, admin identity, optional BYO-Postgres), password **hand-off** (user types it into the file), finalize via `deploy_preflight`, then `docker compose up` locally or hand off the VM steps. Prints the connector + admin URLs.
- **`plugins/agami/scripts/prepare_deploy.py`** — stdlib helper that scaffolds the bundle + writes a `.env` with **non-secret values only**. Takes no password/secret arg; preserves an existing `.env` rather than clobbering a typed password / generated secret.
- **`plugins/agami/skills/agami-deploy/bundle/`** — carried templates: image-based `docker-compose.yml` (Caddy auto-TLS, internal Postgres, profiles), `Caddyfile`, `.env.example`, `deploy.sh` (pull + up), `README.md`.
- **`tests/test_prepare_deploy.py`** — 12 tests.

## Verification
- 12 helper tests pass; full suite green (1008); ruff clean; patch coverage ~90%.
- **No secret ever crosses the chat:** the helper has no password arg (asserted), the password is user-typed into the file, the signing secret is generated by `deploy_preflight` into the file.
- **End-to-end against the published image:** scaffolded a bundle, ran `deploy_preflight`, `docker compose up` pulled `ghcr.io/agamiai/agami-core:latest` (anonymous) + bundled Postgres → `/admin/login` 200, `/mcp` 401. `docker inspect` confirmed the GHCR image was used.
- **Honest caveat:** the end-to-end deploy is a manual smoke (no Docker in CI), same posture as ACE-009/025.

## Notes
- Username/password is the only auth this skill sets up; Google/Microsoft ships free but is a manual `.env` step (paved-path scope decision).
- Carries an image-based compose in the plugin (a marketplace install can't see repo-root `deploy/`, which stays the build-from-source path for clone-and-build devs). Drift between the two composes is noted for the docs/repo-hygiene pass.
- Adversarial review (secret-handling + helper correctness): 0 must-fix; 3 nits applied (`_set_key` uncomments hints + prefix-safe, `copytree symlinks=True`, added a `_set_key` test).

Spec: ACE-010