### PR TITLE
Fix: marketplace installs can't import the library (agami-connect broken) + bundle lib

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/dev.py
+++ b/dev.py
@@ -39,6 +39,9 @@ _ROOT = Path(__file__).resolve().parent
 # package; `sync-lib` regenerates the copy and `check` fails on drift. See OCR-030.
 _LIB_SRC = _ROOT / "packages" / "agami-core" / "src"
 _LIB_DST = _ROOT / "plugins" / "agami" / "lib"
+# The module-load import closure of the 4 scripts (all stdlib-only). tests/test_plugin_lib_resolution.py
+# fails if a script gains a module-level import that's missing here; a new *lazy* import from the package
+# would also need adding to this list.
 _VENDORED = ["agami_paths.py", "execute_sql.py", "semantic_model/__init__.py", "semantic_model/units.py"]
 
 

--- a/dev.py
+++ b/dev.py
@@ -15,19 +15,31 @@ Tasks:
   lint    just ruff (lint + format check)
   fmt     apply ruff's auto-formatter to the tree
   cover   patch coverage — are the lines you changed covered by a test?
+  sync-lib  regenerate plugins/agami/lib/ (the vendored slice the plugin scripts import)
 """
 
 from __future__ import annotations
 
+import filecmp
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 RUFF = ["uvx", "ruff@0.15.19"]
 # The suite imports the agami-core library, so install it editable with the [model]
 # extra (pydantic/pyyaml/sqlglot). DB drivers are omitted on purpose — those tests skip without a DB.
 TEST_DEPS = ["--with", "pytest-cov", "--with-editable", "packages/agami-core[model,server]"]
 TARGETS = ["plugins", "packages", "tests", "dev.py"]
+
+_ROOT = Path(__file__).resolve().parent
+# The plugin's runtime scripts import a small stdlib-only slice of the agami-core library. The
+# marketplace ships only plugins/agami/ (no packages/, no pip install), so that slice is vendored —
+# drift-checked — into plugins/agami/lib/ so the scripts resolve it there. Source of truth stays the
+# package; `sync-lib` regenerates the copy and `check` fails on drift. See OCR-030.
+_LIB_SRC = _ROOT / "packages" / "agami-core" / "src"
+_LIB_DST = _ROOT / "plugins" / "agami" / "lib"
+_VENDORED = ["agami_paths.py", "execute_sql.py", "semantic_model/__init__.py", "semantic_model/units.py"]
 
 
 def run(cmd: list[str], *, allow_fail: bool = False) -> int:
@@ -58,11 +70,36 @@ def secrets() -> int:
     return run(["uvx", "pre-commit", "run", "gitleaks", "--all-files"])
 
 
+def sync_lib() -> int:
+    """Regenerate plugins/agami/lib/ from packages/agami-core/src (the vendored closure the scripts import)."""
+    for rel in _VENDORED:
+        dst = _LIB_DST / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(_LIB_SRC / rel, dst)
+        print(f"  synced {dst.relative_to(_ROOT)}")
+    return 0
+
+
+def _lib_drift() -> int:
+    """Fail if plugins/agami/lib/ has drifted from packages/agami-core/src (someone edited the source)."""
+    drifted = [
+        rel
+        for rel in _VENDORED
+        if not (_LIB_DST / rel).exists() or not filecmp.cmp(_LIB_SRC / rel, _LIB_DST / rel, shallow=False)
+    ]
+    if drifted:
+        print(f"\n$ lib drift check\n  ✗ plugins/agami/lib is stale: {', '.join(drifted)}"
+              "\n    run: uv run dev.py sync-lib")
+        return 1
+    return 0
+
+
 def check() -> int:
-    """ruff lint + tests + gitleaks — the same checks CI gates on."""
+    """ruff lint + tests + gitleaks + the vendored-lib drift check — the same checks CI gates on."""
     rc = lint()
     rc |= test()
     rc |= secrets()
+    rc |= _lib_drift()
     print("\n✓ all checks passed" if rc == 0 else "\n✗ some checks failed")
     return rc
 
@@ -83,7 +120,8 @@ def setup() -> int:
     )
 
 
-TASKS = {"setup": setup, "check": check, "test": test, "lint": lint, "fmt": fmt, "cover": cover}
+TASKS = {"setup": setup, "check": check, "test": test, "lint": lint, "fmt": fmt, "cover": cover,
+         "sync-lib": sync_lib}
 
 
 def main() -> int:

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",

--- a/plugins/agami/lib/agami_paths.py
+++ b/plugins/agami/lib/agami_paths.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Single source of truth for agami's on-disk paths — stdlib only.
+
+agami keeps everything under ONE folder the user chooses (the "artifacts dir"):
+
+    <artifacts_dir>/
+      local/              # gitignored — secrets + per-user state (NEVER committed)
+        credentials       # chmod 600 — the only place credentials live
+        .config           # JSON: active_profile, reviewer_email/role, tool_paths, …
+        .pgpass, …        # provider-native auth files materialized from credentials
+        query_log.jsonl   # personal query history
+        charts/, exports/ # per-query outputs
+        model/, review/, examples-validation/   # rendered dashboards
+        tunnels/, serve/  # ssh tunnels, the copied MCP server
+      <profile>/          # the committable semantic model (org.yaml + subject_areas/…)
+      USER_MEMORY.md      # committable cross-database preferences
+      .gitignore          # ignores local/
+
+So there is no separate `~/.agami` — credentials and the model live side by side,
+self-contained, and a teammate who clones the committed folder simply never gets
+`local/` (they have their own credentials).
+
+The ONE thing outside the folder is a non-sensitive pointer at `~/.config/agami/path`
+holding the folder's location, so a fresh shell can find it. `AGAMI_ARTIFACTS_DIR`
+overrides everything.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+POINTER_PATH = Path.home() / ".config" / "agami" / "path"
+DEFAULT_ARTIFACTS_DIR = Path.home() / "agami-artifacts"
+LEGACY_HOME = Path.home() / ".agami"          # the pre-consolidation location
+LOCAL_SUBDIR = "local"                          # gitignored secrets/state dir inside the artifacts dir
+
+
+def artifacts_dir() -> Path:
+    """Resolve the artifacts dir: AGAMI_ARTIFACTS_DIR → the pointer file → default."""
+    env = os.environ.get("AGAMI_ARTIFACTS_DIR")
+    if env:
+        return Path(os.path.expanduser(env)).resolve()
+    try:
+        if POINTER_PATH.exists():
+            p = POINTER_PATH.read_text(encoding="utf-8").strip()
+            if p:
+                return Path(os.path.expanduser(p)).resolve()
+    except OSError:
+        pass
+    return DEFAULT_ARTIFACTS_DIR.resolve()
+
+
+def set_artifacts_dir(path: str | os.PathLike) -> Path:
+    """Persist the chosen artifacts dir to the pointer file (so it survives sessions)."""
+    resolved = Path(os.path.expanduser(str(path))).resolve()
+    POINTER_PATH.parent.mkdir(parents=True, exist_ok=True)
+    POINTER_PATH.write_text(str(resolved) + "\n", encoding="utf-8")
+    return resolved
+
+
+def local_dir(art: Path | None = None) -> Path:
+    """The gitignored secrets/state dir — the consolidated replacement for ~/.agami."""
+    return (art or artifacts_dir()) / LOCAL_SUBDIR
+
+
+# --- specific paths (everything that used to live under ~/.agami) -----------
+
+def credentials_path(art: Path | None = None) -> Path:
+    return local_dir(art) / "credentials"
+
+
+def config_path(art: Path | None = None) -> Path:
+    # JSON file; keeps the legacy name `.config` so the one-shot migration is a pure move.
+    return local_dir(art) / ".config"
+
+
+def query_log_path(art: Path | None = None) -> Path:
+    return local_dir(art) / "query_log.jsonl"
+
+
+def dashboard_dir(kind: str, profile: str, art: Path | None = None) -> Path:
+    """Rendered dashboards: kind in {model, review, examples-validation}."""
+    return local_dir(art) / kind / profile
+
+
+def serve_dir(art: Path | None = None) -> Path:
+    return local_dir(art) / "serve"
+
+
+def profile_dir(profile: str, art: Path | None = None) -> Path:
+    """The committable per-profile semantic model root."""
+    return (art or artifacts_dir()) / profile
+
+
+# --- gitignore + migration --------------------------------------------------
+
+def ensure_gitignore(art: Path | None = None) -> None:
+    """Make sure the artifacts dir's .gitignore excludes the secrets/state dir."""
+    art = art or artifacts_dir()
+    gi = art / ".gitignore"
+    line = f"{LOCAL_SUBDIR}/"
+    try:
+        existing = gi.read_text(encoding="utf-8") if gi.exists() else ""
+        if line not in existing.split():
+            art.mkdir(parents=True, exist_ok=True)
+            with gi.open("a", encoding="utf-8") as fh:
+                if existing and not existing.endswith("\n"):
+                    fh.write("\n")
+                fh.write(f"# agami secrets + per-user state — never commit\n{line}\n")
+    except OSError:
+        pass
+
+
+def _legacy_artifacts_dir() -> Path | None:
+    """The custom artifacts dir the OLD `~/.agami/.config` recorded, if any — so the
+    migration consolidates into the user's existing model location, not the default."""
+    cfg = LEGACY_HOME / ".config"
+    if not cfg.exists():
+        return None
+    try:
+        import json
+        ad = json.loads(cfg.read_text(encoding="utf-8")).get("artifacts_dir")
+        if ad:
+            return Path(os.path.expanduser(str(ad))).resolve()
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def migrate_legacy_home(art: Path | None = None) -> bool:
+    """Move a pre-consolidation `~/.agami/` into `<artifacts_dir>/local/`, once.
+
+    When `art` is None, consolidates into the artifacts dir the old config recorded
+    (preserving a custom location), else the current/default one. Idempotent: a no-op
+    if there's no legacy home or `local/` already exists. Leaves a tombstone behind.
+    """
+    if not LEGACY_HOME.is_dir():
+        return False
+    if art is None:
+        art = _legacy_artifacts_dir() or artifacts_dir()
+    dest = local_dir(art)
+    if dest.exists():
+        # Already consolidated. But a stale/cached process (e.g. an old pre-consolidation Desktop
+        # MCP copy) can RESURRECT `~/.agami/.config` — the live config lives in `dest`, nothing
+        # reads the legacy one, so sweep it back to an inert tombstone instead of letting it linger
+        # and look authoritative.
+        stale = LEGACY_HOME / ".config"
+        if stale.exists():
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        LEGACY_HOME.rename(dest)
+    except OSError:
+        # rename() raises EXDEV when the artifacts dir is on a different
+        # filesystem than ~/.agami (external drive, separate mount). Fall back
+        # to a copy+delete move, which crosses devices.
+        import shutil
+        shutil.move(str(LEGACY_HOME), str(dest))
+    ensure_gitignore(art)
+    set_artifacts_dir(art)
+    try:
+        LEGACY_HOME.mkdir(parents=True, exist_ok=True)
+        (LEGACY_HOME / "MOVED.txt").write_text(
+            f"agami now keeps everything under your artifacts folder.\n"
+            f"This dir's contents moved to: {dest}\n", encoding="utf-8")
+    except OSError:
+        pass
+    return True
+
+
+def bootstrap() -> Path:
+    """Call at the start of every entry point: runs the one-shot legacy migration
+    (idempotent — a cheap no-op once done) and returns the resolved artifacts dir."""
+    migrate_legacy_home()
+    return artifacts_dir()

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1,0 +1,785 @@
+#!/usr/bin/env python3
+"""
+Tier 3 — Python execution helper.
+
+Reads <artifacts_dir>/local/credentials (INI), opens a connection to the configured
+database via the appropriate Python driver, runs ONE SQL statement, and
+writes the result as RFC 4180 CSV to stdout. Stdlib + driver-only.
+
+The agami skill calls this when it detects tier=python in <artifacts_dir>/local/.config
+(meaning native CLI tools are unavailable but the relevant Python driver
+is importable). Connect-side and query-database both shell out to:
+
+    python3 scripts/execute_sql.py --profile <profile> --sql-file <path>
+
+The --sql-file form is preferred over --sql so SQL containing quotes,
+backticks, or `$` doesn't get mangled by the shell.
+
+Connects ONLY to the host/port in <artifacts_dir>/local/credentials (the sole credential
+source — no env-var bypass). Never substitutes localhost. Never asks for
+credentials. Hard exits with a clear message if credentials are missing.
+
+Drivers (install only what you need):
+    pip install psycopg2-binary             # Postgres / Redshift
+    pip install pymysql                     # MySQL
+    pip install snowflake-connector-python  # Snowflake
+    pip install google-cloud-bigquery       # BigQuery
+    # SQLite uses the stdlib `sqlite3` module — no install needed.
+
+Exit codes:
+    0  — success, CSV on stdout
+    2  — usage / config error (missing credentials, bad profile, etc.)
+    3  — driver missing for the configured db type
+    4  — connection / authentication failed
+    5  — SQL execution error (syntax, unknown column, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import csv
+import json
+import os
+import stat
+import sys
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+import agami_paths
+
+# Credentials + config now live under <artifacts_dir>/local/ (the consolidated,
+# gitignored replacement for ~/.agami). The path is stable regardless of migration
+# timing — bootstrap() just moves the files into it. See agami_paths.
+CREDENTIALS_PATH = agami_paths.credentials_path()
+CONFIG_PATH = agami_paths.config_path()
+ALLOWED_PERMS = (0o600, 0o400)
+
+
+def _resolve_default_profile() -> str:
+    """Pick the default profile when --profile isn't passed and AGAMI_PROFILE is unset.
+
+    Resolution order:
+      1. AGAMI_PROFILE env var
+      2. active_profile field in <artifacts_dir>/local/.config
+      3. The literal string "default" (legacy fallback)
+    """
+    env = os.environ.get("AGAMI_PROFILE")
+    if env:
+        return env
+    if CONFIG_PATH.exists():
+        try:
+            import json as _json
+            cfg = _json.loads(CONFIG_PATH.read_text())
+            active = cfg.get("active_profile")
+            if isinstance(active, str) and active:
+                return active
+        except (OSError, ValueError):
+            pass
+    return "default"
+
+
+def _err(msg: str, *, code: int = 2) -> int:
+    sys.stderr.write(f"{msg}\n")
+    return code
+
+
+def _load_credentials(profile: str) -> dict[str, str]:
+    """Resolve credentials from <artifacts_dir>/local/credentials (the ONLY source).
+
+    Within the selected profile:
+      - If `url = ...` is set, parse it as a DSN (overrides per-field values)
+      - Otherwise read host / port / user / password / database / type / sslmode
+
+    Credentials come only from the file — there is no env-var bypass. This keeps
+    the one credential path auditable (chmod 600, never on a command line).
+    """
+    if not CREDENTIALS_PATH.exists():
+        sys.stderr.write(
+            "<artifacts_dir>/local/credentials is missing. Run the agami `init` skill to set it up.\n"
+            "Never type credentials into chat — they belong in the file.\n"
+        )
+        sys.exit(2)
+
+    # chmod check: refuse if too permissive. POSIX only — Windows file modes don't
+    # map to Unix permission bits (NTFS ACLs guard the file; a stat() there reports
+    # ~0o666, which would wrongly trip this gate and block the credentials read).
+    if os.name == "posix":
+        mode = stat.S_IMODE(CREDENTIALS_PATH.stat().st_mode)
+        if mode not in ALLOWED_PERMS:
+            sys.stderr.write(
+                f"<artifacts_dir>/local/credentials must be chmod 600 (currently {oct(mode)[2:]})\n"
+                f"Run: chmod 600 <artifacts_dir>/local/credentials\n"
+            )
+            sys.exit(2)
+
+    # IMPORTANT: enable inline-comment stripping for both `#` and `;`. Without
+    # this, a credentials line like `account = xy12345  # locator + region`
+    # parses as `xy12345  # locator + region` (the comment becomes part of the
+    # value), which then gets fed to Snowflake/Postgres/MySQL as a junk
+    # hostname/account and the connection hangs or fails confusingly.
+    cfg = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
+    cfg.read(CREDENTIALS_PATH)
+    if profile not in cfg:
+        sys.stderr.write(
+            f"Profile [{profile}] not found in <artifacts_dir>/local/credentials. "
+            f"Sections present: {cfg.sections()}\n"
+        )
+        sys.exit(2)
+
+    section = {k: (v.strip() if isinstance(v, str) else v) for k, v in cfg[profile].items()}
+
+    # If the profile has `url = ...` (e.g. a Supabase / Neon / RDS DSN), parse it
+    # and merge with any per-field overrides (sslmode, etc.) defined alongside.
+    if "url" in section and section["url"]:
+        from_dsn = _parse_dsn(section["url"])
+        # Per-field values in the same section override DSN values, except for
+        # `url` itself which we drop from the output.
+        merged = dict(from_dsn)
+        for k, v in section.items():
+            if k == "url":
+                continue
+            merged[k] = v
+        return merged
+
+    return section
+
+
+# Schemes we accept. Strip "+driver" suffixes (e.g. postgresql+asyncpg, postgres+psycopg2).
+_POSTGRES_SCHEMES = {"postgres", "postgresql"}
+_MYSQL_SCHEMES = {"mysql", "mariadb"}
+_REDSHIFT_SCHEMES = {"redshift"}        # speaks Postgres wire protocol; port 5439, SSL required
+_SNOWFLAKE_SCHEMES = {"snowflake"}      # native CLI (snowsql) + snowflake-connector-python
+_BIGQUERY_SCHEMES = {"bigquery", "bq"}  # google-cloud-bigquery — auth via service-account JSON or ADC
+
+
+def _parse_dsn(dsn: str) -> dict[str, str]:
+    """Parse a database DSN into a credentials dict.
+
+    Supported schemes (with or without `+driver` suffix):
+      postgresql://, postgres://, postgresql+asyncpg://, postgresql+psycopg2://,
+      postgresql+psycopg://, postgres+asyncpg:// — all map to type=postgres.
+      mysql://, mariadb://, mysql+pymysql:// — all map to type=mysql.
+      sqlite:///absolute/path/to.db — maps to type=sqlite.
+      redshift://user:pass@cluster.region.redshift.amazonaws.com:5439/db — type=redshift
+      snowflake://user:pass@account.region.cloud/database/schema?warehouse=wh&role=r
+        — type=snowflake. The path is `/database` or `/database/schema`. Query
+        params (warehouse, role, application, authenticator) are carried over.
+
+    Cloud Postgres providers (Supabase, Neon, RDS, etc.) frequently use the
+    SQLAlchemy-style `postgresql+asyncpg://...` form. We accept it.
+
+    Query-string parameters on the DSN (e.g. `?sslmode=require`) are merged
+    into the output dict — useful for SSL settings.
+    """
+    u = urllib.parse.urlparse(dsn)
+    raw_scheme = u.scheme.lower()
+
+    # Strip "+driver" suffix: "postgresql+asyncpg" → "postgresql"
+    base_scheme = raw_scheme.split("+", 1)[0]
+
+    if base_scheme in _POSTGRES_SCHEMES:
+        db_type = "postgres"
+        default_port = 5432
+    elif base_scheme in _REDSHIFT_SCHEMES:
+        # Redshift speaks Postgres wire protocol → reuse postgres execution path.
+        # The only thing that's different is the default port (5439 vs 5432) and
+        # that SSL is required by default.
+        db_type = "redshift"
+        default_port = 5439
+    elif base_scheme in _MYSQL_SCHEMES:
+        db_type = "mysql"
+        default_port = 3306
+    elif base_scheme in _SNOWFLAKE_SCHEMES:
+        db_type = "snowflake"
+        default_port = 443  # Snowflake is HTTPS-only; port not used by snowsql/connector
+    elif base_scheme in _BIGQUERY_SCHEMES:
+        # BigQuery URLs follow the SQLAlchemy-bigquery convention:
+        #   bigquery://<project>             — default dataset comes from creds
+        #   bigquery://<project>/<dataset>   — set the default dataset
+        # Query params may carry: service_account, location.
+        # No host:port — BigQuery is HTTPS-only via the Google Cloud REST API.
+        project = u.hostname or ""
+        path_parts = (u.path or "").lstrip("/").split("/") if u.path else []
+        out = {
+            "type": "bigquery",
+            "project": project,
+        }
+        if path_parts and path_parts[0]:
+            out["dataset"] = path_parts[0]
+        if u.query:
+            for k, v in urllib.parse.parse_qsl(u.query):
+                key = k.lower()
+                # `service_account` and `credentials_path` both map to the
+                # file path of the JSON service-account key.
+                if key in ("credentials_path", "service_account"):
+                    out["service_account_path"] = v
+                else:
+                    out[key] = v
+        return out
+    elif base_scheme == "sqlite":
+        # sqlite:///absolute/path or sqlite:relative/path
+        path = dsn[len("sqlite://"):]
+        if path.startswith("/"):
+            path = path[1:] if path[1:2] == "/" else path  # handle `sqlite:////abs`
+        # Trailing path normalization
+        result = {"type": "sqlite", "path": path or u.path.lstrip("/")}
+        return result
+    else:
+        sys.stderr.write(
+            f"Unsupported scheme {raw_scheme!r}. "
+            f"Supported: postgresql[+driver], postgres[+driver], redshift, "
+            f"mysql[+driver], mariadb, snowflake, sqlite.\n"
+        )
+        sys.exit(2)
+
+    # Snowflake's URL is account-shaped, not host:port. The "hostname" portion
+    # of `snowflake://user:pw@xy12345.us-east-1.aws/MYDB/PUBLIC` is the account
+    # identifier, and the path holds DATABASE[/SCHEMA].
+    if db_type == "snowflake":
+        path_parts = (u.path or "").lstrip("/").split("/")
+        out = {
+            "type": "snowflake",
+            "account": u.hostname or "",
+            "user": urllib.parse.unquote(u.username or ""),
+            "password": urllib.parse.unquote(u.password or ""),
+            "database": path_parts[0] if path_parts and path_parts[0] else "",
+        }
+        if len(path_parts) > 1 and path_parts[1]:
+            out["schema"] = path_parts[1]
+        # Carry warehouse, role, application, authenticator from query params
+        if u.query:
+            for k, v in urllib.parse.parse_qsl(u.query):
+                out[k.lower()] = v
+        return out
+
+    out: dict[str, str] = {
+        "type": db_type,
+        "host": u.hostname or "",
+        "port": str(u.port or default_port),
+        "user": urllib.parse.unquote(u.username or ""),
+        "password": urllib.parse.unquote(u.password or ""),
+        "database": (u.path or "").lstrip("/"),
+    }
+
+    # Merge any query-string params (e.g. ?sslmode=require)
+    if u.query:
+        for k, v in urllib.parse.parse_qsl(u.query):
+            out[k.lower()] = v
+
+    # Redshift defaults: SSL required if not explicitly set
+    if db_type == "redshift" and "sslmode" not in out:
+        out["sslmode"] = "require"
+
+    return out
+
+
+def _require(creds: dict[str, str], *fields: str) -> None:
+    missing = [f for f in fields if not creds.get(f)]
+    if missing:
+        sys.stderr.write(
+            f"Credentials profile is missing required fields: {missing}. "
+            f"Edit <artifacts_dir>/local/credentials and add them.\n"
+        )
+        sys.exit(2)
+
+
+def _execute_postgres(creds: dict[str, str], sql: str) -> int:
+    try:
+        import psycopg2  # type: ignore
+    except ImportError:
+        return _err("psycopg2 not installed. Run: pip install psycopg2-binary", code=3)
+    _require(creds, "host", "port", "user", "password", "database")
+    try:
+        conn = psycopg2.connect(
+            host=creds["host"],
+            port=int(creds["port"]),
+            user=creds["user"],
+            password=creds["password"],
+            dbname=creds["database"],
+            sslmode=creds.get("sslmode", "prefer"),
+            connect_timeout=10,
+        )
+    except Exception as e:
+        return _err(f"Postgres connect failed: {e}", code=4)
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql)
+                _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"Postgres execution error: {e}", code=5)
+    finally:
+        conn.close()
+    return 0
+
+
+def _execute_mysql(creds: dict[str, str], sql: str) -> int:
+    try:
+        import pymysql  # type: ignore
+    except ImportError:
+        return _err("pymysql not installed. Run: pip install pymysql", code=3)
+    _require(creds, "host", "port", "user", "password", "database")
+    try:
+        conn = pymysql.connect(
+            host=creds["host"],
+            port=int(creds["port"]),
+            user=creds["user"],
+            password=creds["password"],
+            database=creds["database"],
+            charset="utf8mb4",
+            connect_timeout=10,
+            autocommit=True,
+        )
+    except Exception as e:
+        return _err(f"MySQL connect failed: {e}", code=4)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"MySQL execution error: {e}", code=5)
+    finally:
+        conn.close()
+    return 0
+
+
+def _execute_snowflake(creds: dict[str, str], sql: str) -> int:
+    """Tier-3 path for Snowflake using snowflake-connector-python."""
+    try:
+        import snowflake.connector  # type: ignore
+    except ImportError:
+        return _err(
+            "snowflake-connector-python not installed. "
+            "Run: pip install snowflake-connector-python",
+            code=3,
+        )
+    _require(creds, "account", "user")
+    if not (creds.get("password") or creds.get("authenticator")):
+        return _err(
+            "Snowflake profile is missing 'password' or 'authenticator'. "
+            "Add one to <artifacts_dir>/local/credentials.",
+            code=2,
+        )
+    conn_kwargs: dict[str, Any] = {
+        "account": creds["account"],
+        "user": creds["user"],
+        "client_session_keep_alive": False,
+        "login_timeout": 15,
+    }
+    for k in ("password", "warehouse", "database", "schema", "role", "authenticator"):
+        if creds.get(k):
+            conn_kwargs[k] = creds[k]
+    try:
+        conn = snowflake.connector.connect(**conn_kwargs)
+    except Exception as e:
+        return _err(f"Snowflake connect failed: {e}", code=4)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"Snowflake execution error: {e}", code=5)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return 0
+
+
+def _execute_bigquery(creds: dict[str, str], sql: str) -> int:
+    """Tier-3 path for BigQuery using google-cloud-bigquery.
+
+    Required: `project`. One of: `service_account_path` (path to a JSON key
+    file), OR no auth at all (falls back to Application Default Credentials —
+    `gcloud auth application-default login`). Optional: `dataset` (sets the
+    default dataset so unqualified table refs resolve), `location` (e.g. `US`,
+    `EU`, `asia-northeast1`).
+    """
+    try:
+        from google.cloud import bigquery  # type: ignore
+        from google.oauth2 import service_account  # type: ignore
+    except ImportError:
+        return _err(
+            "google-cloud-bigquery not installed. "
+            "Run: pip install google-cloud-bigquery",
+            code=3,
+        )
+
+    _require(creds, "project")
+    project = creds["project"]
+    sa_path = creds.get("service_account_path")
+    location = creds.get("location") or None
+
+    client_kwargs: dict[str, Any] = {"project": project}
+    if location:
+        client_kwargs["location"] = location
+
+    if sa_path:
+        sa_path_expanded = os.path.expanduser(sa_path)
+        if not os.path.exists(sa_path_expanded):
+            return _err(
+                f"service_account_path '{sa_path}' doesn't exist. "
+                f"Point at the JSON key file you downloaded from GCP.",
+                code=2,
+            )
+        # Defensive chmod check — service-account JSON contains a private key.
+        try:
+            mode = stat.S_IMODE(os.stat(sa_path_expanded).st_mode)
+            if mode not in ALLOWED_PERMS:
+                sys.stderr.write(
+                    f"Warning: service_account_path '{sa_path}' has permissions "
+                    f"{oct(mode)} — should be 0600. The file contains a private key.\n"
+                )
+        except Exception:
+            pass
+        try:
+            creds_obj = service_account.Credentials.from_service_account_file(
+                sa_path_expanded
+            )
+            client_kwargs["credentials"] = creds_obj
+        except Exception as e:
+            return _err(f"BigQuery credentials load failed: {e}", code=2)
+
+    try:
+        client = bigquery.Client(**client_kwargs)
+    except Exception as e:
+        return _err(f"BigQuery client init failed: {e}", code=4)
+
+    # If `dataset` was set, prefix unqualified table references via the
+    # default_dataset job config so the SQL can omit `<project>.<dataset>.`
+    job_config_kwargs: dict[str, Any] = {}
+    if creds.get("dataset"):
+        try:
+            job_config_kwargs["default_dataset"] = f"{project}.{creds['dataset']}"
+        except Exception:
+            pass
+
+    try:
+        if job_config_kwargs:
+            job_config = bigquery.QueryJobConfig(**job_config_kwargs)
+            job = client.query(sql, job_config=job_config)
+        else:
+            job = client.query(sql)
+        results = job.result()  # waits for completion; raises on error
+    except Exception as e:
+        return _err(f"BigQuery execution error: {e}", code=5)
+
+    # Stream rows to stdout as CSV. results.schema gives column metadata.
+    writer = csv.writer(sys.stdout)
+    if results.schema:
+        writer.writerow([f.name for f in results.schema])
+        for row in results:
+            writer.writerow([row[i] for i in range(len(results.schema))])
+
+    return 0
+
+
+def _execute_sqlite(creds: dict[str, str], sql: str) -> int:
+    import sqlite3  # always available in stdlib
+    _require(creds, "path")
+    path = os.path.expanduser(creds["path"])
+    try:
+        conn = sqlite3.connect(path)
+    except Exception as e:
+        return _err(f"SQLite connect failed: {e}", code=4)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"SQLite execution error: {e}", code=5)
+    finally:
+        conn.close()
+    return 0
+
+
+def _execute_sqlserver(creds: dict[str, str], sql: str) -> int:
+    """Tier-3 path for SQL Server / Azure SQL using pymssql."""
+    try:
+        import pymssql  # type: ignore
+    except ImportError:
+        return _err("pymssql not installed. Run: pip install pymssql", code=3)
+    _require(creds, "host", "user", "password")
+    try:
+        conn = pymssql.connect(
+            server=creds["host"], port=int(creds.get("port", 1433)),
+            user=creds["user"], password=creds["password"],
+            database=creds.get("database", ""), login_timeout=15,
+        )
+    except Exception as e:
+        return _err(f"SQL Server connect failed: {e}", code=4)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"SQL Server execution error: {e}", code=5)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return 0
+
+
+def _execute_oracle(creds: dict[str, str], sql: str) -> int:
+    """Tier-3 path for Oracle using python-oracledb (thin mode — no client libs)."""
+    try:
+        import oracledb  # type: ignore
+    except ImportError:
+        return _err("python-oracledb not installed. Run: pip install oracledb", code=3)
+    _require(creds, "user", "password")
+    dsn = creds.get("dsn") or creds.get("url")
+    if not dsn:
+        _require(creds, "host", "service_name")
+        dsn = oracledb.makedsn(creds["host"], int(creds.get("port", 1521)),
+                               service_name=creds["service_name"])
+    try:
+        conn = oracledb.connect(user=creds["user"], password=creds["password"], dsn=dsn)
+    except Exception as e:
+        return _err(f"Oracle connect failed: {e}", code=4)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"Oracle execution error: {e}", code=5)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return 0
+
+
+def _execute_databricks(creds: dict[str, str], sql: str) -> int:
+    """Tier-3 path for Databricks SQL warehouses using databricks-sql-connector."""
+    try:
+        from databricks import sql as dbsql  # type: ignore
+    except ImportError:
+        return _err(
+            "databricks-sql-connector not installed. Run: pip install databricks-sql-connector",
+            code=3,
+        )
+    _require(creds, "host", "http_path", "token")
+    try:
+        conn = dbsql.connect(
+            server_hostname=creds["host"], http_path=creds["http_path"],
+            access_token=creds["token"],
+        )
+    except Exception as e:
+        return _err(f"Databricks connect failed: {e}", code=4)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"Databricks execution error: {e}", code=5)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return 0
+
+
+def _execute_trino(creds: dict[str, str], sql: str) -> int:
+    """Tier-3 path for Trino / Presto using the trino python client."""
+    try:
+        import trino  # type: ignore
+    except ImportError:
+        return _err("trino not installed. Run: pip install trino", code=3)
+    _require(creds, "host", "user")
+    try:
+        auth = None
+        if creds.get("password"):
+            auth = trino.auth.BasicAuthentication(creds["user"], creds["password"])
+        conn = trino.dbapi.connect(
+            host=creds["host"], port=int(creds.get("port", 8080)), user=creds["user"],
+            catalog=creds.get("catalog"), schema=creds.get("schema"),
+            http_scheme="https" if creds.get("password") else "http", auth=auth,
+        )
+    except Exception as e:
+        return _err(f"Trino connect failed: {e}", code=4)
+    try:
+        cur = conn.cursor()
+        cur.execute(sql)
+        _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"Trino execution error: {e}", code=5)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return 0
+
+
+def _execute_duckdb(creds: dict[str, str], sql: str) -> int:
+    """Tier-3 path for DuckDB using the duckdb python module (file or in-memory)."""
+    try:
+        import duckdb  # type: ignore
+    except ImportError:
+        return _err("duckdb not installed. Run: pip install duckdb", code=3)
+    path = creds.get("path") or creds.get("database") or ":memory:"
+    try:
+        conn = duckdb.connect(path, read_only=True)
+    except Exception as e:
+        return _err(f"DuckDB open failed: {e}", code=4)
+    try:
+        cur = conn.execute(sql)
+        _write_cursor_csv(cur)
+    except Exception as e:
+        return _err(f"DuckDB execution error: {e}", code=5)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    return 0
+
+
+def _write_cursor_csv(cur: Any) -> None:
+    writer = csv.writer(sys.stdout)
+    if cur.description is not None:
+        writer.writerow([d[0] for d in cur.description])
+        for row in cur.fetchall():
+            writer.writerow(row)
+
+
+def _model_safety(sql: str, profile: str, area: str | None):
+    """Semantic-model safety pass before execution: fan-trap / chasm-trap pre-flight
+    + default_filters auto-application, reading the model at <artifacts>/<profile>/.
+
+    Returns (sql_to_run, exit_code). exit_code is None to continue, or an int to
+    short-circuit (a fan/chasm-trap refusal the caller must consume). Inert (returns
+    the SQL unchanged) when there is no model, or the model package isn't importable.
+    """
+    try:
+        from semantic_model import loader as L
+        from semantic_model import runtime as RT
+    except Exception:
+        return sql, None  # model package not available -> no-op
+    artifacts = Path(
+        os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")
+    )
+    root = artifacts / profile
+    if not (root / "org.yaml").exists():
+        return sql, None  # no model for this profile -> no-op
+    try:
+        org = L.load_organization(root)
+    except Exception as e:
+        sys.stderr.write(f"[agami] could not load semantic model; skipping safety pass: {e}\n")
+        return sql, None
+
+    pf = RT.pre_flight_check(sql, org)
+    if pf.risk and pf.action == "refuse":
+        json.dump({"error": {"kind": "preflight_refused", "risk": pf.risk,
+                             "reason": pf.reason, "suggestion": pf.suggestion,
+                             "triggering_joins": pf.triggering_joins}}, sys.stderr)
+        sys.stderr.write("\n")
+        return sql, 1
+    if pf.risk and pf.action == "auto_rewrite" and pf.rewritten_sql:
+        sys.stderr.write(f"[agami] auto-corrected {pf.risk}: ran rewritten SQL. {pf.reason}\n")
+        sql = pf.rewritten_sql
+
+    # Sensitive-column (PII) guard — refuse to PROJECT raw sensitive values. Same
+    # deterministic chokepoint as the fan/chasm pre-flight, so the agami-query skill,
+    # the local MCP server, and cron all protect PII identically (not just whichever
+    # path happened to read a prose rule). Aggregates / filters / joins are allowed.
+    sens = RT.check_sensitive_projection(sql, org)
+    if sens.action == "refuse":
+        json.dump({"error": {"kind": "sensitive_columns", "columns": sens.columns,
+                             "reason": sens.reason, "suggestion": sens.suggestion}}, sys.stderr)
+        sys.stderr.write("\n")
+        return sql, 1
+
+    new_sql, applied = RT.apply_default_filters(sql, org, area=area)
+    if applied:
+        sys.stderr.write(f"[agami] applied default_filters: {applied}\n")
+        sql = new_sql
+    return sql, None
+
+
+def main() -> int:
+    # One-shot migration of a legacy <artifacts_dir>/local into <artifacts_dir>/local/, then re-resolve
+    # the paths (the migration can set the artifacts-dir pointer to a custom location).
+    global CREDENTIALS_PATH, CONFIG_PATH
+    agami_paths.bootstrap()
+    CREDENTIALS_PATH = agami_paths.credentials_path()
+    CONFIG_PATH = agami_paths.config_path()
+    p = argparse.ArgumentParser(
+        description="Tier-3 Python SQL executor for agami. Reads credentials, runs SQL, emits CSV.",
+    )
+    p.add_argument(
+        "--profile",
+        default=None,
+        help="Credentials profile to use. Defaults to AGAMI_PROFILE env, then .config.active_profile, then 'default'.",
+    )
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--sql", help="SQL statement (use --sql-file for SQL with special characters)")
+    src.add_argument("--sql-file", help="Path to a file containing one SQL statement")
+    p.add_argument("--area", default=None,
+                   help="Subject area for the semantic-model safety pass (pre-flight + default_filters).")
+    p.add_argument("--no-safety", action="store_true",
+                   help="Skip the semantic-model pre-flight / default_filters pass.")
+    args = p.parse_args()
+
+    if args.sql_file:
+        sql = Path(os.path.expanduser(args.sql_file)).read_text()
+    else:
+        sql = args.sql
+
+    profile = args.profile or _resolve_default_profile()
+
+    # Semantic-model safety pass (fan/chasm pre-flight + default_filters). Inert when
+    # there's no model for the profile, so this is safe for every caller.
+    if not args.no_safety:
+        sql, _rc = _model_safety(sql, profile, args.area)
+        if _rc is not None:
+            return _rc
+    creds = _load_credentials(profile)
+    db_type = creds.get("type", "").lower()
+    if not db_type:
+        return _err(f"Credentials profile [{profile}] is missing the 'type' field.")
+    if db_type == "postgres":
+        return _execute_postgres(creds, sql)
+    if db_type == "redshift":
+        # Redshift speaks Postgres wire protocol; psycopg2 connects fine.
+        # The credentials dict has type=redshift, but _execute_postgres reads
+        # host/port/etc. directly so the type field doesn't matter.
+        if "sslmode" not in creds:
+            creds = {**creds, "sslmode": "require"}
+        return _execute_postgres(creds, sql)
+    if db_type == "mysql":
+        return _execute_mysql(creds, sql)
+    if db_type == "sqlite":
+        return _execute_sqlite(creds, sql)
+    if db_type == "snowflake":
+        return _execute_snowflake(creds, sql)
+    if db_type == "bigquery":
+        return _execute_bigquery(creds, sql)
+    if db_type in ("sqlserver", "mssql"):
+        return _execute_sqlserver(creds, sql)
+    if db_type == "oracle":
+        return _execute_oracle(creds, sql)
+    if db_type == "databricks":
+        return _execute_databricks(creds, sql)
+    if db_type in ("trino", "presto"):
+        return _execute_trino(creds, sql)
+    if db_type == "duckdb":
+        return _execute_duckdb(creds, sql)
+    if db_type == "supabase":
+        # Supabase is hosted Postgres.
+        return _execute_postgres(creds, sql)
+    return _err(
+        f"Unsupported db type {db_type!r}. Supported: postgres, supabase, redshift, "
+        f"mysql, sqlite, snowflake, bigquery, sqlserver, oracle, databricks, trino, duckdb."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/agami/lib/semantic_model/__init__.py
+++ b/plugins/agami/lib/semantic_model/__init__.py
@@ -1,0 +1,35 @@
+"""agami semantic model — provider-portable, standard-concepts hierarchy.
+
+This is **the** agami semantic model: a hierarchy of Organization → Storage
+Connection (physical) + Subject Area (logical) → Table / Entity / Metric /
+Relationship, with provider-portable declarative fields (default_filters,
+value_transform, caveats, value_pattern, sensitive, cardinality, …) so that any
+LLM can progressively traverse it and construct reliable queries against any
+backend.
+
+Layout on disk (the canonical profile format, rooted at `<artifacts_dir>/<profile>/`):
+
+    org.yaml                                 # org desc + storage_connections + subject_areas
+    datasources/<connection>/storage.yaml    # physical: storage_type, storage_config
+    subject_areas/<name>/
+      subject_area.yaml                      # desc, default_time_window, tables (TableRefs)
+      tables/<t>.yaml                        # canonical Table definitions
+      entities/<e>.yaml
+      metrics/<m>.yaml
+      relationships.yaml                     # intra-area FK graph
+    cross_subject_area_relationships.yaml    # optional, org-level
+    prompt_examples/<subject_area>/examples.yaml
+
+Modules:
+  models.py     — Pydantic v2 models (structural validation).
+  validator.py  — cross-cutting invariants (sizing, orphans, type-compat, …).
+  loader.py     — read the on-disk tree; context assembly.
+  runtime.py    — examples-first traversal, entity ID, fan/chasm pre-flight.
+  cli.py        — one dispatch surface.
+
+Depends on Pydantic v2 + sqlglot (see requirements.txt).
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/plugins/agami/lib/semantic_model/units.py
+++ b/plugins/agami/lib/semantic_model/units.py
@@ -1,0 +1,192 @@
+"""Deterministic unit/currency formatting.
+
+A column or metric's `unit` (an ISO currency code like INR/USD, or a plain unit like
+`percent`/`cents`/`days`) drives how its values are displayed — symbol, grouping,
+decimals — WITHOUT the LLM re-interpreting a prose caveat each query. The chart
+renderer and the query result formatter both call `format_value` so a number renders
+identically everywhere.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Optional
+
+# ISO code -> symbol. Extend freely; unknown codes fall back to the bare code.
+CURRENCY_SYMBOLS: dict[str, str] = {
+    "USD": "$", "EUR": "€", "GBP": "£", "JPY": "¥", "CNY": "¥", "INR": "₹",
+    "AUD": "A$", "CAD": "C$", "CHF": "CHF ", "SGD": "S$", "HKD": "HK$",
+    "NZD": "NZ$", "ZAR": "R", "BRL": "R$", "RUB": "₽", "KRW": "₩", "MXN": "MX$",
+    "AED": "د.إ ", "SAR": "﷼ ", "TRY": "₺", "THB": "฿", "IDR": "Rp", "MYR": "RM",
+    "PHP": "₱", "VND": "₫", "NGN": "₦", "PKR": "₨", "BDT": "৳", "LKR": "Rs ",
+}
+
+# Currencies that conventionally show no minor units (no decimals).
+_ZERO_DECIMAL = {"JPY", "KRW", "VND", "IDR"}
+
+
+def _norm(unit: Optional[str]) -> str:
+    return (unit or "").strip().upper()
+
+
+def is_currency(unit: Optional[str]) -> bool:
+    return _norm(unit) in CURRENCY_SYMBOLS
+
+
+def currency_symbol(unit: Optional[str]) -> Optional[str]:
+    """Symbol for an ISO currency code, or None if `unit` isn't a known currency."""
+    return CURRENCY_SYMBOLS.get(_norm(unit))
+
+
+def _group_western(int_part: str) -> str:
+    # 1234567 -> 1,234,567
+    digits = int_part[::-1]
+    chunks = [digits[i:i + 3] for i in range(0, len(digits), 3)]
+    return ",".join(chunks)[::-1]
+
+
+def _group_indian(int_part: str) -> str:
+    # 1234567 -> 12,34,567 (last 3, then groups of 2)
+    if len(int_part) <= 3:
+        return int_part
+    head, tail = int_part[:-3], int_part[-3:]
+    head_r = head[::-1]
+    chunks = [head_r[i:i + 2] for i in range(0, len(head_r), 2)]
+    return ",".join(chunks)[::-1] + "," + tail
+
+
+# Date storage encodings → seconds divisor for the integer value.
+_EPOCH_DIVISORS = {"epoch_s": 1.0, "epoch_ms": 1_000.0, "epoch_us": 1_000_000.0,
+                   "epoch_ns": 1_000_000_000.0}
+_DATE_FORMATS = set(_EPOCH_DIVISORS) | {"yyyymmdd", "iso8601"}
+
+
+def is_date_format(token: Optional[str]) -> bool:
+    return (token or "").strip().lower() in _DATE_FORMATS
+
+
+def format_date(value, date_format: Optional[str]) -> str:
+    """Render a stored date/time value human-readably. Deterministic.
+
+    - epoch_s/ms/us/ns → `YYYY-MM-DD HH:MM:SS UTC` (Unix time is UTC by definition).
+    - yyyymmdd (integer 20240115) → `YYYY-MM-DD`.
+    - iso8601 / anything else → passed through (the DB already returns it readable).
+    Non-numeric epoch values pass through unchanged.
+    """
+    if value is None:
+        return ""
+    t = (date_format or "").strip().lower()
+    if t in _EPOCH_DIVISORS:
+        try:
+            secs = float(value) / _EPOCH_DIVISORS[t]
+        except (TypeError, ValueError):
+            return str(value)
+        return _dt.datetime.fromtimestamp(secs, tz=_dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S") + " UTC"
+    if t == "yyyymmdd":
+        try:
+            i = int(float(value))
+        except (TypeError, ValueError):
+            return str(value)
+        try:
+            return _dt.date(i // 10000, (i // 100) % 100, i % 100).strftime("%Y-%m-%d")
+        except ValueError:
+            return str(value)
+    return str(value)
+
+
+def format_value(value, unit: Optional[str]) -> str:
+    """Format a numeric value for display given its unit. Deterministic.
+
+    - a date encoding (epoch_s/ms/us/ns, yyyymmdd) → human-readable date via `format_date`.
+    - currency → `<symbol><grouped number>` (Indian grouping for INR, western else;
+      2 decimals, or 0 for zero-decimal currencies like JPY).
+    - `percent`/`%` → `<n>%`.
+    - any other unit → `<grouped number> <unit>` (e.g. `1,234 days`).
+    - unknown/None unit, or non-numeric value → `str(value)` unchanged.
+    """
+    if value is None:
+        return ""
+    if is_date_format(unit):
+        return format_date(value, unit)
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+    code = _norm(unit)
+    if code in CURRENCY_SYMBOLS:
+        decimals = 0 if code in _ZERO_DECIMAL else 2
+        neg = num < 0
+        n = abs(num)
+        int_part = str(int(round(n))) if decimals == 0 else f"{n:.{decimals}f}".split(".")[0]
+        frac = "" if decimals == 0 else "." + f"{n:.{decimals}f}".split(".")[1]
+        grouped = _group_indian(int_part) if code == "INR" else _group_western(int_part)
+        return f"{'-' if neg else ''}{CURRENCY_SYMBOLS[code]}{grouped}{frac}"
+
+    lower = (unit or "").strip().lower()
+    if lower in ("percent", "%", "pct"):
+        s = f"{num:g}"
+        return f"{s}%"
+    if not unit:
+        return str(value)
+    # generic unit label
+    if num == int(num):
+        grouped = _group_western(str(int(num)))
+    else:
+        grouped = str(num)
+    return f"{grouped} {unit}"
+
+
+def _looks_numeric(s: str) -> bool:
+    t = (s or "").strip().replace(",", "")
+    if t in ("", "-", "+"):
+        return False
+    try:
+        float(t)
+        return True
+    except ValueError:
+        return False
+
+
+def format_cell(value, unit: Optional[str]) -> str:
+    """One result cell, formatted EXACTLY (no abbreviation, no precision loss) — for
+    verification surfaces. A unit'd column → `format_value`; a bare number → grouped
+    in full; anything else passes through unchanged."""
+    if unit:
+        return format_value(value, unit)
+    s = "" if value is None else str(value)
+    if _looks_numeric(s):
+        n = float(s.replace(",", ""))
+        if n == int(n):
+            return _group_western(str(int(n)))
+        # keep the source's exact decimals — don't round
+        ip, fp = s.replace(",", "").lstrip("-").split(".") if "." in s else (s.replace(",", "").lstrip("-"), "")
+        grouped = _group_western(ip)
+        return ("-" if n < 0 else "") + grouped + ("." + fp if fp else "")
+    return s
+
+
+def format_table(headers: list[str], rows: list[list], units: Optional[dict] = None) -> str:
+    """Render a GitHub-flavoured markdown table with every numeric cell formatted
+    deterministically and in full (exact value, thousands/lakh grouping, currency
+    symbol) — never abbreviated. `units` maps a header to its unit (currency code or
+    label). The query skill and the MCP both call this so the numbers a user verifies
+    are identical regardless of which LLM renders the surrounding answer."""
+    units = units or {}
+    cols = [str(h) for h in headers]
+
+    def _unit_for(i: int) -> Optional[str]:
+        # by output name first, then by position (`#i`) — the positional key carries
+        # units for columns the DB auto-named (an unaliased MAX(amount), etc.)
+        h = cols[i] if i < len(cols) else ""
+        return units.get(h) or units.get(f"#{i}")
+
+    fmt_rows = [[format_cell(c, _unit_for(i)) for i, c in enumerate(r)] for r in rows]
+    head = "| " + " | ".join(cols) + " |"
+    sep = "| " + " | ".join("---" for _ in cols) + " |"
+    body = "\n".join("| " + " | ".join(c.replace("|", "\\|") for c in r) + " |" for r in fmt_rows)
+    return "\n".join([head, sep, body]) if body else "\n".join([head, sep])
+
+
+__all__ = ["CURRENCY_SYMBOLS", "is_currency", "currency_symbol", "is_date_format",
+           "format_value", "format_date", "format_cell", "format_table"]

--- a/plugins/agami/scripts/_agami_lib.py
+++ b/plugins/agami/scripts/_agami_lib.py
@@ -24,7 +24,10 @@ _SCRIPTS = Path(__file__).resolve().parent
 
 
 def ensure_importable() -> None:
-    """Ensure the agami-core library modules can be imported. Idempotent; safe to call at every script's top."""
+    """Ensure the agami-core library modules can be imported. Idempotent; safe to call at every script's top.
+
+    Raises ImportError with a clear message if the library can't be found in any layout, rather than
+    letting the caller's `import agami_paths` fail with a harder-to-diagnose ModuleNotFoundError."""
     try:
         import agami_paths  # noqa: F401  — a pip-installed package wins; nothing to add.
 
@@ -32,8 +35,20 @@ def ensure_importable() -> None:
     except ImportError:
         pass
     # `<scripts>/../lib` resolves in the marketplace cache (`<version>/lib`) AND a dev checkout
-    # (`plugins/agami/lib`); the packages/ source is only there in a dev checkout.
+    # (`plugins/agami/lib`); the packages/ source is only there in a dev checkout. Verify each candidate
+    # actually provides the library (a present-but-incomplete dir shouldn't count as success).
     for candidate in (_SCRIPTS.parent / "lib", _SCRIPTS.parents[2] / "packages" / "agami-core" / "src"):
-        if candidate.is_dir():
-            sys.path.insert(0, str(candidate))
+        if not candidate.is_dir():
+            continue
+        sys.path.insert(0, str(candidate))
+        try:
+            import agami_paths  # noqa: F401
+
             return
+        except ImportError:
+            sys.path.pop(0)  # this candidate didn't provide the library — try the next
+    raise ImportError(
+        "agami-core library not found: no installed package, and the plugin's bundled lib/ is "
+        "missing or incomplete. Reinstall the agami plugin, or (in a dev checkout) run "
+        "`uv run dev.py sync-lib`."
+    )

--- a/plugins/agami/scripts/_agami_lib.py
+++ b/plugins/agami/scripts/_agami_lib.py
@@ -1,0 +1,39 @@
+"""Make the agami-core library importable for the plugin's runtime scripts.
+
+OCR-028 moved the library (`agami_paths`, `execute_sql`, `semantic_model`, …) out of this scripts dir
+into the pip package `packages/agami-core/src`. The marketplace ships only `plugins/agami/`, so those
+modules aren't on `sys.path` there and nothing pip-installs them — which broke every marketplace install
+(agami-connect died on `import agami_paths`). This resolver makes the library importable in every layout,
+**no pip required**:
+
+  1. already importable  → a pip-installed package wins; do nothing.
+  2. the bundled `lib/`   → the drift-checked copy shipped next to the scripts (`plugins/agami/lib/`),
+                            present in BOTH the marketplace cache and a dev checkout (kept in sync by
+                            `dev.py sync-lib`).
+  3. the dev source       → `…/packages/agami-core/src`, a belt-and-suspenders fallback for a dev checkout.
+
+Stdlib only (it runs before the library is even on the path).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+
+
+def ensure_importable() -> None:
+    """Ensure the agami-core library modules can be imported. Idempotent; safe to call at every script's top."""
+    try:
+        import agami_paths  # noqa: F401  — a pip-installed package wins; nothing to add.
+
+        return
+    except ImportError:
+        pass
+    # `<scripts>/../lib` resolves in the marketplace cache (`<version>/lib`) AND a dev checkout
+    # (`plugins/agami/lib`); the packages/ source is only there in a dev checkout.
+    for candidate in (_SCRIPTS.parent / "lib", _SCRIPTS.parents[2] / "packages" / "agami-core" / "src"):
+        if candidate.is_dir():
+            sys.path.insert(0, str(candidate))
+            return

--- a/plugins/agami/scripts/build_duckdb_attach.py
+++ b/plugins/agami/scripts/build_duckdb_attach.py
@@ -42,11 +42,14 @@ import secrets
 import sys
 from pathlib import Path
 
-# setup_pgauth stays a skill-side helper (scripts/); agami_paths lives in the agami-core
-# package. Add both: the scripts dir (for setup_pgauth) and the package src.
+# setup_pgauth stays a skill-side helper (scripts/); agami_paths lives in the agami-core package.
+# Add the scripts dir (for the sibling setup_pgauth + _agami_lib imports); the resolver then makes
+# agami_paths importable in every layout (pip-installed / the plugin's bundled lib / a dev checkout).
 _SCRIPTS = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPTS))
-sys.path.insert(0, str(_SCRIPTS.parents[2] / "packages" / "agami-core" / "src"))
+from _agami_lib import ensure_importable  # noqa: E402
+
+ensure_importable()
 import agami_paths  # noqa: E402
 from setup_pgauth import _atomic_write, _load_section  # noqa: E402
 

--- a/plugins/agami/scripts/connect_resolve.py
+++ b/plugins/agami/scripts/connect_resolve.py
@@ -46,7 +46,6 @@ import os
 import shutil
 import stat
 import subprocess
-import sys
 from pathlib import Path
 
 # agami_paths lives in the agami-core package; the resolver puts it on the path in every layout

--- a/plugins/agami/scripts/connect_resolve.py
+++ b/plugins/agami/scripts/connect_resolve.py
@@ -49,9 +49,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-# agami_paths lives in the agami-core package; add its src so this resolves whether or not
-# the package is pip-installed yet.
-sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "packages" / "agami-core" / "src"))
+# agami_paths lives in the agami-core package; the resolver puts it on the path in every layout
+# (pip-installed / the plugin's bundled lib / a dev checkout) with no pip required.
+from _agami_lib import ensure_importable  # noqa: E402
+
+ensure_importable()
 import agami_paths  # noqa: E402
 
 # import module to probe per DB type (sqlite/duckdb need no external driver)

--- a/plugins/agami/scripts/csv_to_sections.py
+++ b/plugins/agami/scripts/csv_to_sections.py
@@ -41,11 +41,12 @@ import argparse
 import csv
 import io
 import json
-import sys
 from pathlib import Path
 
-# semantic_model lives in the agami-core package.
-sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "packages" / "agami-core" / "src"))
+# semantic_model lives in the agami-core package; the resolver makes it importable in every layout.
+from _agami_lib import ensure_importable  # noqa: E402
+
+ensure_importable()
 from semantic_model import units  # noqa: E402  (stdlib-only module)
 
 

--- a/plugins/agami/scripts/setup_pgauth.py
+++ b/plugins/agami/scripts/setup_pgauth.py
@@ -48,9 +48,11 @@ import sys
 import tempfile
 from pathlib import Path
 
-# agami_paths + the executor live in the agami-core package; add its src so this resolves
-# them whether or not the package is pip-installed yet.
-sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "packages" / "agami-core" / "src"))
+# agami_paths + the executor live in the agami-core package; the resolver makes them importable in
+# every layout (pip-installed / the plugin's bundled lib / a dev checkout) with no pip required.
+from _agami_lib import ensure_importable  # noqa: E402
+
+ensure_importable()
 import agami_paths  # noqa: E402
 from execute_sql import _parse_dsn  # reuse DSN parsing logic  # noqa: E402
 

--- a/tests/test_plugin_lib_resolution.py
+++ b/tests/test_plugin_lib_resolution.py
@@ -1,0 +1,68 @@
+"""OCR-030 regression: the plugin's runtime scripts must resolve the agami-core library in a
+**marketplace install** — `scripts/` + the bundled `lib/`, with NO `packages/` sibling and no pip
+install — which is the exact layout that broke agami-connect (`import agami_paths` → ModuleNotFoundError).
+
+The trick: the test suite installs the package, so a plain subprocess would import it from site-packages
+and never exercise the bundled `lib/`. We run the scripts under `python -S` (site-packages disabled) so an
+installed agami-core is invisible — faithfully simulating the marketplace "no package" env. A guard fixture
+skips if `-S` fails to hide it, so the tests never pass vacuously.
+
+Also guards the vendored `lib/` against drift from `packages/agami-core/src` (the source of truth).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "plugins" / "agami" / "scripts"
+LIB = REPO / "plugins" / "agami" / "lib"
+SRC = REPO / "packages" / "agami-core" / "src"
+VENDORED = ["agami_paths.py", "execute_sql.py", "semantic_model/__init__.py", "semantic_model/units.py"]
+
+# `-S` disables site.py, so an installed (incl. editable) agami-core is not on the path — the same
+# "the package isn't available" state a marketplace user's plain python3 is in.
+_NOPKG = [sys.executable, "-S"]
+_ENV = {**os.environ, "PYTHONPATH": ""}
+
+
+def _package_hidden() -> bool:
+    return subprocess.run([*_NOPKG, "-c", "import agami_paths"], env=_ENV, capture_output=True).returncode != 0
+
+
+@pytest.fixture
+def marketplace_cache(tmp_path):
+    """A marketplace-like cache: scripts/ + lib/ with NO packages/ sibling. Skips if we can't hide the pkg."""
+    if not _package_hidden():
+        pytest.skip("cannot simulate a package-less interpreter here (-S does not hide agami-core)")
+    root = tmp_path / "cache"
+    shutil.copytree(SCRIPTS, root / "scripts")
+    shutil.copytree(LIB, root / "lib")
+    return root
+
+
+def test_connect_resolve_runs_in_marketplace_layout(marketplace_cache):
+    r = subprocess.run([*_NOPKG, str(marketplace_cache / "scripts" / "connect_resolve.py")],
+                       env=_ENV, capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    json.loads(r.stdout)  # valid JSON → agami_paths resolved via the bundled lib, not site-packages
+
+
+@pytest.mark.parametrize("mod", ["csv_to_sections", "setup_pgauth", "build_duckdb_attach"])
+def test_scripts_import_in_marketplace_layout(marketplace_cache, mod):
+    code = f"import sys; sys.path.insert(0, {str(marketplace_cache / 'scripts')!r}); import {mod}"
+    r = subprocess.run([*_NOPKG, "-c", code], env=_ENV, capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+
+
+def test_vendored_lib_matches_source():
+    """The bundled lib/ is a drift-checked mirror; if this fails, run `uv run dev.py sync-lib`."""
+    for rel in VENDORED:
+        assert (LIB / rel).read_bytes() == (SRC / rel).read_bytes(), f"{rel} drifted from the package source"


### PR DESCRIPTION
## Summary
**P0 fix.** After OCR-028 relocated `agami_paths` / `execute_sql` / `semantic_model` into `packages/agami-core/src`, four plugin scripts still imported them via a **dev-checkout-only** path (`sys.path.insert(parents[3]/packages/agami-core/src)`). A marketplace install ships only `plugins/agami/` (no `packages/`, no pip install), so that path doesn't exist → `ModuleNotFoundError: agami_paths` → **agami-connect died on its first step for every v0.3.0 user**.

Fix: make the library resolvable in every layout with **no pip required**, by shipping a drift-checked copy inside the plugin.

## Changes
- **`plugins/agami/scripts/_agami_lib.py`** (new) — `ensure_importable()`: pip-installed package wins → else the bundled `lib/` (present in the cache *and* a dev checkout) → else the dev `packages/agami-core/src`.
- **The 4 scripts** (`connect_resolve`, `csv_to_sections`, `setup_pgauth`, `build_duckdb_attach`) call the resolver instead of the hardcoded insert. No logic change.
- **`plugins/agami/lib/`** (new) — a committed, **drift-checked** copy of the stdlib-only closure (`agami_paths.py`, `execute_sql.py`, `semantic_model/{__init__,units}.py`). The marketplace serves git directly, so it must be committed.
- **`dev.py`** — `sync-lib` task (regenerates `lib/` from the package) + `_lib_drift()` wired into `check()` so the copy can't silently drift. Source of truth stays the package.
- **`tests/test_plugin_lib_resolution.py`** — reproduces the marketplace layout (`scripts/` + `lib/`, no `packages/`) under `python -S` (hides the installed package); a guard fixture prevents a vacuous pass. Plus a byte-match drift test.
- **Version 0.3.0 → 0.3.1** (`plugin.json`, `marketplace.json` ×2) so the marketplace serves the fix.

## Verification
- New regression test **runs (not skipped) and passes** — verified `-S` genuinely hides the installed package, and the old code reproduces the `ModuleNotFoundError` in the same harness.
- Drift check rc 0; full suite **1017 passed**; ruff clean (incl. the vendored `lib/`).
- Adversarial review: path math (dev + cache), import-first preference, test non-vacuity, drift catch, and no-behavior-change all independently verified — 0 must-fix.

## Follow-up (not this PR)
Shipping to users needs the marketplace to serve **v0.3.1** (owner refreshes / tags the release). Interim workaround for affected users: `pip install "agami-core[model] @ git+https://github.com/AgamiAI/agami-core@v0.3.1#subdirectory=packages/agami-core"`.

Spec: OCR-030