### PR TITLE
Fix: marketplace installs can't build a model — install the published agami-core[model], not the dev path

### DIFF
--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.0"
+version = "0.3.1"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/scripts/sm
+++ b/plugins/agami/scripts/sm
@@ -83,13 +83,17 @@ _pip_try() { "$PY" -m pip install --user -q "$@" >&2 2>/dev/null || "$PY" -m pip
 # is version-pinned and moves on every update.) Install source by layout — dev editable → the
 # published package on an index (lights up once agami-core is on PyPI, OCR-032) → pinned git (public
 # repo, no auth) → git main. First success wins.
+_imports_ok() { "$PY" -c 'import semantic_model, pydantic, sqlglot, yaml' 2>/dev/null; }
+
 ensure_pkg() {
-  "$PY" -c 'import semantic_model, pydantic, sqlglot, yaml' 2>/dev/null && return 0
+  _imports_ok && return 0
   echo "agami: installing agami-core (semantic model) into $PY …" >&2
-  { [ -n "$DEV_PKG_DIR" ] && _pip_try -e "$DEV_PKG_DIR[model]"; } && return 0
-  _pip_try "agami-core[model]" && return 0
-  _pip_try "agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core" && return 0
-  _pip_try "agami-core[model] @ ${GIT_BASE}@main#subdirectory=packages/agami-core" && return 0
+  # Re-verify the imports after each attempt: a pip that exits 0 but leaves the import broken (e.g.
+  # "already satisfied" into the wrong site) must fall through to the next source, not falsely succeed.
+  { [ -n "$DEV_PKG_DIR" ] && _pip_try -e "$DEV_PKG_DIR[model]"; } && _imports_ok && return 0
+  _pip_try "agami-core[model]" && _imports_ok && return 0
+  _pip_try "agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core" && _imports_ok && return 0
+  _pip_try "agami-core[model] @ ${GIT_BASE}@main#subdirectory=packages/agami-core" && _imports_ok && return 0
   echo "agami: couldn't install agami-core into $PY." >&2
   echo "       Try:  $PY -m pip install --user \"agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core\"" >&2
   echo "       Or point agami at a Python that has it:  export AGAMI_PYTHON=/path/to/python" >&2

--- a/plugins/agami/scripts/sm
+++ b/plugins/agami/scripts/sm
@@ -73,7 +73,9 @@ if [ -z "$PY" ]; then
 fi
 
 # Try a pip requirement `--user` first, then a plain install. "$@" preserves arg boundaries so a
-# PEP-508 direct reference (`agami-core[model] @ git+…`) stays a single argument.
+# PEP-508 direct reference (`agami-core[model] @ git+…`) stays a single argument. On the --user attempt
+# `>&2 2>/dev/null` sends its stdout to our stderr but swallows its stderr, so a "--user rejected"
+# environment falls through quietly to the plain install instead of printing a scary error.
 _pip_try() { "$PY" -m pip install --user -q "$@" >&2 2>/dev/null || "$PY" -m pip install -q "$@" >&2; }
 
 # Ensure the agami-core package (+ its model deps) is importable in $PY; install once if not.

--- a/plugins/agami/scripts/sm
+++ b/plugins/agami/scripts/sm
@@ -22,9 +22,20 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# The CLI runs as `python -m semantic_model.cli` against the installed agami-core package;
-# we install it (with the model extra, which brings pydantic/sqlglot/pyyaml) on demand below.
-PKG_DIR="$(cd "$SCRIPT_DIR/../../../packages/agami-core" && pwd)"
+# The CLI runs as `python -m semantic_model.cli` against the INSTALLED agami-core package; we install it
+# (with the model extra: pydantic/sqlglot/pyyaml) on demand below. The source differs by layout:
+#   - a dev checkout has packages/agami-core → editable install;
+#   - a marketplace install ships only plugins/agami/ (no packages/) → install the PUBLISHED package
+#     (PyPI once available, else pinned git). So packages/ is OPTIONAL here — never fatal (OCR-031).
+DEV_PKG_DIR=""
+if [ -f "$SCRIPT_DIR/../../../packages/agami-core/pyproject.toml" ]; then
+  DEV_PKG_DIR="$(cd "$SCRIPT_DIR/../../../packages/agami-core" && pwd)"
+fi
+# Pin the git-install fallback to the plugin version (the cache dir name, e.g. .../agami-core/0.3.1/);
+# fall back to `main` outside a versioned cache (e.g. a dev checkout, where DEV_PKG_DIR wins anyway).
+VER="$(basename "$(cd "$SCRIPT_DIR/.." && pwd)")"
+case "$VER" in [0-9]*) GIT_REF="v$VER" ;; *) GIT_REF="main" ;; esac
+GIT_BASE="git+https://github.com/AgamiAI/agami-core"
 
 resolve_python() {
   if [ -n "${AGAMI_PYTHON:-}" ]; then echo "$AGAMI_PYTHON"; return; fi
@@ -61,19 +72,34 @@ if [ -z "$PY" ]; then
   exit 3
 fi
 
-# Ensure the agami-core package + its model deps are importable in $PY; install once if not.
-# (A broken/moved editable install fails this import and self-heals via the reinstall — which
-# matters because the plugin's cache dir is version-pinned and moves on every update.)
-if ! "$PY" -c 'import semantic_model, pydantic, sqlglot, yaml' 2>/dev/null; then
+# Try a pip requirement `--user` first, then a plain install. "$@" preserves arg boundaries so a
+# PEP-508 direct reference (`agami-core[model] @ git+…`) stays a single argument.
+_pip_try() { "$PY" -m pip install --user -q "$@" >&2 2>/dev/null || "$PY" -m pip install -q "$@" >&2; }
+
+# Ensure the agami-core package (+ its model deps) is importable in $PY; install once if not.
+# (A broken/moved install fails this import and self-heals via the reinstall — the plugin cache dir
+# is version-pinned and moves on every update.) Install source by layout — dev editable → the
+# published package on an index (lights up once agami-core is on PyPI, OCR-032) → pinned git (public
+# repo, no auth) → git main. First success wins.
+ensure_pkg() {
+  "$PY" -c 'import semantic_model, pydantic, sqlglot, yaml' 2>/dev/null && return 0
   echo "agami: installing agami-core (semantic model) into $PY …" >&2
-  if ! "$PY" -m pip install --user -q -e "$PKG_DIR[model]" >&2 2>/dev/null; then
-    if ! "$PY" -m pip install -q -e "$PKG_DIR[model]" >&2; then
-      echo "agami: couldn't install agami-core into $PY." >&2
-      echo "       Run:  $PY -m pip install -e \"$PKG_DIR[model]\"" >&2
-      echo "       Or point agami at a Python that has it:  export AGAMI_PYTHON=/path/to/python" >&2
-      exit 3
-    fi
-  fi
+  { [ -n "$DEV_PKG_DIR" ] && _pip_try -e "$DEV_PKG_DIR[model]"; } && return 0
+  _pip_try "agami-core[model]" && return 0
+  _pip_try "agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core" && return 0
+  _pip_try "agami-core[model] @ ${GIT_BASE}@main#subdirectory=packages/agami-core" && return 0
+  echo "agami: couldn't install agami-core into $PY." >&2
+  echo "       Try:  $PY -m pip install --user \"agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core\"" >&2
+  echo "       Or point agami at a Python that has it:  export AGAMI_PYTHON=/path/to/python" >&2
+  exit 3
+}
+
+# `sm install` just ensures the package is present (agami-connect calls this before a model exists).
+if [ "${1:-}" = "install" ]; then
+  ensure_pkg
+  echo "agami: agami-core ready in $PY" >&2
+  exit 0
 fi
 
+ensure_pkg
 exec "$PY" -m semantic_model.cli "$@"

--- a/plugins/agami/skills/agami-connect/SKILL.md
+++ b/plugins/agami/skills/agami-connect/SKILL.md
@@ -240,7 +240,7 @@ The model (introspection, validation, traversal, curation — everything the `sm
 If they're present, continue. If missing, **confirm via AskUserQuestion before installing** (same convention as the DB-driver install above — agami never installs silently):
 > agami needs the **agami-core** package (which pulls `pydantic`, `sqlglot`, `pyyaml`) to build and read the semantic model. Install it now? (one-time, user-site — `pip install --user`)
 
-On **Yes**: `"$PY" -m pip install --user -e "$AGAMI_PLUGIN_ROOT/../../packages/agami-core[model]"` (fall back to a plain `pip install` if `--user` is rejected). This installs the agami-core library so `python -m execute_sql` / `python -m semantic_model.cli` and the `sm` launcher all resolve it. On **No**: stop with *"Can't build the model without it — re-run when you're ready to install."* — don't proceed to introspect.
+On **Yes**: `bash "$AGAMI_PLUGIN_ROOT/scripts/sm" install` — the `sm` launcher is the single place that installs the agami-core library into the resolved interpreter (editable from a dev checkout, else the published package via PyPI or pinned git — so it works in a marketplace install with no `packages/` dir), and everything (`python -m execute_sql` / `python -m semantic_model.cli` / `sm`) then resolves it. On **No**: stop with *"Can't build the model without it — re-run when you're ready to install."* — don't proceed to introspect.
 
 (The `sm` wrapper also self-installs these on first use as a safety net, but doing it here makes it explicit, confirmed, and at a predictable moment rather than mid-introspection.)
 
@@ -331,7 +331,7 @@ If `<artifacts_dir>/agami-example/org.yaml` already exists, the sample is alread
 ```
 
 1. **Set up `local/`** (same as 0a.1): `mkdir -p "<artifacts_dir>/local" && chmod 700 "<artifacts_dir>/local"`. Ensure `<artifacts_dir>/.gitignore` ignores `local/`. Resolve `<artifacts_dir>` per Phase 0 (first run: ask via 0a.6, default `~/agami-artifacts`).
-2. **Resolve `$PY` + the agami-core package** (trimmed 0a.5/0a.5b): SQLite needs **no DB driver** (stdlib), so only ensure the **agami-core** package is importable in `$PY` — confirm via AskUserQuestion, then `"$PY" -m pip install --user -e "$AGAMI_PLUGIN_ROOT/../../packages/agami-core[model]"` (the one, one-time install; brings pydantic/sqlglot/pyyaml). Detect the `sqlite3` CLI with `which sqlite3` → `tier = cli` if present else `python`.
+2. **Resolve `$PY` + the agami-core package** (trimmed 0a.5/0a.5b): SQLite needs **no DB driver** (stdlib), so only ensure the **agami-core** package is importable in `$PY` — confirm via AskUserQuestion, then `bash "$AGAMI_PLUGIN_ROOT/scripts/sm" install` (the one, one-time install via the `sm` launcher; brings pydantic/sqlglot/pyyaml and works with no `packages/` dir). Detect the `sqlite3` CLI with `which sqlite3` → `tier = cli` if present else `python`.
 3. **Build the `.db`** into the gitignored `local/` (it's regenerable machine state, not committed):
    ```bash
    "$PY" "$AGAMI_PLUGIN_ROOT/samples/store/build_sample.py" --out "<artifacts_dir>/local/samples/store.db"

--- a/tests/test_sm_install_resolution.py
+++ b/tests/test_sm_install_resolution.py
@@ -1,0 +1,88 @@
+"""OCR-031 regression: the `sm` launcher must install agami-core[model] in a **marketplace** layout —
+`scripts/` + `lib/` with NO `packages/` sibling and no pip install — without crashing and without pointing
+at the dev-only `packages/agami-core` path (the failure the real run-through hit).
+
+We run `sm install` with a **fake `$PY` shim** (`AGAMI_PYTHON`) that logs every pip-install it's asked to
+run and fails the bare index requirement `agami-core[model]` (simulating "not on PyPI yet") so we can
+observe the git fallback — no real network install happens. Also asserts the dev checkout still uses the
+editable install, and that the skill delegates to `sm install` (no hardcoded dev-path).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SM = REPO / "plugins" / "agami" / "scripts" / "sm"
+SCRIPTS = REPO / "plugins" / "agami" / "scripts"
+LIB = REPO / "plugins" / "agami" / "lib"
+SKILL = REPO / "plugins" / "agami" / "skills" / "agami-connect" / "SKILL.md"
+
+# A fake interpreter: force the install path (`-c import…` → fail), log each pip install, and fail the
+# bare index name so the git fallback is exercised; the `-e` (dev) and git requirements "succeed".
+_SHIM = """#!/usr/bin/env python3
+import os, sys
+args = sys.argv[1:]
+with open(os.environ["SM_SHIM_LOG"], "a") as f:
+    f.write(" ".join(args) + "\\n")
+if args[:1] == ["-c"]:
+    sys.exit(1)  # `import semantic_model, …` fails -> sm proceeds to install
+if "pip" in args and "install" in args:
+    joined = " ".join(args)
+    if "agami-core[model]" in joined and "git+" not in joined and "-e" not in args:
+        sys.exit(1)  # bare index name: pretend it's not on an index yet
+    sys.exit(0)      # -e (dev) and git requirements install fine
+sys.exit(0)
+"""
+
+
+def _run_install(sm_path: Path, tmp_path: Path):
+    shim = tmp_path / "pyshim"
+    shim.write_text(_SHIM)
+    shim.chmod(0o755)
+    log = tmp_path / "pip.log"
+    env = {
+        **os.environ,
+        "AGAMI_PYTHON": str(shim),
+        "SM_SHIM_LOG": str(log),
+        "AGAMI_ARTIFACTS_DIR": str(tmp_path / "art"),
+    }
+    r = subprocess.run(["bash", str(sm_path), "install"], env=env, capture_output=True, text=True)
+    lines = log.read_text().splitlines() if log.exists() else []
+    installs = [ln for ln in lines if "pip" in ln and "install" in ln]
+    return r, installs
+
+
+def test_marketplace_layout_installs_from_git_not_devpath(tmp_path):
+    cache = tmp_path / "agami-core" / "0.3.1"  # the cache dir name is the version
+    shutil.copytree(SCRIPTS, cache / "scripts")
+    shutil.copytree(LIB, cache / "lib")  # NO packages/ sibling
+    r, installs = _run_install(cache / "scripts" / "sm", tmp_path)
+
+    assert r.returncode == 0, r.stderr  # no crash at the old PKG_DIR line
+    assert installs, "sm attempted no install"
+    # Never the dev-only editable path.
+    assert not any("-e" in ln.split() for ln in installs), installs
+    assert not any("/packages/agami-core" in ln for ln in installs), installs
+    # Index tried first, git as the fallback, pinned to the cache's version.
+    idx = next(i for i, ln in enumerate(installs) if "agami-core[model]" in ln and "git+" not in ln)
+    git = next(i for i, ln in enumerate(installs) if "git+" in ln)
+    assert idx < git, installs
+    assert "git+https://github.com/AgamiAI/agami-core@v0.3.1#subdirectory=packages/agami-core" in "\n".join(installs)
+
+
+def test_dev_checkout_uses_editable(tmp_path):
+    # The real repo has packages/agami-core → editable install wins; git never tried.
+    r, installs = _run_install(SM, tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert any("-e" in ln.split() and ln.rstrip().endswith("/packages/agami-core[model]") for ln in installs), installs
+
+
+def test_skill_delegates_install_to_sm():
+    txt = SKILL.read_text()
+    assert "packages/agami-core[model]" not in txt  # no hardcoded dev-path install command
+    assert 'scripts/sm" install' in txt

--- a/tests/test_sm_install_resolution.py
+++ b/tests/test_sm_install_resolution.py
@@ -10,6 +10,7 @@ editable install, and that the skill delegates to `sm install` (no hardcoded dev
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -20,21 +21,27 @@ SM = REPO / "plugins" / "agami" / "scripts" / "sm"
 SCRIPTS = REPO / "plugins" / "agami" / "scripts"
 LIB = REPO / "plugins" / "agami" / "lib"
 SKILL = REPO / "plugins" / "agami" / "skills" / "agami-connect" / "SKILL.md"
+# The plugin version drives the cache-dir name + the pinned git ref sm derives — read it from the
+# manifest so a version bump needs no edit here.
+PLUGIN_VERSION = json.loads((REPO / ".claude-plugin" / "marketplace.json").read_text())["metadata"]["version"]
 
-# A fake interpreter: force the install path (`-c import…` → fail), log each pip install, and fail the
-# bare index name so the git fallback is exercised; the `-e` (dev) and git requirements "succeed".
+# A fake interpreter: the import check fails until a successful install "lands" it (a marker file), each
+# pip install is logged, and the bare index name fails so the git fallback is exercised — the `-e` (dev)
+# and git requirements "succeed" and drop the marker so the post-install re-check passes.
 _SHIM = """#!/usr/bin/env python3
 import os, sys
 args = sys.argv[1:]
 with open(os.environ["SM_SHIM_LOG"], "a") as f:
     f.write(" ".join(args) + "\\n")
+marker = os.environ["SM_SHIM_INSTALLED"]
 if args[:1] == ["-c"]:
-    sys.exit(1)  # `import semantic_model, …` fails -> sm proceeds to install
+    sys.exit(0 if os.path.exists(marker) else 1)  # `import semantic_model, …` works only once installed
 if "pip" in args and "install" in args:
     joined = " ".join(args)
     if "agami-core[model]" in joined and "git+" not in joined and "-e" not in args:
         sys.exit(1)  # bare index name: pretend it's not on an index yet
-    sys.exit(0)      # -e (dev) and git requirements install fine
+    open(marker, "w").close()  # -e (dev) and git requirements install the package
+    sys.exit(0)
 sys.exit(0)
 """
 
@@ -48,6 +55,7 @@ def _run_install(sm_path: Path, tmp_path: Path):
         **os.environ,
         "AGAMI_PYTHON": str(shim),
         "SM_SHIM_LOG": str(log),
+        "SM_SHIM_INSTALLED": str(tmp_path / "installed.marker"),
         "AGAMI_ARTIFACTS_DIR": str(tmp_path / "art"),
     }
     r = subprocess.run(["bash", str(sm_path), "install"], env=env, capture_output=True, text=True)
@@ -57,7 +65,7 @@ def _run_install(sm_path: Path, tmp_path: Path):
 
 
 def test_marketplace_layout_installs_from_git_not_devpath(tmp_path):
-    cache = tmp_path / "agami-core" / "0.3.1"  # the cache dir name is the version
+    cache = tmp_path / "agami-core" / PLUGIN_VERSION  # the cache dir name is the version
     shutil.copytree(SCRIPTS, cache / "scripts")
     shutil.copytree(LIB, cache / "lib")  # NO packages/ sibling
     r, installs = _run_install(cache / "scripts" / "sm", tmp_path)
@@ -71,7 +79,7 @@ def test_marketplace_layout_installs_from_git_not_devpath(tmp_path):
     idx = next(i for i, ln in enumerate(installs) if "agami-core[model]" in ln and "git+" not in ln)
     git = next(i for i, ln in enumerate(installs) if "git+" in ln)
     assert idx < git, installs
-    assert "git+https://github.com/AgamiAI/agami-core@v0.3.1#subdirectory=packages/agami-core" in "\n".join(installs)
+    assert f"git+https://github.com/AgamiAI/agami-core@v{PLUGIN_VERSION}#subdirectory=packages/agami-core" in "\n".join(installs)
 
 
 def test_dev_checkout_uses_editable(tmp_path):

--- a/tests/test_sm_install_resolution.py
+++ b/tests/test_sm_install_resolution.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary
**P1, companion to OCR-030.** OCR-030 made the *query* path work in a marketplace install (bundled `lib/`). But *model-building* (`/agami-connect`'s core job) needs the full `semantic_model` engine + heavy deps, and both install paths pointed at `packages/agami-core` — a dir that only exists in a **dev checkout**, not the marketplace cache. So `sm` crashed at its `PKG_DIR` line and `pip install -e` failed (`not a valid editable requirement`), and a real run-through degraded to the prebuilt sample. This installs the **published** package instead — works today via git, auto-upgrades to PyPI when OCR-032 lands.

## Changes
- **`plugins/agami/scripts/sm`** — the single install chokepoint, now marketplace-safe:
  - `packages/agami-core` is **optional** (`DEV_PKG_DIR`, only if `pyproject.toml` is present) — no more crash under `set -euo pipefail`.
  - `ensure_pkg()` tries in order: **dev editable** → **index** `agami-core[model]` → **git @v<ver>** (pinned to the cache version) → **git @main**; first success wins, clear error otherwise.
  - new **`sm install`** subcommand (ensures the package, no CLI) for the skill to call before a model exists.
- **`agami-connect/SKILL.md`** — the two install steps now run `bash "$AGAMI_PLUGIN_ROOT/scripts/sm" install` instead of the hardcoded dev-path `pip install -e`.
- **`tests/test_sm_install_resolution.py`** — a fake-`$PY` shim proves: marketplace layout installs from **git, never the dev-path** (and doesn't crash); dev layout uses `-e`; index is tried before git; the skill delegates to `sm install`.
- **`packages/agami-core/pyproject.toml`** — version `0.3.0 → 0.3.1` (align with the plugin release).

## Verification
- New regression: 3/3 pass; the shim genuinely exercises the git fallback (verified it fails if `sm` regresses to `-e packages/`).
- Full suite **1020** green; ruff clean; `sm` syntax-checked.
- Adversarial review (bash `set -e` fallback chain, arg boundaries, version derivation, git-URL validity, test non-vacuity): **0 must-fix**.

## Follow-up
The **index** requirement lights up automatically once **OCR-032** publishes `agami-core` to PyPI (trusted publishing) — no re-work here. Interim, the git install (public repo, no auth) unblocks marketplace model-building now.

Spec: OCR-031