### PR TITLE
OCR-032: publish agami-core to PyPI on release (trusted publishing)

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,53 @@
+name: Release PyPI
+
+# Builds the agami-core sdist + wheel from packages/agami-core and publishes them to PyPI via
+# TRUSTED PUBLISHING (OIDC) -- so a marketplace `/agami-connect` can `pip install "agami-core[model]"`
+# from the index instead of the git fallback. OCR-031's `sm` installer already tries the index before
+# git, so the moment a version lands on PyPI every marketplace install upgrades with no code change.
+# The version published is packages/agami-core/pyproject.toml `version` (a release tag must match it).
+#
+# Manual prerequisite (ONE-TIME, no secret to manage): register the `agami-core` project on PyPI and add
+# a GitHub Actions "trusted publisher" -- owner AgamiAI, repo agami-core, workflow release-pypi.yml,
+# environment (none). Add the same trusted publisher on TestPyPI to enable the workflow_dispatch smoke
+# test below. Trusted publishing uses the OIDC `id-token` minted per-run (see permissions) -- there is
+# NO PyPI API token stored in the repo.
+
+on:
+  release:
+    types: [published]
+  # Manual smoke-test: publishes to TestPyPI (not the real index) so the pipeline can be proven before
+  # the first real release. Requires the TestPyPI trusted publisher from the prerequisite above.
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: build + publish (sdist + wheel -> PyPI)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # checkout
+      id-token: write    # OIDC token for trusted publishing -- this is what replaces an API token
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      # Build both artifacts from the package subdir into repo-root dist/ (the pypa action's default
+      # packages-dir), using the PEP 517 frontend.
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build --sdist --wheel --outdir dist packages/agami-core
+
+      # Two gated publish steps (mirrors release-image.yml's release-vs-dispatch split): a dispatch run
+      # goes to TestPyPI to prove the pipeline; a real release goes to the default index (PyPI).
+      - name: Publish to TestPyPI (smoke test)
+        if: github.event_name == 'workflow_dispatch'
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -33,6 +33,20 @@ jobs:
         with:
           python-version: "3.12"
 
+      # `python -m build` publishes whatever pyproject says, regardless of the release tag -- so a
+      # mistagged release (tag v0.3.2 while pyproject is still 0.3.1) would permanently mislabel a PyPI
+      # version. Fail fast on a mismatch. (Release-only: a workflow_dispatch has no version tag.)
+      - name: Verify release tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(python -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("packages/agami-core/pyproject.toml").read_text())["project"]["version"])')"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::release tag '$GITHUB_REF_NAME' (-> '$tag') != pyproject version '$pkg'"
+            exit 1
+          fi
+          echo "release tag matches package version: $pkg"
+
       # Build both artifacts from the package subdir into repo-root dist/ (the pypa action's default
       # packages-dir), using the PEP 517 frontend.
       - name: Build sdist + wheel

--- a/tests/test_release_pypi_workflow.py
+++ b/tests/test_release_pypi_workflow.py
@@ -56,6 +56,19 @@ def test_builds_from_agami_core_package():
     assert "packages/agami-core" in build["run"], build["run"]
 
 
+def test_release_guards_tag_matches_version():
+    # A release run must fail fast if the tag and pyproject version disagree (else PyPI records a
+    # mislabeled version permanently). The guard is the release-only `run` step.
+    wf, _ = _load()
+    steps = wf["jobs"]["publish"]["steps"]
+    guard = next(
+        (s for s in steps if s.get("if") == "github.event_name == 'release'" and "run" in s), None
+    )
+    assert guard is not None, "no release-only tag/version guard step"
+    assert "pyproject.toml" in guard["run"], guard["run"]
+    assert "GITHUB_REF_NAME" in guard["run"], guard["run"]
+
+
 def test_release_goes_to_pypi_dispatch_to_testpypi():
     wf, _ = _load()
     steps = wf["jobs"]["publish"]["steps"]

--- a/tests/test_release_pypi_workflow.py
+++ b/tests/test_release_pypi_workflow.py
@@ -1,0 +1,71 @@
+"""OCR-032 guard: the PyPI release workflow publishes via TRUSTED PUBLISHING and carries NO API token.
+
+The workflow itself (`.github/workflows/release-pypi.yml`) isn't ruff/pytest-covered — it only runs on a
+GitHub release — so this test locks the invariants OCR-032 promises: OIDC `id-token: write` (not a stored
+PyPI token), the `pypa/gh-action-pypi-publish` action, a build from `packages/agami-core`, and the
+release-vs-dispatch (PyPI vs TestPyPI) split. A change that reintroduces an API-token publish path or
+points the build elsewhere fails here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "release-pypi.yml"
+
+
+def _load():
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    # YAML 1.1 parses the bare key `on:` as the boolean True (the "Norway problem"), so the trigger block
+    # lives under wf[True], not wf["on"].
+    triggers = wf.get("on", wf.get(True))
+    return wf, triggers
+
+
+def test_triggers_are_release_and_dispatch():
+    _, triggers = _load()
+    assert "release" in triggers, triggers
+    assert "workflow_dispatch" in triggers, triggers
+    assert triggers["release"]["types"] == ["published"], triggers
+
+
+def test_trusted_publishing_no_api_token():
+    wf, _ = _load()
+    job = wf["jobs"]["publish"]
+    # OIDC token minted per-run is what replaces a stored PyPI API token.
+    assert job["permissions"].get("id-token") == "write", job["permissions"]
+    assert job["permissions"].get("contents") == "read", job["permissions"]
+
+    raw = WORKFLOW.read_text()
+    # No API-token publish path: the pypa action must never be handed a password, and no secret is
+    # referenced anywhere in the workflow (trusted publishing needs none).
+    assert "password:" not in raw, "publish must not use a password/API token"
+    assert "secrets." not in raw, "no repo secret should be referenced (trusted publishing is tokenless)"
+
+    publish_steps = [s for s in job["steps"] if "gh-action-pypi-publish" in str(s.get("uses", ""))]
+    assert publish_steps, "no pypa/gh-action-pypi-publish step found"
+
+
+def test_builds_from_agami_core_package():
+    wf, _ = _load()
+    steps = wf["jobs"]["publish"]["steps"]
+    build = next((s for s in steps if "python -m build" in str(s.get("run", ""))), None)
+    assert build is not None, "no `python -m build` step"
+    assert "packages/agami-core" in build["run"], build["run"]
+
+
+def test_release_goes_to_pypi_dispatch_to_testpypi():
+    wf, _ = _load()
+    steps = wf["jobs"]["publish"]["steps"]
+    publish = [s for s in steps if "gh-action-pypi-publish" in str(s.get("uses", ""))]
+
+    dispatch = [s for s in publish if s.get("if") == "github.event_name == 'workflow_dispatch'"]
+    release = [s for s in publish if s.get("if") == "github.event_name == 'release'"]
+    assert len(dispatch) == 1, "expected one workflow_dispatch (TestPyPI) publish step"
+    assert len(release) == 1, "expected one release (PyPI) publish step"
+
+    # Dispatch → TestPyPI; release → default index (no repository-url override = real PyPI).
+    assert "test.pypi.org" in str(dispatch[0].get("with", {}).get("repository-url", "")), dispatch[0]
+    assert "repository-url" not in (release[0].get("with") or {}), release[0]


### PR DESCRIPTION
## Summary

Publishes `agami-core` to PyPI on release via **trusted publishing** (OIDC), so a marketplace `/agami-connect` can `pip install "agami-core[model]"` from the index instead of the git fallback. OCR-031's `sm` installer already tries the index before git, so the moment a version lands on PyPI every marketplace install upgrades **with no code change**. This is the packaging companion to the shipped ACE-025 (which publishes the server *image* to GHCR) — same trigger shape, same `workflow_dispatch` smoke-test, same "no long-lived secret" posture, for the Python *package*.

## Changes

- **`.github/workflows/release-pypi.yml`** (new) — builds the sdist + wheel from `packages/agami-core` (`python -m build`) and publishes via `pypa/gh-action-pypi-publish`. `permissions: id-token: write` mints the OIDC token per-run — **no PyPI API token is stored in the repo**. A published `release` publishes to PyPI; `workflow_dispatch` publishes to **TestPyPI** so the pipeline can be smoke-tested first. All actions SHA-pinned.
- **`tests/test_release_pypi_workflow.py`** (new) — locks the invariants CI can't otherwise see: `id-token: write` at job scope, **no `password:`/`secrets.*`** on the publish path, the build sources `packages/agami-core`, and the release→PyPI / dispatch→TestPyPI split.

## One-time manual prerequisite (👤, before the first real publish)

Register the `agami-core` project on PyPI + add a GitHub Actions **trusted publisher** (owner `AgamiAI`, repo `agami-core`, workflow `release-pypi.yml`), and the same on **TestPyPI** to enable the `workflow_dispatch` smoke test. Like ACE-025's "make the GHCR package public" — the workflow is built + TestPyPI-smoke-testable now; the real publish waits on it. There is no secret to manage (OIDC).

## Checklist

- [x] `Spec: OCR-032`
- [x] Full gate green locally — 1024 tests pass, ruff lint + format clean, gitleaks clean
- [x] New behavior ships with a test (`test_release_pypi_workflow.py`, 4 assertions)
- [x] No secrets / no customer data; trusted publishing is tokenless
- [ ] 👤 PyPI + TestPyPI trusted-publisher registration (owner, before first publish)

Spec: OCR-032
