### PR TITLE
Release v0.3.2: bump package + plugin to 0.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.1"
+version = "0.3.2"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary

Version bump to **0.3.2** across the package and the plugin, so the first real PyPI publish of `agami-core` rides a clean, honest version.

**Why not just publish 0.3.1:** the `v0.3.1` git tag points at `94f8933` (0.3.0-era code) — the `0.3.1` bump landed in #64 (`205ce79`), *after* the tag was cut. Cutting `v0.3.2` at current `main` avoids rewriting a public tag and publishes the current OCR-030/031/032 code as `0.3.2`.

## Changes

- `packages/agami-core/pyproject.toml` — `0.3.1` → `0.3.2`
- `.claude-plugin/marketplace.json` — metadata + plugin entry `0.3.1` → `0.3.2`
- `plugins/agami/.claude-plugin/plugin.json` — `0.3.1` → `0.3.2`

## Follow-up (not in this PR)

After merge: tag `v0.3.2` at the merge commit + publish the GitHub Release → fires `release-pypi.yml` (publishes `0.3.2` to PyPI via trusted publishing) and `release-image.yml` (GHCR). The pipeline is already TestPyPI-proven.

## Checklist

- [x] Full gate green locally — 1025 tests, ruff lint + format, gitleaks
- [x] No code changes — version metadata only
- [x] No secrets / no customer data
