### PR TITLE
Release v0.3.3: bump package + plugin to 0.3.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.2"
+version = "0.3.3"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary

Version bump to **0.3.3** across the package + plugin, so the marketplace serves the 0.3.2 run-through fixes and PyPI/GHCR publish the new version.

## Changes

- `packages/agami-core/pyproject.toml`, `.claude-plugin/marketplace.json` (metadata + plugin entry), `plugins/agami/.claude-plugin/plugin.json` — `0.3.2` → `0.3.3`.

## What 0.3.3 ships

- **OCR-033 (#67)** — `sm` hardened as the single install chokepoint (`.cli` readiness + cwd path isolation + PEP-668 tier); `promote_credentials.py` + `setup_desktop_mcp.py` migrated to `_agami_lib` + `sm install`. Fixes the 3 🔴 marketplace-install blockers.
- **OCR-034 (#68)** — sample 6B codifies its carve-outs + opens the model-explorer; preflight stops inventing a `main` profile on first-run; agami-query guardrail against hand-rolled model dumps.

## Follow-up (after merge)

Tag `v0.3.3` at the merge commit + publish the release → fires `release-pypi.yml` (PyPI) and `release-image.yml` (GHCR). Then re-run the 0.3.3 marketplace run-through to confirm all 8 issues resolved end-to-end.

## Checklist

- [x] Full gate green (1040 tests, ruff, gitleaks)
- [x] Version-only bump — no code/logic change
- [x] No secrets / no customer data
