### PR TITLE
Docs: refresh + slim for 0.3.3 (versions, PyPI install, leaner README, CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.3.3] — 2026-07-02
+
+### Fixed
+
+- **Marketplace-install reliability.** Credential promotion and the Claude Desktop
+  setup (`/agami-serve`) no longer fail on a fresh marketplace install — they resolve
+  the bundled library the same way every other script does, and install the model
+  engine through the single `sm install` path.
+- **Externally-managed Python + package shadowing.** The installer now works on an
+  externally-managed interpreter (Homebrew / PEP 668) and can no longer be shadowed by
+  a partially-installed package (the model CLI is verified from a neutral path).
+
+### Changed
+
+- **Sample "watch it build" opens the model explorer** when the build completes, and
+  skips the prompts that don't apply to the curated sample (no table-prune / org /
+  data-dictionary questions).
+- **First-time setup no longer shows a placeholder profile name** — it reads as
+  "first-time setup" until you name your profile.
+
+## [0.3.2] — 2026-07-01
+
+### Added
+
+- **Published to PyPI.** `pip install "agami-core[model]"` (and `[server]`) installs
+  the library from the index, and the plugin's model-build step uses it automatically.
+  Published via GitHub trusted publishing (no stored token). The self-host server image
+  is published to GHCR (`ghcr.io/agamiai/agami-core`) so a deploy pulls it — no clone,
+  no build.
+
+## [0.3.1] — 2026-07-01
+
+### Fixed
+
+- **Marketplace installs can query and build models with no dev checkout.** Bundled the
+  stdlib query library into the plugin, so a marketplace install answers questions with
+  no `pip install`; and the model-build step installs the engine from a source that
+  exists in a marketplace layout (the published package, else git) instead of a
+  dev-only path.
+
 ## [0.3.0] — 2026-06-24
 
 ### Added
@@ -75,5 +115,8 @@ First version tracked in this changelog. Earlier history lives in the git log.
   other clients — stdio, no auth, no network.
 - Fan-trap / chasm-trap pre-flight that refuses to silently double-count.
 
+[0.3.3]: https://github.com/AgamiAI/agami-core/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/AgamiAI/agami-core/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/AgamiAI/agami-core/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/AgamiAI/agami-core/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/AgamiAI/agami-core/releases/tag/v0.2.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,9 +107,9 @@ Use semver:
 |---|---|
 | Bug fix, doc-only change, internal refactor with no user-visible behavior shift | **patch** (1.1.0 → 1.1.1) |
 | New feature, new skill, new database type, new optional flag — anything additive | **minor** (1.1.0 → 1.2.0) |
-| Skill rename, file-layout change, removed flag, default behavior change, anything that breaks an existing install | **minor pre-launch, MAJOR after** (1.1.0 → 1.2.0 pre-launch; 1.1.0 → 2.0.0 post-launch) |
+| Skill rename, file-layout change, removed flag, default behavior change, anything that breaks an existing install | **major** (1.1.0 → 2.0.0) |
 
-Pre-launch (before public availability), even breaking changes are minor bumps — the implicit promise is that you've told all your alpha users they need to reinstall. Post-launch, semver-strict: a major bump is the contract that says "this will break your config".
+Semver is the contract: a **major** bump is the signal that says "this will break your config — you'll need to reinstall / re-migrate". Don't fold a breaking change into a minor bump.
 
 **The most common mistake** is renaming a skill (e.g., `init` → `agami-init`) or changing a file path (e.g., `<artifacts_dir>/local/<profile>/` → `<artifacts_dir>/<profile>/`) without bumping. Users installed at the old version see neither rename. Always bump on those changes.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-fair--code-blue.svg" alt="License: fair-code"></a>
-  <img src="https://img.shields.io/badge/version-0.3.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.3.3-blue" alt="Version">
   <img src="https://img.shields.io/badge/status-pre--public-orange" alt="Status">
   <a href="#quickstart-under-5-minutes"><img src="https://img.shields.io/badge/try%20the%20sample-no%20database%20needed-brightgreen" alt="Try the sample"></a>
 </p>
@@ -109,7 +109,7 @@ The same plugin works across Claude Code CLI, VS Code, and Cursor.
 /plugin marketplace add AgamiAI/agami-core
 /plugin install agami-core@agami
 ```
-Verify with `/plugin list` → you should see `agami-core@agami v0.3.0`.
+Verify with `/plugin list` → you should see `agami-core@agami v0.3.3`.
 
 **VS Code / Cursor** — install the **Claude Code** extension, type `/plugin` in the
 chat to open **Manage Plugins**, add the `AgamiAI/agami-core` marketplace, then install
@@ -175,40 +175,15 @@ cloud (a multi-tenant model registry over a remote MCP endpoint, shared governed
 always-on evals). The boundary, stated plainly:
 [docs/open-vs-hosted.md](docs/open-vs-hosted.md).
 
-## Self-hosting the HTTP server (any cloud)
+## Self-hosting the team server
 
-The HTTP MCP server (the `[server]` extra) is **cloud-neutral** — a VM + Postgres, or a stateless
-platform (Cloud Run / Container Apps) + managed Postgres. No GCP service is required to boot: no
-Cloud SQL connector, no Secret Manager, no Cloud Logging (a regression test enforces this). Config
-is entirely environment variables:
-
-| Variable | Required | Purpose |
-|----------|----------|---------|
-| `AGAMI_DB_URL` | yes (server) | The store: `postgresql://…` in prod, `sqlite://…` for a small/local run. `APP_DATABASE_URL` is accepted as an alias for the cloud-platform convention (`AGAMI_DB_URL` wins if both are set). Unset ⇒ the local file path. |
-| `PUBLIC_BASE_URL` | yes (server) | Backs OAuth/MCP discovery + the `WWW-Authenticate` resource URL. Set it explicitly — it can't be auto-detected behind a proxy/LB; the server fails fast at startup if it's missing. |
-| `AGAMI_ORG_ID` | no | The single configured org id (default `local`). The server is single-tenant by default. |
-| `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its own session JWTs with. When set, the server validates real tokens (the password / OIDC login flow); unset ⇒ the bearer-presence local default. |
-
-All serving state lives in Postgres — a fresh instance with only `AGAMI_DB_URL` serves identically,
-so the server survives restarts and stateless platforms. The serving path is **LLM-free and
-zero-egress by default**: the client is the brain, `execute_sql` runs SQL against your own database,
-and the other tools just read the model. Nothing leaves your environment.
-
-### Optional: social login (OIDC)
-
-"Sign in with Google / Microsoft" is **off by default**. Configure a provider's client id/secret to
-enable it (the option is hidden when unset; username/password still works):
-
-| Variable | Provider | Notes |
-|----------|----------|-------|
-| `AGAMI_OIDC_GOOGLE_CLIENT_ID` / `_SECRET` | Google | requires `email_verified` |
-| `AGAMI_OIDC_MICROSOFT_CLIENT_ID` / `_SECRET` | Microsoft | also set `AGAMI_OIDC_MICROSOFT_TENANT` to a **pinned** tenant id (not `common`/`organizations`) — the tenant is the trust boundary |
-| `AGAMI_PUBLIC_SIGNUP` | — | default off. When on, an unknown verified email self-provisions a **demo** account — intended only for a dedicated "Try for free" instance whose data is non-sensitive. Leave off for any real deployment (it's onboarded-only: an admin must add the user first). |
-
-**Egress note:** OIDC is the one feature where the **hosted** server reaches out — it calls the
-identity provider to verify a login. Everything else stays local. If you want a strictly no-egress
-deployment, leave OIDC unconfigured (or run the local `agami serve`); the skill and the query path
-never make a network call regardless.
+Beyond the local single-player setup, agami ships an **HTTP MCP server** so a team can point their
+Claude at one shared, governed model. It's cloud-neutral (a VM + Postgres, or a stateless platform
+like Cloud Run + managed Postgres), configured entirely by environment variables, and **LLM-free +
+zero-egress by default**. The full setup — the `pip install "agami-core[server]"` install, the
+env-var contract, and optional Google / Microsoft (OIDC) login — is in
+**[docs/self-hosting.md](docs/self-hosting.md)**. For a one-command deploy bundle, use the
+`/agami-deploy` skill.
 
 ## Documentation
 
@@ -217,6 +192,7 @@ never make a network call regardless.
 - [The trust layer](docs/trust-layer.md) — confidence, sign-off, receipts, snapshots
 - [Format spec](docs/format-spec.md) — the semantic-model layout + a worked example
 - [MCP server](docs/mcp-server.md) — use agami from Claude Desktop
+- [Self-hosting the team server](docs/self-hosting.md) — the HTTP server, env-var contract, OIDC
 - [Troubleshooting & uninstall](docs/troubleshooting.md)
 - [Fair-code vs hosted](docs/open-vs-hosted.md) · [Privacy](docs/privacy.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ When reporting, include where possible:
 
 ## Supported Versions
 
-agami-core is in early development. We only support the **latest released version**; older releases will not receive security backports.
+We support the **latest released version**; older releases will not receive security backports.
 
 ## Scope
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -35,7 +35,7 @@ agami's state splits across two directories. See [plugins/agami/shared/file-layo
 
 `USER_MEMORY.md` is **distinct** from Claude Code's auto-memory at `~/.claude/projects/<workspace>/memory/MEMORY.md`. The auto-memory is host-managed and project-scoped; `USER_MEMORY.md` is agami-managed, lives in the artifacts dir, and persists across Claude Code hosts (CLI / VS Code extension / Cursor extension) the same way the rest of `<artifacts_dir>/` does.
 
-`USER_MEMORY.md` covers **user preferences that apply across every database** (default time windows, display preferences, exclude rules). The per-database `**ORGANIZATION.md`** at `<artifacts_dir>/<profile>/ORGANIZATION.md` covers **domain knowledge for that specific database** (terminology, key metrics, what the data represents). See [plugins/agami/shared/organization-context-format.md](../plugins/agami/shared/organization-context-format.md).
+`USER_MEMORY.md` covers **user preferences that apply across every database** (default time windows, display preferences, exclude rules). The per-database **`ORGANIZATION.md`** at `<artifacts_dir>/<profile>/ORGANIZATION.md` covers **domain knowledge for that specific database** (terminology, key metrics, what the data represents). See [plugins/agami/shared/organization-context-format.md](../plugins/agami/shared/organization-context-format.md).
 
 `<profile>` matches the section name in `<artifacts_dir>/local/credentials` (default: `default`). One *directory* per profile under `<artifacts_dir>/`. The `agami-connect` skill auto-migrates v1.0 (single-file) and v1.1 (under `<artifacts_dir>/local/`) installs on first run after upgrade.
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -1,6 +1,6 @@
 # Format specs
 
-agami's state splits across two directories. See `[plugins/agami/shared/file-layout.md](../plugins/agami/shared/file-layout.md)` for the full design rationale; this page is the per-file format reference.
+agami's state splits across two directories. See [plugins/agami/shared/file-layout.md](../plugins/agami/shared/file-layout.md) for the full design rationale; this page is the per-file format reference.
 
 ## `<artifacts_dir>/local/` — secrets + per-user state — **NEVER commit**
 
@@ -35,13 +35,13 @@ agami's state splits across two directories. See `[plugins/agami/shared/file-lay
 
 `USER_MEMORY.md` is **distinct** from Claude Code's auto-memory at `~/.claude/projects/<workspace>/memory/MEMORY.md`. The auto-memory is host-managed and project-scoped; `USER_MEMORY.md` is agami-managed, lives in the artifacts dir, and persists across Claude Code hosts (CLI / VS Code extension / Cursor extension) the same way the rest of `<artifacts_dir>/` does.
 
-`USER_MEMORY.md` covers **user preferences that apply across every database** (default time windows, display preferences, exclude rules). The per-database `**ORGANIZATION.md`** at `<artifacts_dir>/<profile>/ORGANIZATION.md` covers **domain knowledge for that specific database** (terminology, key metrics, what the data represents). See `[plugins/agami/shared/organization-context-format.md](../plugins/agami/shared/organization-context-format.md)`.
+`USER_MEMORY.md` covers **user preferences that apply across every database** (default time windows, display preferences, exclude rules). The per-database `**ORGANIZATION.md`** at `<artifacts_dir>/<profile>/ORGANIZATION.md` covers **domain knowledge for that specific database** (terminology, key metrics, what the data represents). See [plugins/agami/shared/organization-context-format.md](../plugins/agami/shared/organization-context-format.md).
 
 `<profile>` matches the section name in `<artifacts_dir>/local/credentials` (default: `default`). One *directory* per profile under `<artifacts_dir>/`. The `agami-connect` skill auto-migrates v1.0 (single-file) and v1.1 (under `<artifacts_dir>/local/`) installs on first run after upgrade.
 
 ## Why the split
 
-Three concrete wins (full design in `[shared/file-layout.md](../plugins/agami/shared/file-layout.md)`):
+Three concrete wins (full design in [shared/file-layout.md](../plugins/agami/shared/file-layout.md)):
 
 1. **Zero credential-leak risk on commit.** `<artifacts_dir>/local/` is gitignored by default; `<artifacts_dir>/` is the only place anything goes when teams share.
 2. **Team workflows just work.** `cd ~/code/myteam/data && git add agami/` commits everyone's tuned semantic model, examples, ORGANIZATION.md, and USER_MEMORY.md preferences.
@@ -51,7 +51,7 @@ Three concrete wins (full design in `[shared/file-layout.md](../plugins/agami/sh
 
 ## 1. Credentials INI
 
-See `[plugins/agami/shared/credentials-format.md](../plugins/agami/shared/credentials-format.md)`. `chmod 600` is enforced by `agami-connect` Phase 0a.
+See [plugins/agami/shared/credentials-format.md](../plugins/agami/shared/credentials-format.md). `chmod 600` is enforced by `agami-connect` Phase 0a.
 
 ```ini
 [default]
@@ -213,7 +213,7 @@ examples:
 
 Seeded by `agami-connect` Phase 0a on first run with section hints (HTML comments). User edits by hand, OR the `agami-save-correction` skill appends a bullet when it classifies a correction as `user_preference` ("from now on, always exclude test users where email matches @example.com").
 
-Full spec: `[plugins/agami/shared/user-memory-format.md](../plugins/agami/shared/user-memory-format.md)`.
+Full spec: [plugins/agami/shared/user-memory-format.md](../plugins/agami/shared/user-memory-format.md).
 
 ## 5. Internal state files
 
@@ -283,7 +283,7 @@ Fields per line:
 
 ## 6. Chart artifacts (`<artifacts_dir>/local/charts/<ts>.html`)
 
-Self-contained Chart.js v4 HTML, rendered from `[plugins/agami/shared/chart-template.html](../plugins/agami/shared/chart-template.html)` with placeholders substituted (`{{TITLE}}`, `{{CHART_TYPE}}`, `{{LABELS}}`, `{{DATASETS}}`, `{{GENERATED_AT}}`, `{{SQL}}`). Open in any browser.
+Self-contained Chart.js v4 HTML, rendered from [plugins/agami/shared/chart-template.html](../plugins/agami/shared/chart-template.html) with placeholders substituted (`{{TITLE}}`, `{{CHART_TYPE}}`, `{{LABELS}}`, `{{DATASETS}}`, `{{GENERATED_AT}}`, `{{SQL}}`). Open in any browser.
 
 ## 7. CSV exports (`<artifacts_dir>/local/exports/<ts>.csv`)
 

--- a/docs/install/claude-code-cli.md
+++ b/docs/install/claude-code-cli.md
@@ -52,7 +52,7 @@ Added marketplace: agami (AgamiAI)
 Expected output:
 
 ```
-Installed agami-core v0.3.0 (from agami)
+Installed agami-core v0.3.3 (from agami)
 5 skills available: agami-connect, agami-query, agami-model, agami-save-correction, agami-reconcile
 ```
 
@@ -62,7 +62,7 @@ Installed agami-core v0.3.0 (from agami)
 /plugin list
 ```
 
-You should see `agami-core v0.3.0` in the active list.
+You should see `agami-core v0.3.3` in the active list.
 
 Try invoking it:
 

--- a/docs/install/claude-code-cli.md
+++ b/docs/install/claude-code-cli.md
@@ -53,7 +53,7 @@ Expected output:
 
 ```
 Installed agami-core v0.3.3 (from agami)
-5 skills available: agami-connect, agami-query, agami-model, agami-save-correction, agami-reconcile
+7 skills available: agami-connect, agami-query, agami-model, agami-save-correction, agami-reconcile, agami-serve, agami-deploy
 ```
 
 ## 5. Verify

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -41,7 +41,8 @@ the schema + examples these tools return) — exactly as with the hosted connect
   (it provides `mcp_harness` + `execute_sql`):
 
   ```bash
-  pip install -e "packages/agami-core[model]"
+  pip install "agami-core[model]"                 # from PyPI
+  # or, from a checkout (dev):  pip install -e "packages/agami-core[model]"
   ```
 
 - A **Python driver** for your database, because the server executes via
@@ -120,7 +121,7 @@ If you'd rather edit by hand, mind these two gotchas — both silently produce
    `C:\Users\you\AppData\Local\Programs\Python\Python312\python.exe`.
 2. **Install agami-core into that Python and run it as a module.** The server is
    `python -m mcp_harness`, which needs the agami-core package importable in the
-   interpreter from gotcha #1: `"/abs/python3" -m pip install -e "/path/to/agami-core/packages/agami-core[model]"`.
+   interpreter from gotcha #1: `"/abs/python3" -m pip install "agami-core[model]"` (from a checkout, `-e "/path/to/packages/agami-core[model]"`).
    This is what the helper automates — and why it survives the plugin cache dir moving
    on each update (the code is installed, not referenced by a moving path).
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -20,7 +20,11 @@ pip install "agami-core[server]"
 
 ## Run
 
+Both steps read `AGAMI_DB_URL` (the store) — set it in the environment or inline as shown:
+
 ```bash
+export AGAMI_DB_URL=postgresql://user:pass@host:5432/agami
+
 # 1. migrate the store + load the model into Postgres (idempotent, fail-closed)
 python -m model_deploy
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,59 @@
+# Self-hosting the team server
+
+Beyond the local single-player setup, agami ships an **HTTP MCP server** so a team can point their
+Claude at one shared, governed model. It's **cloud-neutral** — a VM + Postgres, or a stateless
+platform (Cloud Run / Container Apps) + managed Postgres. No GCP service is required to boot: no
+Cloud SQL connector, no Secret Manager, no Cloud Logging (a regression test enforces this).
+
+> **The easy path:** the **`/agami-deploy`** skill writes a ready-to-run bundle (docker-compose +
+> Caddy auto-TLS + a filled `.env`) that pulls the published image `ghcr.io/agamiai/agami-core` — no
+> clone, no build. See [deploy/README.md](../deploy/README.md). The manual steps below are for when
+> you'd rather wire it up yourself.
+
+## Install
+
+The server lives in the published `agami-core` package's `[server]` extra:
+
+```bash
+pip install "agami-core[server]"
+```
+
+## Run
+
+```bash
+# 1. migrate the store + load the model into Postgres (idempotent, fail-closed)
+python -m model_deploy
+
+# 2. serve (also re-migrates + seeds the admin on startup; both idempotent)
+PUBLIC_BASE_URL=https://your-host python -m mcp_http
+```
+
+All serving state lives in Postgres — a fresh instance with only `AGAMI_DB_URL` serves identically,
+so the server survives restarts and stateless platforms. The serving path is **LLM-free and
+zero-egress by default**: the client is the brain, `execute_sql` runs SQL against your own database,
+and the other tools just read the model. Nothing leaves your environment.
+
+## Configuration (environment variables)
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `AGAMI_DB_URL` | yes (server) | The store: `postgresql://…` in prod, `sqlite://…` for a small/local run. `APP_DATABASE_URL` is accepted as an alias for the cloud-platform convention (`AGAMI_DB_URL` wins if both are set). Unset ⇒ the local file path. |
+| `PUBLIC_BASE_URL` | yes (server) | Backs OAuth/MCP discovery + the `WWW-Authenticate` resource URL. Set it explicitly — it can't be auto-detected behind a proxy/LB; the server fails fast at startup if it's missing. |
+| `AGAMI_ORG_ID` | no | The single configured org id (default `local`). The server is single-tenant by default. |
+| `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its own session JWTs with. When set, the server validates real tokens (the password / OIDC login flow); unset ⇒ the bearer-presence local default. |
+
+## Optional: social login (OIDC)
+
+"Sign in with Google / Microsoft" is **off by default**. Configure a provider's client id/secret to
+enable it (the option is hidden when unset; username/password still works):
+
+| Variable | Provider | Notes |
+|----------|----------|-------|
+| `AGAMI_OIDC_GOOGLE_CLIENT_ID` / `_SECRET` | Google | requires `email_verified` |
+| `AGAMI_OIDC_MICROSOFT_CLIENT_ID` / `_SECRET` | Microsoft | also set `AGAMI_OIDC_MICROSOFT_TENANT` to a **pinned** tenant id (not `common`/`organizations`) — the tenant is the trust boundary |
+| `AGAMI_PUBLIC_SIGNUP` | — | default off. When on, an unknown verified email self-provisions a **demo** account — intended only for a dedicated "Try for free" instance whose data is non-sensitive. Leave off for any real deployment (it's onboarded-only: an admin must add the user first). |
+
+**Egress note:** OIDC is the one feature where the **hosted** server reaches out — it calls the
+identity provider to verify a login. Everything else stays local. If you want a strictly no-egress
+deployment, leave OIDC unconfigured (or run the local stdio server, `python -m mcp_harness`); the
+skill and the query path never make a network call regardless.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@
 | `psql: command not found` | `brew install postgresql` (or use DuckDB: `brew install duckdb`) |
 | `mysql: command not found` | `brew install mysql` (or DuckDB) |
 | `bq: command not found` | Install the [`gcloud` SDK](https://cloud.google.com/sdk/docs/install) and run `gcloud components install bq`. Or `pip install google-cloud-bigquery` for the Python path. |
-| `snowsql` flag-guessing failures | Snowflake CLI is fussy about flag ordering; use the explicit invocation table in `connection-reference.md`. |
+| `snowsql` flag-guessing failures | Snowflake CLI is fussy about flag ordering; use the explicit invocation table in [connection-reference.md](../plugins/agami/shared/connection-reference.md). |
 | `connection refused` on a remote DB | Check VPN / firewall, then connect with your native CLI (`psql -h ... -U ...` or `snowsql -a ... -u ...`) directly to confirm. |
 | "I don't have a model for `<profile>`" | Tell agami "introspect my schema" or run `/agami-connect`. The skill picks up `AGAMI_PROFILE` automatically. |
 | The generated SQL keeps using a column that doesn't exist | The model is stale. Run `/agami-connect reintrospect` — it preserves your hand-edits, refreshes from the DB, and surfaces any new entries in the review queue. See [When the database schema changes](usage.md#when-the-database-schema-changes-new-tables--new-columns--dropped-columns). |

--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -10,9 +10,12 @@ downstream that imports the same flat module names.
 ## Install
 
 ```bash
-pip install -e packages/agami-core            # executor + stdio harness (pure-stdlib)
-pip install -e 'packages/agami-core[model]'   # + the semantic model (pydantic / sqlglot / pyyaml)
+pip install agami-core            # executor + stdio harness (pure-stdlib)
+pip install 'agami-core[model]'   # + the semantic model (pydantic / sqlglot / pyyaml)
+pip install 'agami-core[server]'  # + the networked HTTP MCP server (see below)
 ```
+
+From a checkout, swap in the editable path — `pip install -e 'packages/agami-core[model]'`.
 
 ## Flat module names (an invariant)
 
@@ -36,7 +39,7 @@ python -m mcp_http             # the networked HTTP MCP server (see below)
 
 ## HTTP server — networked, with auth (`python -m mcp_http`)
 
-The `[server]` extra (`pip install -e 'packages/agami-core[server]'`) adds a networked MCP
+The `[server]` extra (`pip install 'agami-core[server]'`) adds a networked MCP
 transport: the same `TOOLS` surface as the stdio server, but over HTTP with OAuth + a small admin
 console. It's the self-host shape of the hosted product.
 

--- a/plugins/agami/shared/db_error_classifier.md
+++ b/plugins/agami/shared/db_error_classifier.md
@@ -1,41 +1,62 @@
 # Database error classifier
 
-Friendly error routing for database-layer failures. Owned by `agami-data:query-database` and `agami-data-admin:refresh-log-dashboards` / `refresh-admin-dashboards`; consumed wherever a SQL execution touches a live database.
+Friendly error routing for database-layer failures. Consumed wherever a SQL execution touches a live
+database — `agami-connect` (introspection), `agami-query` (the query path), and `agami-save-correction`
+(when an EXPLAIN of a corrected query fails).
 
-The contract: every raw exception from any of the connection methods (MCP / native CLI / Python driver / DuckDB) gets classified before it reaches the user. A solo OSS user staring at `psycopg2.errors.UndefinedColumn: column "x" does not exist` has no support channel to ask what to do; the classifier turns it into "Run `/agami-data-admin:update-semantic-model` to sync schema."
+The contract: every raw exception from any connection method (native CLI / Python driver / DuckDB) gets
+classified before it reaches the user. A solo user staring at `psycopg2.errors.UndefinedColumn: column
+"x" does not exist` has no support channel; the classifier turns it into one actionable line — e.g. "your
+model references a column that's no longer in the live DB; re-introspect with `/agami-connect`."
 
-This file is the single source of truth for the classification rules. `query-database` and the refresh skills both implement the same classifier; the refresh skills additionally use it to populate the `_repair` block on dashboard widget payloads so the dashboard SPA can render a "needs repair" card via `chart.js` (see [build-dashboard SKILL.md → Widget repair card](../skills/build-dashboard/SKILL.md)).
+This file is the single source of truth for the classification rules.
 
 ## Classification rules
 
-When SQL execution raises an exception, match the exception class and message against this table **in order**. First match wins. If no class matches, fall through to `kind: other` and surface the raw error.
+When SQL execution raises an exception, match the exception class and message against this table **in
+order**. First match wins. If no class matches, fall through to `kind: other` and surface the raw error.
+Credentials live in `<artifacts_dir>/local/credentials` (per-profile `[section]`s).
 
 | Class | Detection (any of) | Remediation |
 |---|---|---|
-| `auth` | psycopg2 `OperationalError` with "password authentication failed", "FATAL: password", "no pg_hba.conf entry"; mysql `Access denied`; snowflake `Incorrect username or password`; SF/HTTP 401; `KeyError` on a missing env var that resolves to a known credential field (`PASSWORD`, `PWD`, `USER`, `TOKEN`, `KEY`) | `"Edit <org_path>/local/.env (or <org_path>/.env) — your <db> credentials may have rotated, the password env var may be missing, or the user may not have permission to log in. Re-run after fixing."` |
-| `dsn` | "could not translate host name", "Name or service not known", "getaddrinfo ENOTFOUND", "Unknown MySQL server host"; mysql `Can't connect`; "no such file or directory" against a sqlite/duckdb path | `"Check <org_path>/local/.env: the <DB_HOST or path env var> doesn't resolve. Common causes: typo in hostname, VPN not connected, server moved. For local sqlite/duckdb, confirm the file path exists."` |
+| `auth` | psycopg2 `OperationalError` with "password authentication failed", "FATAL: password", "no pg_hba.conf entry"; mysql `Access denied`; snowflake `Incorrect username or password`; SF/HTTP 401; `KeyError` on a missing credential field (`PASSWORD`, `PWD`, `USER`, `TOKEN`, `KEY`) | `"Edit <artifacts_dir>/local/credentials — your <db> credentials may have rotated, a field may be missing, or the user may lack login permission. Re-run after fixing."` |
+| `dsn` | "could not translate host name", "Name or service not known", "getaddrinfo ENOTFOUND", "Unknown MySQL server host"; mysql `Can't connect`; "no such file or directory" against a sqlite/duckdb path | `"Check <artifacts_dir>/local/credentials: the host/path for this profile doesn't resolve. Common causes: typo in hostname, VPN not connected, server moved. For local sqlite/duckdb, confirm the file path exists."` |
 | `network` | "Connection refused", "timed out", "Connection reset by peer", `socket.timeout`, requests `ConnectTimeout` / `ReadTimeout`, snowflake `OperationalError` with "Could not connect", "SSL: WRONG_VERSION_NUMBER" | `"Network error reaching <db_host>. Common causes: VPN not connected, firewall blocking the port, server is down, SSL/TLS misconfiguration. Test with: nc -zv <host> <port> (or your usual reachability check)."` |
-| `driver_missing` | `ModuleNotFoundError` / `ImportError` for `psycopg2`, `pymysql`, `pyodbc`, `snowflake.connector`, `simple_salesforce`, `google.cloud.bigquery`, `redshift_connector`, `duckdb`; native-CLI shell error "command not found: <psql\|mysql\|bq\|snowsql\|sqlite3>" | `"Driver missing: pip install <driver_pkg>. Or install the CLI: brew install <cli_pkg>. The doctor (/agami-data:doctor) can tell you which datasources need which drivers."` |
-| `permission` | "permission denied for table", "permission denied for relation", "permission denied for schema", "INSUFFICIENT_PRIVILEGES" (Snowflake), MySQL `1142` `SELECT command denied to user`, BigQuery `Access Denied`, SF `INSUFFICIENT_ACCESS_OR_READONLY` | `"Your DB user can connect but cannot read <object>. Grant SELECT on <schema>.<table> (or the higher-level GRANT USAGE on the schema), then re-run."` |
-| `column_not_found` | psycopg2 `UndefinedColumn`; mysql `1054` `Unknown column`; snowflake `Invalid identifier`; BigQuery `Name <x> not found`; sqlite `no such column`; SF `INVALID_FIELD` | If the missing column **is** in the local semantic model YAML: `"Your semantic model references <col> but it's no longer in the live database. Schema may have drifted — run /agami-data-admin:update-semantic-model to sync."` Otherwise: `"Generated SQL referenced a column that doesn't exist. The model may have an outdated entry, or the SQL generator hallucinated. Re-run the query — it'll auto-retry with corrected SQL."` |
-| `table_not_found` | psycopg2 `UndefinedTable`; mysql `1146` `Table doesn't exist`; snowflake `Object <x> does not exist`; BigQuery `Table <x> not found`; sqlite `no such table` | If the missing table **is** in the local semantic model: `"Your semantic model references <table> but it's no longer in the live database. Schema may have drifted — run /agami-data-admin:update-semantic-model to sync."` Otherwise: `"Generated SQL referenced a table that doesn't exist in this datasource. Re-run the query."` |
-| `syntax` | psycopg2 `SyntaxError` (DB-side); mysql `1064` `You have an error in your SQL syntax`; snowflake `compilation error`; sqlite `near "X": syntax error` | `"SQL syntax error from the generator. Re-run the query — auto-retry usually fixes generator slips."` (Most syntax errors clear after one retry per the existing auto-retry-up-to-2 behaviour in query-database Phase 3.) |
-| `timeout` | psycopg2 `QueryCanceled`; mysql `2013 Lost connection during query`; snowflake `query was canceled`; explicit `statement_timeout` errors | `"Query timed out. Try adding a tighter filter, a LIMIT, or a date range — large unfiltered scans on production tables hit the DB's statement_timeout. The performance-hints risk-assessor (query-database Phase 3) is meant to catch this before execution; if it didn't, the table may need a recommended_filters entry in its semantic-model YAML."` |
-| `other` | anything else | `"<original error message>. If this keeps happening, /agami-data:doctor can sanity-check your environment, and the connection-reference.md docs cover deeper troubleshooting per datasource type."` |
+| `driver_missing` | `ModuleNotFoundError` / `ImportError` for `psycopg2`, `pymysql`, `pyodbc`, `snowflake.connector`, `google.cloud.bigquery`, `redshift_connector`, `duckdb`; native-CLI shell error "command not found: <psql\|mysql\|bq\|snowsql\|sqlite3>" | `"Driver missing: pip install <driver_pkg> (or install the CLI, e.g. brew install <cli_pkg>). See docs/credentials.md for the driver per dialect."` |
+| `permission` | "permission denied for table", "permission denied for relation", "permission denied for schema", "INSUFFICIENT_PRIVILEGES" (Snowflake), MySQL `1142` `SELECT command denied to user`, BigQuery `Access Denied`, SF `INSUFFICIENT_ACCESS_OR_READONLY` | `"Your DB user can connect but cannot read <object>. Grant SELECT on <schema>.<table> (or GRANT USAGE on the schema), then re-run."` |
+| `column_not_found` | psycopg2 `UndefinedColumn`; mysql `1054` `Unknown column`; snowflake `Invalid identifier`; BigQuery `Name <x> not found`; sqlite `no such column`; SF `INVALID_FIELD` | If the missing column **is** in the local semantic model YAML: `"Your model references <col> but it's no longer in the live database — schema drift. Re-introspect with /agami-connect to sync."` Otherwise: `"Generated SQL referenced a column that doesn't exist. Re-run the query — it'll auto-retry with corrected SQL."` |
+| `table_not_found` | psycopg2 `UndefinedTable`; mysql `1146` `Table doesn't exist`; snowflake `Object <x> does not exist`; BigQuery `Table <x> not found`; sqlite `no such table` | If the missing table **is** in the local semantic model: `"Your model references <table> but it's no longer in the live database — schema drift. Re-introspect with /agami-connect to sync."` Otherwise: `"Generated SQL referenced a table that doesn't exist in this datasource. Re-run the query."` |
+| `syntax` | psycopg2 `SyntaxError` (DB-side); mysql `1064` `You have an error in your SQL syntax`; snowflake `compilation error`; sqlite `near "X": syntax error` | `"SQL syntax error from the generator. Re-run the query — auto-retry usually fixes generator slips."` |
+| `timeout` | psycopg2 `QueryCanceled`; mysql `2013 Lost connection during query`; snowflake `query was canceled`; explicit `statement_timeout` errors | `"Query timed out. Add a tighter filter, a LIMIT, or a date range — large unfiltered scans hit the DB's statement_timeout. If a big table keeps timing out, give it a recommended_filters entry in its semantic-model YAML."` |
+| `other` | anything else | `"<original error message>. For deeper per-datasource troubleshooting see the connection reference (plugins/agami/shared/connection-reference.md) and docs/troubleshooting.md."` |
 
 ## Drift-aware column / table classification
 
-The `column_not_found` and `table_not_found` cases need a follow-up step before remediation: **does the missing object exist in the local semantic model?**
+The `column_not_found` and `table_not_found` cases need a follow-up step before remediation: **does the
+missing object exist in the local semantic model?**
 
 For column errors:
-1. **Extract the qualified name when available.** Most drivers emit a qualified form somewhere in the error: psycopg2's `UndefinedColumn` includes "of relation `<schema>.<table>`" in its `diag` block; Snowflake's `Invalid identifier '<schema>.<table>.<column>'` is fully qualified; BigQuery's `Name <project>.<dataset>.<table>.<column> not found` is fully qualified. Parse the most-qualified form available (preferring `<schema>.<table>.<column>` > `<table>.<column>` > `<column>`).
+1. **Extract the qualified name when available.** Most drivers emit a qualified form somewhere in the
+   error: psycopg2's `UndefinedColumn` includes "of relation `<schema>.<table>`" in its `diag` block;
+   Snowflake's `Invalid identifier '<schema>.<table>.<column>'` is fully qualified; BigQuery's `Name
+   <project>.<dataset>.<table>.<column> not found` is fully qualified. Parse the most-qualified form
+   available (preferring `<schema>.<table>.<column>` > `<table>.<column>` > `<column>`).
 2. **Match strategy by qualification level:**
-   - **Fully qualified** (`<schema>.<table>.<column>`): exact match against the loaded semantic model. If the schema-qualified table exists locally and contains the column, emit `drift_match: true` with `drift_candidates: [{schema, table, column}]`. If the table exists but lacks the column, that's the textbook drift signal — same `drift_match: true`. If the table doesn't exist locally, emit `drift_match: false`.
-   - **Table-qualified** (`<table>.<column>`, no schema): find every loaded table whose unqualified name matches; check each for the column. If exactly one match, emit `drift_match: true` with that single candidate. If multiple match (rare — same table name across schemas), emit `drift_match: true` with `drift_candidates: [...]` listing all matches; the remediation message asks the user which schema's table drifted.
-   - **Bare column name** (no driver-supplied qualification): scan all loaded tables for any whose `columns:` block contains a key matching the bare name. If exactly one, emit `drift_match: true` with that candidate. If multiple, emit `drift_match: true` with a `drift_candidates: [...]` list — the remediation text should then list the candidate tables and prompt the user, since `update-semantic-model` will sync all of them anyway but the user's mental model needs the disambiguation.
-3. **Regex parse miss** (the message format is unrecognized — e.g. a Postgres / MySQL fork like CockroachDB or AlloyDB worded the error differently): emit `kind: other` with `classifier_unmatched: true` rather than silently routing to a generic `column_not_found` "auto-retry will fix" remediation. Auto-retry won't fix drift, and a Cockroach-flavoured wording for "column does not exist" should not silently degrade. The Training dashboard's failure-by-kind widget surfaces `classifier_unmatched: true` rows so unmatched message formats become a backlog of new patterns to add to the rules above.
+   - **Fully qualified** (`<schema>.<table>.<column>`): exact match against the loaded model. If the
+     schema-qualified table exists locally and contains the column, `drift_match: true`. If the table
+     exists but lacks the column, that's the textbook drift signal — same `drift_match: true`. If the
+     table doesn't exist locally, `drift_match: false`.
+   - **Table-qualified** (`<table>.<column>`, no schema): find every loaded table whose unqualified name
+     matches; check each for the column. One match → `drift_match: true` with that candidate. Multiple →
+     `drift_match: true` with `drift_candidates: [...]`; the remediation asks which schema's table drifted.
+   - **Bare column name**: scan all loaded tables for a `columns:` key matching the bare name. One match →
+     that candidate; multiple → `drift_candidates: [...]` and prompt the user.
+3. **Regex parse miss** (an unrecognized wording — e.g. a Postgres/MySQL fork like CockroachDB or AlloyDB):
+   emit `kind: other` with `classifier_unmatched: true` rather than silently routing to a generic
+   "auto-retry will fix" remediation — auto-retry won't fix drift.
 
-For table errors: same flow — match against the table-YAML index built in query-database Step 1b. Qualified matching uses `<schema>.<table>` exact match; unqualified falls back to scanning all loaded tables. The `kind: other` + `classifier_unmatched: true` fallback applies the same way.
+For table errors: same flow — qualified matching uses `<schema>.<table>` exact match; unqualified falls
+back to scanning all loaded tables. The `kind: other` + `classifier_unmatched: true` fallback applies.
 
 ## Output shape
 
@@ -47,36 +68,21 @@ The classifier returns:
   "remediation": "<one-line user-facing remediation message>",
   "raw_message": "<original exception message, truncated to 500 chars>",
   "drift_match": True | False,    # set only on column_not_found / table_not_found
-  "tier": "mcp | cli | python | duckdb",
+  "tier": "cli | python | duckdb",
   "datasource": "<datasource name>"
 }
 ```
 
-Callers use `kind` for control flow and `remediation` for the user-facing message. `raw_message` is preserved so `--verbose` mode and the query log capture the original; `drift_match` lets refresh skills decide whether to populate `_repair.kind` as `"schema_drift"` vs the generic `"column_not_found"`.
+Callers use `kind` for control flow and `remediation` for the user-facing message. `raw_message` is
+preserved so the query log captures the original.
 
 ## Where this is consumed
 
-- **`query-database`** — wrap each connection method's SQL call. On classified `auth` / `dsn` / `network` / `driver_missing` / `permission`, emit the remediation **before** moving to the next available method (auth failures cascade across every method; surfacing once is correct). On `column_not_found` / `table_not_found`, route through the drift-match step and emit the appropriate message. On `timeout` / `syntax`, the existing auto-retry-up-to-2 in Phase 3 fires; the classifier just labels the failure for the log.
-- **`refresh-log-dashboards`** and **`refresh-admin-dashboards`** — these skills don't execute saved widget queries (their widgets are built from local JSONL aggregation and metadata); they don't need the classifier directly. *Saved-query widget refresh* belongs to **`build-dashboard`'s `refresh` intent**, which is where the classifier matters: when a saved query fails on refresh, build-dashboard populates the widget's `_repair` block via this classifier instead of letting the chart render empty.
-- **`build-dashboard`** — `refresh` intent runs each saved query, classifies failures, writes `_repair` blocks. Sidebar repair-count is computed from the count of widgets with `_repair` present. Per-widget UI in `chart.js` reads `_repair` and renders the friendly "needs repair" card variant of the empty-state component.
-
-## `_repair` block shape (writeable to insights.json)
-
-```json
-{
-  "_repair": {
-    "kind": "schema_drift | column_not_found | table_not_found | auth | dsn | network | permission | timeout | syntax | other",
-    "message": "Your semantic model references customer_name but it's no longer in the live database.",
-    "remediation": "Run /agami-data-admin:update-semantic-model to sync schema.",
-    "last_failed_at": "2026-04-26T10:00:00Z",
-    "raw_message": "column \"customer_name\" does not exist"
-  }
-}
-```
-
-Lifecycle:
-- **Set** by `build-dashboard refresh` on a widget whose saved SQL fails.
-- **Read** by `chart.js renderInsight` to dispatch to the "needs repair" variant of the empty-state component.
-- **Cleared** the next time the widget refreshes successfully (or the user manually clears it via the dashboard SPA).
-
-When `_repair` is set, the widget MUST still preserve its original `sql`, `user_query`, `data_source`, and `title` — those are what the user needs to manually fix or re-run the widget. The classifier never overwrites those fields.
+- **`agami-query`** — wraps each connection method's SQL call. On `auth` / `dsn` / `network` /
+  `driver_missing` / `permission`, surface the remediation and stop. On `column_not_found` /
+  `table_not_found`, run the drift-match step and emit the appropriate message. On `syntax` / `timeout`,
+  the query path's auto-retry fires; the classifier just labels the failure.
+- **`agami-connect`** — when an introspection query fails, classify it and surface the one-line
+  remediation instead of a raw driver traceback.
+- **`agami-save-correction`** — when the EXPLAIN of a user-corrected query fails, route it here, surface
+  the one-line remediation, and don't save the correction until it EXPLAINs clean.


### PR DESCRIPTION
## Summary

A docs pass for 0.3.3 — make the README quick to read and get people started, refresh staleness, surface the now-published PyPI install, and fix a few broken/stale bits. **No code changes.** Customer-safety re-verified clean across all 47 md files.

## Changes

- **README — leaner + current.** Version badge `0.3.0 → 0.3.3` (+ the `/plugin list` line); **moved** the dense "Self-hosting the HTTP server" + OIDC env-var tables into a new **`docs/self-hosting.md`**, leaving a short pointer (README is ~46 lines lighter, onboarding-focused).
- **CHANGELOG — backfilled** `[0.3.1]` / `[0.3.2]` / `[0.3.3]` (it stopped at 0.3.0) + compare links.
- **PyPI install surfaced** — `docs/mcp-server.md` + `packages/agami-core/README.md` now lead with `pip install "agami-core[model]"` / `[server]` (published), keeping the `-e packages/…` editable form labeled dev-only. `docs/install/claude-code-cli.md` version → 0.3.3.
- **`shared/db_error_classifier.md` refreshed** — it was written against a defunct skill set (`agami-data:query-database`, `build-dashboard`, `_repair`/dashboard machinery, `/agami-data-admin:update-semantic-model`, `<org_path>/.env`). Rewritten against the current 7 skills + `<artifacts_dir>/local/credentials`, keeping the (still-accurate) classification table.
- **Small fixes** — clickable `connection-reference` link (troubleshooting); unwrapped 6 backtick-wrapped markdown links (format-spec, which rendered as code); dropped stale "pre-launch"/"early development" framing (CONTRIBUTING, SECURITY).

## Checklist

- [x] Full gate green (1040 tests, ruff, gitleaks)
- [x] Docs-only — no code/behavior change
- [x] No secrets / no customer data (verified across all md)
- [x] All internal links verified to resolve (only `docs/assets/demo.gif` is intentionally-absent-until-created)
