### PR TITLE
Chore: remove internal spec-ID references from the public repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Code owners for agami-core (OCR-025).
+# Code owners for agami-core.
 #
 # With branch protection's "require review from Code Owners" on, a PR touching any
 # path below needs approval from one of the listed maintainers. The point is that the

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,7 +7,7 @@ name: CLA Assistant
 #
 # Manual prerequisite: a `PERSONAL_ACCESS_TOKEN` repo secret (a PAT with `repo` scope)
 # must exist so the Action can write the signatures file. The published "CLA Assistant"
-# status check is what branch protection should require (F13 / OCR-025).
+# status check is what branch protection should require.
 
 on:
   issue_comment:

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -2,7 +2,7 @@ name: Release PyPI
 
 # Builds the agami-core sdist + wheel from packages/agami-core and publishes them to PyPI via
 # TRUSTED PUBLISHING (OIDC) -- so a marketplace `/agami-connect` can `pip install "agami-core[model]"`
-# from the index instead of the git fallback. OCR-031's `sm` installer already tries the index before
+# from the index instead of the git fallback. The `sm` installer already tries the index before
 # git, so the moment a version lands on PyPI every marketplace install upgrades with no code change.
 # The version published is packages/agami-core/pyproject.toml `version` (a release tag must match it).
 #

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -24,5 +24,5 @@ else:
     sys.exit("entrypoint: database not reachable after 60s")
 PY
 
-python -m model_deploy      # migrate (ACE-019) + load the model into Postgres (ACE-022); fail-closed
+python -m model_deploy      # migrate + load the model into Postgres; fail-closed
 exec python -m mcp_http     # serve (also re-migrates + seeds the admin on startup; both idempotent)

--- a/dev.py
+++ b/dev.py
@@ -36,7 +36,7 @@ _ROOT = Path(__file__).resolve().parent
 # The plugin's runtime scripts import a small stdlib-only slice of the agami-core library. The
 # marketplace ships only plugins/agami/ (no packages/, no pip install), so that slice is vendored —
 # drift-checked — into plugins/agami/lib/ so the scripts resolve it there. Source of truth stays the
-# package; `sync-lib` regenerates the copy and `check` fails on drift. See OCR-030.
+# package; `sync-lib` regenerates the copy and `check` fails on drift.
 _LIB_SRC = _ROOT / "packages" / "agami-core" / "src"
 _LIB_DST = _ROOT / "plugins" / "agami" / "lib"
 # The module-load import closure of the 4 scripts (all stdlib-only). tests/test_plugin_lib_resolution.py

--- a/migrations/core/009_tool_calls_correlation.sql
+++ b/migrations/core/009_tool_calls_correlation.sql
@@ -1,4 +1,4 @@
--- Add the **turn** level to the tool-call log (ACE-015). ACE-008 captured `thread_id` (the whole
+-- Add the **turn** level to the tool-call log. An earlier migration captured `thread_id` (the whole
 -- conversation) and the per-call `user_question`/`agent_query`; this adds `correlation_id` — the turn,
 -- i.e. the ONE user question whose answer fanned out into several agent sub-queries. Self-reported by
 -- Claude (the MCP protocol carries no turn boundary, so the server can't mint it), nullable and

--- a/packages/agami-core/src/deploy_preflight.py
+++ b/packages/agami-core/src/deploy_preflight.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
-# The hard-floor inputs (see the ACE-009 `.env` contract). The warehouse credentials are NOT an env var —
+# The hard-floor inputs (see the `.env` contract). The warehouse credentials are NOT an env var —
 # they travel in the mounted artifacts (`<artifacts>/local/credentials`), so there's no DATASOURCE_URL here.
 _REQUIRED = ("PUBLIC_BASE_URL", "AGAMI_ADMIN_USERNAME")
 _OIDC_PROVIDERS = {"google": "GOOGLE", "microsoft": "MICROSOFT"}  # provider → AGAMI_OIDC_<PREFIX>_CLIENT_*

--- a/packages/agami-core/src/model_deploy.py
+++ b/packages/agami-core/src/model_deploy.py
@@ -3,7 +3,7 @@
 The hosted server serves the model **from the database** (`tools._serve_model` reads the DB when one is
 configured), so a deploy has to push the YAML model into Postgres. The read→write primitives already exist
 and are idempotent; this is the orchestrator that wires them for every datasource under the artifacts dir.
-Run by the deploy entrypoint (ACE-009) and re-run on restart to pick up an edited model.
+Run by the deploy entrypoint and re-run on restart to pick up an edited model.
 
     AGAMI_DB_URL=postgresql://…  AGAMI_ARTIFACTS_DIR=/…/agami-artifacts  python -m model_deploy [datasource …]
 """
@@ -92,7 +92,7 @@ def main(argv: list[str] | None = None) -> int:
         print("model_deploy: no database configured (set AGAMI_DB_URL).", file=sys.stderr)
         return 2
     # Ensure the model tables exist before writing — this runs in the deploy entrypoint *before* the
-    # server (whose lifespan auto-migrates, ACE-019) is up, so the schema may not be applied yet.
+    # server (whose lifespan auto-migrates) is up, so the schema may not be applied yet.
     # run_migrations is idempotent, so the later lifespan pass is a harmless no-op.
     store.run_migrations()
     artifacts_dir = agami_paths.artifacts_dir()

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -444,6 +444,6 @@ def list_sessions(store: Store, *, limit: int = 500) -> list[dict[str, Any]]:
         s["call_count"] = len(cs)
         s["error_count"] = sum(1 for c in cs if not c["success"])
         s["avg_ms"] = round(sum(ms) / len(ms)) if ms else None  # over calls that recorded latency
-        s["turns"] = _group_turns(cs)  # the within-conversation turn level (ACE-015)
+        s["turns"] = _group_turns(cs)  # the within-conversation turn level
         out.append(s)
     return out

--- a/plugins/agami/scripts/_agami_lib.py
+++ b/plugins/agami/scripts/_agami_lib.py
@@ -1,6 +1,6 @@
 """Make the agami-core library importable for the plugin's runtime scripts.
 
-OCR-028 moved the library (`agami_paths`, `execute_sql`, `semantic_model`, …) out of this scripts dir
+A refactor moved the library (`agami_paths`, `execute_sql`, `semantic_model`, …) out of this scripts dir
 into the pip package `packages/agami-core/src`. The marketplace ships only `plugins/agami/`, so those
 modules aren't on `sys.path` there and nothing pip-installs them — which broke every marketplace install
 (agami-connect died on `import agami_paths`). This resolver makes the library importable in every layout,

--- a/plugins/agami/scripts/sm
+++ b/plugins/agami/scripts/sm
@@ -26,7 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # (with the model extra: pydantic/sqlglot/pyyaml) on demand below. The source differs by layout:
 #   - a dev checkout has packages/agami-core → editable install;
 #   - a marketplace install ships only plugins/agami/ (no packages/) → install the PUBLISHED package
-#     (PyPI once available, else pinned git). So packages/ is OPTIONAL here — never fatal (OCR-031).
+#     (PyPI once available, else pinned git). So packages/ is OPTIONAL here — never fatal.
 DEV_PKG_DIR=""
 if [ -f "$SCRIPT_DIR/../../../packages/agami-core/pyproject.toml" ]; then
   DEV_PKG_DIR="$(cd "$SCRIPT_DIR/../../../packages/agami-core" && pwd)"
@@ -96,9 +96,9 @@ _pip_try() {
 # Ensure the agami-core package (+ its model deps) is importable in $PY; install once if not.
 # (A broken/moved install fails this import and self-heals via the reinstall — the plugin cache dir
 # is version-pinned and moves on every update.) Install source by layout — dev editable → the
-# published package on an index (lights up once agami-core is on PyPI, OCR-032) → pinned git (public
+# published package on an index (lights up once agami-core is on PyPI) → pinned git (public
 # repo, no auth) → git main. First success wins.
-# Verify the REAL entrypoint (`semantic_model.cli`), not just the package — the OCR-030 bundled `lib/`
+# Verify the REAL entrypoint (`semantic_model.cli`), not just the package — the bundled `lib/`
 # ships a stub `semantic_model` (only __init__ + units, no cli) that satisfies a bare `import
 # semantic_model` and would let a stub/partial install pass this check. Probe from a neutral cwd (`cd /`)
 # so a `semantic_model` in the caller's cwd can't shadow the installed package (`python -c` puts cwd on
@@ -128,7 +128,7 @@ if [ "${1:-}" = "install" ]; then
 fi
 
 ensure_pkg
-# Run the CLI from a neutral cwd so a `semantic_model` in the caller's cwd (notably the OCR-030 stub in
+# Run the CLI from a neutral cwd so a `semantic_model` in the caller's cwd (notably the bundled stub in
 # the plugin's lib/) can't shadow the installed package via `python -m` putting cwd on sys.path[0]. The
 # CLI's path args are absolute (the skill passes <artifacts_dir> absolute), so cwd is irrelevant to what
 # it does. PYTHONSAFEPATH (3.11+; ignored below) is a belt-and-suspenders second guard; `cd /` is the

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -223,7 +223,7 @@ def test_activity_does_not_leak_the_password_hash(client, env):
 
 
 def test_activity_tab_has_one_unified_tab_and_no_split_tabs(client, env):
-    # ACE-016: one Activity tab — the Tool-calls / Sessions split is gone from the rendered nav.
+    # one Activity tab — the Tool-calls / Sessions split is gone from the rendered nav.
     _login(client)
     html = client.get("/admin?tab=activity").text
     assert ">Activity</a>" in html
@@ -233,7 +233,7 @@ def test_activity_tab_has_one_unified_tab_and_no_split_tabs(client, env):
     assert "Queries grouped into conversations" not in html
 
 
-# --- ACE-015: the turn level (correlation_id) --------------------------------
+# --- the turn level (correlation_id) --------------------------------
 
 
 def test_correlation_id_round_trips(env):
@@ -379,7 +379,7 @@ def test_activity_drawer_renders_turn_with_user_asked_and_agent_queries(client, 
     assert "2 calls" in html
 
 
-# --- ACE-016: every tool carries the grouping ids ----------------------------
+# --- every tool carries the grouping ids ----------------------------
 
 
 def test_all_tools_expose_thread_and_correlation_ids():

--- a/tests/test_admin_seed_on_startup.py
+++ b/tests/test_admin_seed_on_startup.py
@@ -1,4 +1,4 @@
-"""ACE-009 — the server seeds the configured admin on startup, so a fresh deploy can sign in.
+"""The server seeds the configured admin on startup, so a fresh deploy can sign in.
 
 Nothing else creates the configured admin in a deployment (the local `seed.py` is test-only), so the
 `mcp_http` lifespan seeds it from `AGAMI_ADMIN_*` right after migrating — create-if-absent + idempotent.

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -1,4 +1,4 @@
-"""ACE-019 — the server applies pending migrations on first DB open (idempotent, locked, fail-closed).
+"""The server applies pending migrations on first DB open (idempotent, locked, fail-closed).
 
 Covers the read helper (`Store.run_migrations`: the Postgres advisory-lock bracketing, idempotency, and
 fail-closed-on-error) and the startup wiring (`mcp_http` lifespan applies them before serving + propagates).

--- a/tests/test_deploy_preflight.py
+++ b/tests/test_deploy_preflight.py
@@ -1,4 +1,4 @@
-"""ACE-009 — the host-side deploy preflight: validate the `.env`, persist the signing secret, derive the host."""
+"""The host-side deploy preflight: validate the `.env`, persist the signing secret, derive the host."""
 
 from __future__ import annotations
 

--- a/tests/test_marketplace_script_imports.py
+++ b/tests/test_marketplace_script_imports.py
@@ -1,4 +1,4 @@
-"""OCR-033 regression: `promote_credentials.py` and `setup_desktop_mcp.py` must run in a **marketplace**
+"""Regression: `promote_credentials.py` and `setup_desktop_mcp.py` must run in a **marketplace**
 layout — `scripts/` + `lib/` with NO `packages/` sibling and no `agami_paths.py` next to the script —
 without a `ModuleNotFoundError` (they used to bare-import `agami_paths` off their own dir / a dev
 `packages/src`, issue #1), and `setup_desktop_mcp.py` must NOT install from a hardcoded `packages/agami-core`

--- a/tests/test_model_deploy.py
+++ b/tests/test_model_deploy.py
@@ -1,4 +1,4 @@
-"""ACE-022 — `model_deploy` loads the local YAML model into serving Postgres (idempotent, fail-closed).
+"""`model_deploy` loads the local YAML model into serving Postgres (idempotent, fail-closed).
 
 Builds a minimal NEUTRAL artifacts fixture in a tmp dir and runs the real loader → real DB writers (no
 mocking), then asserts the served model round-trips, re-running is idempotent, and the error paths exit non-zero.

--- a/tests/test_plugin_lib_resolution.py
+++ b/tests/test_plugin_lib_resolution.py
@@ -1,4 +1,4 @@
-"""OCR-030 regression: the plugin's runtime scripts must resolve the agami-core library in a
+"""Regression: the plugin's runtime scripts must resolve the agami-core library in a
 **marketplace install** — `scripts/` + the bundled `lib/`, with NO `packages/` sibling and no pip
 install — which is the exact layout that broke agami-connect (`import agami_paths` → ModuleNotFoundError).
 

--- a/tests/test_release_pypi_workflow.py
+++ b/tests/test_release_pypi_workflow.py
@@ -1,7 +1,7 @@
-"""OCR-032 guard: the PyPI release workflow publishes via TRUSTED PUBLISHING and carries NO API token.
+"""Guard: the PyPI release workflow publishes via TRUSTED PUBLISHING and carries NO API token.
 
 The workflow itself (`.github/workflows/release-pypi.yml`) isn't ruff/pytest-covered — it only runs on a
-GitHub release — so this test locks the invariants OCR-032 promises: OIDC `id-token: write` (not a stored
+GitHub release — so this test locks the invariants the release promises: OIDC `id-token: write` (not a stored
 PyPI token), the `pypa/gh-action-pypi-publish` action, a build from `packages/agami-core`, and the
 release-vs-dispatch (PyPI vs TestPyPI) split. A change that reintroduces an API-token publish path or
 points the build elsewhere fails here.

--- a/tests/test_setup_desktop_mcp.py
+++ b/tests/test_setup_desktop_mcp.py
@@ -125,7 +125,7 @@ def test_desktop_config_path_linux(monkeypatch):
     assert p.parts[-3:] == (".config", "Claude", "claude_desktop_config.json")
 
 
-# --- package install (delegates to `sm install`, OCR-033 #8) ----------------
+# --- package install (delegates to `sm install`) ----------------
 
 def test_ensure_package_installed_dry_run_delegates_no_exec(monkeypatch, capsys):
     calls = []

--- a/tests/test_sm_install_resolution.py
+++ b/tests/test_sm_install_resolution.py
@@ -1,4 +1,4 @@
-"""OCR-031 regression: the `sm` launcher must install agami-core[model] in a **marketplace** layout —
+"""Regression: the `sm` launcher must install agami-core[model] in a **marketplace** layout —
 `scripts/` + `lib/` with NO `packages/` sibling and no pip install — without crashing and without pointing
 at the dev-only `packages/agami-core` path (the failure the real run-through hit).
 
@@ -47,7 +47,7 @@ sys.exit(0)
 
 
 # Externally-managed interpreter (PEP 668): refuse BOTH `--user` and plain pip; only
-# `--break-system-packages` is allowed to install. Proves `sm` reaches that last-resort tier (OCR-033 #2).
+# `--break-system-packages` is allowed to install. Proves `sm` reaches that last-resort tier.
 _SHIM_PEP668 = """#!/usr/bin/env python3
 import os, sys
 args = sys.argv[1:]
@@ -116,14 +116,14 @@ def test_skill_delegates_install_to_sm():
 
 def test_pep668_reaches_break_system_packages(tmp_path):
     # An externally-managed interpreter refuses --user + plain; sm must fall through to the
-    # --break-system-packages tier and still install (OCR-033 #2). Dev layout → the `-e` requirement.
+    # --break-system-packages tier and still install. Dev layout → the `-e` requirement.
     r, installs = _run_install(SM, tmp_path, shim_src=_SHIM_PEP668)
     assert r.returncode == 0, r.stderr
     assert any("--break-system-packages" in ln for ln in installs), installs
 
 
 def test_readiness_probes_cli_entrypoint_and_isolates_cwd():
-    # OCR-033 #5: the readiness probe must import the real entrypoint `semantic_model.cli` (not just the
+    # the readiness probe must import the real entrypoint `semantic_model.cli` (not just the
     # package, which the bundled stub's __init__ would satisfy), and the CLI must run from a neutral cwd
     # so a `semantic_model` in the caller's cwd can't shadow the installed package.
     txt = SM.read_text()


### PR DESCRIPTION
## Summary

Removes internal spec-ID references (`OCR-<n>` / `ACE-<n>` / `F<n>`) from the public repo. Policy: those IDs belong only in PR bodies, never in shipped code, comments, tests, or CI config. A hygiene audit found ~31 of them embedded across 21 files (comments, test docstrings, CI/config, one migration, CODEOWNERS).

## Changes

- **Reword, not just delete** — every comment/docstring keeps its full explanatory meaning; only the ID token is dropped (e.g. `"""OCR-031 regression: the sm launcher…"""` → `"""Regression: the sm launcher…"""`; `the OCR-030 bundled lib/` → `the bundled lib/`; `# Code owners for agami-core (OCR-025).` → `# Code owners for agami-core.`).
- **21 files** — 9 source/config (`sm`, `_agami_lib.py`, `dev.py`, `deploy/entrypoint.sh`, `model_deploy.py`, `model_store.py`, `deploy_preflight.py`, a migration, `.github/{CODEOWNERS,workflows/release-pypi.yml,workflows/cla.yml}`) + 10 test files.
- **No behavior change** — every edit is in a comment/docstring/config comment. `CHANGELOG.md` (release history) untouched.

## Verification

- `rg -e 'OCR-[0-9]' -e 'ACE-[0-9]' -e '\bF[0-9]{1,2}\b'` (excluding CHANGELOG) → **zero** hits.
- Full gate green: **1038 tests**, ruff, gitleaks; `bash -n sm` OK.

## Checklist

- [x] No behavior change (comments/docstrings/config only)
- [x] No secrets / no customer data
- [x] Full gate green
