### PR TITLE
Release v0.3.4: bump package + plugin to 0.3.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.3.4] — 2026-07-03
+
+### Fixed
+
+- **Table-prune step of a real-DB onboarding no longer crashes on an installed
+  build.** The `discover` pass (which renders the prune page where you pick which
+  tables to model) failed with `ModuleNotFoundError` on a pip/marketplace install;
+  it now resolves its renderer via the plugin root and works everywhere.
+
+### Docs
+
+- Refreshed for the current release: README slimmed (self-hosting moved to
+  `docs/self-hosting.md`), the published PyPI install surfaced
+  (`pip install "agami-core[model]"`), and the changelog backfilled.
+
 ## [0.3.3] — 2026-07-02
 
 ### Fixed
@@ -115,6 +130,7 @@ First version tracked in this changelog. Earlier history lives in the git log.
   other clients — stdio, no auth, no network.
 - Fan-trap / chasm-trap pre-flight that refuses to silently double-count.
 
+[0.3.4]: https://github.com/AgamiAI/agami-core/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/AgamiAI/agami-core/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/AgamiAI/agami-core/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/AgamiAI/agami-core/compare/v0.3.0...v0.3.1

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.3"
+version = "0.3.4"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary

Version bump to **0.3.4** across the package + plugin, so the marketplace serves the `sm discover` fix and PyPI/GHCR publish the new version.

## Changes

- `packages/agami-core/pyproject.toml`, `.claude-plugin/marketplace.json` (metadata + plugin entry), `plugins/agami/.claude-plugin/plugin.json` — `0.3.3` → `0.3.4`.
- `CHANGELOG.md` — `[0.3.4]` entry (the discover-crash fix + docs refresh) + compare link.

## What 0.3.4 ships (all already on `main`)

- **Fix:** `sm discover` (the table-prune step of a real-DB onboarding) no longer `ModuleNotFoundError`s on a pip/marketplace install — it resolves its renderer via the plugin root.
- **Docs:** README slimmed + PyPI install surfaced + changelog backfilled.
- **Internal:** removed spec-ID references from the public repo; dead-code + test hygiene.

## Follow-up (after merge)

Tag `v0.3.4` at the merge commit + publish the release → fires the PyPI + GHCR workflows.

## Checklist

- [x] Full gate green (1038 tests, ruff, gitleaks)
- [x] Version-only bump — no code/logic change
- [x] No secrets / no customer data
