### PR TITLE
Env-var warehouse credentials in the shared executor (env-first, file-fallback)

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -106,13 +106,19 @@ def _env_datasource_dsn(profile: str) -> str | None:
         env channel supports the schemes `_parse_dsn` handles (postgres / redshift /
         mysql / snowflake / bigquery / sqlite). A warehouse type without a DSN scheme
         (databricks, oracle, sqlserver, trino, duckdb) still uses the per-field file.
-      - An empty value is treated as unset (falls through to the next source) — set the
-        var to a real DSN to take effect; don't set it to "" expecting to *disable* one.
+      - The value is stripped (secret stores / `.env` / `$(cat file)` commonly append a
+        trailing newline, which would otherwise mis-parse), and an empty-or-whitespace-only
+        value is treated as unset (falls through to the next source) — set the var to a real
+        DSN to take effect; don't set it to "" expecting to *disable* one.
       - The token folds every non-alphanumeric char to `_`, so profiles differing only in
         punctuation (`sales-pg` vs `sales.pg`) map to the same var — name profiles distinctly.
     """
     token = "".join(c if c.isalnum() else "_" for c in profile).upper()
-    return os.environ.get(f"DATASOURCE_URL__{token}") or os.environ.get("DATASOURCE_URL")
+    for name in (f"DATASOURCE_URL__{token}", "DATASOURCE_URL"):
+        val = os.environ.get(name)
+        if val and val.strip():
+            return val.strip()  # match the file path's per-field .strip()
+    return None
 
 
 def _load_credentials(profile: str) -> dict[str, str]:

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -100,6 +100,16 @@ def _env_datasource_dsn(profile: str) -> str | None:
     from Postgres when configured, else the file): env carries no file mode and is
     inherited by this subprocess, so it sidesteps the mounted-secret + chmod-600
     problems the file has under a container uid that doesn't own it.
+
+    Scope / gotchas (deliberately minimal — the file remains the fuller channel):
+      - A DSN carries the same expressiveness as the file's `url = ...` field, so the
+        env channel supports the schemes `_parse_dsn` handles (postgres / redshift /
+        mysql / snowflake / bigquery / sqlite). A warehouse type without a DSN scheme
+        (databricks, oracle, sqlserver, trino, duckdb) still uses the per-field file.
+      - An empty value is treated as unset (falls through to the next source) — set the
+        var to a real DSN to take effect; don't set it to "" expecting to *disable* one.
+      - The token folds every non-alphanumeric char to `_`, so profiles differing only in
+        punctuation (`sales-pg` vs `sales.pg`) map to the same var — name profiles distinctly.
     """
     token = "".join(c if c.isalnum() else "_" for c in profile).upper()
     return os.environ.get(f"DATASOURCE_URL__{token}") or os.environ.get("DATASOURCE_URL")

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -15,9 +15,10 @@ is importable). Connect-side and query-database both shell out to:
 The --sql-file form is preferred over --sql so SQL containing quotes,
 backticks, or `$` doesn't get mangled by the shell.
 
-Connects ONLY to the host/port in <artifacts_dir>/local/credentials (the sole credential
-source — no env-var bypass). Never substitutes localhost. Never asks for
-credentials. Hard exits with a clear message if credentials are missing.
+Credentials resolve env-first then file: a DSN in DATASOURCE_URL[__<PROFILE>] (the
+self-host channel), else <artifacts_dir>/local/credentials. Connects ONLY to the
+host/port that resolution yields. Never substitutes localhost. Never asks for
+credentials. Hard exits with a clear message if neither source has them.
 
 Drivers (install only what you need):
     pip install psycopg2-binary             # Postgres / Redshift
@@ -85,20 +86,49 @@ def _err(msg: str, *, code: int = 2) -> int:
     return code
 
 
-def _load_credentials(profile: str) -> dict[str, str]:
-    """Resolve credentials from <artifacts_dir>/local/credentials (the ONLY source).
+def _env_datasource_dsn(profile: str) -> str | None:
+    """A warehouse DSN supplied via the environment for `profile`, or None.
 
-    Within the selected profile:
-      - If `url = ...` is set, parse it as a DSN (overrides per-field values)
-      - Otherwise read host / port / user / password / database / type / sslmode
+    Two forms, checked in order:
+      1. DATASOURCE_URL__<PROFILE> — per-datasource. <PROFILE> is the profile id
+         upper-cased with every non-alphanumeric char folded to `_` (so `sales-pg`
+         → DATASOURCE_URL__SALES_PG). Lets a deployment carry heterogeneous
+         warehouses side by side, one var each.
+      2. DATASOURCE_URL — the single-datasource default.
 
-    Credentials come only from the file — there is no env-var bypass. This keeps
-    the one credential path auditable (chmod 600, never on a command line).
+    This is the container / self-host credential channel (cf. how the model reads
+    from Postgres when configured, else the file): env carries no file mode and is
+    inherited by this subprocess, so it sidesteps the mounted-secret + chmod-600
+    problems the file has under a container uid that doesn't own it.
     """
+    token = "".join(c if c.isalnum() else "_" for c in profile).upper()
+    return os.environ.get(f"DATASOURCE_URL__{token}") or os.environ.get("DATASOURCE_URL")
+
+
+def _load_credentials(profile: str) -> dict[str, str]:
+    """Resolve credentials for `profile`, env-first then the file.
+
+    Source order:
+      1. A DSN from the environment (DATASOURCE_URL[__<PROFILE>]) — the self-host
+         channel; parsed by `_parse_dsn`, no file read, no chmod gate.
+      2. <artifacts_dir>/local/credentials (the local-plugin default), where within
+         the selected profile a `url = ...` DSN (merged with per-field overrides) or
+         per-field host / port / user / password / database / type / sslmode is read.
+
+    The env is an added *source*, not a fork: the file path — and its chmod-600 gate
+    (never on a command line) — is unchanged, and is skipped only when a deployment
+    opts into the env var (and so has no file to protect).
+    """
+    dsn = _env_datasource_dsn(profile)
+    if dsn:
+        return _parse_dsn(dsn)
+
     if not CREDENTIALS_PATH.exists():
         sys.stderr.write(
-            "<artifacts_dir>/local/credentials is missing. Run the agami `init` skill to set it up.\n"
-            "Never type credentials into chat — they belong in the file.\n"
+            f"No warehouse credentials for profile [{profile}]. Set DATASOURCE_URL "
+            f"(or DATASOURCE_URL__{''.join(c if c.isalnum() else '_' for c in profile).upper()}) "
+            "in the environment, or create <artifacts_dir>/local/credentials via the agami `init` skill.\n"
+            "Never type credentials into chat — they belong in the environment or the file.\n"
         )
         sys.exit(2)
 

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -86,6 +86,12 @@ def _err(msg: str, *, code: int = 2) -> int:
     return code
 
 
+def _env_token(profile: str) -> str:
+    """The env-var suffix for a datasource: the profile id upper-cased with every non-alphanumeric char
+    folded to `_` (so `sales-pg` → `SALES_PG`, used as `DATASOURCE_URL__SALES_PG`)."""
+    return "".join(c if c.isalnum() else "_" for c in profile).upper()
+
+
 def _env_datasource_dsn(profile: str) -> str | None:
     """A warehouse DSN supplied via the environment for `profile`, or None.
 
@@ -113,7 +119,7 @@ def _env_datasource_dsn(profile: str) -> str | None:
       - The token folds every non-alphanumeric char to `_`, so profiles differing only in
         punctuation (`sales-pg` vs `sales.pg`) map to the same var — name profiles distinctly.
     """
-    token = "".join(c if c.isalnum() else "_" for c in profile).upper()
+    token = _env_token(profile)
     for name in (f"DATASOURCE_URL__{token}", "DATASOURCE_URL"):
         val = os.environ.get(name)
         if val and val.strip():
@@ -142,7 +148,7 @@ def _load_credentials(profile: str) -> dict[str, str]:
     if not CREDENTIALS_PATH.exists():
         sys.stderr.write(
             f"No warehouse credentials for profile [{profile}]. Set DATASOURCE_URL "
-            f"(or DATASOURCE_URL__{''.join(c if c.isalnum() else '_' for c in profile).upper()}) "
+            f"(or DATASOURCE_URL__{_env_token(profile)}) "
             "in the environment, or create <artifacts_dir>/local/credentials via the agami `init` skill.\n"
             "Never type credentials into chat — they belong in the environment or the file.\n"
         )

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -106,13 +106,19 @@ def _env_datasource_dsn(profile: str) -> str | None:
         env channel supports the schemes `_parse_dsn` handles (postgres / redshift /
         mysql / snowflake / bigquery / sqlite). A warehouse type without a DSN scheme
         (databricks, oracle, sqlserver, trino, duckdb) still uses the per-field file.
-      - An empty value is treated as unset (falls through to the next source) — set the
-        var to a real DSN to take effect; don't set it to "" expecting to *disable* one.
+      - The value is stripped (secret stores / `.env` / `$(cat file)` commonly append a
+        trailing newline, which would otherwise mis-parse), and an empty-or-whitespace-only
+        value is treated as unset (falls through to the next source) — set the var to a real
+        DSN to take effect; don't set it to "" expecting to *disable* one.
       - The token folds every non-alphanumeric char to `_`, so profiles differing only in
         punctuation (`sales-pg` vs `sales.pg`) map to the same var — name profiles distinctly.
     """
     token = "".join(c if c.isalnum() else "_" for c in profile).upper()
-    return os.environ.get(f"DATASOURCE_URL__{token}") or os.environ.get("DATASOURCE_URL")
+    for name in (f"DATASOURCE_URL__{token}", "DATASOURCE_URL"):
+        val = os.environ.get(name)
+        if val and val.strip():
+            return val.strip()  # match the file path's per-field .strip()
+    return None
 
 
 def _load_credentials(profile: str) -> dict[str, str]:

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -100,6 +100,16 @@ def _env_datasource_dsn(profile: str) -> str | None:
     from Postgres when configured, else the file): env carries no file mode and is
     inherited by this subprocess, so it sidesteps the mounted-secret + chmod-600
     problems the file has under a container uid that doesn't own it.
+
+    Scope / gotchas (deliberately minimal — the file remains the fuller channel):
+      - A DSN carries the same expressiveness as the file's `url = ...` field, so the
+        env channel supports the schemes `_parse_dsn` handles (postgres / redshift /
+        mysql / snowflake / bigquery / sqlite). A warehouse type without a DSN scheme
+        (databricks, oracle, sqlserver, trino, duckdb) still uses the per-field file.
+      - An empty value is treated as unset (falls through to the next source) — set the
+        var to a real DSN to take effect; don't set it to "" expecting to *disable* one.
+      - The token folds every non-alphanumeric char to `_`, so profiles differing only in
+        punctuation (`sales-pg` vs `sales.pg`) map to the same var — name profiles distinctly.
     """
     token = "".join(c if c.isalnum() else "_" for c in profile).upper()
     return os.environ.get(f"DATASOURCE_URL__{token}") or os.environ.get("DATASOURCE_URL")

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -15,9 +15,10 @@ is importable). Connect-side and query-database both shell out to:
 The --sql-file form is preferred over --sql so SQL containing quotes,
 backticks, or `$` doesn't get mangled by the shell.
 
-Connects ONLY to the host/port in <artifacts_dir>/local/credentials (the sole credential
-source — no env-var bypass). Never substitutes localhost. Never asks for
-credentials. Hard exits with a clear message if credentials are missing.
+Credentials resolve env-first then file: a DSN in DATASOURCE_URL[__<PROFILE>] (the
+self-host channel), else <artifacts_dir>/local/credentials. Connects ONLY to the
+host/port that resolution yields. Never substitutes localhost. Never asks for
+credentials. Hard exits with a clear message if neither source has them.
 
 Drivers (install only what you need):
     pip install psycopg2-binary             # Postgres / Redshift
@@ -85,20 +86,49 @@ def _err(msg: str, *, code: int = 2) -> int:
     return code
 
 
-def _load_credentials(profile: str) -> dict[str, str]:
-    """Resolve credentials from <artifacts_dir>/local/credentials (the ONLY source).
+def _env_datasource_dsn(profile: str) -> str | None:
+    """A warehouse DSN supplied via the environment for `profile`, or None.
 
-    Within the selected profile:
-      - If `url = ...` is set, parse it as a DSN (overrides per-field values)
-      - Otherwise read host / port / user / password / database / type / sslmode
+    Two forms, checked in order:
+      1. DATASOURCE_URL__<PROFILE> — per-datasource. <PROFILE> is the profile id
+         upper-cased with every non-alphanumeric char folded to `_` (so `sales-pg`
+         → DATASOURCE_URL__SALES_PG). Lets a deployment carry heterogeneous
+         warehouses side by side, one var each.
+      2. DATASOURCE_URL — the single-datasource default.
 
-    Credentials come only from the file — there is no env-var bypass. This keeps
-    the one credential path auditable (chmod 600, never on a command line).
+    This is the container / self-host credential channel (cf. how the model reads
+    from Postgres when configured, else the file): env carries no file mode and is
+    inherited by this subprocess, so it sidesteps the mounted-secret + chmod-600
+    problems the file has under a container uid that doesn't own it.
     """
+    token = "".join(c if c.isalnum() else "_" for c in profile).upper()
+    return os.environ.get(f"DATASOURCE_URL__{token}") or os.environ.get("DATASOURCE_URL")
+
+
+def _load_credentials(profile: str) -> dict[str, str]:
+    """Resolve credentials for `profile`, env-first then the file.
+
+    Source order:
+      1. A DSN from the environment (DATASOURCE_URL[__<PROFILE>]) — the self-host
+         channel; parsed by `_parse_dsn`, no file read, no chmod gate.
+      2. <artifacts_dir>/local/credentials (the local-plugin default), where within
+         the selected profile a `url = ...` DSN (merged with per-field overrides) or
+         per-field host / port / user / password / database / type / sslmode is read.
+
+    The env is an added *source*, not a fork: the file path — and its chmod-600 gate
+    (never on a command line) — is unchanged, and is skipped only when a deployment
+    opts into the env var (and so has no file to protect).
+    """
+    dsn = _env_datasource_dsn(profile)
+    if dsn:
+        return _parse_dsn(dsn)
+
     if not CREDENTIALS_PATH.exists():
         sys.stderr.write(
-            "<artifacts_dir>/local/credentials is missing. Run the agami `init` skill to set it up.\n"
-            "Never type credentials into chat — they belong in the file.\n"
+            f"No warehouse credentials for profile [{profile}]. Set DATASOURCE_URL "
+            f"(or DATASOURCE_URL__{''.join(c if c.isalnum() else '_' for c in profile).upper()}) "
+            "in the environment, or create <artifacts_dir>/local/credentials via the agami `init` skill.\n"
+            "Never type credentials into chat — they belong in the environment or the file.\n"
         )
         sys.exit(2)
 

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -86,6 +86,12 @@ def _err(msg: str, *, code: int = 2) -> int:
     return code
 
 
+def _env_token(profile: str) -> str:
+    """The env-var suffix for a datasource: the profile id upper-cased with every non-alphanumeric char
+    folded to `_` (so `sales-pg` → `SALES_PG`, used as `DATASOURCE_URL__SALES_PG`)."""
+    return "".join(c if c.isalnum() else "_" for c in profile).upper()
+
+
 def _env_datasource_dsn(profile: str) -> str | None:
     """A warehouse DSN supplied via the environment for `profile`, or None.
 
@@ -113,7 +119,7 @@ def _env_datasource_dsn(profile: str) -> str | None:
       - The token folds every non-alphanumeric char to `_`, so profiles differing only in
         punctuation (`sales-pg` vs `sales.pg`) map to the same var — name profiles distinctly.
     """
-    token = "".join(c if c.isalnum() else "_" for c in profile).upper()
+    token = _env_token(profile)
     for name in (f"DATASOURCE_URL__{token}", "DATASOURCE_URL"):
         val = os.environ.get(name)
         if val and val.strip():
@@ -142,7 +148,7 @@ def _load_credentials(profile: str) -> dict[str, str]:
     if not CREDENTIALS_PATH.exists():
         sys.stderr.write(
             f"No warehouse credentials for profile [{profile}]. Set DATASOURCE_URL "
-            f"(or DATASOURCE_URL__{''.join(c if c.isalnum() else '_' for c in profile).upper()}) "
+            f"(or DATASOURCE_URL__{_env_token(profile)}) "
             "in the environment, or create <artifacts_dir>/local/credentials via the agami `init` skill.\n"
             "Never type credentials into chat — they belong in the environment or the file.\n"
         )

--- a/tests/test_env_credentials.py
+++ b/tests/test_env_credentials.py
@@ -1,0 +1,108 @@
+"""
+Env-var warehouse-credential resolution in execute_sql (`_load_credentials`).
+
+The self-host / container path supplies the warehouse DSN in the environment
+(DATASOURCE_URL[__<PROFILE>]) instead of the mounted `local/credentials` file — env
+carries no file mode, so it sidesteps the chmod-600 gate + the container-uid mismatch.
+This covers env-first resolution, per-datasource precedence, the type-from-scheme reuse
+of `_parse_dsn`, that the file path is untouched when no env is set, and the
+both-sources-named error.
+
+Run: pytest tests/test_env_credentials.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import execute_sql  # noqa: E402
+from execute_sql import _env_datasource_dsn, _load_credentials  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clear_datasource_env(monkeypatch):
+    """Start every test from a clean slate — no ambient DATASOURCE_URL* leaking in."""
+    import os
+
+    for k in list(os.environ):
+        if k == "DATASOURCE_URL" or k.startswith("DATASOURCE_URL__"):
+            monkeypatch.delenv(k, raising=False)
+
+
+# --- env-first, no file needed ---------------------------------------------
+
+def test_env_dsn_resolves_without_a_file(monkeypatch, tmp_path):
+    """DATASOURCE_URL set + NO creds file → resolve from env, no file read, no chmod gate."""
+    monkeypatch.setenv("DATASOURCE_URL", "postgresql://u:p@warehouse:5432/analytics")
+    # Point the file path at something that does not exist: if the code touched it we'd SystemExit.
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", tmp_path / "nope" / "credentials")
+
+    out = _load_credentials("default")
+    assert out == {
+        "type": "postgres", "host": "warehouse", "port": "5432",
+        "user": "u", "password": "p", "database": "analytics",
+    }
+
+
+# --- per-datasource precedence ---------------------------------------------
+
+def test_per_datasource_overrides_bare_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATASOURCE_URL", "postgresql://u:p@pg:5432/main")
+    monkeypatch.setenv("DATASOURCE_URL__SALES", "mysql://mu:mp@mysqlhost:3306/salesdb")
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", tmp_path / "nope")
+
+    assert _load_credentials("sales")["type"] == "mysql"       # the per-datasource var wins
+    assert _load_credentials("other")["type"] == "postgres"    # unrelated profile → bare default
+
+
+def test_profile_id_is_normalized_to_an_env_token(monkeypatch):
+    """A profile like `sales-pg` maps to DATASOURCE_URL__SALES_PG (upper + non-alnum→_)."""
+    monkeypatch.setenv("DATASOURCE_URL__SALES_PG", "postgresql://u:p@h:5432/db")
+    assert _env_datasource_dsn("sales-pg") == "postgresql://u:p@h:5432/db"
+    assert _env_datasource_dsn("SALES.PG") == "postgresql://u:p@h:5432/db"
+
+
+# --- type + params come from the DSN (reusing _parse_dsn) -------------------
+
+def test_snowflake_env_dsn_carries_scheme_type_and_query_params(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "DATASOURCE_URL",
+        "snowflake://u:p@acct.us-east-1/analytics/public?warehouse=WH&role=ANALYST",
+    )
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", tmp_path / "nope")
+
+    out = _load_credentials("default")
+    assert out["type"] == "snowflake"
+    assert out["warehouse"] == "WH"
+    assert out["role"] == "ANALYST"
+
+
+# --- no fork: the file path is unchanged when no env is set ----------------
+
+def test_no_env_falls_through_to_the_file(monkeypatch, tmp_path):
+    creds = tmp_path / "credentials"
+    creds.write_text("[default]\nurl = postgresql://fu:fp@filehost:5432/filedb\n", encoding="utf-8")
+    import os
+    if os.name == "posix":
+        creds.chmod(0o600)  # the gate the file path still enforces
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", creds)
+
+    out = _load_credentials("default")
+    assert out["host"] == "filehost" and out["type"] == "postgres"
+
+
+# --- neither source → an error that names both -----------------------------
+
+def test_missing_both_sources_names_env_and_file(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", tmp_path / "absent")
+    with pytest.raises(SystemExit):
+        _load_credentials("default")
+    err = capsys.readouterr().err
+    assert "DATASOURCE_URL" in err
+    assert "credentials" in err

--- a/tests/test_env_credentials.py
+++ b/tests/test_env_credentials.py
@@ -68,6 +68,15 @@ def test_profile_id_is_normalized_to_an_env_token(monkeypatch):
     assert _env_datasource_dsn("SALES.PG") == "postgresql://u:p@h:5432/db"
 
 
+def test_env_dsn_is_stripped_and_whitespace_only_is_unset(monkeypatch):
+    """A trailing newline (common from secret stores / `.env`) is stripped; blank → unset."""
+    monkeypatch.setenv("DATASOURCE_URL", "  postgresql://u:p@h:5432/db\n")
+    assert _env_datasource_dsn("default") == "postgresql://u:p@h:5432/db"
+    # A whitespace-only per-datasource var must NOT shadow the real generic one — it falls through.
+    monkeypatch.setenv("DATASOURCE_URL__SALES", "   \n")
+    assert _env_datasource_dsn("sales") == "postgresql://u:p@h:5432/db"
+
+
 # --- type + params come from the DSN (reusing _parse_dsn) -------------------
 
 def test_snowflake_env_dsn_carries_scheme_type_and_query_params(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
`execute_sql._load_credentials` gains an **environment** source resolved *ahead of* the `local/credentials` file. This is the self-host / container credential channel: a mounted 600-mode creds file can't be read by a container running as a different uid (and `execute_sql` rejects the file if perms are widened) — env has no file mode and is inherited by the subprocess, so it sidesteps that whole class. Motivated by a field deploy where queries failed on `Permission denied` reading the mounted credentials.

It's an added **source, not a fork** (REQ-002): with no env var set, resolution is byte-for-byte the old file path — the local plugin and its chmod-600 gate are untouched. Env secrets are the cloud-neutral pattern (REQ-007).

## Changes
- `packages/agami-core/src/execute_sql.py`
  - New `_env_datasource_dsn(profile)` — returns a DSN from `DATASOURCE_URL__<PROFILE>` (per-datasource; profile id upper-cased, non-alphanumeric → `_`) then `DATASOURCE_URL` (single default), or `None`.
  - `_load_credentials` tries env first (parsed by the **existing** `_parse_dsn`, so the DSN scheme carries the warehouse type and query params merge), else the unchanged file read.
  - Missing-both error now names **both** `DATASOURCE_URL` and the file. Module docstring corrected.
- `tests/test_env_credentials.py` — 6 tests: env-first with no file, per-datasource precedence, profile-id normalization, snowflake scheme+params via env, no-env-falls-through-to-file (no-fork regression), missing-both error names both.
- `plugins/agami/lib/execute_sql.py` — re-synced (`dev.py sync-lib`).

## Checklist
- [x] `uv run dev.py check` green — **1044 passed**, ruff clean, gitleaks clean
- [x] New behavior covered by tests (no live DB — env parsing + precedence + no-file path)
- [x] No fork: file path + 600 gate unchanged when no env is set (regression test)
- [x] No secret on a command line / in logs; env inherited by the subprocess
- [x] Customer-safety: neutral placeholders only (`warehouse`, `acme`-style), no real names

Consumed by ACE-027 (deploy wiring: `.env` carries the DSN, bundle drops `local/`).

Spec: ACE-026