### PR TITLE
Serve /mcp without a 307 trailing-slash redirect (claude.ai connector connects)

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -201,6 +201,27 @@ class _AuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+class _NormalizeMcpSlash:
+    """Rewrite the exact path ``/mcp`` → ``/mcp/`` before routing.
+
+    Starlette's ``Mount("/mcp", …)`` answers a request to the bare ``/mcp`` (no trailing slash) with a
+    307 redirect to ``/mcp/``. claude.ai posts the connector URL ``{base}/mcp`` and does **not** follow
+    that redirect, so the connector errors right after login. ``handle_mcp`` ignores the sub-path, so
+    normalizing here is loss-free. Pure ASGI (not ``BaseHTTPMiddleware``) so it edits the scope path
+    with no request-body buffering; only the exact ``/mcp`` is touched — ``/mcp/…`` and every other
+    route pass through untouched. Placed outermost so it runs before auth + routing; the fix lives in
+    the app, so it also covers the Caddy-less ``cloud-run`` profile (no proxy rewrite needed).
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope.get("path") == "/mcp":
+            scope = dict(scope, path="/mcp/", raw_path=b"/mcp/")
+        await self.app(scope, receive, send)
+
+
 async def _protected_resource(request: Request) -> JSONResponse:
     """RFC 9728 — tells the client where the authorization server is."""
     base = public_base_url()
@@ -362,7 +383,10 @@ def build_app() -> Starlette:
         Mount("/mcp", app=handle_mcp),
     ]
     middleware = [
-        Middleware(_AuthMiddleware, resolver=_build_org_resolver(), auth=auth_provider)
+        # Outermost: normalize the bare `/mcp` → `/mcp/` before routing so Starlette's Mount doesn't
+        # 307-redirect it (claude.ai posts `{base}/mcp` and won't follow the redirect). See _NormalizeMcpSlash.
+        Middleware(_NormalizeMcpSlash),
+        Middleware(_AuthMiddleware, resolver=_build_org_resolver(), auth=auth_provider),
     ]
     return Starlette(routes=routes, middleware=middleware, lifespan=lifespan)
 

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -136,6 +136,33 @@ def test_non_bearer_and_empty_tokens_are_rejected(base_url):
         assert r.status_code == 401, authz
 
 
+def test_mcp_bare_path_is_not_307_redirected(base_url):
+    """Regression: Mount('/mcp') 307-redirects the no-slash /mcp to /mcp/, and claude.ai (unlike
+    TestClient's default) does NOT follow it, so the connector errors right after login. The shim must
+    let an authed POST /mcp reach the handler directly — a non-307 status, matching /mcp/.
+
+    `follow_redirects=False` is load-bearing: with the default (follow on), the auto-followed 307
+    would hide the bug — which is exactly why it shipped."""
+    headers = {
+        "Authorization": "Bearer present",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    init = {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                   "clientInfo": {"name": "t", "version": "1"}},
+    }
+    with TestClient(mcp_http.build_app(), follow_redirects=False) as c:
+        # Auth still gates the bare path (the shim must not become a bypass) — no bearer → 401, not a 307.
+        assert c.post("/mcp", json=init).status_code == 401
+        bare = c.post("/mcp", headers=headers, json=init)
+        slashed = c.post("/mcp/", headers=headers, json=init)
+    assert bare.status_code != 307              # the fix: the bare path is served, not redirected
+    assert bare.status_code == 200              # reaches `initialize` directly
+    assert bare.status_code == slashed.status_code  # parity with the trailing-slash form
+
+
 def test_http_tools_list_is_the_same_five(base_url):
     """Authed end-to-end: initialize → tools/list over HTTP returns exactly the 5 product tools —
     the same surface stdio advertises (mirrored, not forked)."""


### PR DESCRIPTION
## Summary
Starlette's `Mount("/mcp", app=handle_mcp)` answers the bare `/mcp` (no trailing slash) with a **307 → `/mcp/`**. The canonical connector URL is `{base}/mcp`, and **claude.ai's MCP client doesn't follow the redirect** — so the connector errors in a loop right after login. A field tester patched it with a Caddy rewrite, but that misses the **`cloud-run` profile (no Caddy)**; the fix belongs in the server.

`handle_mcp` is a bare ASGI callable that ignores the sub-path, so normalizing `/mcp` → `/mcp/` before routing is loss-free.

## Changes
- `packages/agami-core/src/mcp_http.py`
  - New `_NormalizeMcpSlash` pure-ASGI middleware: rewrites the **exact** `/mcp` → `/mcp/` in the scope before routing. Added **outermost** in the middleware list (before auth + routing). Only `/mcp` is touched; `/mcp/…` and all other routes pass through.
- `tests/test_mcp_http.py` — `test_mcp_bare_path_is_not_307_redirected`: with `follow_redirects=False` (load-bearing — the default *follow* is exactly why the bug hid in tests), an authed `POST /mcp` reaches `initialize` (200, **not 307**) with parity to `/mcp/`, and an unauth'd `/mcp` still **401s** (the shim is not a bypass).

## Why a middleware, not `redirect_slashes=False` or a `Route`
Both were tried and rejected (verified against this Starlette): `app.router.redirect_slashes = False` **404s** `/mcp`; wrapping the ASGI app in a `Route` raises `TypeError` (a `Route` endpoint is called `f(request)`, not as an ASGI app). The scope-path shim is the one that works and keeps `build_app()` returning a `Starlette`.

## Checklist
- [x] `uv run dev.py check` green — ruff clean, gitleaks clean, full suite passes
- [x] Regression test proves non-307 on the bare path + auth still gates (no bypass)
- [x] No Caddyfile change needed — fix covers every profile incl. `cloud-run`/`tunnel`
- [x] No secret/PII; no behavior change beyond path normalization

Independent of ACE-026/027 (the creds/perms chain).

Spec: ACE-029