### PR TITLE
Deploy: env-var warehouse creds + world-readable model (no mounted secret, no perm crash)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -17,8 +17,12 @@ AGAMI_ADMIN_PASSWORD=choose-a-strong-password
 # AGAMI_OIDC_GOOGLE_CLIENT_ID=
 # AGAMI_OIDC_GOOGLE_CLIENT_SECRET=
 
-# NOTE: the WAREHOUSE the model queries is NOT configured here — its credentials travel in your mounted
-# artifacts at `<artifacts>/local/credentials` (an INI keyed by datasource), the same file agami uses locally.
+# The WAREHOUSE the model queries — its connection DSN. This is a CREDENTIAL: type it here by hand and
+# never share it in chat. The scheme picks the type (postgresql:// mysql:// redshift:// snowflake://…);
+# add query params as needed (e.g. ?sslmode=require, or Snowflake ?warehouse=…&role=…). For a SECOND
+# datasource, add DATASOURCE_URL__<NAME> (e.g. DATASOURCE_URL__SALES=…) — <NAME> is the datasource id
+# upper-cased with non-alphanumerics folded to `_`.
+# DATASOURCE_URL=postgresql://user:pass@your-warehouse.example:5432/analytics?sslmode=require
 
 # External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).
 # Use a PLAIN postgresql:// URL (e.g. a Cloud-SQL-like service via its IP + sslmode=require) — not a cloud connector.

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -67,7 +67,7 @@ def _build_env(example: str, args: argparse.Namespace) -> str:
 def _widen_one(path: Path) -> None:
     """`a+rX` on a single path: add read for all, plus execute/traverse for a directory (or a file that
     already has an execute bit). Add-only — never removes a bit, so a read-only snapshot stays readable
-    and never wider. A symlink is skipped so a link's target (possibly outside the bundle) is untouched."""
+    (perms only widen, never narrow). A symlink is skipped so a link's target (possibly outside the bundle) is untouched."""
     st = path.lstat()
     if stat.S_ISLNK(st.st_mode):
         return
@@ -120,6 +120,10 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
         # copied into a shippable bundle or mounted into the container (the uid-mismatch crash this
         # replaces). symlinks=True keeps links as links; dirs_exist_ok so a re-run refreshes in place.
         staged = target / "artifacts"
+        # `dirs_exist_ok=True` merges into an existing bundle, and `ignore` only skips COPYING `local/` —
+        # it does NOT delete a `local/` a PRIOR (older) prepare_deploy staged. Purge it explicitly, so a
+        # re-run over an old bundle can't keep a stale credentials file sitting in the mounted volume.
+        shutil.rmtree(staged / "local", ignore_errors=True)
         shutil.copytree(
             artifacts, staged, symlinks=True, dirs_exist_ok=True,
             ignore=shutil.ignore_patterns("local"),

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -18,6 +18,7 @@ Stdout is a single status line (first token machine-readable); the skill reads i
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import stat
 import sys
@@ -63,22 +64,34 @@ def _build_env(example: str, args: argparse.Namespace) -> str:
     return text
 
 
+def _widen_one(path: Path) -> None:
+    """`a+rX` on a single path: add read for all, plus execute/traverse for a directory (or a file that
+    already has an execute bit). Add-only — never removes a bit, so a read-only snapshot stays readable
+    and never wider. A symlink is skipped so a link's target (possibly outside the bundle) is untouched."""
+    st = path.lstat()
+    if stat.S_ISLNK(st.st_mode):
+        return
+    mode = stat.S_IMODE(st.st_mode)
+    add = 0o444  # a+r
+    if stat.S_ISDIR(st.st_mode) or (mode & 0o111):  # a+X: dirs, or files already carrying an execute bit
+        add |= 0o111
+    path.chmod(mode | add)
+
+
 def _grant_world_read(root: Path) -> None:
-    """`chmod -R a+rX` in Python over the staged model: add read for all, and traverse (execute) for
-    directories (and any file already executable). The deployed container runs as uid 10001, not the
-    operator who owns these files, and mounts them read-only — without this the boot-time model load
-    fails "Permission denied" on ORGANIZATION.md and the container crash-loops. Add-only (never removes
-    a bit, so a read-only snapshot stays readable and never wider); symlinks are skipped so a link's
-    target outside the bundle is never touched. Only non-secret model files reach here — `local/`
-    (credentials + .pgpass) is excluded from staging."""
-    for path in [root, *root.rglob("*")]:
-        if path.is_symlink():
-            continue
-        mode = stat.S_IMODE(path.stat().st_mode)
-        add = 0o444  # a+r
-        if path.is_dir() or (mode & 0o111):  # a+X: dirs, or files that already carry an execute bit
-            add |= 0o111
-        path.chmod(mode | add)
+    """`chmod -R a+rX` over the staged model. The deployed container runs as uid 10001, not the operator
+    who owns these files, and mounts them read-only — without this the boot-time model load fails
+    "Permission denied" on ORGANIZATION.md and the container crash-loops. Only non-secret model files
+    reach here (`local/` is excluded from staging).
+
+    Uses `os.walk(followlinks=False)` — NOT `rglob("**")`, which follows directory symlinks on Python
+    ≤3.12 and could chmod files *outside* the bundle — and it streams rather than materializing every
+    path, so a large model doesn't build a giant list."""
+    _widen_one(root)
+    for dirpath, dirnames, filenames in os.walk(root):  # followlinks=False (default): never enters a symlinked dir
+        base = Path(dirpath)
+        for name in (*dirnames, *filenames):
+            _widen_one(base / name)
 
 
 def prepare(args: argparse.Namespace) -> tuple[str, int]:

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -121,9 +121,13 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
         # replaces). symlinks=True keeps links as links; dirs_exist_ok so a re-run refreshes in place.
         staged = target / "artifacts"
         # `dirs_exist_ok=True` merges into an existing bundle, and `ignore` only skips COPYING `local/` —
-        # it does NOT delete a `local/` a PRIOR (older) prepare_deploy staged. Purge it explicitly, so a
-        # re-run over an old bundle can't keep a stale credentials file sitting in the mounted volume.
-        shutil.rmtree(staged / "local", ignore_errors=True)
+        # it does NOT delete a `local/` a PRIOR (older) prepare_deploy staged. Purge it explicitly so a
+        # re-run over an old bundle can't keep a stale credentials file in the mounted volume. Fail-CLOSED:
+        # NOT `ignore_errors` — a failed purge (a perms/read-only issue) must surface as an ERROR, never
+        # silently leave the secret behind. A missing `local/` is fine (nothing to purge).
+        stale_local = staged / "local"
+        if stale_local.exists():
+            shutil.rmtree(stale_local)
         shutil.copytree(
             artifacts, staged, symlinks=True, dirs_exist_ok=True,
             ignore=shutil.ignore_patterns("local"),

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import shutil
+import stat
 import sys
 from pathlib import Path
 
@@ -62,6 +63,24 @@ def _build_env(example: str, args: argparse.Namespace) -> str:
     return text
 
 
+def _grant_world_read(root: Path) -> None:
+    """`chmod -R a+rX` in Python over the staged model: add read for all, and traverse (execute) for
+    directories (and any file already executable). The deployed container runs as uid 10001, not the
+    operator who owns these files, and mounts them read-only — without this the boot-time model load
+    fails "Permission denied" on ORGANIZATION.md and the container crash-loops. Add-only (never removes
+    a bit, so a read-only snapshot stays readable and never wider); symlinks are skipped so a link's
+    target outside the bundle is never touched. Only non-secret model files reach here — `local/`
+    (credentials + .pgpass) is excluded from staging."""
+    for path in [root, *root.rglob("*")]:
+        if path.is_symlink():
+            continue
+        mode = stat.S_IMODE(path.stat().st_mode)
+        add = 0o444  # a+r
+        if path.is_dir() or (mode & 0o111):  # a+X: dirs, or files that already carry an execute bit
+            add |= 0o111
+        path.chmod(mode | add)
+
+
 def prepare(args: argparse.Namespace) -> tuple[str, int]:
     """Returns (status_line, exit_code). The status line's first token is machine-readable."""
     target = Path(args.target).expanduser().resolve()
@@ -82,10 +101,18 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
             shutil.copy2(_BUNDLE_SRC / name, target / name)
         (target / "deploy.sh").chmod(0o755)
 
-        # Stage the model + warehouse credentials so the bundle is self-contained + shippable. copy2
-        # preserves the chmod-600 on local/credentials; symlinks=True keeps links as links rather than
-        # materializing their targets into the bundle. dirs_exist_ok so a re-run refreshes in place.
-        shutil.copytree(artifacts, target / "artifacts", symlinks=True, dirs_exist_ok=True)
+        # Stage the MODEL only — never a secret. `local/` (credentials + .pgpass) is excluded: the
+        # deployed server reads warehouse creds from DATASOURCE_URL in .env, so no 600-mode file is
+        # copied into a shippable bundle or mounted into the container (the uid-mismatch crash this
+        # replaces). symlinks=True keeps links as links; dirs_exist_ok so a re-run refreshes in place.
+        staged = target / "artifacts"
+        shutil.copytree(
+            artifacts, staged, symlinks=True, dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("local"),
+        )
+        # The model is non-secret, but the container runs as a different uid than the file owner — widen
+        # the staged copy to world-readable/traversable so the read-only mount is readable regardless.
+        _grant_world_read(staged)
 
         env_path = target / ".env"
         if env_path.exists():

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -89,8 +89,9 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
     if not _BUNDLE_SRC.is_dir():
         return f"ERROR carried bundle templates not found at {_BUNDLE_SRC}", 1
     if not (artifacts / "local").is_dir():
-        # No staged model/creds to ship — the deploy would have nothing to serve.
-        return f"ERROR no artifacts (model + credentials) found at {artifacts} — run /agami-connect first", 1
+        # `local/` marks a real agami-artifacts dir (i.e. /agami-connect has run) — it is the precondition,
+        # NOT something we stage (creds now travel in .env via DATASOURCE_URL; the model is staged below).
+        return f"ERROR no agami-artifacts at {artifacts} (run /agami-connect first)", 1
     if target == artifacts or target.is_relative_to(artifacts) or artifacts.is_relative_to(target):
         # Else the copytree(artifacts -> target/artifacts) would recurse into the bundle it just created.
         return f"ERROR --target must not be inside --artifacts-dir (or vice versa): {target}", 1

--- a/plugins/agami/skills/agami-deploy/SKILL.md
+++ b/plugins/agami/skills/agami-deploy/SKILL.md
@@ -72,14 +72,20 @@ have the user set `APP_DATABASE_URL` in `.env` by hand, never on the command lin
 line: `PREPARED <dir>` (fresh) or `PREPARED_KEPT_ENV <dir>` (an existing `.env` was preserved — tell the
 user to edit it directly to change values).
 
-## Phase 2: Hand off the password (then end the turn)
-Tell the user (do **not** proceed past this in the same turn):
+## Phase 2: Hand off the secrets (then end the turn)
+Tell the user (do **not** proceed past this in the same turn). These are credentials — the user types
+them by hand; you never see them, they stay in the file on their machine:
 
-> Open `~/agami-deploy/.env`, set **`AGAMI_ADMIN_PASSWORD=`** to a strong password (and, if you chose
-> managed Postgres, set **`APP_DATABASE_URL=`** too), and save. Then tell me to continue. (I never see
-> them — they stay in the file on your machine.)
+> Open `~/agami-deploy/.env` and set, then save:
+> - **`AGAMI_ADMIN_PASSWORD=`** — a strong admin password.
+> - **`DATASOURCE_URL=`** — the warehouse the model queries, as a connection DSN
+>   (e.g. `postgresql://user:pass@host:5432/db`; the scheme picks the type). A second datasource uses
+>   `DATASOURCE_URL__<NAME>`. *(The warehouse creds live here now — they are **not** shipped in the bundle.)*
+> - *(only if you chose managed Postgres)* **`APP_DATABASE_URL=`** — your Postgres URL.
+>
+> Then tell me to continue.
 
-End the turn here. The user fills the password and re-invokes (or says "continue").
+End the turn here. The user fills the secrets and re-invokes (or says "continue").
 
 ## Phase 3: Finalize + deploy
 1. **Validate + generate the signing secret:** `$PY -m deploy_preflight ~/agami-deploy/.env`. If it

--- a/plugins/agami/skills/agami-deploy/bundle/.env.example
+++ b/plugins/agami/skills/agami-deploy/bundle/.env.example
@@ -19,8 +19,12 @@ AGAMI_ADMIN_LAST_NAME=Kim
 # and set AGAMI_ADMIN_PROVIDER + the matching AGAMI_OIDC_* vars instead — see the in-repo deploy README.)
 AGAMI_ADMIN_PASSWORD=
 
-# NOTE: the WAREHOUSE the model queries is NOT configured here — its credentials travel in your mounted
-# artifacts at `<artifacts>/local/credentials` (the same file agami uses locally).
+# The WAREHOUSE the model queries — its connection DSN. This is a CREDENTIAL: type it here by hand and
+# never share it in chat. The scheme picks the type (postgresql:// mysql:// redshift:// snowflake://…);
+# add query params as needed (e.g. ?sslmode=require, or Snowflake ?warehouse=…&role=…). For a SECOND
+# datasource, add DATASOURCE_URL__<NAME> (e.g. DATASOURCE_URL__SALES=…) — <NAME> is the datasource id
+# upper-cased with non-alphanumerics folded to `_`.
+# DATASOURCE_URL=postgresql://user:pass@your-warehouse.example:5432/analytics?sslmode=require
 
 # External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).
 # Use a PLAIN postgresql:// URL (e.g. a Cloud-SQL-like service via its IP + sslmode=require) — not a cloud connector.

--- a/plugins/agami/skills/agami-deploy/bundle/.env.example
+++ b/plugins/agami/skills/agami-deploy/bundle/.env.example
@@ -1,5 +1,6 @@
 # agami self-host config. `/agami-deploy` fills the non-secret values and runs `deploy_preflight`, which
-# generates AGAMI_SIGNING_SECRET + derives AGAMI_PUBLIC_HOST. You only type AGAMI_ADMIN_PASSWORD by hand.
+# generates AGAMI_SIGNING_SECRET + derives AGAMI_PUBLIC_HOST. You type the CREDENTIALS by hand:
+# AGAMI_ADMIN_PASSWORD + DATASOURCE_URL (and APP_DATABASE_URL / OIDC secrets only if you use them).
 
 # Which parts of the stack to run (see docker-compose.yml). Default = the secure VM bundle.
 COMPOSE_PROFILES=bundled-db,edge

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -85,6 +85,19 @@ def test_local_secrets_are_never_staged(tmp_path):
     assert list(target.glob("artifacts/**/.pgpass")) == []
 
 
+def test_rerun_purges_a_stale_local_from_an_older_bundle(tmp_path):
+    """A bundle made by an OLDER prepare_deploy staged `local/` (with credentials). Re-running must
+    delete that stale secret — `ignore=` only skips copying, and `dirs_exist_ok` merges, so without an
+    explicit purge the old credentials file would linger in the mounted volume."""
+    art = _artifacts(tmp_path)
+    target = tmp_path / "bundle"
+    stale = target / "artifacts" / "local"
+    stale.mkdir(parents=True)
+    (stale / "credentials").write_text("[demo]\nhost = stale\n", encoding="utf-8")
+    prepare_deploy.prepare(_args(target, art))
+    assert not (target / "artifacts" / "local").exists()
+
+
 def test_staged_model_is_world_readable(tmp_path):
     """The container runs as a different uid and mounts the model read-only — every staged dir must be
     world-traversable and every file world-readable, else the boot-time load crashes (issue #1's fix)."""

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -99,6 +99,21 @@ def test_staged_model_is_world_readable(tmp_path):
     assert stat.S_IMODE((prof / "org.yaml").stat().st_mode) & 0o004     # file: others readable
 
 
+def test_widen_does_not_chmod_through_a_dir_symlink(tmp_path):
+    """The widening must never follow a directory symlink out of the bundle and chmod external files
+    (rglob('**') would on Python ≤3.12; os.walk(followlinks=False) does not)."""
+    art = _artifacts(tmp_path)
+    external = tmp_path / "outside"
+    external.mkdir()
+    secret = external / "secret.txt"
+    secret.write_text("x", encoding="utf-8")
+    secret.chmod(0o600)
+    # A directory symlink inside the model pointing at the external dir (copied into the bundle as a link).
+    (art / "demo" / "link").symlink_to(external, target_is_directory=True)
+    prepare_deploy.prepare(_args(tmp_path / "bundle", art))
+    assert stat.S_IMODE(secret.stat().st_mode) == 0o600  # untouched — not widened through the symlink
+
+
 def test_env_ships_a_datasource_url_hint_left_unset(tmp_path):
     """The warehouse DSN is a Phase-2 hand-off (a credential): .env carries a commented hint, and the
     helper never sets it to a value (same discipline as APP_DATABASE_URL / the admin password)."""
@@ -106,7 +121,9 @@ def test_env_ships_a_datasource_url_hint_left_unset(tmp_path):
     prepare_deploy.prepare(_args(target, _artifacts(tmp_path)))
     env = (target / ".env").read_text()
     assert "# DATASOURCE_URL=" in env       # the hint ships
-    assert "\nDATASOURCE_URL=" not in env    # but is never written as a live value by the helper
+    # No line assigns DATASOURCE_URL a live value (commented hint only) — checked per-line so it holds
+    # even at the start of the file, and doesn't false-match the `DATASOURCE_URL__<NAME>` form.
+    assert not any(ln.lstrip().startswith("DATASOURCE_URL=") for ln in env.splitlines())
 
 
 def test_env_has_non_secrets_and_a_blank_password(tmp_path):

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -63,9 +63,50 @@ def test_prepares_a_complete_bundle(tmp_path):
     assert "image: ghcr.io/agamiai/agami-core:" in compose
     assert "build:" not in compose
 
-    # The model + credentials are staged so the bundle is self-contained + shippable.
+    # The MODEL is staged so the bundle is self-contained + shippable...
     assert (target / "artifacts" / "demo" / "org.yaml").exists()
-    assert (target / "artifacts" / "local" / "credentials").exists()
+    # ...but no secret travels: `local/` (credentials + .pgpass) is excluded entirely (creds come from
+    # DATASOURCE_URL in .env now), so no 600-mode file lands in a shippable bundle or a mounted volume.
+    assert not (target / "artifacts" / "local").exists()
+    assert list(target.glob("artifacts/**/credentials")) == []
+
+
+def test_local_secrets_are_never_staged(tmp_path):
+    """`local/` — credentials AND .pgpass — must not enter a shippable bundle (the field tester had to
+    chown both to the container uid; with them gone, neither exists to fix)."""
+    art = _artifacts(tmp_path)
+    pgpass = art / "local" / ".pgpass"
+    pgpass.write_text("db.example:5432:*:u:p\n", encoding="utf-8")
+    pgpass.chmod(0o600)
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, art))
+    assert not (target / "artifacts" / "local").exists()
+    assert list(target.glob("artifacts/**/credentials")) == []
+    assert list(target.glob("artifacts/**/.pgpass")) == []
+
+
+def test_staged_model_is_world_readable(tmp_path):
+    """The container runs as a different uid and mounts the model read-only — every staged dir must be
+    world-traversable and every file world-readable, else the boot-time load crashes (issue #1's fix)."""
+    art = _artifacts(tmp_path)
+    # Simulate a restrictive owner-only source (umask 077); the widening must repair it in the bundle.
+    (art / "demo" / "org.yaml").chmod(0o600)
+    (art / "demo").chmod(0o700)
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, art))
+    prof = target / "artifacts" / "demo"
+    assert stat.S_IMODE(prof.stat().st_mode) & 0o005 == 0o005          # dir: others r-x (traversable)
+    assert stat.S_IMODE((prof / "org.yaml").stat().st_mode) & 0o004     # file: others readable
+
+
+def test_env_ships_a_datasource_url_hint_left_unset(tmp_path):
+    """The warehouse DSN is a Phase-2 hand-off (a credential): .env carries a commented hint, and the
+    helper never sets it to a value (same discipline as APP_DATABASE_URL / the admin password)."""
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, _artifacts(tmp_path)))
+    env = (target / ".env").read_text()
+    assert "# DATASOURCE_URL=" in env       # the hint ships
+    assert "\nDATASOURCE_URL=" not in env    # but is never written as a live value by the helper
 
 
 def test_env_has_non_secrets_and_a_blank_password(tmp_path):


### PR DESCRIPTION
## Summary
The `/agami-deploy` bundle mounted the operator's entire `~/agami-artifacts` (incl. the 600-mode `local/credentials`) read-only into a container that runs as **uid 10001**. Two field failures, both from the uid mismatch: (1) the model files weren't world-readable → boot-time `model_deploy` crashed `Permission denied: ORGANIZATION.md` → 502 crash-loop; (2) even past that, `execute_sql` couldn't read the 600 creds file (and rejects it if perms are widened).

This makes the deploy consume ACE-026's env-var creds: the warehouse DSN travels in `.env` (`DATASOURCE_URL`), the bundle **stops shipping `local/`**, and the (non-secret) model is staged **world-readable**. Net: no secret is ever mounted, and the operator never runs `chmod`.

## Changes
- `plugins/agami/scripts/prepare_deploy.py`
  - Stage the **model only** — `copytree(..., ignore=ignore_patterns("local"))` — so `local/credentials` and `local/.pgpass` never enter the bundle.
  - `_grant_world_read` widens the staged model (`chmod -R a+rX` semantics: add-only, dirs traversable + files readable; symlinks skipped) so uid 10001 reads it through the read-only mount.
- `deploy/.env.example` + `plugins/agami/skills/agami-deploy/bundle/.env.example` — delete the now-false NOTE ("credentials travel in your mounted artifacts") and add a commented `DATASOURCE_URL` hint (+ `DATASOURCE_URL__<NAME>` for a second warehouse). It's a credential, so the helper never writes it.
- `plugins/agami/skills/agami-deploy/SKILL.md` — Phase-2 hand-off asks the user to set `DATASOURCE_URL` by hand (alongside the admin password), and notes the warehouse creds are no longer shipped.
- `tests/test_prepare_deploy.py` — +4: `local/` excluded, `.pgpass` excluded, staged model world-readable (the crash regression), `DATASOURCE_URL` hint ships but is left unset. Updated the old "credentials staged" assertion to its opposite.

## Checklist
- [x] `uv run dev.py check` green — ruff clean, gitleaks clean, full suite passes
- [x] Crash regression covered: staged model dirs others-`r-x`, files others-`r` (repairs a 0o700/0o600 source)
- [x] No secret in a shippable bundle or a mounted volume; DSN is a `.env` hand-off, never on a command line
- [x] Customer-safety: neutral placeholders only (`acme`, `your-warehouse.example`, `you@example.com`)

Depends on **ACE-026** (#74) for the executor to read `DATASOURCE_URL`. Also revises the ACE-009 `.env` contract (creds file → env).

Spec: ACE-027