### PR TITLE
Release v0.3.5: env-var creds + mountless-secret deploy + /mcp 307 fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.3.5] — 2026-07-04
+
+### Fixed
+
+- **Self-host deploy no longer crash-loops on artifact permissions.** The team
+  server runs as a non-root container user; the deploy now stages the model
+  **world-readable**, so the boot-time model load can't fail `Permission denied`
+  on `ORGANIZATION.md` under a mismatched host owner.
+- **claude.ai connects to a self-hosted server.** The `/mcp` endpoint no longer
+  answers the bare (no-trailing-slash) URL with a `307` redirect that the MCP
+  client won't follow — the server normalizes it internally, so `{base}/mcp`
+  works on every deploy profile (including the Caddy-less Cloud Run one).
+
+### Changed
+
+- **Warehouse credentials come from the environment (`DATASOURCE_URL`), not a
+  mounted file.** The executor resolves a connection DSN from
+  `DATASOURCE_URL[__<datasource>]` env-first, falling back to the local
+  `credentials` file — one code path, no fork. The self-host bundle now carries
+  the DSN in `.env` and **ships no secret**: `local/` (credentials, `.pgpass`)
+  is never staged, and a re-run purges any stale copy from an older bundle.
+
 ## [0.3.4] — 2026-07-03
 
 ### Fixed
@@ -130,6 +152,7 @@ First version tracked in this changelog. Earlier history lives in the git log.
   other clients — stdio, no auth, no network.
 - Fan-trap / chasm-trap pre-flight that refuses to silently double-count.
 
+[0.3.5]: https://github.com/AgamiAI/agami-core/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/AgamiAI/agami-core/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/AgamiAI/agami-core/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/AgamiAI/agami-core/compare/v0.3.1...v0.3.2

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.4"
+version = "0.3.5"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary
Cuts **v0.3.5**, shipping the self-host deploy fixes surfaced by a field run-through (all merged: #74, #75, #76).

## Changes
- Version bump 0.3.4 → **0.3.5** in `packages/agami-core/pyproject.toml`, `.claude-plugin/marketplace.json` (×2), `plugins/agami/.claude-plugin/plugin.json`.
- `CHANGELOG.md` — `[0.3.5]` entry (Fixed: perm crash + `/mcp` 307; Changed: env-var warehouse creds, no mounted secret).

## What ships
- **ACE-026** — `execute_sql` reads warehouse creds from `DATASOURCE_URL[__<ds>]` env-first, file-fallback.
- **ACE-027** — deploy stages no secret + world-readable model; kills the boot-time permission crash.
- **ACE-029** — `/mcp` served without the 307 redirect so claude.ai connects (all profiles).

## Checklist
- [x] `uv run dev.py check` green
- [x] All four version spots bumped consistently
- [x] Tag `v0.3.5` will be pushed post-merge → triggers the PyPI trusted-publish + GHCR image workflows

Merging this, then tagging `v0.3.5`.