### PR TITLE
Upgrade-aware /agami-deploy re-run + multi-datasource select

### DIFF
--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -106,10 +106,12 @@ def _env_key(line: str) -> str | None:
 
 
 def _merge_env(existing: str, template: str, image_tag: str | None) -> tuple[str, list[str]]:
-    """Non-destructive upgrade of an existing `agami.env`: **keep every existing line/value** (never touch a
+    """Non-destructive upgrade of an existing `agami.env`: **preserve every existing value** (never touch a
     typed password / generated secret), **append any template key not already present** (as the template's
     own line — a commented hint or a value, so a key new in this version like `DATASOURCE_URL` shows up), and
-    — only when `image_tag` is given — bump the non-secret `AGAMI_IMAGE_TAG`. Returns (merged_text, new_keys)."""
+    — only when `image_tag` is given — bump the non-secret `AGAMI_IMAGE_TAG`. The output is LF-normalized
+    (docker's `env_file` + the generated file use LF; a value's content is unchanged by that). Returns
+    (merged_text, new_keys)."""
     present = {k for line in existing.splitlines() if (k := _env_key(line))}
     merged = existing if existing.endswith("\n") else existing + "\n"
     new_lines: list[str] = []
@@ -127,7 +129,8 @@ def _merge_env(existing: str, template: str, image_tag: str | None) -> tuple[str
         )
     if image_tag is not None:
         merged = _set_key(merged, "AGAMI_IMAGE_TAG", image_tag)
-    return merged, new_keys
+    # Normalize to LF so appending LF lines to a CRLF file (Windows) can't produce mixed newlines.
+    return merged.replace("\r\n", "\n").replace("\r", "\n"), new_keys
 
 
 def _stage_ignore(artifacts: Path, datasources: list[str] | None):
@@ -197,6 +200,13 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
                 return f"ERROR --datasources matched no model in {artifacts}: {', '.join(dslist)}", 1
             if unknown:
                 sys.stderr.write(f"warning: --datasources not found (staged nothing for them): {', '.join(unknown)}\n")
+            # On a re-run, drop any previously-staged model NOT in the chosen set — copytree(dirs_exist_ok)
+            # merges and won't delete, so without this a dropped datasource would linger and still be served.
+            chosen = set(dslist)
+            if staged.exists():
+                for d in staged.iterdir():
+                    if d.is_dir() and (d / "org.yaml").is_file() and d.name not in chosen:
+                        shutil.rmtree(d)
         shutil.copytree(
             artifacts, staged, symlinks=True, dirs_exist_ok=True,
             ignore=_stage_ignore(artifacts, dslist),  # drops `local/`, and non-chosen models when dslist set

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -185,6 +185,13 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
             shutil.rmtree(stale_local)
         datasources = getattr(args, "datasources", None)
         dslist = [s.strip() for s in datasources.split(",") if s.strip()] if datasources else None
+        if dslist:
+            # Warn (don't fail) on a name that isn't a model here — staging it silently would deploy a
+            # server missing that datasource. A warning to stderr keeps the stdout status line clean.
+            available = {d.name for d in artifacts.iterdir() if d.is_dir() and (d / "org.yaml").is_file()}
+            unknown = [d for d in dslist if d not in available]
+            if unknown:
+                sys.stderr.write(f"warning: --datasources not found (staged nothing for them): {', '.join(unknown)}\n")
         shutil.copytree(
             artifacts, staged, symlinks=True, dirs_exist_ok=True,
             ignore=_stage_ignore(artifacts, dslist),  # drops `local/`, and non-chosen models when dslist set

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -186,7 +186,9 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
         # NOT `ignore_errors` — a failed purge (a perms/read-only issue) must surface as an ERROR, never
         # silently leave the secret behind. A missing `local/` is fine (nothing to purge).
         stale_local = staged / "local"
-        if stale_local.exists():
+        if stale_local.is_symlink():
+            stale_local.unlink()  # rmtree() raises on a symlink — drop the link, never its target
+        elif stale_local.exists():
             shutil.rmtree(stale_local)
         datasources = getattr(args, "datasources", None)
         dslist = [s.strip() for s in datasources.split(",") if s.strip()] if datasources else None
@@ -205,7 +207,11 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
             chosen = set(dslist)
             if staged.exists():
                 for d in staged.iterdir():
-                    if d.is_dir() and (d / "org.yaml").is_file() and d.name not in chosen:
+                    if d.name in chosen or not (d / "org.yaml").is_file():
+                        continue  # keep chosen models + non-model entries (e.g. USER_MEMORY.md)
+                    if d.is_symlink():
+                        d.unlink()  # a symlinked model: drop the link, never rmtree its target
+                    else:
                         shutil.rmtree(d)
         shutil.copytree(
             artifacts, staged, symlinks=True, dirs_exist_ok=True,

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -98,7 +98,9 @@ def _env_key(line: str) -> str | None:
     """The KEY of an `agami.env` line (`KEY=…` or `# KEY=…`), or None for prose/blank. A key is
     UPPER_SNAKE (letters/digits/underscore), so a comment sentence that happens to contain `=`
     (e.g. `?sslmode=require`) isn't mistaken for a setting."""
-    s = line.lstrip("#").lstrip()
+    # Whitespace FIRST, then the comment marker(s): an INDENTED commented key ("  # KEY=…") must still be
+    # recognized, else _merge_env would think it's missing and re-append it (a duplicate).
+    s = line.lstrip().lstrip("#").lstrip()
     key = s.split("=", 1)[0].strip() if "=" in s else ""
     return key if key and all(c.isupper() or c.isdigit() or c == "_" for c in key) else None
 
@@ -186,10 +188,13 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
         datasources = getattr(args, "datasources", None)
         dslist = [s.strip() for s in datasources.split(",") if s.strip()] if datasources else None
         if dslist:
-            # Warn (don't fail) on a name that isn't a model here — staging it silently would deploy a
-            # server missing that datasource. A warning to stderr keeps the stdout status line clean.
             available = {d.name for d in artifacts.iterdir() if d.is_dir() and (d / "org.yaml").is_file()}
             unknown = [d for d in dslist if d not in available]
+            # Fail fast if NONE of the requested datasources exist — a modelless bundle would only break
+            # later at runtime. If SOME are unknown, warn (stderr keeps the stdout status line clean) and
+            # stage the valid ones.
+            if not any(d in available for d in dslist):
+                return f"ERROR --datasources matched no model in {artifacts}: {', '.join(dslist)}", 1
             if unknown:
                 sys.stderr.write(f"warning: --datasources not found (staged nothing for them): {', '.join(unknown)}\n")
         shutil.copytree(

--- a/plugins/agami/scripts/prepare_deploy.py
+++ b/plugins/agami/scripts/prepare_deploy.py
@@ -5,15 +5,15 @@ model artifacts, and write `agami.env` with the NON-SECRET values the skill gath
 This helper never touches a secret: the admin password is typed by the user into the file afterwards
 (the agami-connect hand-off pattern), `deploy_preflight` generates the signing secret, and an external
 `APP_DATABASE_URL` (itself a credential) is likewise edited into `agami.env` by the user — never passed
-here on the command line. So that a re-run can't wipe a password the user already typed or a secret already
-generated, an EXISTING `agami.env` is preserved untouched — only the other bundle files (and the artifacts
-copy) are refreshed.
+here on the command line. On a re-run over an EXISTING bundle it upgrades non-destructively: every value the
+user typed is kept, keys new in this version are appended (so an upgrade surfaces e.g. `DATASOURCE_URL`), and
+the image tag bumps only if one was passed.
 
 Stdout is a single status line (first token machine-readable); the skill reads it and acts. Stdlib only.
 
-  PREPARED <target>           fresh bundle written; user must set AGAMI_ADMIN_PASSWORD next        [0]
-  PREPARED_KEPT_ENV <target>  bundle refreshed; an existing agami.env was preserved (not overwritten) [0]
-  ERROR <message>             templates missing / artifacts missing / write failed                  [1]
+  PREPARED <target>                    fresh bundle written; user must set the secrets next          [0]
+  UPGRADED <target> new_keys=<a,b,…>   existing bundle upgraded in place; new_keys = keys just added [0]
+  ERROR <message>                      templates missing / artifacts missing / write failed          [1]
 """
 from __future__ import annotations
 
@@ -54,7 +54,7 @@ def _build_env(example: str, args: argparse.Namespace) -> str:
     password line is left blank (the user types it); the signing secret is left for deploy_preflight."""
     text = example if example.endswith("\n") else example + "\n"
     text = _set_key(text, "COMPOSE_PROFILES", args.profiles)
-    text = _set_key(text, "AGAMI_IMAGE_TAG", args.image_tag)
+    text = _set_key(text, "AGAMI_IMAGE_TAG", getattr(args, "image_tag", None) or "latest")
     text = _set_key(text, "PUBLIC_BASE_URL", args.public_base_url)
     text = _set_key(text, "AGAMI_ADMIN_USERNAME", args.admin_email)
     text = _set_key(text, "AGAMI_ADMIN_FIRST_NAME", args.admin_first)
@@ -94,6 +94,61 @@ def _grant_world_read(root: Path) -> None:
             _widen_one(base / name)
 
 
+def _env_key(line: str) -> str | None:
+    """The KEY of an `agami.env` line (`KEY=…` or `# KEY=…`), or None for prose/blank. A key is
+    UPPER_SNAKE (letters/digits/underscore), so a comment sentence that happens to contain `=`
+    (e.g. `?sslmode=require`) isn't mistaken for a setting."""
+    s = line.lstrip("#").lstrip()
+    key = s.split("=", 1)[0].strip() if "=" in s else ""
+    return key if key and all(c.isupper() or c.isdigit() or c == "_" for c in key) else None
+
+
+def _merge_env(existing: str, template: str, image_tag: str | None) -> tuple[str, list[str]]:
+    """Non-destructive upgrade of an existing `agami.env`: **keep every existing line/value** (never touch a
+    typed password / generated secret), **append any template key not already present** (as the template's
+    own line — a commented hint or a value, so a key new in this version like `DATASOURCE_URL` shows up), and
+    — only when `image_tag` is given — bump the non-secret `AGAMI_IMAGE_TAG`. Returns (merged_text, new_keys)."""
+    present = {k for line in existing.splitlines() if (k := _env_key(line))}
+    merged = existing if existing.endswith("\n") else existing + "\n"
+    new_lines: list[str] = []
+    new_keys: list[str] = []
+    for line in template.splitlines():
+        k = _env_key(line)
+        if k and k not in present and k not in new_keys:
+            new_lines.append(line)
+            new_keys.append(k)
+    if new_lines:
+        merged += (
+            "\n# --- added on upgrade by /agami-deploy (new in this version — fill any you need) ---\n"
+            + "\n".join(new_lines)
+            + "\n"
+        )
+    if image_tag is not None:
+        merged = _set_key(merged, "AGAMI_IMAGE_TAG", image_tag)
+    return merged, new_keys
+
+
+def _stage_ignore(artifacts: Path, datasources: list[str] | None):
+    """A `copytree` ignore callable: always drop `local/` (secrets never ship), and — when `datasources`
+    is given — also drop any TOP-LEVEL profile dir (a dir with an `org.yaml`) not in the chosen set.
+    Install-global files (e.g. `USER_MEMORY.md`) and non-profile entries are always kept. Default
+    (`datasources is None`) stages every model, preserving prior behavior."""
+    chosen = set(datasources) if datasources else None
+
+    def _ignore(dirpath: str, names: list[str]) -> set[str]:
+        drop: set[str] = set()
+        if Path(dirpath) == artifacts:  # only prune at the artifacts root
+            drop.add("local")
+            if chosen is not None:
+                for name in names:
+                    d = artifacts / name
+                    if name not in chosen and d.is_dir() and (d / "org.yaml").is_file():
+                        drop.add(name)
+        return drop
+
+    return _ignore
+
+
 def prepare(args: argparse.Namespace) -> tuple[str, int]:
     """Returns (status_line, exit_code). The status line's first token is machine-readable."""
     target = Path(args.target).expanduser().resolve()
@@ -128,9 +183,11 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
         stale_local = staged / "local"
         if stale_local.exists():
             shutil.rmtree(stale_local)
+        datasources = getattr(args, "datasources", None)
+        dslist = [s.strip() for s in datasources.split(",") if s.strip()] if datasources else None
         shutil.copytree(
             artifacts, staged, symlinks=True, dirs_exist_ok=True,
-            ignore=shutil.ignore_patterns("local"),
+            ignore=_stage_ignore(artifacts, dslist),  # drops `local/`, and non-chosen models when dslist set
         )
         # The model is non-secret, but the container runs as a different uid than the file owner — widen
         # the staged copy to world-readable/traversable so the read-only mount is readable regardless.
@@ -139,13 +196,18 @@ def prepare(args: argparse.Namespace) -> tuple[str, int]:
         # The operator-editable config is `agami.env` — a visible name (a dot-file like `.env` is hidden in
         # Finder, and this is the one file the user must open). docker-compose reads it via `--env-file` in
         # deploy.sh + the `env_file:` directive, since it no longer auto-loads by the `.env` name.
+        example = (_BUNDLE_SRC / "agami.env.example").read_text(encoding="utf-8")
         env_path = target / "agami.env"
         if env_path.exists():
-            # Never clobber an agami.env that may already hold a typed password / a generated signing secret —
-            # but do reassert chmod 600 in case an editor/umask loosened it (the file holds secrets).
-            env_path.chmod(0o600)
-            return f"PREPARED_KEPT_ENV {target}", 0
-        example = (_BUNDLE_SRC / "agami.env.example").read_text(encoding="utf-8")
+            # Upgrade-aware, NON-DESTRUCTIVE: keep the operator's typed password / generated secret, append
+            # any key new in this version (so an upgrade surfaces e.g. DATASOURCE_URL), and bump the image
+            # tag only if one was passed (a model-only re-stage passes none, so the pin is left alone).
+            merged, new_keys = _merge_env(
+                env_path.read_text(encoding="utf-8"), example, getattr(args, "image_tag", None)
+            )
+            env_path.write_text(merged, encoding="utf-8")
+            env_path.chmod(0o600)  # reassert 600 in case an editor/umask loosened it
+            return f"UPGRADED {target} new_keys={','.join(new_keys)}", 0
         env_path.write_text(_build_env(example, args), encoding="utf-8")
         env_path.chmod(0o600)
     except OSError as e:
@@ -163,7 +225,11 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--admin-first", required=True)
     p.add_argument("--admin-last", required=True)
     p.add_argument("--profiles", default="bundled-db,edge", help="COMPOSE_PROFILES (default: single-server)")
-    p.add_argument("--image-tag", default="latest", help="ghcr.io/agamiai/agami-core tag to pull")
+    p.add_argument("--image-tag", default=None,
+                   help="ghcr.io/agamiai/agami-core tag (fresh: defaults to 'latest'; on a re-run, set it to "
+                        "bump the version — omit to leave an existing pin alone)")
+    p.add_argument("--datasources", default=None,
+                   help="comma-separated datasource ids to stage (default: every model in the artifacts dir)")
     # Deliberately NO --password / --app-database-url / secret args: a credential never travels on the
     # command line (it would leak into chat logs / shell history). The user edits those into agami.env.
     args = p.parse_args(argv)

--- a/plugins/agami/skills/agami-deploy/SKILL.md
+++ b/plugins/agami/skills/agami-deploy/SKILL.md
@@ -72,9 +72,11 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/prepare_deploy.py" \
   --public-base-url "https://<host>" \
   --admin-email "<email>" --admin-first "<first>" --admin-last "<last>" \
   --profiles "bundled-db,edge"
-  # add --datasources "a,b" to stage a subset; on a version UPGRADE add --image-tag "<version>"
-  # (omit --image-tag on a model-only re-stage so an existing pin isn't changed)
 ```
+
+**Append these flags to the command when they apply** (add each as another `\`-continued line): `--datasources
+"a,b"` to stage a subset of models; on a **version upgrade** `--image-tag "<version>"` to bump it (omit it on a
+model-only re-stage so an existing pin isn't changed).
 
 (Use `--profiles "bundled-db,tunnel"` for the tunnel, or `--profiles "edge"` for managed Postgres — then
 have the user set `APP_DATABASE_URL` in `agami.env` by hand, never on the command line.)

--- a/plugins/agami/skills/agami-deploy/SKILL.md
+++ b/plugins/agami/skills/agami-deploy/SKILL.md
@@ -55,6 +55,11 @@ Ask only these (everything else is defaulted or generated). Prefer one compact e
 3. *(only if they bring their own Postgres)* note it → use profiles `edge` (drops the bundled DB). The
    managed `postgresql://…` URL is a **credential**, so do **not** collect it in chat — after the bundle
    is written, the user sets `APP_DATABASE_URL` in `agami.env` themselves (the same hand-off as the password).
+4. **Which datasource(s)?** — list the models in the artifacts dir (one per profile:
+   `<artifacts_dir>/<profile>/org.yaml`). If there's exactly one, use it silently. If there's **more than
+   one**, ask: *"You have N datasources — `<names>`. Deploy all, or pick?"* Pass the chosen set as
+   `--datasources a,b` (omit to deploy all). The server serves **every** datasource you stage, and each needs
+   its own DSN (Phase 2).
 
 **Confirm where to write the bundle.** Ask: *"Where should I put the deploy bundle? (default `~/agami-deploy`)"*
 and use their answer as `--target`. It must **not** be inside the artifacts dir (prepare_deploy rejects that —
@@ -67,12 +72,20 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/prepare_deploy.py" \
   --public-base-url "https://<host>" \
   --admin-email "<email>" --admin-first "<first>" --admin-last "<last>" \
   --profiles "bundled-db,edge"
+  # add --datasources "a,b" to stage a subset; on a version UPGRADE add --image-tag "<version>"
+  # (omit --image-tag on a model-only re-stage so an existing pin isn't changed)
 ```
 
 (Use `--profiles "bundled-db,tunnel"` for the tunnel, or `--profiles "edge"` for managed Postgres — then
-have the user set `APP_DATABASE_URL` in `agami.env` by hand, never on the command line.) Report the status
-line: `PREPARED <dir>` (fresh) or `PREPARED_KEPT_ENV <dir>` (an existing `agami.env` was preserved — tell the
-user to edit it directly to change values).
+have the user set `APP_DATABASE_URL` in `agami.env` by hand, never on the command line.)
+
+**Read the status line** and branch on the first token:
+- `PREPARED <dir>` — a **fresh** bundle. Go to Phase 2 (fill the secrets).
+- `UPGRADED <dir> new_keys=<a,b,…>` — an **existing** bundle upgraded **in place**: every value the user
+  typed (password, secret, DSN) is kept. If `new_keys` is **non-empty**, this version added settings — tell
+  the user exactly which to set (e.g. *"this version added `DATASOURCE_URL` — set it in `agami.env` before we
+  restart"*). If it's **empty**, nothing new is needed. Existing secrets are already there — don't re-ask;
+  continue to Phase 3 (deploy).
 
 ## Phase 2: Hand off the secrets (then end the turn)
 **Open the file for them** so they don't have to hunt for it (it's a plain visible file, `agami.env`, in the
@@ -83,9 +96,13 @@ credentials — the user types them by hand; you never see them, they stay in th
 
 > Open `<target>/agami.env` (I just opened it for you) and set, then save:
 > - **`AGAMI_ADMIN_PASSWORD=`** — a strong admin password.
-> - **`DATASOURCE_URL=`** — the warehouse the model queries, as a connection DSN
->   (e.g. `postgresql://user:pass@host:5432/db`; the scheme picks the type). A second datasource uses
->   `DATASOURCE_URL__<NAME>`. *(The warehouse creds live here now — they are **not** shipped in the bundle.)*
+> - the **warehouse DSN(s)** — the connection string(s) the model queries (the scheme picks the type:
+>   `postgresql://` `mysql://` `redshift://` `snowflake://…`). *(These live here now — **not** shipped in
+>   the bundle.)* Name them per the datasource(s) you deployed:
+>   - **one datasource** → **`DATASOURCE_URL=`** (e.g. `postgresql://<user>:<password>@host:5432/db`).
+>   - **several** → one per datasource: **`DATASOURCE_URL__<TOKEN>=`**, where `<TOKEN>` is the datasource id
+>     upper-cased with every non-alphanumeric char turned to `_` (so `sales-pg` → `DATASOURCE_URL__SALES_PG`).
+>     *(List the exact var names for the datasources they chose in Phase 1.4.)*
 > - *(only if you chose managed Postgres)* **`APP_DATABASE_URL=`** — your Postgres URL.
 >
 > Then tell me to continue.
@@ -110,9 +127,16 @@ End the turn here. The user fills the secrets and re-invokes (or says "continue"
 - **Docker** on the host: `curl -fsSL https://get.docker.com | sudo sh`.
 - Then `./deploy.sh` on the host → wait ~30s for Caddy to issue the cert → open `<PUBLIC_BASE_URL>/admin`.
 
-## Updating the model later
-They refresh the model locally → re-run `/agami-deploy` (re-stages `artifacts/`) → on the host
-`docker compose restart agami`. The server re-ingests the model on boot — no rebuild, no DB access.
+## Re-running later (model update vs version upgrade)
+A re-run of `/agami-deploy` over an existing bundle is **non-destructive** — it never touches the secrets the
+user typed (`UPGRADED` status); it re-stages the model, appends any settings new in this version, and reports
+them as `new_keys`. Two cases:
+
+- **Model update** (they changed the semantic model): re-run **without** `--image-tag` (keeps the pinned
+  version), then on the host `docker compose restart agami` — the server re-ingests the model on boot. No
+  rebuild, no DB access.
+- **Version upgrade** (a newer agami release): re-run **with** `--image-tag "<version>"` (bumps it), set any
+  `new_keys` the run reports, then `cd <target> && ./deploy.sh` (pulls the new image + recreates).
 
 ## Notes
 - This is the **team** path. For a quick local feel of the same tools, that's `agami-serve` (stdio, no

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -374,6 +374,22 @@ def test_rerun_with_datasources_drops_a_previously_staged_model(tmp_path):
     assert not (target / "artifacts" / "ops").exists()               # stale ops purged
 
 
+def test_rerun_drops_a_symlinked_datasource_without_touching_its_target(tmp_path):
+    """A dropped datasource that was staged as a symlink must be unlinked (rmtree raises on a symlink), and
+    its target — which may live outside the bundle — must be left intact."""
+    art = _artifacts(tmp_path)  # model `demo`
+    external = tmp_path / "external-ops"
+    external.mkdir()
+    (external / "org.yaml").write_text("name: ops\n", encoding="utf-8")
+    (art / "ops").symlink_to(external, target_is_directory=True)  # a symlinked model in the artifacts dir
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, art))                       # stages demo + the ops symlink
+    status, code = prepare_deploy.prepare(_args(target, art, datasources="demo"))  # drop ops on re-run
+    assert code == 0 and status.startswith("UPGRADED ")
+    assert not (target / "artifacts" / "ops").exists()               # the staged symlink is gone
+    assert (external / "org.yaml").exists()                          # its target is untouched
+
+
 def test_all_unknown_datasources_fails_fast(tmp_path):
     """If NONE of the requested datasources exist, error out — don't build a modelless bundle that only
     breaks later at runtime."""

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -45,7 +45,7 @@ def _args(target: Path, artifacts: Path, **over) -> argparse.Namespace:
         admin_first="Alex",
         admin_last="Kim",
         profiles="bundled-db,edge",
-        image_tag="latest",
+        image_tag=None,  # match the CLI default (None → fresh builds pin 'latest'; a re-run leaves the pin)
         datasources=None,
     )
     base.update(over)
@@ -302,6 +302,15 @@ def test_merge_preserves_secrets_and_surfaces_new_keys():
     assert "AGAMI_ADMIN_PASSWORD" not in new_keys and "PUBLIC_BASE_URL" not in new_keys
 
 
+def test_merge_recognizes_an_indented_commented_key_and_wont_duplicate():
+    """An indented `  # KEY=…` in the existing file must be seen as present, else the template's KEY would
+    be re-appended (a duplicate). Guards the _env_key strip order."""
+    existing = "  # DATASOURCE_URL=postgresql://<user>:<password>@h/db\nAGAMI_ADMIN_PASSWORD=x\n"
+    merged, new_keys = prepare_deploy._merge_env(existing, _TEMPLATE, None)
+    assert "DATASOURCE_URL" not in new_keys        # already present (indented comment) → not re-added
+    assert merged.count("DATASOURCE_URL=") == 1
+
+
 def test_merge_bumps_image_tag_only_when_passed():
     existing = "AGAMI_IMAGE_TAG=0.3.4\nAGAMI_ADMIN_PASSWORD=x\n"
     # A model-only re-stage passes no tag → the pin is left alone (no silent version change).
@@ -341,3 +350,11 @@ def test_unknown_datasource_name_warns_but_does_not_fail(tmp_path, capsys):
     assert code == 0 and status.startswith("PREPARED ")
     assert (target / "artifacts" / "demo" / "org.yaml").exists()
     assert "nope" in capsys.readouterr().err
+
+
+def test_all_unknown_datasources_fails_fast(tmp_path):
+    """If NONE of the requested datasources exist, error out — don't build a modelless bundle that only
+    breaks later at runtime."""
+    art = _artifacts(tmp_path)  # model `demo`
+    status, code = prepare_deploy.prepare(_args(tmp_path / "bundle", art, datasources="nope,alsonope"))
+    assert code == 1 and status.startswith("ERROR ") and "matched no model" in status

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -213,7 +213,7 @@ def test_helper_takes_no_password_argument(tmp_path):
 
 def test_rerun_upgrades_in_place_and_preserves_typed_secrets(tmp_path):
     """A re-run over an existing bundle UPGRADES non-destructively: the typed password + generated secret
-    survive byte-for-byte, and the status is UPGRADED (not a fresh PREPARED)."""
+    values are preserved (line endings normalize to LF), and the status is UPGRADED (not a fresh PREPARED)."""
     target = tmp_path / "bundle"
     art = _artifacts(tmp_path)
     prepare_deploy.prepare(_args(target, art))

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -46,6 +46,7 @@ def _args(target: Path, artifacts: Path, **over) -> argparse.Namespace:
         admin_last="Kim",
         profiles="bundled-db,edge",
         image_tag="latest",
+        datasources=None,
     )
     base.update(over)
     return argparse.Namespace(**base)
@@ -210,16 +211,16 @@ def test_helper_takes_no_password_argument(tmp_path):
         )
 
 
-def test_existing_env_is_preserved(tmp_path):
+def test_rerun_upgrades_in_place_and_preserves_typed_secrets(tmp_path):
+    """A re-run over an existing bundle UPGRADES non-destructively: the typed password + generated secret
+    survive byte-for-byte, and the status is UPGRADED (not a fresh PREPARED)."""
     target = tmp_path / "bundle"
     art = _artifacts(tmp_path)
     prepare_deploy.prepare(_args(target, art))
-    # Simulate the user typing a password + a generated secret, then a re-run.
     env_path = target / "agami.env"
     env_path.write_text("AGAMI_ADMIN_PASSWORD=typed-by-user\nAGAMI_SIGNING_SECRET=deadbeef\n", encoding="utf-8")
     status, code = prepare_deploy.prepare(_args(target, art))
-    assert code == 0 and status.startswith("PREPARED_KEPT_ENV ")
-    # The user's filled agami.env is untouched (no clobbered password / wiped secret).
+    assert code == 0 and status.startswith("UPGRADED ")
     kept = env_path.read_text()
     assert "AGAMI_ADMIN_PASSWORD=typed-by-user" in kept
     assert "AGAMI_SIGNING_SECRET=deadbeef" in kept
@@ -269,3 +270,63 @@ def test_generated_env_passes_deploy_preflight(tmp_path):
     after = env_path.read_text()
     assert "AGAMI_SIGNING_SECRET=" in after
     assert "AGAMI_PUBLIC_HOST=agami.acme.example" in after
+
+
+# --- ACE-031: upgrade-aware re-run (_merge_env) + multi-datasource selection ---
+
+_TEMPLATE = (
+    "COMPOSE_PROFILES=bundled-db,edge\n"
+    "AGAMI_IMAGE_TAG=latest\n"
+    "PUBLIC_BASE_URL=https://agami.your-domain.example\n"
+    "AGAMI_ADMIN_PASSWORD=\n"
+    "# DATASOURCE_URL=postgresql://<user>:<password>@your-warehouse.example:5432/analytics?sslmode=require\n"
+    "# APP_DATABASE_URL=postgresql://user@your-managed-pg.example:5432/agami?sslmode=require\n"
+)
+
+
+def test_merge_preserves_secrets_and_surfaces_new_keys():
+    existing = (
+        "AGAMI_ADMIN_PASSWORD=typed-by-user\n"
+        "AGAMI_SIGNING_SECRET=deadbeef\n"
+        "PUBLIC_BASE_URL=https://me.example\n"
+    )
+    merged, new_keys = prepare_deploy._merge_env(existing, _TEMPLATE, None)
+    # Existing values are byte-preserved — including a password even though the template ships it blank.
+    assert "AGAMI_ADMIN_PASSWORD=typed-by-user" in merged
+    assert "AGAMI_SIGNING_SECRET=deadbeef" in merged
+    assert "PUBLIC_BASE_URL=https://me.example" in merged
+    assert merged.count("PUBLIC_BASE_URL=") == 1  # not re-appended
+    # Keys new in this version are appended + reported; an already-present key is neither.
+    assert "DATASOURCE_URL" in new_keys and "COMPOSE_PROFILES" in new_keys
+    assert "# DATASOURCE_URL=" in merged
+    assert "AGAMI_ADMIN_PASSWORD" not in new_keys and "PUBLIC_BASE_URL" not in new_keys
+
+
+def test_merge_bumps_image_tag_only_when_passed():
+    existing = "AGAMI_IMAGE_TAG=0.3.4\nAGAMI_ADMIN_PASSWORD=x\n"
+    # A model-only re-stage passes no tag → the pin is left alone (no silent version change).
+    kept, _ = prepare_deploy._merge_env(existing, _TEMPLATE, None)
+    assert "AGAMI_IMAGE_TAG=0.3.4" in kept
+    # An upgrade passes the new tag → bumped in place, no duplicate.
+    bumped, _ = prepare_deploy._merge_env(existing, _TEMPLATE, "0.3.5")
+    assert "AGAMI_IMAGE_TAG=0.3.5" in bumped and "AGAMI_IMAGE_TAG=0.3.4" not in bumped
+    assert bumped.count("AGAMI_IMAGE_TAG=") == 1
+
+
+def test_merge_reports_no_new_keys_when_file_has_them_all():
+    merged, new_keys = prepare_deploy._merge_env(_TEMPLATE, _TEMPLATE, None)
+    assert new_keys == []
+    assert "added on upgrade" not in merged  # nothing appended
+
+
+def test_selective_datasources_stages_only_chosen(tmp_path):
+    """`--datasources` stages only the named models; others drop, install-global files always stay."""
+    art = _artifacts(tmp_path)  # has model `demo`
+    (art / "ops").mkdir()
+    (art / "ops" / "org.yaml").write_text("name: ops\n", encoding="utf-8")
+    (art / "USER_MEMORY.md").write_text("hi\n", encoding="utf-8")
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, art, datasources="demo"))
+    assert (target / "artifacts" / "demo" / "org.yaml").exists()
+    assert not (target / "artifacts" / "ops").exists()        # not chosen → dropped
+    assert (target / "artifacts" / "USER_MEMORY.md").exists()  # install-global → always staged

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -330,3 +330,14 @@ def test_selective_datasources_stages_only_chosen(tmp_path):
     assert (target / "artifacts" / "demo" / "org.yaml").exists()
     assert not (target / "artifacts" / "ops").exists()        # not chosen → dropped
     assert (target / "artifacts" / "USER_MEMORY.md").exists()  # install-global → always staged
+
+
+def test_unknown_datasource_name_warns_but_does_not_fail(tmp_path, capsys):
+    """A typo'd --datasources name warns to stderr (deploying a server silently missing a datasource is bad)
+    but the run still succeeds for the valid ones."""
+    art = _artifacts(tmp_path)  # model `demo`
+    target = tmp_path / "bundle"
+    status, code = prepare_deploy.prepare(_args(target, art, datasources="demo,nope"))
+    assert code == 0 and status.startswith("PREPARED ")
+    assert (target / "artifacts" / "demo" / "org.yaml").exists()
+    assert "nope" in capsys.readouterr().err

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -322,6 +322,14 @@ def test_merge_bumps_image_tag_only_when_passed():
     assert bumped.count("AGAMI_IMAGE_TAG=") == 1
 
 
+def test_merge_normalizes_crlf_to_lf():
+    """A CRLF existing file (Windows) must not yield mixed newlines after a merge; values are unchanged."""
+    existing = "AGAMI_ADMIN_PASSWORD=typed\r\nAGAMI_SIGNING_SECRET=deadbeef\r\n"
+    merged, _ = prepare_deploy._merge_env(existing, _TEMPLATE, "0.3.5")
+    assert "\r" not in merged
+    assert "AGAMI_ADMIN_PASSWORD=typed" in merged and "AGAMI_SIGNING_SECRET=deadbeef" in merged
+
+
 def test_merge_reports_no_new_keys_when_file_has_them_all():
     merged, new_keys = prepare_deploy._merge_env(_TEMPLATE, _TEMPLATE, None)
     assert new_keys == []
@@ -350,6 +358,20 @@ def test_unknown_datasource_name_warns_but_does_not_fail(tmp_path, capsys):
     assert code == 0 and status.startswith("PREPARED ")
     assert (target / "artifacts" / "demo" / "org.yaml").exists()
     assert "nope" in capsys.readouterr().err
+
+
+def test_rerun_with_datasources_drops_a_previously_staged_model(tmp_path):
+    """Dropping a datasource on a re-run must actually remove it from the bundle (copytree merges; it won't
+    delete on its own) — else the server would keep serving a model the operator meant to drop."""
+    art = _artifacts(tmp_path)  # model `demo`
+    (art / "ops").mkdir()
+    (art / "ops" / "org.yaml").write_text("name: ops\n", encoding="utf-8")
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, art))                       # first run stages all → demo + ops
+    assert (target / "artifacts" / "ops").exists()
+    prepare_deploy.prepare(_args(target, art, datasources="demo"))   # re-run: only demo
+    assert (target / "artifacts" / "demo").exists()
+    assert not (target / "artifacts" / "ops").exists()               # stale ops purged
 
 
 def test_all_unknown_datasources_fails_fast(tmp_path):


### PR DESCRIPTION
## Summary
A re-run of `/agami-deploy` used to leave an existing `agami.env` **completely untouched** — safe for secrets, but it meant a version that added a required setting (like v0.3.5's `DATASOURCE_URL`) never surfaced, and a pinned image never moved. And multiple models deployed silently. This makes the re-run **upgrade-aware** and multi-datasource an **explicit choice** — an upgrade now feels like the first deploy: run the skill, fill anything genuinely new, done.

## Changes
- `prepare_deploy.py`
  - **`_merge_env`** (non-destructive upgrade): keeps every existing value (never touches a typed password/secret), **appends any template key new in this version** (as its commented hint — so `DATASOURCE_URL` shows up), and **bumps `AGAMI_IMAGE_TAG` only if `--image-tag` is passed** (a model-only re-stage leaves the pin). New status **`UPGRADED <dir> new_keys=<a,b,…>`**.
  - **`--datasources a,b`** — selective staging via a `copytree` ignore that drops non-chosen profile dirs, always keeping `local/`-exclusion + install-global files (default: all models).
  - `--image-tag` now defaults to `None` (fresh → `latest`).
- `SKILL.md`
  - Phase 1 asks **which datasource(s)** to deploy when there's more than one; reads `PREPARED` vs `UPGRADED`+`new_keys` and surfaces the new settings to the user.
  - Phase 2 gives **per-datasource DSN guidance** (`DATASOURCE_URL` / `DATASOURCE_URL__<TOKEN>`).
  - "Re-running later" splits **model update** (no `--image-tag`, restart) vs **version upgrade** (`--image-tag`, `./deploy.sh`).
- `tests` — +7 (merge preserves secrets & surfaces new keys, tag-bump-only-when-passed, no-spurious-keys, selective staging); re-run test updated to `UPGRADED`.

## Checklist
- [x] `uv run dev.py check` green
- [x] Merge invariant tested: existing values byte-preserved; `new_keys` accurate; tag bumps only when passed
- [x] Secret-safe: no existing value changed/removed; no secret logged or on a command line
- [x] Placeholders are `<user>:<password>` (no GitGuardian-tripping `user:pass`)

Builds on **ACE-030** (visible `agami.env`) and **ACE-026** (`DATASOURCE_URL`). Completes the deploy-UX pair.

Spec: ACE-031