### PR TITLE
Release v0.3.6: deploy lifecycle UX (visible agami.env + upgrade-aware re-run + multi-datasource)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.3.6] — 2026-07-04
+
+### Changed
+
+- **`/agami-deploy` is easier to find and safe to re-run.** The config file is now
+  a **visible `agami.env`** (not a hidden `.env`), and the skill opens it for you.
+  A **re-run upgrades in place, non-destructively**: your typed password/secret and
+  DSN are kept, any setting new in a version is surfaced (e.g. `DATASOURCE_URL`),
+  and the image tag bumps only when you pass one — so a model update is just
+  re-run + restart, and a version upgrade tells you exactly what's new.
+- **Multi-datasource deploys are an explicit choice.** With more than one model,
+  the skill asks which to deploy (all or a subset) and names the per-datasource
+  `DATASOURCE_URL__<NAME>` to set; dropping one on a re-run removes it cleanly.
+
 ## [0.3.5] — 2026-07-04
 
 ### Fixed
@@ -152,6 +166,7 @@ First version tracked in this changelog. Earlier history lives in the git log.
   other clients — stdio, no auth, no network.
 - Fan-trap / chasm-trap pre-flight that refuses to silently double-count.
 
+[0.3.6]: https://github.com/AgamiAI/agami-core/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/AgamiAI/agami-core/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/AgamiAI/agami-core/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/AgamiAI/agami-core/compare/v0.3.2...v0.3.3

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.5"
+version = "0.3.6"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary
Cuts **v0.3.6**, shipping the deploy-UX pair (ACE-030 + ACE-031, both merged).

## Changes
- Version bump 0.3.5 → **0.3.6** across the four spots (pyproject, marketplace ×2, plugin.json).
- `CHANGELOG.md` — `[0.3.6]` entry.

## What ships
- **ACE-030** — the deploy config is a **visible `agami.env`** (not a hidden dot-file), and the skill opens it + confirms the target dir.
- **ACE-031** — a re-run is **upgrade-aware / non-destructive** (keeps typed secrets, surfaces new settings like `DATASOURCE_URL`, bumps the image only when asked), and **multi-datasource** is an explicit pick with per-datasource DSN guidance.

## Checklist
- [x] `uv run dev.py check` green
- [x] All four version spots bumped consistently
- [x] Tag `v0.3.6` pushed post-merge → triggers PyPI trusted-publish + GHCR image

Spec: ACE-030, ACE-031