### PR TITLE
Cap per-container log growth in the deploy compose

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     logging: *default-logging
     command: tunnel --no-autoupdate run
     environment:
-      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}  # from your Cloudflare Zero Trust tunnel
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN:-}  # from your Cloudflare Zero Trust tunnel
 
 volumes:
   pgdata:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,11 +7,20 @@
 #   (none)            — agami only, behind the platform's own TLS (e.g. Cloud Run); set APP_DATABASE_URL
 name: agami
 
+# Cap per-container log growth (default json-file is unbounded) so a long-running deploy can't fill the
+# disk — 3 rotated files × 10 MB per service. Applied to every service via the `*default-logging` anchor.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   caddy:
     image: caddy:2
     profiles: ["edge"]
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "80:80"
       - "443:443"
@@ -27,6 +36,7 @@ services:
       context: ..
       dockerfile: deploy/Dockerfile
     restart: unless-stopped
+    logging: *default-logging
     env_file: agami.env
     environment:
       # Bundled Postgres by default; set APP_DATABASE_URL in agami.env to point at managed Postgres instead.
@@ -43,6 +53,7 @@ services:
     image: postgres:16
     profiles: ["bundled-db"]
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_DB: agami
       POSTGRES_USER: agami
@@ -61,6 +72,7 @@ services:
     image: cloudflare/cloudflared:latest
     profiles: ["tunnel"]
     restart: unless-stopped
+    logging: *default-logging
     command: tunnel --no-autoupdate run
     environment:
       TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}  # from your Cloudflare Zero Trust tunnel

--- a/plugins/agami/skills/agami-deploy/bundle/docker-compose.yml
+++ b/plugins/agami/skills/agami-deploy/bundle/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     logging: *default-logging
     command: tunnel --no-autoupdate run
     environment:
-      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}  # from your Cloudflare Zero Trust tunnel
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN:-}  # from your Cloudflare Zero Trust tunnel
 
 volumes:
   pgdata:

--- a/plugins/agami/skills/agami-deploy/bundle/docker-compose.yml
+++ b/plugins/agami/skills/agami-deploy/bundle/docker-compose.yml
@@ -9,11 +9,20 @@
 # Unlike the in-repo deploy/ stack, this bundle PULLS a pre-built image (no build context, no clone).
 name: agami
 
+# Cap per-container log growth (default json-file is unbounded) so a long-running deploy can't fill the
+# disk — 3 rotated files × 10 MB per service. Applied to every service via the `*default-logging` anchor.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   caddy:
     image: caddy:2
     profiles: ["edge"]
     restart: unless-stopped
+    logging: *default-logging
     ports:
       - "80:80"
       - "443:443"
@@ -27,6 +36,7 @@ services:
   agami:
     image: ghcr.io/agamiai/agami-core:${AGAMI_IMAGE_TAG:-latest}
     restart: unless-stopped
+    logging: *default-logging
     env_file: agami.env
     environment:
       # Bundled Postgres by default; set APP_DATABASE_URL in agami.env to point at managed Postgres instead.
@@ -43,6 +53,7 @@ services:
     image: postgres:16
     profiles: ["bundled-db"]
     restart: unless-stopped
+    logging: *default-logging
     environment:
       POSTGRES_DB: agami
       POSTGRES_USER: agami
@@ -61,6 +72,7 @@ services:
     image: cloudflare/cloudflared:latest
     profiles: ["tunnel"]
     restart: unless-stopped
+    logging: *default-logging
     command: tunnel --no-autoupdate run
     environment:
       TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN}  # from your Cloudflare Zero Trust tunnel

--- a/tests/test_prepare_deploy.py
+++ b/tests/test_prepare_deploy.py
@@ -83,6 +83,15 @@ def test_config_is_visible_agami_env_wired_through_compose_and_deploy(tmp_path):
     assert "--env-file agami.env" in (target / "deploy.sh").read_text()
 
 
+def test_staged_compose_caps_container_logs(tmp_path):
+    """The shipped compose caps per-container log growth — the default json-file driver is unbounded and
+    would slowly fill a small VM disk on a long-running deploy."""
+    target = tmp_path / "bundle"
+    prepare_deploy.prepare(_args(target, _artifacts(tmp_path)))
+    compose = (target / "docker-compose.yml").read_text()
+    assert "logging:" in compose and 'max-size: "10m"' in compose and 'max-file: "3"' in compose
+
+
 def test_local_secrets_are_never_staged(tmp_path):
     """`local/` — credentials AND .pgpass — must not enter a shippable bundle (the field tester had to
     chown both to the container uid; with them gone, neither exists to fix)."""


### PR DESCRIPTION
## Summary
Docker's default `json-file` log driver is **unbounded** — a long-running self-host deploy slowly fills a small VM disk (a 1-person deploy can be 10–20 GB). This caps it in the compose so it ships with the bundle and needs no VM-side `daemon.json` step.

## Changes
- Both compose copies (`bundle/` + in-repo `deploy/`): an `x-logging` anchor (`json-file`, `max-size: "10m"`, `max-file: "3"` → ≤30 MB/container) applied to **every** service (caddy, agami, postgres, cloudflared).
- `tests/test_prepare_deploy.py` — assert the staged compose carries the cap.

## Checklist
- [x] `uv run dev.py check` green
- [x] Both composes parse; all 4 services capped (verified via YAML load)
- [x] No secrets, no behavior change beyond log rotation

Spec: ACE-032