### PR TITLE
docs(agami): nudge users to connect with a read-only DB user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [Unreleased]
+
+### Added
+
+- **Read-only database user guidance.** `/agami-connect` and `/agami-deploy` now
+  recommend connecting agami with a **read-only** database user — agami only ever
+  runs read-only SELECT queries, so read access is all it needs. A new
+  [readonly-grants.md](plugins/agami/shared/readonly-grants.md) ships copy-paste
+  `CREATE USER` / `GRANT SELECT` SQL for every supported dialect (Postgres/Redshift,
+  MySQL, Snowflake, SQL Server, Oracle, Databricks, Trino, BigQuery). Ask agami for
+  "the read-only grant" to get the exact SQL for your database.
+
 ## [0.3.6] — 2026-07-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ When you're ready to connect your own database:
 /agami-connect
 
 # 2. Fill in the template, then save + lock it down
+#    (agami only runs read-only queries, so use a read-only DB user if you can —
+#     ask agami for "the read-only grant" to get the exact GRANT SQL)
 $EDITOR <artifacts_dir>/local/credentials.example
 mv <artifacts_dir>/local/credentials.example <artifacts_dir>/local/credentials
 chmod 600 <artifacts_dir>/local/credentials

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -15,7 +15,7 @@ exposed ports.
 ## Deploy (the secure VM bundle — the default)
 ```bash
 git clone <this repo> && cd <repo>/deploy
-cp agami.env.example agami.env            # then edit: PUBLIC_BASE_URL (your hostname), admin email + password, DATASOURCE_URL
+cp agami.env.example agami.env            # then edit: PUBLIC_BASE_URL (your hostname), admin email + password, DATASOURCE_URL (use a read-only DB user — see Security notes)
 ln -s /path/to/your/agami-artifacts ./artifacts   # or set AGAMI_ARTIFACTS_DIR in agami.env
 ./deploy.sh                     # validates agami.env, generates the signing secret, builds + starts
 ```
@@ -45,6 +45,9 @@ re-ingests the model on boot. **No rebuild, no new VM, no database access** — 
   gated by per-user OAuth. Both need the HTTPS that Caddy provides.
 - `agami.env` holds the signing secret and DB creds — it stays on your host and is never committed. **No data ever
   leaves your environment.**
+- **Use a read-only warehouse user** in `DATASOURCE_URL` — agami only runs read-only SELECTs and never needs
+  write access, so a read-only user is the safest thing to connect. Copy-paste `GRANT SELECT` SQL per database
+  is in [../plugins/agami/shared/readonly-grants.md](../plugins/agami/shared/readonly-grants.md).
 - **Always deploy via `./deploy.sh`** (it runs the preflight). If you `docker compose up` directly without
   having run the preflight, `AGAMI_PUBLIC_HOST` is unset and Caddy fails to start (loudly, never insecurely) —
   run `python -m deploy_preflight agami.env` first.

--- a/deploy/agami.env.example
+++ b/deploy/agami.env.example
@@ -23,6 +23,8 @@ AGAMI_ADMIN_PASSWORD=
 # add query params as needed (e.g. ?sslmode=require, or Snowflake ?warehouse=…&role=…). For a SECOND
 # datasource, add DATASOURCE_URL__<NAME> (e.g. DATASOURCE_URL__SALES=…) — <NAME> is the datasource id
 # upper-cased with non-alphanumerics folded to `_`.
+# agami only runs read-only SELECTs — use a read-only warehouse user here (safest). Copy-paste GRANT
+# SQL per database: plugins/agami/shared/readonly-grants.md (or ask agami for "the read-only grant").
 # DATASOURCE_URL=postgresql://<user>:<password>@your-warehouse.example:5432/analytics?sslmode=require
 
 # External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).

--- a/deploy/agami.env.example
+++ b/deploy/agami.env.example
@@ -24,7 +24,8 @@ AGAMI_ADMIN_PASSWORD=
 # datasource, add DATASOURCE_URL__<NAME> (e.g. DATASOURCE_URL__SALES=…) — <NAME> is the datasource id
 # upper-cased with non-alphanumerics folded to `_`.
 # agami only runs read-only SELECTs — use a read-only warehouse user here (safest). Copy-paste GRANT
-# SQL per database: plugins/agami/shared/readonly-grants.md (or ask agami for "the read-only grant").
+# SQL per database: https://github.com/AgamiAI/agami-core/blob/main/plugins/agami/shared/readonly-grants.md
+# (or ask agami for "the read-only grant").
 # DATASOURCE_URL=postgresql://<user>:<password>@your-warehouse.example:5432/analytics?sslmode=require
 
 # External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -26,6 +26,16 @@ chmod 600 <artifacts_dir>/local/credentials
 `agami` refuses to read the file unless it's `chmod 600` — the same protection
 `ssh` uses for private keys.
 
+## Use a read-only user
+
+`agami` only ever runs read-only SELECT queries, so the `user` above only needs
+read access. Connecting a **read-only database user** is the safest choice,
+especially against a production database. Copy-paste `CREATE USER` / `GRANT SELECT`
+SQL for every dialect (Postgres, MySQL, Snowflake, SQL Server, Oracle, Databricks,
+Trino, BigQuery) is in
+[`plugins/agami/shared/readonly-grants.md`](../plugins/agami/shared/readonly-grants.md)
+— or just ask agami for "the read-only grant" for your database.
+
 ## Multiple databases
 
 Add more `[<profile>]` sections. Switch with `AGAMI_PROFILE=staging`:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,8 @@ You: Snowflake
 ✓ Wrote <artifacts_dir>/local/credentials.example with a [main] section for Snowflake.
   Fill it in (account, user, password OR authenticator=externalbrowser,
   warehouse, role, database, schema) then save as <artifacts_dir>/local/credentials.
+  Tip: agami only runs read-only queries — a read-only DB user is safest.
+  Ask for "the read-only grant" to get the exact SQL for your database.
 
 # After filling in the file:
 $ /agami-connect

--- a/plugins/agami/shared/credentials-format.md
+++ b/plugins/agami/shared/credentials-format.md
@@ -20,6 +20,10 @@ Resolution order when a skill needs to know which profile to use:
 2. **If the file is missing, invoke agami-connect Phase 0a.** Init writes `credentials.example`, sets `<artifacts_dir>/local/` permissions, and tells the user to fill it in. The user edits the template in place and comes back; agami promotes it (`mv` → `<artifacts_dir>/local/credentials`, `chmod 600`) — no manual save/chmod. Never ask "where's your database?" — that's what credentials are for.
 3. **Connect ONLY to the host/port in the file.** Never substitute `localhost` as a fallback. Never probe for a "running database nearby" — if the credentials file says `host = remote-prod.example.com`, that's the only acceptable target.
 
+## Use a read-only user (recommended)
+
+agami only ever runs read-only SELECT queries, so the `user` you put here only needs read access. Connecting a **read-only database user** is the safest posture (especially against production) and never limits what agami can do. Copy-paste `CREATE USER` / `GRANT SELECT` SQL for every dialect is in [`readonly-grants.md`](readonly-grants.md).
+
 ## Format
 
 ```ini

--- a/plugins/agami/shared/readonly-grants.md
+++ b/plugins/agami/shared/readonly-grants.md
@@ -4,7 +4,7 @@ agami only ever runs **read-only SELECT** queries (query generation refuses `INS
 
 Create the user with one of the blocks below, then put **its** credentials in your profile: the `user` / `password` (or `url = …`) in `<artifacts_dir>/local/credentials` for the single-player flow, or the `DATASOURCE_URL` in `agami.env` for a self-host deploy.
 
-Replace `<password>` / `<db>` / `<schema>` / `<warehouse>` / `<catalog>` with your values. For **multiple schemas**, repeat the `USAGE` + `SELECT` grants once per schema.
+Replace the `<…>` placeholders — `<password>`, `<db>`, `<schema>`, `<warehouse>`, `<catalog>`, `<project>`, `<dataset>`, and the `agami_ro` user/role name — with your values (each block uses only some of them). For **multiple schemas**, repeat the `USAGE` + `SELECT` grants once per schema.
 
 ## PostgreSQL / Redshift
 
@@ -47,7 +47,9 @@ GRANT ROLE agami_ro TO USER agami_ro_user;
 
 Put `role = agami_ro` in your Snowflake profile so the read-only role is the one used.
 
-## SQL Server / Azure SQL
+## SQL Server / Azure SQL Managed Instance
+
+A server login plus a database user mapped to it (`db_datareader` is the built-in read-only role):
 
 ```sql
 CREATE LOGIN agami_ro WITH PASSWORD = '<password>';
@@ -56,7 +58,16 @@ CREATE USER agami_ro FOR LOGIN agami_ro;
 ALTER ROLE db_datareader ADD MEMBER agami_ro;   -- SELECT on every table/view
 ```
 
-(On Azure SQL create the login in `master`, then the user in your database. `db_datareader` is the built-in read-only role.)
+(On a Managed Instance, create the login in `master` first.)
+
+## Azure SQL Database
+
+Azure SQL Database doesn't support server logins — create a **contained user** with its own password, connected to the target database:
+
+```sql
+CREATE USER agami_ro WITH PASSWORD = '<password>';
+ALTER ROLE db_datareader ADD MEMBER agami_ro;   -- SELECT on every table/view
+```
 
 ## Oracle
 
@@ -100,4 +111,4 @@ bq add-iam-policy-binding --member="serviceAccount:agami-ro@<project>.iam.gservi
 
 ## SQLite / DuckDB
 
-File-based — there's no user or role. The control is filesystem permissions: point agami at a **read-only copy** of the file, or mark the file read-only for the account agami runs as. (agami already opens local SQLite / DuckDB files in read-only mode.)
+File-based — there's no user or role. Safety comes from agami's **read-only SQL guard** (it refuses anything that isn't a `SELECT`) plus **filesystem permissions**. DuckDB files are additionally opened in read-only mode; SQLite is not, so for a hard guarantee point agami at a **read-only copy** of the file, or mark the file read-only for the account agami runs as.

--- a/plugins/agami/shared/readonly-grants.md
+++ b/plugins/agami/shared/readonly-grants.md
@@ -1,0 +1,103 @@
+# Read-only database user — copy-paste grants
+
+agami only ever runs **read-only SELECT** queries (query generation refuses `INSERT` / `UPDATE` / `DELETE` / DDL, and the local MCP server double-checks every statement). So the safest thing to connect it to is a **read-only user** that can read your data and nothing else. It's optional — read-write credentials work too — but recommended, especially against a production database.
+
+Create the user with one of the blocks below, then put **its** credentials in your profile: the `user` / `password` (or `url = …`) in `<artifacts_dir>/local/credentials` for the single-player flow, or the `DATASOURCE_URL` in `agami.env` for a self-host deploy.
+
+Replace `<password>` / `<db>` / `<schema>` / `<warehouse>` / `<catalog>` with your values. For **multiple schemas**, repeat the `USAGE` + `SELECT` grants once per schema.
+
+## PostgreSQL / Redshift
+
+```sql
+CREATE USER agami_ro WITH PASSWORD '<password>';
+GRANT CONNECT ON DATABASE <db> TO agami_ro;
+GRANT USAGE ON SCHEMA <schema> TO agami_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO agami_ro;
+-- keep future tables readable too (run once per schema):
+ALTER DEFAULT PRIVILEGES IN SCHEMA <schema> GRANT SELECT ON TABLES TO agami_ro;
+```
+
+(Redshift uses the same statements. `<schema>` defaults to `public` if you didn't set one.)
+
+## MySQL / MariaDB
+
+```sql
+CREATE USER 'agami_ro'@'%' IDENTIFIED BY '<password>';
+GRANT SELECT ON <db>.* TO 'agami_ro'@'%';
+FLUSH PRIVILEGES;
+```
+
+(Tighten `'%'` to a specific host if agami connects from a fixed IP.)
+
+## Snowflake
+
+```sql
+CREATE ROLE IF NOT EXISTS agami_ro;
+GRANT USAGE ON WAREHOUSE <warehouse> TO ROLE agami_ro;
+GRANT USAGE ON DATABASE  <db>            TO ROLE agami_ro;
+GRANT USAGE ON SCHEMA    <db>.<schema>   TO ROLE agami_ro;
+GRANT SELECT ON ALL    TABLES IN SCHEMA <db>.<schema> TO ROLE agami_ro;
+GRANT SELECT ON FUTURE TABLES IN SCHEMA <db>.<schema> TO ROLE agami_ro;
+GRANT SELECT ON ALL    VIEWS  IN SCHEMA <db>.<schema> TO ROLE agami_ro;
+GRANT SELECT ON FUTURE VIEWS  IN SCHEMA <db>.<schema> TO ROLE agami_ro;
+-- a user to carry the role (or grant agami_ro to an existing user):
+CREATE USER IF NOT EXISTS agami_ro_user PASSWORD = '<password>' DEFAULT_ROLE = agami_ro;
+GRANT ROLE agami_ro TO USER agami_ro_user;
+```
+
+Put `role = agami_ro` in your Snowflake profile so the read-only role is the one used.
+
+## SQL Server / Azure SQL
+
+```sql
+CREATE LOGIN agami_ro WITH PASSWORD = '<password>';
+-- then, connected to the target database:
+CREATE USER agami_ro FOR LOGIN agami_ro;
+ALTER ROLE db_datareader ADD MEMBER agami_ro;   -- SELECT on every table/view
+```
+
+(On Azure SQL create the login in `master`, then the user in your database. `db_datareader` is the built-in read-only role.)
+
+## Oracle
+
+Oracle has no single "grant select on all tables", so grant per table (or use the broad `SELECT ANY TABLE` if that's acceptable):
+
+```sql
+CREATE USER agami_ro IDENTIFIED BY "<password>";
+GRANT CREATE SESSION TO agami_ro;
+GRANT SELECT ON <schema>.<table> TO agami_ro;   -- repeat per table
+-- broad alternative (reads every schema — use only if that's fine):
+-- GRANT SELECT ANY TABLE TO agami_ro;
+```
+
+## Databricks (Unity Catalog)
+
+agami connects with a token, so the "user" is the token's owner — use a **service principal** that only has read:
+
+```sql
+GRANT USE CATALOG ON CATALOG <catalog>            TO `agami_ro`;
+GRANT USE SCHEMA  ON SCHEMA  <catalog>.<schema>   TO `agami_ro`;
+GRANT SELECT      ON SCHEMA  <catalog>.<schema>   TO `agami_ro`;
+```
+
+## Trino / Presto
+
+Trino itself doesn't store data — it defers reads to the underlying connector. Make the **backing user read-only**: create a read-only user on each source database (the Postgres / MySQL / etc. blocks above) and point the Trino catalog at it, and/or restrict the Trino user with `access-control` rules. There's no single Trino grant that covers every catalog.
+
+## BigQuery
+
+Not SQL — it's IAM. Give the service account (or user) in your `credentials` **viewer + job-runner** roles:
+
+```bash
+# run queries at all:
+gcloud projects add-iam-policy-binding <project> \
+  --member="serviceAccount:agami-ro@<project>.iam.gserviceaccount.com" \
+  --role="roles/bigquery.jobUser"
+# read data (dataset-level is finer than project-level bigquery.dataViewer):
+bq add-iam-policy-binding --member="serviceAccount:agami-ro@<project>.iam.gserviceaccount.com" \
+  --role="roles/bigquery.dataViewer" <project>:<dataset>
+```
+
+## SQLite / DuckDB
+
+File-based — there's no user or role. The control is filesystem permissions: point agami at a **read-only copy** of the file, or mark the file read-only for the account agami runs as. (agami already opens local SQLite / DuckDB files in read-only mode.)

--- a/plugins/agami/skills/agami-connect/SKILL.md
+++ b/plugins/agami/skills/agami-connect/SKILL.md
@@ -304,7 +304,8 @@ Show the read-only **Tip** line only for dialects with a user/role concept (`pos
 `redshift`, `mysql`, `snowflake`, `sqlserver`, `oracle`, `databricks`, `trino`); **omit** it for
 `sqlite` / `duckdb` (file-based, no user) and when BigQuery auth is ADC. If the user asks for the
 grant, read [`shared/readonly-grants.md`](../../shared/readonly-grants.md), pick the `$DB_TYPE`
-block, and fill `<db>` / `<schema>` / `<user>` from the values they entered.
+block, and fill in whatever `<…>` placeholders it uses (e.g. `<db>` / `<schema>` / `<warehouse>` /
+`<catalog>` / `<project>` / `<dataset>`) from the values they entered.
 
 ### 0a.10 — On re-entry: promote the filled-in template, then continue
 The user filled in `<artifacts_dir>/local/credentials.example` and came back (or asked a data question / said "introspect my database"). **Promote it deterministically** with the helper — do NOT hand-roll an `mv`/append, and do NOT assume "no file yet." The script handles all four cases (first profile → move; Nth profile → append; name clash → refuse; placeholders → refuse), so the second-profile and `[main]`/`[main]` cases can't silently corrupt the file:

--- a/plugins/agami/skills/agami-connect/SKILL.md
+++ b/plugins/agami/skills/agami-connect/SKILL.md
@@ -141,6 +141,9 @@ Use the **Write tool**. Shared header first, then the `$DB_TYPE` body with `[$PR
 # Fill in your values below, then come back and say "introspect my database".
 # agami moves this file to <artifacts_dir>/local/credentials and chmod-600s it for you — no
 # manual save or chmod needed. (Don't rename it yourself.)
+# agami only runs read-only SELECT queries, so a read-only database user is all it needs
+# (and the safest thing to connect). Copy-paste GRANT SQL for your database:
+# plugins/agami/shared/readonly-grants.md — or ask agami for "the read-only grant".
 # Format reference: plugins/agami/shared/credentials-format.md
 # Switch profiles with AGAMI_PROFILE=<name>.
 ```
@@ -289,10 +292,19 @@ Next:
 2. Come back and say "introspect my database" — I'll secure the file and run the
    full introspect → enrich → seed flow.
 
+Tip: agami only runs read-only queries, so a read-only database user is all it needs
+(and safest). Want the exact GRANT SQL for your database? Just ask.
+
 Heads-up: a cold cloud warehouse (Snowflake especially) makes introspect the slow
 step — ~5–15 min for a sizable account. Postgres / MySQL are seconds.
 ```
 **End the turn.** Do NOT continue to Phase 1.
+
+Show the read-only **Tip** line only for dialects with a user/role concept (`postgres`,
+`redshift`, `mysql`, `snowflake`, `sqlserver`, `oracle`, `databricks`, `trino`); **omit** it for
+`sqlite` / `duckdb` (file-based, no user) and when BigQuery auth is ADC. If the user asks for the
+grant, read [`shared/readonly-grants.md`](../../shared/readonly-grants.md), pick the `$DB_TYPE`
+block, and fill `<db>` / `<schema>` / `<user>` from the values they entered.
 
 ### 0a.10 — On re-entry: promote the filled-in template, then continue
 The user filled in `<artifacts_dir>/local/credentials.example` and came back (or asked a data question / said "introspect my database"). **Promote it deterministically** with the helper — do NOT hand-roll an `mv`/append, and do NOT assume "no file yet." The script handles all four cases (first profile → move; Nth profile → append; name clash → refuse; placeholders → refuse), so the second-profile and `[main]`/`[main]` cases can't silently corrupt the file:

--- a/plugins/agami/skills/agami-deploy/SKILL.md
+++ b/plugins/agami/skills/agami-deploy/SKILL.md
@@ -105,6 +105,8 @@ credentials — the user types them by hand; you never see them, they stay in th
 >   - **several** → one per datasource: **`DATASOURCE_URL__<TOKEN>=`**, where `<TOKEN>` is the datasource id
 >     upper-cased with every non-alphanumeric char turned to `_` (so `sales-pg` → `DATASOURCE_URL__SALES_PG`).
 >     *(List the exact var names for the datasources they chose in Phase 1.4.)*
+>     agami only runs read-only SELECTs, so the warehouse user only needs read access — a read-only user is
+>     safest. Ask for "the read-only grant" and I'll hand you the SQL ([`shared/readonly-grants.md`](../../shared/readonly-grants.md)).
 > - *(only if you chose managed Postgres)* **`APP_DATABASE_URL=`** — your Postgres URL.
 >
 > Then tell me to continue.

--- a/plugins/agami/skills/agami-deploy/bundle/agami.env.example
+++ b/plugins/agami/skills/agami-deploy/bundle/agami.env.example
@@ -25,8 +25,9 @@ AGAMI_ADMIN_PASSWORD=
 # add query params as needed (e.g. ?sslmode=require, or Snowflake ?warehouse=…&role=…). For a SECOND
 # datasource, add DATASOURCE_URL__<NAME> (e.g. DATASOURCE_URL__SALES=…) — <NAME> is the datasource id
 # upper-cased with non-alphanumerics folded to `_`.
-# agami only runs read-only SELECTs — use a read-only warehouse user here (safest). Copy-paste GRANT
-# SQL per database: plugins/agami/shared/readonly-grants.md (or ask agami for "the read-only grant").
+# agami only runs read-only SELECTs — use a read-only warehouse user here (safest). Ask agami for
+# "the read-only grant", or see the copy-paste GRANT SQL per database at
+# https://github.com/AgamiAI/agami-core/blob/main/plugins/agami/shared/readonly-grants.md
 # DATASOURCE_URL=postgresql://<user>:<password>@your-warehouse.example:5432/analytics?sslmode=require
 
 # External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).

--- a/plugins/agami/skills/agami-deploy/bundle/agami.env.example
+++ b/plugins/agami/skills/agami-deploy/bundle/agami.env.example
@@ -25,6 +25,8 @@ AGAMI_ADMIN_PASSWORD=
 # add query params as needed (e.g. ?sslmode=require, or Snowflake ?warehouse=…&role=…). For a SECOND
 # datasource, add DATASOURCE_URL__<NAME> (e.g. DATASOURCE_URL__SALES=…) — <NAME> is the datasource id
 # upper-cased with non-alphanumerics folded to `_`.
+# agami only runs read-only SELECTs — use a read-only warehouse user here (safest). Copy-paste GRANT
+# SQL per database: plugins/agami/shared/readonly-grants.md (or ask agami for "the read-only grant").
 # DATASOURCE_URL=postgresql://<user>:<password>@your-warehouse.example:5432/analytics?sslmode=require
 
 # External/managed Postgres for the app's own state. Omit to use the bundled `postgres` (bundled-db profile).


### PR DESCRIPTION
## What

agami only ever runs **read-only SELECT** queries (query generation refuses DML/DDL; the local MCP server double-checks every statement). So the right thing to connect it to is a **read-only database user**. Today nothing in setup says that or shows how — a few example usernames say `readonly` but there's no recommendation and no grant SQL.

This adds a **non-blocking** read-only recommendation at every credential-collection point, made **actionable** with copy-paste `GRANT` SQL. Read-write credentials still work; nothing is gated.

## Changes

- **New [`plugins/agami/shared/readonly-grants.md`](../blob/readonly-user-nudge/plugins/agami/shared/readonly-grants.md)** — copy-paste `CREATE USER` / `GRANT SELECT` per dialect: Postgres/Redshift, MySQL, Snowflake, SQL Server, Oracle, Databricks (Unity Catalog), Trino, BigQuery (IAM), plus a SQLite/DuckDB file-permission note.
- **`agami-connect` Phase 0a** — read-only lines in the `credentials.example` header (lands in every user's file) + a hand-off **Tip** shown only for dialects with a user/role concept (skipped for sample / SQLite / DuckDB / BigQuery-ADC).
- **`agami-deploy`** — nudge in the Phase 2 `DATASOURCE_URL` hand-off and in **both** `agami.env.example` templates (skill `bundle/` + top-level `deploy/`), plus a **Security notes** bullet in `deploy/README.md`.
- **Reference / public docs** — `credentials-format.md`, `docs/credentials.md`, `docs/usage.md`, `README.md`, and a `CHANGELOG` (Unreleased) entry.

Every surface links to the new grants doc (relative links verified to resolve).

## Scope notes

- No changes to the connection / introspection code path — guidance + docs only.
- Deliberately skipped `SECURITY.md` (a vuln-reporting policy) and `docs/trust-layer.md` (model confidence/review) as not natural fits; `docs/self-hosting.md` documents the app **store** DSN, not the warehouse datasource, so no read-only row there.
- Possible follow-up (out of scope here): an active privilege probe at introspect time that warns if the connected user can write.

## Verification

- All relative links to `readonly-grants.md` resolve from each file.
- Dry-run the flow: `/agami-connect` → PostgreSQL shows the nudge in the template + hand-off; the sample-database path shows none.
- Ask "give me the read-only grant" and confirm the Postgres block comes back with `<db>`/`<schema>`/`<user>` filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)