### PR TITLE
docs: scope the serverless runtime identity to least privilege

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -48,3 +48,43 @@ re-ingests the model on boot. **No rebuild, no new VM, no database access** — 
 - **Always deploy via `./deploy.sh`** (it runs the preflight). If you `docker compose up` directly without
   having run the preflight, `AGAMI_PUBLIC_HOST` is unset and Caddy fails to start (loudly, never insecurely) —
   run `python -m deploy_preflight agami.env` first.
+
+## Runtime identity on serverless platforms
+
+The **Cloud Run / serverless** variant above runs the container under a **cloud identity**, and every
+managed-container platform hands you an over-privileged *default* one unless you say otherwise. Because
+`/mcp` and `/admin` are internet-facing, a compromised container can read that identity's token from the
+platform metadata endpoint and inherit all of its cloud permissions. So run agami under a **dedicated,
+least-privilege identity** that can do only two things: read the specific secrets agami uses
+(`AGAMI_SIGNING_SECRET`, `APP_DATABASE_URL`, `DATASOURCE_URL`, `AGAMI_ADMIN_PASSWORD`) and reach the
+database. Nothing else. Never the platform default.
+
+- **GCP Cloud Run** — the default Compute Engine service account has project **Editor**; don't use it.
+  Create a dedicated SA, grant `roles/cloudsql.client` (if you use Cloud SQL) and `secretAccessor`
+  **per secret** (not project-wide), then deploy with `--service-account`:
+  ```bash
+  gcloud iam service-accounts create agami-run
+  gcloud projects add-iam-policy-binding PROJECT \
+    --member=serviceAccount:agami-run@PROJECT.iam.gserviceaccount.com \
+    --role=roles/cloudsql.client
+  # grant secret access PER-SECRET, not project-wide:
+  for s in agami-signing-secret app-database-url datasource-url agami-admin-password; do
+    gcloud secrets add-iam-policy-binding "$s" \
+      --member=serviceAccount:agami-run@PROJECT.iam.gserviceaccount.com \
+      --role=roles/secretmanager.secretAccessor
+  done
+  gcloud run deploy agami --service-account=agami-run@PROJECT.iam.gserviceaccount.com ...
+  ```
+- **AWS ECS / Fargate / App Runner** — give the task a dedicated **task role** with only
+  `secretsmanager:GetSecretValue` on the specific secret ARNs (and `rds-db:connect` only if you use RDS
+  IAM auth). Keep it separate from the **execution** role, and don't attach broad managed policies
+  (`AdministratorAccess`, `PowerUserAccess`).
+- **Azure Container Apps / ACI** — assign a **user-assigned managed identity** with a Key Vault access
+  policy / RBAC role scoped to `get` on those specific secrets only — not a subscription- or vault-wide role.
+- **VM / docker-compose (the default bundle)** — this doesn't apply the same way: there's no ambient cloud
+  identity to inherit, and the container already runs as a non-root user (`uid 10001`). Just don't run the
+  host itself with cloud credentials broader than the deployment needs.
+
+This is defense-in-depth **alongside** the read-only `DATASOURCE_URL` database user and the app-layer
+SELECT-only enforcement: the read-only user limits database damage; a least-privilege runtime identity
+limits cloud-account damage.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,8 +60,8 @@ least-privilege identity** that can do only two things: read the specific secret
 database. Nothing else. Never the platform default.
 
 - **GCP Cloud Run** — the default Compute Engine service account has project **Editor**; don't use it.
-  Create a dedicated SA, grant `roles/cloudsql.client` (if you use Cloud SQL) and `secretAccessor`
-  **per secret** (not project-wide), then deploy with `--service-account`:
+  Create a dedicated SA, grant `roles/cloudsql.client` (if you use Cloud SQL) and
+  `roles/secretmanager.secretAccessor` **per secret** (not project-wide), then deploy with `--service-account`:
   ```bash
   gcloud iam service-accounts create agami-run
   gcloud projects add-iam-policy-binding PROJECT \
@@ -81,9 +81,11 @@ database. Nothing else. Never the platform default.
   (`AdministratorAccess`, `PowerUserAccess`).
 - **Azure Container Apps / ACI** — assign a **user-assigned managed identity** with a Key Vault access
   policy / RBAC role scoped to `get` on those specific secrets only — not a subscription- or vault-wide role.
-- **VM / docker-compose (the default bundle)** — this doesn't apply the same way: there's no ambient cloud
-  identity to inherit, and the container already runs as a non-root user (`uid 10001`). Just don't run the
-  host itself with cloud credentials broader than the deployment needs.
+- **VM / docker-compose (the default bundle)** — the platform doesn't assign the *container* its own
+  identity here, and the container already runs as a non-root user (`uid 10001`). But on a cloud VM (GCE,
+  EC2, an Azure VM) the VM's own attached identity is still reachable from the box via the instance metadata
+  endpoint, so keep that identity scoped to only what the deployment needs (or block the container's route to
+  metadata) — the same least-privilege rule, one level down.
 
 This is defense-in-depth **alongside** the read-only `DATASOURCE_URL` database user and the app-layer
 SELECT-only enforcement: the read-only user limits database damage; a least-privilege runtime identity

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -46,6 +46,10 @@ and the other tools just read the model. Nothing leaves your environment.
 | `AGAMI_ORG_ID` | no | The single configured org id (default `local`). The server is single-tenant by default. |
 | `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its own session JWTs with. When set, the server validates real tokens (the password / OIDC login flow); unset ⇒ the bearer-presence local default. |
 
+> **Serverless note:** on a managed-container platform (Cloud Run, ECS/Fargate, Container Apps) the server
+> runs under a cloud identity — scope it to a dedicated least-privilege one, not the platform default. See
+> [Runtime identity on serverless platforms](../deploy/README.md#runtime-identity-on-serverless-platforms).
+
 ## Optional: social login (OIDC)
 
 "Sign in with Google / Microsoft" is **off by default**. Configure a provider's client id/secret to


### PR DESCRIPTION
## What

Adds a **Runtime identity on serverless platforms** section to `deploy/README.md`, with a pointer from `docs/self-hosting.md`. Docs only — no code change.

## Why

On a managed-container platform (Cloud Run, ECS/Fargate/App Runner, Azure Container Apps) the agami server runs under a **cloud identity**, and every platform hands you an over-privileged *default* one unless you specify otherwise. Because `/mcp` and `/admin` are internet-facing, a compromised container could read that identity's token from the platform metadata endpoint and inherit all of its cloud permissions. The serverless deploy variant was documented but said nothing about scoping that identity — this closes the gap.

## What it says

Run agami under a **dedicated, least-privilege identity** that can do only two things: read the specific secrets agami uses (`AGAMI_SIGNING_SECRET`, `APP_DATABASE_URL`, `DATASOURCE_URL`, `AGAMI_ADMIN_PASSWORD`) and reach the database. Nothing else. Never the platform default. Per-platform steps:

- **GCP Cloud Run** — dedicated SA, `roles/cloudsql.client` + `secretAccessor` **per secret** (not project-wide), `--service-account`.
- **AWS ECS / Fargate / App Runner** — dedicated task role, `secretsmanager:GetSecretValue` on specific ARNs only, separate from the execution role, no broad managed policies.
- **Azure Container Apps / ACI** — user-assigned managed identity scoped to `get` on those secrets only.
- **VM / docker-compose** — doesn't apply the same way (no ambient cloud identity; container already runs non-root as `uid 10001`).

Framed as defense-in-depth **alongside** the read-only `DATASOURCE_URL` database user and the app-layer SELECT-only enforcement.

## Notes

- The read-only `DATASOURCE_URL` database user is referenced here but owned by a separate PR — this assumes that lands first.
- Matches the existing terse / second-person / em-dash house style of the deploy docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)