### PR TITLE
security: harden read-only execute_sql guard at the shared executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [Unreleased]
+
+### Security
+
+- **Hardened the read-only `execute_sql` gate.** SQL execution now runs through a
+  single guard (`sql_guard`) at the shared executor, so the stdio server, the hosted
+  HTTP server, the skills, and cron are all protected identically (previously the
+  check lived only on the MCP tool path; a direct `python -m execute_sql` call — used
+  by the skills and cron — was unguarded). Beyond "must start with `SELECT`/`WITH`",
+  it now rejects multi-statement SQL (including bypasses hidden in string literals,
+  comments, or double-quoted identifiers), data-modifying CTEs, transaction-control /
+  session-state / prepared statements, `SELECT ... INTO`, row-level locks, and
+  dangerous server-side functions (`pg_read_file`, `lo_export`, `dblink`,
+  `copy_program`, `pg_sleep`, advisory locks, `query_to_xml`, …). Legitimate analytics
+  SQL is unaffected — a large false-positive corpus pins that. Enforcement is not
+  bypassable via `--no-safety` (that flag only skips the semantic-model pass).
+
 ## [0.3.6] — 2026-07-04
 
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,4 +33,24 @@ Out of scope:
 - Vulnerabilities in Claude Code itself (report those to Anthropic).
 - Issues that require physical access to a user's machine or already-compromised credentials.
 
+## SQL execution model
+
+`execute_sql` is read-only by construction. A single gate (`sql_guard`) runs at the
+shared executor, so every path that can run SQL — the stdio server, the hosted HTTP
+server, the skills, and cron — is protected identically. It rejects, before any
+database connection is opened:
+
+- anything that isn't a single `SELECT` / `WITH...SELECT` (DML, DDL, `SELECT ... INTO`);
+- multi-statement SQL, including bypasses hidden in string literals, comments, or
+  double-quoted identifiers;
+- data-modifying CTEs (`WITH ... DELETE/INSERT/UPDATE ... RETURNING`);
+- transaction-control, session-state, and prepared statements, and row-level locks;
+- dangerous server-side functions — file I/O (`pg_read_file`, `lo_export`), OS/command
+  execution (`copy_program`), remote SQL (`dblink*`), and resource-exhaustion (`pg_sleep`,
+  advisory locks).
+
+This is defense in depth at the application layer; you should still connect with a
+read-only database role. A guard bypass — SQL that mutates data or reaches a blocked
+function yet passes the gate — is in scope for a report.
+
 Thank you for helping keep agami-core and its users safe.

--- a/dev.py
+++ b/dev.py
@@ -42,7 +42,7 @@ _LIB_DST = _ROOT / "plugins" / "agami" / "lib"
 # The module-load import closure of the 4 scripts (all stdlib-only). tests/test_plugin_lib_resolution.py
 # fails if a script gains a module-level import that's missing here; a new *lazy* import from the package
 # would also need adding to this list.
-_VENDORED = ["agami_paths.py", "execute_sql.py", "semantic_model/__init__.py", "semantic_model/units.py"]
+_VENDORED = ["agami_paths.py", "execute_sql.py", "sql_guard.py", "semantic_model/__init__.py", "semantic_model/units.py"]
 
 
 def run(cmd: list[str], *, allow_fail: bool = False) -> int:

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -175,7 +175,13 @@ A stdio MCP server has **no authentication**, and that is correct:
 - It does **not** widen your attack surface beyond already having `psql` + a
   `.pgpass` on your laptop.
 - **Read-only is enforced**: `execute_sql` rejects anything that isn't a single
-  `SELECT` / `WITH...SELECT` (see `shared/sql-generation-rules.md → Safety Rules`).
+  `SELECT` / `WITH...SELECT`. The gate (`sql_guard`) also blocks multi-statement SQL
+  (including comment- and quoted-identifier-hidden bypasses), data-modifying CTEs,
+  transaction-control / session-state / prepared statements, row-level locks, and
+  dangerous server-side functions (`pg_read_file`, `lo_export`, `dblink`,
+  `copy_program`, `pg_sleep`, …). It runs at the shared executor so the stdio server,
+  the hosted HTTP server, the skills, and cron are all guarded identically (see
+  `shared/sql-generation-rules.md → Safety Rules`).
 - **It is stdio-only on purpose.** It never binds a network port. Doing so would
   create an *unauthenticated network listener* exposing query execution. If you
   need networked, multi-user serving with auth + RBAC + audit, that is the hosted

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -787,6 +787,20 @@ def main() -> int:
 
     profile = args.profile or _resolve_default_profile()
 
+    # Read-only / dangerous-SQL guard — the hard security gate, at the shared executor
+    # chokepoint so EVERY caller (both MCP servers, the agami-query skill, cron) is
+    # protected, not just whichever path happened to pre-check. This is NOT bypassable
+    # via --no-safety: that flag skips only the *semantic-model* pass (fan/chasm +
+    # default_filters), never write / RCE / DoS protection. Same gate the MCP tool layer
+    # fail-fast pre-checks (tools.check_read_only -> sql_guard).
+    import sql_guard
+
+    guard_reason = sql_guard.check_read_only(sql)
+    if guard_reason is not None:
+        json.dump({"error": {"kind": "permission", "remediation": guard_reason}}, sys.stderr)
+        sys.stderr.write("\n")
+        return 1
+
     # Semantic-model safety pass (fan/chasm pre-flight + default_filters). Inert when
     # there's no model for the profile, so this is safe for every caller.
     if not args.no_safety:

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -1,0 +1,184 @@
+"""
+Read-only / dangerous-SQL guard — the single source of truth for "is this SQL
+safe to run against the user's database?".
+
+This gate runs at the shared executor chokepoint (`execute_sql.py::main`) and as a
+fail-fast pre-check in the MCP tool layer (`tools.check_read_only`), so the stdio
+server, the HTTP/OAuth server, the agami-query skill, and cron are all protected
+identically — not just whichever path happened to read a prose rule.
+
+It is defense in depth at the application layer; the underlying connection is *also*
+expected to run under a read-only role. Postgres / Redshift are the primary concern
+(the dangerous functions below are Postgres server-side primitives), but the checks
+are neutral enough to be safe across the other supported engines.
+
+`check_read_only(sql)` returns `None` when the SQL is a single safe read-only
+statement, else a short human-readable reason string. Callers decide how to wrap it
+(the MCP tools attach `kind="permission"`).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Hard cap on SQL length. Prevents a compromised client from POSTing a multi-MB
+# SQL blob that takes the parser / planner / this gate down a slow path. Real
+# analytics SQL fits in ~10KB; 50KB is conservative.
+_MAX_SQL_CHARS = 50_000
+
+# Match SQL comments (line `--` and block `/* */`).
+# CRITICAL: callers MUST sub with a SINGLE SPACE, never with empty string.
+# Replacing with empty welds adjacent tokens together (`SELECT/**/INTO` ->
+# `SELECTINTO`) and defeats the `\b` word-boundary in every downstream regex.
+#
+# Line comments stop at `\r` OR `\n` — Postgres' scanner ends `--` at either.
+# Stopping only at `\n` is exploitable: `SELECT 1 --x\r;DROP TABLE y\n` would be
+# scrubbed to `SELECT 1 ` by a `[^\n]*`-only regex (the `\r;DROP...` is eaten as
+# part of the comment), masking a multi-statement attack.
+_SQL_COMMENT_RE = re.compile(r"--[^\r\n]*|/\*.*?\*/", re.DOTALL)
+
+# Single-quoted string literals so `;` / keywords inside them don't trip the
+# deny-list. PG / Redshift / Snowflake all support doubled-quote escaping inside
+# literals. Double-quoted IDENTIFIERS are handled separately (the gate strips the
+# quote chars via `.replace('"', '')` so `"pg_sleep"(10)` reduces to `pg_sleep(10)`
+# and the dangerous-function regex catches it).
+_SQL_SINGLE_QUOTED_RE = re.compile(r"'(?:''|[^'])*'")
+
+# Allowed opening keyword. `WITH` covers CTEs whose final clause is a SELECT.
+# Leading `(` / whitespace is tolerated so a parenthesized set operation —
+# `(SELECT 1) UNION (SELECT 2)` — is still recognized as read-only.
+_READ_ONLY_OPEN_RE = re.compile(r"^[\s(]*(?:SELECT|WITH)\b", re.IGNORECASE)
+
+# Deny-list of statement-level keywords that must NOT appear anywhere in the
+# stripped (comments + literals removed) SQL.
+#   - DML/DDL: writes / schema changes.
+#   - TCL: `COMMIT`/`ROLLBACK`/`SAVEPOINT`/`RELEASE` can escape a read-only
+#     transaction (a known bypass class for SQL-execution servers).
+#     `BEGIN`/`START`/`END` are omitted — the opening-keyword check already rejects
+#     anything not starting with SELECT/WITH, and `END` is a false-positive
+#     landmine (`CASE ... END`).
+#   - Session: `SET`/`RESET`/`DISCARD` corrupt pooled connection state.
+#   - Pub/sub + locking: `LISTEN`/`NOTIFY`/`LOCK` aren't analytics primitives.
+#   - Prepared: `PREPARE`/`DEALLOCATE` are an alternative query-stacking path.
+#   - `INTO`: `SELECT ... INTO new_table` is a write that starts with SELECT, so
+#     the opening-keyword check passes it — deny `INTO` to close that write path.
+_DML_DDL_KEYWORDS = "INSERT|UPDATE|DELETE|MERGE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|COPY|CALL|VACUUM|REINDEX|CLUSTER|EXECUTE|INTO"
+_TCL_KEYWORDS = "COMMIT|ROLLBACK|SAVEPOINT|RELEASE"
+_SESSION_KEYWORDS = "RESET|DISCARD|SET"
+_PUBSUB_LOCK_KEYWORDS = "LISTEN|NOTIFY|UNLISTEN|LOCK"
+_PREPARED_KEYWORDS = "PREPARE|DEALLOCATE"
+_DENY_KEYWORD_RE = re.compile(
+    rf"\b({_DML_DDL_KEYWORDS}|{_TCL_KEYWORDS}|{_SESSION_KEYWORDS}|{_PUBSUB_LOCK_KEYWORDS}|{_PREPARED_KEYWORDS})\b",
+    re.IGNORECASE,
+)
+
+# Row-level lock clauses inside an otherwise-valid SELECT. `FOR UPDATE`,
+# `FOR SHARE`, `FOR NO KEY UPDATE`, `FOR KEY SHARE` — none belong in analytics.
+_ROW_LOCK_RE = re.compile(r"\bFOR\s+(UPDATE|SHARE|NO\s+KEY\s+UPDATE|KEY\s+SHARE)\b", re.IGNORECASE)
+
+# Dangerous function calls — these read server files, execute OS commands via
+# `COPY ... FROM PROGRAM` (when callable), drain server-side IO, sleep to burn
+# worker time, kill other backends, mutate session state via the function path
+# that bypasses the `SET` keyword deny, hold session-survival advisory locks, or
+# execute a nested SQL string passed as a function arg (the `query_to_xml(text)`
+# family). Match against `name(` so identifiers sharing a prefix aren't matched.
+_DANGEROUS_FN_RE = re.compile(
+    r"\b("
+    # Time wasters / DoS
+    r"pg_sleep|pg_sleep_for|pg_sleep_until|"
+    # Server-side file I/O
+    r"pg_read_file|pg_read_binary_file|pg_read_server_files|pg_write_server_files|"
+    r"pg_ls_dir|pg_stat_file|pg_ls_logdir|pg_ls_waldir|pg_ls_tmpdir|"
+    # Large objects — full set including legacy `loread`/`lowrite` and the
+    # open/seek/tell/close API that lets an attacker chain `lo_open` -> `loread`
+    # to read arbitrary LO content without using `lo_export`.
+    r"lo_export|lo_import|lo_create|lo_unlink|lo_get|lo_put|lo_from_bytea|"
+    r"lo_open|lo_read|lo_write|lo_close|lo_lseek|lo_lseek64|lo_tell|lo_tell64|lo_truncate|lo_truncate64|"
+    r"loread|lowrite|"
+    # Remote SQL execution — `dblink\w*` catches every variant.
+    r"dblink\w*|"
+    # Shell out via COPY
+    r"copy_program|"
+    # Backend / process control
+    r"pg_terminate_backend|pg_cancel_backend|pg_reload_conf|"
+    r"pg_rotate_logfile|pg_logfile_rotate|"
+    # Session-state mutation that bypasses the `SET` keyword deny.
+    r"set_config|current_setting|"
+    # Session-survival advisory locks — survive connection return and can DoS.
+    r"pg_advisory_lock|pg_advisory_xact_lock|"
+    r"pg_advisory_unlock|pg_advisory_unlock_all|"
+    # Nested-SQL execution via XML/JSON conversion — these execute the SQL passed
+    # as a string argument server-side, bypassing the outer gate.
+    r"query_to_xml|query_to_xmlschema|query_to_json|cursor_to_xml"
+    r")\s*\(",
+    re.IGNORECASE,
+)
+
+
+def check_read_only(sql: str | None) -> str | None:
+    """Return None if `sql` is a single safe read-only statement, else a reason string.
+
+    Rejection ladder (each step has its own message so the caller can correct):
+      0. Empty SQL
+      1. SQL longer than `_MAX_SQL_CHARS`
+      2. Multi-statement (any `;` outside literals/comments, except one trailing `;`)
+      3. Doesn't open with SELECT or WITH (leading `(` tolerated)
+      4. Contains a forbidden keyword (DML/DDL/TCL/session/pub-sub/lock/prepared/INTO)
+      5. Contains a row-level lock clause (`FOR UPDATE` etc.)
+      6. Calls a dangerous function (`pg_sleep`, `pg_read_file`, `dblink`, ...)
+    """
+    if not sql or not sql.strip():
+        return "empty statement"
+
+    if len(sql) > _MAX_SQL_CHARS:
+        return (
+            f"SQL is {len(sql)} characters; the guard caps at {_MAX_SQL_CHARS}. "
+            "Real analytics SQL fits well under this."
+        )
+
+    # CRITICAL: strip string literals BEFORE comments. The reverse order is
+    # exploitable — `SELECT '--'; DROP TABLE x` has `--` inside a literal, but the
+    # comment regex would otherwise eat from the `--` through end-of-line (taking
+    # the injected `; DROP ...` with it) and the multi-statement check would pass.
+    # Replacing literals first kills any embedded `--` / `/*` before the comment
+    # regex runs.
+    #
+    # Then strip PG-quoted identifier delimiters (`"`) so `"pg_sleep"(10)` reduces
+    # to `pg_sleep(10)` and the dangerous-function regex catches it. The trade-off:
+    # a pathological column named `"a;b"` ends up as `a;b` and trips the
+    # multi-statement check — a deliberate hardening choice.
+    stripped = _SQL_COMMENT_RE.sub(" ", _SQL_SINGLE_QUOTED_RE.sub("''", sql))
+    stripped = stripped.replace('"', "").strip()
+
+    # Allow exactly one trailing `;`. Any other `;` indicates a second statement —
+    # the classic statement-stacking bypass (`COMMIT; DROP SCHEMA public CASCADE`).
+    if stripped.endswith(";"):
+        stripped = stripped[:-1].rstrip()
+    if not stripped:
+        return "empty statement"
+    if ";" in stripped:
+        return "multiple statements are not allowed — send one SELECT"
+
+    if not _READ_ONLY_OPEN_RE.match(stripped):
+        head = stripped.lstrip("(").split(None, 1)
+        head = head[0].upper() if head else "?"
+        return f"only SELECT / WITH...SELECT is allowed (statement starts with {head})"
+
+    deny = _DENY_KEYWORD_RE.search(stripped)
+    if deny:
+        return (
+            f"keyword '{deny.group(1).upper()}' is not allowed — send a single "
+            "SELECT / WITH...SELECT (no DML, DDL, transaction control, session-state, "
+            "or prepared statements)"
+        )
+
+    if _ROW_LOCK_RE.search(stripped):
+        return "row-level lock clauses (FOR UPDATE / FOR SHARE / ...) are not allowed"
+
+    fn = _DANGEROUS_FN_RE.search(stripped)
+    if fn:
+        return (
+            f"function `{fn.group(1)}` is not allowed — server-file / OS / "
+            "process-control / sleep / remote-SQL functions are blocked"
+        )
+    return None

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -182,37 +182,18 @@ def _db_type_for(profile: str, creds: dict[str, dict[str, str]]) -> str:
 # Read-only SQL guard (mirrors shared/sql-generation-rules.md → Safety Rules)
 # ---------------------------------------------------------------------------
 
-_COMMENT_LINE = re.compile(r"--[^\n]*")
-_COMMENT_BLOCK = re.compile(r"/\*.*?\*/", re.DOTALL)
-# Data-modifying statements that could ride after a leading WITH (Postgres
-# allows `WITH x AS (...) DELETE ...`). DDL (DROP/CREATE/ALTER/TRUNCATE) cannot
-# follow WITH, and a single statement that begins with SELECT/WITH otherwise
-# cannot mutate — so guarding these four keywords + the leading-token + the
-# single-statement rule is sufficient without the false positives of scanning
-# every DDL keyword (which collide with identifiers like create_date).
-_MUTATION = re.compile(r"\b(INSERT|UPDATE|DELETE|MERGE)\b", re.IGNORECASE)
-
-
-def _strip_comments(sql: str) -> str:
-    return _COMMENT_BLOCK.sub(" ", _COMMENT_LINE.sub(" ", sql))
-
-
 def check_read_only(sql: str) -> str | None:
-    """Return None if the SQL is a safe single read-only statement, else a reason string."""
-    stripped = _strip_comments(sql).strip()
-    # Tolerate a single trailing semicolon; reject any interior one (multi-statement).
-    if stripped.endswith(";"):
-        stripped = stripped[:-1].strip()
-    if not stripped:
-        return "empty statement"
-    if ";" in stripped:
-        return "multiple statements are not allowed — send one SELECT"
-    head = stripped.lstrip("(").split(None, 1)[0].upper() if stripped else ""
-    if head not in ("SELECT", "WITH"):
-        return f"only SELECT / WITH...SELECT is allowed (statement starts with {head or '?'})"
-    if _MUTATION.search(stripped):
-        return "statement contains a data-modifying keyword (INSERT/UPDATE/DELETE/MERGE)"
-    return None
+    """Return None if the SQL is a safe single read-only statement, else a reason string.
+
+    Thin fail-fast wrapper over the shared `sql_guard` — the SAME gate the executor
+    (`execute_sql.py`) enforces — so the stdio server, the HTTP/OAuth server, the
+    agami-query skill, and cron all reject writes / DDL / dangerous functions
+    identically. Blocking here also avoids spawning the executor subprocess for a
+    query that would be rejected anyway.
+    """
+    import sql_guard
+
+    return sql_guard.check_read_only(sql)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -787,6 +787,20 @@ def main() -> int:
 
     profile = args.profile or _resolve_default_profile()
 
+    # Read-only / dangerous-SQL guard — the hard security gate, at the shared executor
+    # chokepoint so EVERY caller (both MCP servers, the agami-query skill, cron) is
+    # protected, not just whichever path happened to pre-check. This is NOT bypassable
+    # via --no-safety: that flag skips only the *semantic-model* pass (fan/chasm +
+    # default_filters), never write / RCE / DoS protection. Same gate the MCP tool layer
+    # fail-fast pre-checks (tools.check_read_only -> sql_guard).
+    import sql_guard
+
+    guard_reason = sql_guard.check_read_only(sql)
+    if guard_reason is not None:
+        json.dump({"error": {"kind": "permission", "remediation": guard_reason}}, sys.stderr)
+        sys.stderr.write("\n")
+        return 1
+
     # Semantic-model safety pass (fan/chasm pre-flight + default_filters). Inert when
     # there's no model for the profile, so this is safe for every caller.
     if not args.no_safety:

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -1,0 +1,184 @@
+"""
+Read-only / dangerous-SQL guard — the single source of truth for "is this SQL
+safe to run against the user's database?".
+
+This gate runs at the shared executor chokepoint (`execute_sql.py::main`) and as a
+fail-fast pre-check in the MCP tool layer (`tools.check_read_only`), so the stdio
+server, the HTTP/OAuth server, the agami-query skill, and cron are all protected
+identically — not just whichever path happened to read a prose rule.
+
+It is defense in depth at the application layer; the underlying connection is *also*
+expected to run under a read-only role. Postgres / Redshift are the primary concern
+(the dangerous functions below are Postgres server-side primitives), but the checks
+are neutral enough to be safe across the other supported engines.
+
+`check_read_only(sql)` returns `None` when the SQL is a single safe read-only
+statement, else a short human-readable reason string. Callers decide how to wrap it
+(the MCP tools attach `kind="permission"`).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Hard cap on SQL length. Prevents a compromised client from POSTing a multi-MB
+# SQL blob that takes the parser / planner / this gate down a slow path. Real
+# analytics SQL fits in ~10KB; 50KB is conservative.
+_MAX_SQL_CHARS = 50_000
+
+# Match SQL comments (line `--` and block `/* */`).
+# CRITICAL: callers MUST sub with a SINGLE SPACE, never with empty string.
+# Replacing with empty welds adjacent tokens together (`SELECT/**/INTO` ->
+# `SELECTINTO`) and defeats the `\b` word-boundary in every downstream regex.
+#
+# Line comments stop at `\r` OR `\n` — Postgres' scanner ends `--` at either.
+# Stopping only at `\n` is exploitable: `SELECT 1 --x\r;DROP TABLE y\n` would be
+# scrubbed to `SELECT 1 ` by a `[^\n]*`-only regex (the `\r;DROP...` is eaten as
+# part of the comment), masking a multi-statement attack.
+_SQL_COMMENT_RE = re.compile(r"--[^\r\n]*|/\*.*?\*/", re.DOTALL)
+
+# Single-quoted string literals so `;` / keywords inside them don't trip the
+# deny-list. PG / Redshift / Snowflake all support doubled-quote escaping inside
+# literals. Double-quoted IDENTIFIERS are handled separately (the gate strips the
+# quote chars via `.replace('"', '')` so `"pg_sleep"(10)` reduces to `pg_sleep(10)`
+# and the dangerous-function regex catches it).
+_SQL_SINGLE_QUOTED_RE = re.compile(r"'(?:''|[^'])*'")
+
+# Allowed opening keyword. `WITH` covers CTEs whose final clause is a SELECT.
+# Leading `(` / whitespace is tolerated so a parenthesized set operation —
+# `(SELECT 1) UNION (SELECT 2)` — is still recognized as read-only.
+_READ_ONLY_OPEN_RE = re.compile(r"^[\s(]*(?:SELECT|WITH)\b", re.IGNORECASE)
+
+# Deny-list of statement-level keywords that must NOT appear anywhere in the
+# stripped (comments + literals removed) SQL.
+#   - DML/DDL: writes / schema changes.
+#   - TCL: `COMMIT`/`ROLLBACK`/`SAVEPOINT`/`RELEASE` can escape a read-only
+#     transaction (a known bypass class for SQL-execution servers).
+#     `BEGIN`/`START`/`END` are omitted — the opening-keyword check already rejects
+#     anything not starting with SELECT/WITH, and `END` is a false-positive
+#     landmine (`CASE ... END`).
+#   - Session: `SET`/`RESET`/`DISCARD` corrupt pooled connection state.
+#   - Pub/sub + locking: `LISTEN`/`NOTIFY`/`LOCK` aren't analytics primitives.
+#   - Prepared: `PREPARE`/`DEALLOCATE` are an alternative query-stacking path.
+#   - `INTO`: `SELECT ... INTO new_table` is a write that starts with SELECT, so
+#     the opening-keyword check passes it — deny `INTO` to close that write path.
+_DML_DDL_KEYWORDS = "INSERT|UPDATE|DELETE|MERGE|TRUNCATE|DROP|ALTER|CREATE|GRANT|REVOKE|COPY|CALL|VACUUM|REINDEX|CLUSTER|EXECUTE|INTO"
+_TCL_KEYWORDS = "COMMIT|ROLLBACK|SAVEPOINT|RELEASE"
+_SESSION_KEYWORDS = "RESET|DISCARD|SET"
+_PUBSUB_LOCK_KEYWORDS = "LISTEN|NOTIFY|UNLISTEN|LOCK"
+_PREPARED_KEYWORDS = "PREPARE|DEALLOCATE"
+_DENY_KEYWORD_RE = re.compile(
+    rf"\b({_DML_DDL_KEYWORDS}|{_TCL_KEYWORDS}|{_SESSION_KEYWORDS}|{_PUBSUB_LOCK_KEYWORDS}|{_PREPARED_KEYWORDS})\b",
+    re.IGNORECASE,
+)
+
+# Row-level lock clauses inside an otherwise-valid SELECT. `FOR UPDATE`,
+# `FOR SHARE`, `FOR NO KEY UPDATE`, `FOR KEY SHARE` — none belong in analytics.
+_ROW_LOCK_RE = re.compile(r"\bFOR\s+(UPDATE|SHARE|NO\s+KEY\s+UPDATE|KEY\s+SHARE)\b", re.IGNORECASE)
+
+# Dangerous function calls — these read server files, execute OS commands via
+# `COPY ... FROM PROGRAM` (when callable), drain server-side IO, sleep to burn
+# worker time, kill other backends, mutate session state via the function path
+# that bypasses the `SET` keyword deny, hold session-survival advisory locks, or
+# execute a nested SQL string passed as a function arg (the `query_to_xml(text)`
+# family). Match against `name(` so identifiers sharing a prefix aren't matched.
+_DANGEROUS_FN_RE = re.compile(
+    r"\b("
+    # Time wasters / DoS
+    r"pg_sleep|pg_sleep_for|pg_sleep_until|"
+    # Server-side file I/O
+    r"pg_read_file|pg_read_binary_file|pg_read_server_files|pg_write_server_files|"
+    r"pg_ls_dir|pg_stat_file|pg_ls_logdir|pg_ls_waldir|pg_ls_tmpdir|"
+    # Large objects — full set including legacy `loread`/`lowrite` and the
+    # open/seek/tell/close API that lets an attacker chain `lo_open` -> `loread`
+    # to read arbitrary LO content without using `lo_export`.
+    r"lo_export|lo_import|lo_create|lo_unlink|lo_get|lo_put|lo_from_bytea|"
+    r"lo_open|lo_read|lo_write|lo_close|lo_lseek|lo_lseek64|lo_tell|lo_tell64|lo_truncate|lo_truncate64|"
+    r"loread|lowrite|"
+    # Remote SQL execution — `dblink\w*` catches every variant.
+    r"dblink\w*|"
+    # Shell out via COPY
+    r"copy_program|"
+    # Backend / process control
+    r"pg_terminate_backend|pg_cancel_backend|pg_reload_conf|"
+    r"pg_rotate_logfile|pg_logfile_rotate|"
+    # Session-state mutation that bypasses the `SET` keyword deny.
+    r"set_config|current_setting|"
+    # Session-survival advisory locks — survive connection return and can DoS.
+    r"pg_advisory_lock|pg_advisory_xact_lock|"
+    r"pg_advisory_unlock|pg_advisory_unlock_all|"
+    # Nested-SQL execution via XML/JSON conversion — these execute the SQL passed
+    # as a string argument server-side, bypassing the outer gate.
+    r"query_to_xml|query_to_xmlschema|query_to_json|cursor_to_xml"
+    r")\s*\(",
+    re.IGNORECASE,
+)
+
+
+def check_read_only(sql: str | None) -> str | None:
+    """Return None if `sql` is a single safe read-only statement, else a reason string.
+
+    Rejection ladder (each step has its own message so the caller can correct):
+      0. Empty SQL
+      1. SQL longer than `_MAX_SQL_CHARS`
+      2. Multi-statement (any `;` outside literals/comments, except one trailing `;`)
+      3. Doesn't open with SELECT or WITH (leading `(` tolerated)
+      4. Contains a forbidden keyword (DML/DDL/TCL/session/pub-sub/lock/prepared/INTO)
+      5. Contains a row-level lock clause (`FOR UPDATE` etc.)
+      6. Calls a dangerous function (`pg_sleep`, `pg_read_file`, `dblink`, ...)
+    """
+    if not sql or not sql.strip():
+        return "empty statement"
+
+    if len(sql) > _MAX_SQL_CHARS:
+        return (
+            f"SQL is {len(sql)} characters; the guard caps at {_MAX_SQL_CHARS}. "
+            "Real analytics SQL fits well under this."
+        )
+
+    # CRITICAL: strip string literals BEFORE comments. The reverse order is
+    # exploitable — `SELECT '--'; DROP TABLE x` has `--` inside a literal, but the
+    # comment regex would otherwise eat from the `--` through end-of-line (taking
+    # the injected `; DROP ...` with it) and the multi-statement check would pass.
+    # Replacing literals first kills any embedded `--` / `/*` before the comment
+    # regex runs.
+    #
+    # Then strip PG-quoted identifier delimiters (`"`) so `"pg_sleep"(10)` reduces
+    # to `pg_sleep(10)` and the dangerous-function regex catches it. The trade-off:
+    # a pathological column named `"a;b"` ends up as `a;b` and trips the
+    # multi-statement check — a deliberate hardening choice.
+    stripped = _SQL_COMMENT_RE.sub(" ", _SQL_SINGLE_QUOTED_RE.sub("''", sql))
+    stripped = stripped.replace('"', "").strip()
+
+    # Allow exactly one trailing `;`. Any other `;` indicates a second statement —
+    # the classic statement-stacking bypass (`COMMIT; DROP SCHEMA public CASCADE`).
+    if stripped.endswith(";"):
+        stripped = stripped[:-1].rstrip()
+    if not stripped:
+        return "empty statement"
+    if ";" in stripped:
+        return "multiple statements are not allowed — send one SELECT"
+
+    if not _READ_ONLY_OPEN_RE.match(stripped):
+        head = stripped.lstrip("(").split(None, 1)
+        head = head[0].upper() if head else "?"
+        return f"only SELECT / WITH...SELECT is allowed (statement starts with {head})"
+
+    deny = _DENY_KEYWORD_RE.search(stripped)
+    if deny:
+        return (
+            f"keyword '{deny.group(1).upper()}' is not allowed — send a single "
+            "SELECT / WITH...SELECT (no DML, DDL, transaction control, session-state, "
+            "or prepared statements)"
+        )
+
+    if _ROW_LOCK_RE.search(stripped):
+        return "row-level lock clauses (FOR UPDATE / FOR SHARE / ...) are not allowed"
+
+    fn = _DANGEROUS_FN_RE.search(stripped)
+    if fn:
+        return (
+            f"function `{fn.group(1)}` is not allowed — server-file / OS / "
+            "process-control / sleep / remote-SQL functions are blocked"
+        )
+    return None

--- a/plugins/agami/shared/sql-generation-rules.md
+++ b/plugins/agami/shared/sql-generation-rules.md
@@ -132,6 +132,8 @@ For growth rates (QoQ, MoM, YoY):
 - Never include actual credential values in SQL comments or strings
 - Use `NULLIF(denominator, 0)` to guard against division by zero
 
+**These are enforced, not just guidance.** Every query runs through a read-only gate (`sql_guard`, at the executor chokepoint) that rejects anything other than a single `SELECT` / `WITH...SELECT` — multi-statement SQL, data-modifying CTEs, transaction-control / session-state / prepared statements, `SELECT ... INTO`, row-level locks, and dangerous server-side functions (`pg_read_file`, `lo_export`, `dblink`, `copy_program`, `pg_sleep`, advisory locks, `query_to_xml`, …). A rejected query never reaches the database. Generate read-only SQL and this gate stays invisible.
+
 ---
 
 ## Performance Hints

--- a/tests/test_plugin_lib_resolution.py
+++ b/tests/test_plugin_lib_resolution.py
@@ -25,7 +25,7 @@ REPO = Path(__file__).resolve().parent.parent
 SCRIPTS = REPO / "plugins" / "agami" / "scripts"
 LIB = REPO / "plugins" / "agami" / "lib"
 SRC = REPO / "packages" / "agami-core" / "src"
-VENDORED = ["agami_paths.py", "execute_sql.py", "semantic_model/__init__.py", "semantic_model/units.py"]
+VENDORED = ["agami_paths.py", "execute_sql.py", "sql_guard.py", "semantic_model/__init__.py", "semantic_model/units.py"]
 
 # `-S` disables site.py, so an installed (incl. editable) agami-core is not on the path — the same
 # "the package isn't available" state a marketplace user's plain python3 is in.

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -1,0 +1,588 @@
+"""
+Tests for `sql_guard` — the hardened read-only / dangerous-SQL gate shared by the
+stdio server, the HTTP/OAuth server, the agami-query skill, and cron.
+
+Two things are pinned here:
+
+  1. **Security.** Every write / DDL / transaction-control / session-state /
+     dangerous-function / multi-statement / comment-or-quote-bypass vector is
+     rejected — including the vectors that historically bypassed naive guards
+     (comment-in-string, PG-quoted function names, comment-welded word boundaries).
+
+  2. **No false positives.** A large corpus of the analytics SQL an assistant emits
+     every day MUST pass. Over-tightening the deny-list silently degrades every
+     query, so this corpus is the primary safety net.
+
+Bare `pg_catalog` / `information_schema` / environment-introspection blocking is a
+deferred follow-up (see `test_known_deferred_gaps_currently_pass` for the pinned
+current behavior).
+
+`sql_guard.check_read_only` returns None (safe) or a short reason string (rejected).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+from sql_guard import _MAX_SQL_CHARS, check_read_only
+
+# ---------------------------------------------------------------------------
+# Accept — valid single read-only statements
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1",
+        "select 1",  # case-insensitive
+        "  SELECT 1  ",  # leading/trailing whitespace
+        "SELECT 1;",  # one trailing semicolon allowed
+        "SELECT 1 ; ",  # trailing semicolon with whitespace
+        "WITH a AS (SELECT 1) SELECT * FROM a",  # CTE
+        "(SELECT 1) UNION (SELECT 2)",  # parenthesized set operation
+        "-- comment\nSELECT 1",  # leading line comment
+        "/* block comment */ SELECT 1",  # leading block comment
+        "/* multi\nline\ncomment */SELECT 1",  # multi-line block comment
+        "SELECT 'a;b' FROM dual",  # semicolon inside string literal
+        "SELECT 1 /* ;DROP TABLE x; */ FROM dual",  # semicolons inside comment
+        "SELECT 1 -- ; DROP TABLE x",  # semicolon inside line comment
+        # Identifiers whose substrings overlap DML/DDL keywords — the `\b`
+        # word-boundary in the deny-list must NOT false-positive on these.
+        "SELECT updated_at FROM users",
+        "SELECT deleted_at, updated_at FROM accounts",
+        "SELECT * FROM deleted_records",
+        "SELECT drop_count FROM stats",
+        "SELECT * FROM events WHERE event_name = 'user_created'",
+        "SELECT * FROM jsonb_call_data WHERE id = 1",
+    ],
+)
+def test_accepts_valid_selects(sql: str) -> None:
+    assert check_read_only(sql) is None, f"Expected pass, got rejection: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Identifiers overlapping the expanded deny-list keywords.
+        "SELECT committed_at FROM events",  # COMMIT
+        "SELECT rollback_count FROM stats",  # ROLLBACK
+        "SELECT begin_date, end_date FROM bookings",  # BEGIN / END
+        "SELECT set_id FROM datasets",  # SET
+        "SELECT reset_count FROM users",  # RESET
+        "SELECT discard_pile FROM games",  # DISCARD
+        "SELECT lock_version FROM accounts",  # LOCK
+        "SELECT prepared_at FROM orders",  # PREPARE
+        "SELECT pinto_color FROM cars",  # 'into' substring
+        "SELECT intolerance_level FROM patients",  # starts with 'into'
+        "SELECT set_config_id FROM audit",  # not a set_config( call
+        "SELECT pg_advisory_lock_id FROM custom_table",  # column, not a call
+        "SELECT a.id FROM accounts a JOIN contacts c ON a.id = c.account_id",  # aliases
+    ],
+)
+def test_accepts_identifiers_with_keyword_substrings(sql: str) -> None:
+    assert check_read_only(sql) is None, (
+        f"Legit identifier-with-keyword-substring rejected: {sql!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # `CASE ... END` — END must NOT be in the deny-list.
+        "SELECT CASE WHEN status = 'open' THEN 1 ELSE 0 END AS is_open FROM tickets",
+        "SELECT name, CASE x WHEN 1 THEN 'a' WHEN 2 THEN 'b' ELSE 'c' END AS bucket FROM t",
+        "SELECT SUM(CASE WHEN region = 'NA' THEN amount END) FROM orders",
+        "SELECT CASE WHEN a > 0 THEN CASE WHEN b > 0 THEN 'pp' ELSE 'pn' END ELSE 'n' END FROM t",
+    ],
+)
+def test_accepts_case_when_end(sql: str) -> None:
+    assert check_read_only(sql) is None, f"CASE...END false-positived: {sql!r}"
+
+
+# ---------------------------------------------------------------------------
+# Reject — non-SELECT (DML / DDL)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "INSERT INTO x VALUES (1)",
+        "UPDATE x SET a = 1",
+        "DELETE FROM x",
+        "DROP TABLE x",
+        "TRUNCATE TABLE x",
+        "ALTER TABLE x ADD COLUMN y INT",
+        "CREATE TABLE x (a INT)",
+        "COPY x FROM '/etc/passwd'",
+        "GRANT SELECT ON x TO public",
+        "REVOKE ALL ON x FROM public",
+        "VACUUM x",
+        "MERGE INTO x USING y ON x.a = y.a",
+        "CALL my_proc()",
+    ],
+)
+def test_rejects_non_select(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Expected rejection: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1; SELECT 2",
+        "SELECT 1; DROP TABLE x",
+        "SELECT 1;DELETE FROM x",  # no whitespace around semicolon
+        "SELECT 1; -- second statement after comment\nSELECT 2",
+        "WITH a AS (SELECT 1) SELECT * FROM a; DROP TABLE a",
+    ],
+)
+def test_rejects_multi_statement(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Expected rejection: {sql!r}"
+
+
+@pytest.mark.parametrize("sql", ["", "   ", None, "-- just a comment", "/* only a comment */"])
+def test_rejects_empty(sql: Any) -> None:
+    assert check_read_only(sql) is not None
+
+
+# ---------------------------------------------------------------------------
+# Reject — known bypasses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Comment-inside-string bypass: prior strip-order (comments first) let `--`
+        # inside a literal eat through end-of-line and hide an injected `; DROP ...`.
+        "SELECT '--'; DROP TABLE x",
+        "SELECT 'foo' || '--'; UPDATE t SET a=1",
+        "SELECT '-- not a comment' AS s; DELETE FROM t",
+        "SELECT '--' ; DROP TABLE x",
+    ],
+)
+def test_rejects_comment_in_string_bypass(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Comment-in-string bypass not caught: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Data-modifying CTEs — open with WITH so the opener alone lets them through;
+        # the deny-list scan catches the DML keyword.
+        "WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x",
+        "WITH x AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * FROM x",
+        "WITH x AS (UPDATE t SET a=1 RETURNING *) SELECT * FROM x",
+        "WITH x AS (SELECT 1), y AS (DELETE FROM t RETURNING *) SELECT * FROM x, y",
+    ],
+)
+def test_rejects_data_modifying_ctes(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"DML CTE not caught: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "COMMIT",
+        "COMMIT; SELECT 1",
+        "ROLLBACK",
+        "BEGIN",
+        "BEGIN TRANSACTION READ ONLY",
+        "SAVEPOINT sp1",
+        "RELEASE SAVEPOINT sp1",
+        "START TRANSACTION",
+        "END",
+    ],
+)
+def test_rejects_transaction_control(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"TCL not blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SET statement_timeout = 0",
+        "SET search_path = pg_catalog, public",
+        "RESET ALL",
+        "RESET statement_timeout",
+        "DISCARD ALL",
+        "DISCARD TEMP",
+    ],
+)
+def test_rejects_session_state(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Session-state mutation not blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "LISTEN channel1",
+        "NOTIFY channel1, 'payload'",
+        "UNLISTEN channel1",
+        "LOCK TABLE accounts IN ACCESS EXCLUSIVE MODE",
+        "PREPARE plan1 AS SELECT 1",
+        "DEALLOCATE plan1",
+        "DEALLOCATE ALL",
+        "WITH x AS (LISTEN ch) SELECT 1",  # deny-list catches it mid-statement
+    ],
+)
+def test_rejects_pubsub_lock_prepared(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"pub/sub | lock | prepared not blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # `FOR UPDATE` / `FOR NO KEY UPDATE` are caught by the `UPDATE` keyword deny
+        # (which runs before the row-lock rule) — still rejected, just with the
+        # keyword message. `FOR SHARE` / `FOR KEY SHARE` fall through to the row-lock rule.
+        "SELECT * FROM accounts FOR UPDATE",
+        "SELECT id FROM accounts WHERE id = 1 FOR SHARE",
+        "SELECT * FROM accounts FOR NO KEY UPDATE",
+        "SELECT id FROM accounts FOR KEY SHARE OF accounts",
+    ],
+)
+def test_rejects_row_level_locks(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Row-level lock not blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql", ["SELECT id FROM accounts FOR SHARE", "SELECT id FROM t FOR KEY SHARE"]
+)
+def test_row_lock_rule_names_the_lock(sql: str) -> None:
+    # These use SHARE (not a deny keyword) so the row-lock rule is what fires.
+    reason = check_read_only(sql)
+    assert reason is not None and "lock" in reason.lower(), reason
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * INTO new_table FROM users",
+        "SELECT id, email INTO archive_users FROM users WHERE deleted_at IS NOT NULL",
+        "SELECT 1 INTO scratch FROM dual",
+    ],
+)
+def test_rejects_select_into_write_path(sql: str) -> None:
+    reason = check_read_only(sql)
+    assert reason is not None, f"SELECT INTO not blocked: {sql!r}"
+    assert "INTO" in reason
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Time-wasters / file I/O / OS exec / remote SQL / process control.
+        "SELECT pg_sleep(10)",
+        "SELECT pg_sleep_for('10s')",
+        "SELECT pg_read_file('/etc/passwd')",
+        "SELECT pg_read_binary_file('/etc/passwd')",
+        "SELECT pg_ls_dir('/var/lib/postgresql')",
+        "SELECT pg_stat_file('/etc/passwd')",
+        "SELECT pg_read_server_files('/')",
+        "SELECT pg_write_server_files('/tmp/x', 'data')",
+        "SELECT lo_export(12345, '/tmp/leak')",
+        "SELECT lo_import('/etc/passwd')",
+        "SELECT dblink('host=evil.example.com', 'select 1')",
+        "SELECT dblink_exec('host=evil.example.com', 'drop table x')",
+        "SELECT pg_terminate_backend(123)",
+        "SELECT pg_cancel_backend(123)",
+        "SELECT pg_reload_conf()",
+        # Post-audit additions.
+        "SELECT set_config('statement_timeout', '0', false)",
+        "SELECT current_setting('statement_timeout')",
+        "SELECT pg_advisory_lock(1)",
+        "SELECT pg_advisory_xact_lock(1)",
+        "SELECT pg_advisory_unlock(1)",
+        "SELECT pg_advisory_unlock_all()",
+        "SELECT query_to_xml('SELECT * FROM pg_tables', false, false, '')",
+        "SELECT query_to_xmlschema('SELECT 1', false, false, '')",
+        "SELECT query_to_json('SELECT 1')",
+        "SELECT cursor_to_xml('foo', 1, false, false, '')",
+        "SELECT pg_rotate_logfile()",
+        "SELECT pg_logfile_rotate()",
+        "SELECT copy_program('cat /etc/passwd')",
+    ],
+)
+def test_rejects_dangerous_functions(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Dangerous function not blocked: {sql!r}"
+
+
+def test_rejects_over_length_cap() -> None:
+    payload = "SELECT 1, " + ("a, " * 30_000) + "1"
+    assert len(payload) > _MAX_SQL_CHARS
+    reason = check_read_only(payload)
+    assert reason is not None
+    assert "50000" in reason or "caps" in reason
+
+
+def test_length_cap_exact_boundary() -> None:
+    """At exactly `_MAX_SQL_CHARS` accept; one over must reject. Off-by-one guard."""
+    at_cap = "SELECT 1" + (" " * (_MAX_SQL_CHARS - len("SELECT 1")))
+    assert len(at_cap) == _MAX_SQL_CHARS
+    assert check_read_only(at_cap) is None
+
+    over_cap = at_cap + " "
+    assert len(over_cap) == _MAX_SQL_CHARS + 1
+    assert check_read_only(over_cap) is not None
+
+
+# ---------------------------------------------------------------------------
+# Adversarial / red-team
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # PG-quoted identifier for a dangerous function name. The gate must strip
+        # the `"` chars (not the contents) so `"pg_sleep"(10)` reduces to `pg_sleep(10)`.
+        'SELECT "pg_sleep"(10)',
+        'SELECT "pg_sleep" ( 10 )',
+        'SELECT "PG_SLEEP"(10)',
+        'SELECT "Pg_Sleep"(10)',
+        'SELECT pg_catalog."pg_sleep"(10)',
+        'SELECT "pg_catalog".pg_sleep(10)',
+        'SELECT "pg_catalog"."pg_sleep"(10)',
+        "SELECT \"pg_read_file\"('/etc/passwd')",
+        'SELECT "pg_terminate_backend"(123)',
+        "SELECT \"set_config\"('statement_timeout', '0', false)",
+        "SELECT \"dblink\"('host=evil', 'select 1')",
+        'SELECT "pg_advisory_lock"(1)',
+        "SELECT \"query_to_xml\"('SELECT 1', false, false, '')",
+    ],
+)
+def test_red_team_quoted_dangerous_fn_bypass(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Quoted-fn bypass NOT blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Block comments between keywords must not defeat `\b` word boundaries —
+        # comments are stripped to SPACE, not empty.
+        "SELECT 1 FROM users WHERE id IN (SELECT/**/pg_sleep(10))",
+        "SELECT 1 FROM users WHERE x = (SELECT/**/pg_read_file('/etc/passwd'))",
+        'SELECT 1 FROM users WHERE id IN (SELECT "pg_sleep"(10))',
+        "SELECT 1 INTO/**/new_table FROM users",
+    ],
+)
+def test_red_team_comment_breaks_gate(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Comment-bypass NOT blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Legitimate SELECT with Unicode / non-space whitespace separators must PASS
+        # (`\s` is Unicode-aware for str patterns in Python's re).
+        "SELECT" + chr(0x00A0) + "1",  # NBSP
+        "SELECT" + chr(0x2028) + "1",  # line separator
+        "SELECT\t*\nFROM\nusers",
+        "SELECT\r\n*\r\nFROM\r\nusers",
+    ],
+)
+def test_red_team_unicode_whitespace_accepts_valid(sql: str) -> None:
+    assert check_read_only(sql) is None, f"Unicode-whitespace SELECT should pass: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Deny-list keywords separated by Unicode whitespace must STILL reject.
+        "SELECT\t1\tINTO\tnew_table FROM users",
+        "SELECT" + chr(0x00A0) + "1" + chr(0x00A0) + "INTO" + chr(0x00A0) + "new_table FROM users",
+    ],
+)
+def test_red_team_unicode_whitespace_does_not_bypass_deny(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Unicode-whitespace INTO bypass: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Dollar-quoted strings are NOT stripped — their contents stay visible to the
+        # deny-list. Conservative rejection on pathological cases is intentional.
+        "SELECT $$;DROP TABLE x;$$",
+        "SELECT $$pg_sleep(10)$$",
+        "SELECT $tag$DROP TABLE x$tag$",
+        "DO $$ BEGIN DELETE FROM users; END $$",
+    ],
+)
+def test_red_team_dollar_quoted_conservatively_rejected(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Dollar-quoted bypass: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1; SET statement_timeout = 0; SELECT 2",
+        "SELECT pg_sleep(10) FROM dual",
+        "WITH x AS (LISTEN ch) SELECT 1",
+        "SELECT 1 FROM (SELECT NOTIFY ch1, 'p' AS y) x",
+    ],
+)
+def test_red_team_stacked_keywords(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Stacked attack not blocked: {sql!r}"
+
+
+# ---------------------------------------------------------------------------
+# False-positive guard — the analytics SQL an assistant emits every day. A regex
+# regression that broke any of these would silently degrade every query.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # ----- Time-series rollups -----
+        "SELECT date_trunc('day', created_at) AS d, COUNT(*) FROM orders GROUP BY d ORDER BY d DESC LIMIT 30",
+        "SELECT date_trunc('month', o.created_at), SUM(o.amount) FROM orders o GROUP BY 1",
+        "SELECT EXTRACT(YEAR FROM created_at) AS yr, EXTRACT(MONTH FROM created_at) AS mo, COUNT(*) FROM events GROUP BY yr, mo",
+        "SELECT EXTRACT(DOW FROM o.created_at) AS dow, COUNT(*) FROM orders o GROUP BY dow",
+        # ----- Conditional aggregation -----
+        "SELECT SUM(CASE WHEN status = 'paid' THEN amount ELSE 0 END) FROM invoices",
+        "SELECT COUNT(*) FILTER (WHERE status = 'open') FROM tickets",
+        "SELECT status, COUNT(*) AS n FROM tickets GROUP BY status",
+        # ----- Window functions -----
+        "SELECT id, ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY created_at DESC) AS rn FROM orders",
+        "SELECT id, RANK() OVER (ORDER BY revenue DESC) FROM accounts",
+        "SELECT customer_id, amount, SUM(amount) OVER (PARTITION BY customer_id ORDER BY created_at ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cumulative FROM orders",
+        # ----- CTEs -----
+        "WITH monthly AS (SELECT date_trunc('month', created_at) AS m, COUNT(*) AS n FROM orders GROUP BY 1) SELECT * FROM monthly ORDER BY m",
+        "WITH t1 AS (SELECT id FROM users), t2 AS (SELECT id FROM accounts) SELECT * FROM t1 UNION ALL SELECT * FROM t2",
+        # ----- Recursive CTE -----
+        "WITH RECURSIVE org_tree(id, parent_id, depth) AS (SELECT id, parent_id, 0 FROM departments WHERE parent_id IS NULL UNION ALL SELECT d.id, d.parent_id, t.depth+1 FROM departments d JOIN org_tree t ON d.parent_id = t.id) SELECT * FROM org_tree",
+        # ----- Multi-join -----
+        "SELECT u.email, COUNT(o.id) FROM users u LEFT JOIN orders o ON u.id = o.customer_id GROUP BY u.email HAVING COUNT(o.id) > 5",
+        "SELECT a.name, c.email FROM accounts a JOIN contacts c ON a.id = c.account_id LEFT JOIN opportunities o ON o.account_id = a.id",
+        # ----- Set operations -----
+        "SELECT id FROM users WHERE active UNION SELECT id FROM admins",
+        "SELECT id FROM customers EXCEPT SELECT customer_id FROM churned_customers",
+        "SELECT product_id FROM orders INTERSECT SELECT product_id FROM returns",
+        # ----- String / array / JSON functions -----
+        "SELECT REGEXP_REPLACE(email, '@.*', '') FROM users",
+        "SELECT data->>'name' FROM events WHERE data ? 'id'",
+        "SELECT array_agg(DISTINCT status) FROM tickets",
+        "SELECT jsonb_array_length(items) FROM orders",
+        # ----- Casts & arithmetic -----
+        "SELECT CAST(amount AS DECIMAL(10,2)) FROM invoices",
+        "SELECT amount::numeric * 1.18 AS amount_with_tax FROM orders",
+        "SELECT NULLIF(email, '') FROM users",
+        "SELECT COALESCE(phone, mobile, 'unknown') FROM contacts",
+        # ----- Subqueries -----
+        "SELECT * FROM users WHERE id IN (SELECT user_id FROM admin_users WHERE active)",
+        "SELECT name, (SELECT COUNT(*) FROM orders o WHERE o.user_id = u.id) AS order_count FROM users u",
+        "SELECT id FROM users WHERE EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id)",
+        # ----- Date/time functions -----
+        "SELECT NOW(), CURRENT_DATE, CURRENT_TIMESTAMP",
+        "SELECT created_at + INTERVAL '7 days' FROM events",
+        "SELECT created_at AT TIME ZONE 'UTC' FROM events",
+        # ----- Aliases that overlap reserved-substring patterns -----
+        "SELECT u.created_at, u.updated_at, u.deleted_at FROM users u",
+        "SELECT 1 AS dropped, 2 AS truncated FROM dual",
+        "SELECT prepared_count, committed_at, rollback_total FROM stats",
+        # ----- Comments mid-query (legit) -----
+        "SELECT id /* primary key */, email FROM users",
+        "SELECT id, /* date created */ created_at FROM users",
+        "-- top-of-file comment\nSELECT 1",
+        "SELECT 1 -- trailing comment",
+        "/* block */ SELECT /* inline */ 1 /* end */",
+        # ----- PG-quoted column names that are legit -----
+        'SELECT "user_count" FROM stats',
+        'SELECT "order date", "total amount" FROM legacy_orders',
+        # ----- LATERAL joins -----
+        "SELECT u.id, latest.created_at FROM users u, LATERAL (SELECT created_at FROM orders WHERE user_id = u.id ORDER BY created_at DESC LIMIT 1) latest",
+        # ----- DISTINCT ON -----
+        "SELECT DISTINCT ON (customer_id) customer_id, created_at, amount FROM orders ORDER BY customer_id, created_at DESC",
+        # ----- generate_series -----
+        "SELECT d::date FROM generate_series('2026-01-01'::date, '2026-12-31'::date, INTERVAL '1 day') AS d",
+    ],
+)
+def test_false_positive_guard_legitimate_analytics_sql(sql: str) -> None:
+    assert check_read_only(sql) is None, f"FALSE POSITIVE — legit analytics SQL rejected: {sql!r}"
+
+
+# ---------------------------------------------------------------------------
+# Deferred-scope pins — behaviors intentionally NOT hardened in this pass, so a
+# future change that adds them is a conscious decision (and updates this test).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Bare `pg_catalog` / `information_schema` probing and environment-introspection
+        # keywords/functions are NOT blocked by this gate (schema-scoping is a deferred
+        # follow-up — see the plan). They currently PASS. When the follow-up lands, move
+        # these into a reject test.
+        "SELECT * FROM pg_tables",
+        "SELECT * FROM information_schema.tables",
+        "SELECT current_user",
+        "SELECT current_database()",
+    ],
+)
+def test_known_deferred_gaps_currently_pass(sql: str) -> None:
+    assert check_read_only(sql) is None, (
+        f"Expected this deferred-scope query to pass the read-only gate for now: {sql!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint enforcement — the guard is wired into execute_sql.py::main and is
+# NOT bypassable via --no-safety (that flag only skips the semantic-model pass).
+# This is the regression that closes the direct-`python -m execute_sql` gap.
+# ---------------------------------------------------------------------------
+
+
+def _run_executor(sql: str, tmp_path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "execute_sql", "--profile", "nonexistent", "--sql", sql, *extra],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        # Isolate artifacts dir so bootstrap() never touches the real home dir.
+        env={**os.environ, "AGAMI_ARTIFACTS_DIR": str(tmp_path)},
+    )
+
+
+@pytest.mark.parametrize("extra", [(), ("--no-safety",)])
+def test_executor_blocks_dangerous_sql_even_with_no_safety(tmp_path, extra) -> None:
+    """A write/DDL must be rejected by the executor BEFORE credentials are loaded,
+    regardless of --no-safety. Proves the hard gate is at the shared chokepoint."""
+    proc = _run_executor("DROP TABLE secrets", tmp_path, *extra)
+    assert proc.returncode != 0, proc.stdout
+    # The guard emits a JSON envelope with kind=permission to stderr.
+    envelope = None
+    for line in proc.stderr.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                envelope = json.loads(line)
+            except ValueError:
+                continue
+    assert envelope is not None, f"no JSON error envelope on stderr; got: {proc.stderr!r}"
+    assert envelope["error"]["kind"] == "permission", envelope
+
+
+def test_executor_dangerous_function_blocked(tmp_path) -> None:
+    proc = _run_executor("SELECT pg_read_file('/etc/passwd')", tmp_path)
+    assert proc.returncode != 0
+    assert "permission" in proc.stderr
+
+
+def test_executor_lets_valid_select_past_the_gate(tmp_path) -> None:
+    """A valid SELECT is NOT rejected by the read-only gate — it proceeds to the
+    credential step and fails there instead (proving the gate didn't block it)."""
+    proc = _run_executor("SELECT 1", tmp_path)
+    # It should fail (no such profile / credentials), but NOT with a read-only
+    # permission rejection from the guard.
+    assert '"kind": "permission"' not in proc.stderr, (
+        f"valid SELECT was wrongly blocked by the read-only gate: {proc.stderr!r}"
+    )


### PR DESCRIPTION
## What

Introduces a single stdlib-only read-only SQL guard, **`sql_guard`**, enforced at the shared executor so every path that can run SQL is protected identically.

## Why

Two problems today:

1. **The guard was on the wrong side of the chokepoint.** `check_read_only` ran only inside the MCP `tool_execute_sql`. `execute_sql.py` — invoked directly as `python -m execute_sql` by the `agami-query` skill and cron — enforced *no* read-only guard (only the semantic-model `_model_safety` pass). Those callers ran unguarded SQL. The hosted Docker/HTTP server (`mcp_http.py`) and the stdio server (`mcp_harness.py`) both serve the same `tools.TOOLS` → `tool_execute_sql` → `execute_sql.py`, so this is the internet-facing surface too.
2. **The guard was weak.** It only blocked `INSERT/UPDATE/DELETE/MERGE` and stripped comments *before* string literals — an exploitable multi-statement bypass (`SELECT '--'; DROP TABLE x`), with no dangerous-function or quoted-identifier protection.

## How

- **New `sql_guard.py`** (stdlib-only) is the single source of truth. It runs at the executor chokepoint (`execute_sql.py::main`, **unconditional** — not bypassable by `--no-safety`) and as a fail-fast pre-check in `tools.check_read_only`, so the stdio server, the hosted HTTP/OAuth server, the skills, and cron are all protected identically.
- Beyond "must open with `SELECT`/`WITH`", it rejects: multi-statement SQL (incl. bypasses hidden in string literals, comments — `\r` and `\n` — or double-quoted identifiers), data-modifying CTEs, transaction-control / session-state / prepared statements, `SELECT ... INTO`, row-level locks, and dangerous server-side functions (`pg_read_file`, `lo_export`, `dblink`, `copy_program`, `pg_sleep`, advisory locks, `query_to_xml`, …), plus a 50KB length cap.
- Vendored into `plugins/agami/lib/` for marketplace installs and drift-checked (`dev.py sync-lib` + `test_plugin_lib_resolution.py`).

## Scope

Security-critical hardening only. Deferred to a follow-up (pinned in `test_known_deferred_gaps_currently_pass`): bare `pg_catalog` / `information_schema` / environment-introspection blocking and a full schema allowlist.

## Testing

- **`tests/test_sql_guard.py`** — attack vectors (DML/DDL, multi-statement, comment/quote bypasses, TCL/session/prepared, dangerous functions, red-team) **plus a large false-positive corpus** of real analytics SQL (window fns, recursive CTEs, `CASE…END`, `EXTRACT(… FROM …)`, set ops, JSON, identifiers overlapping keywords like `created_date`) so the deny-list can't silently degrade legit queries.
- Subprocess tests pin the executor chokepoint and marketplace (`python -S`) enforcement.
- **Introspection verified unaffected** — all 12 dialects introspect via `SELECT` (SQLite wraps PRAGMA in `SELECT ... FROM pragma_table_info(...)`).
- Full suite green: **1277 passed**; `ruff check` clean.

## Docs

`docs/mcp-server.md`, `plugins/agami/shared/sql-generation-rules.md`, `SECURITY.md` (new "SQL execution model" section), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)