### PR TITLE
security: close dollar-quote stacking bypass in the read-only SQL guard (fast-follow to #84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ below corresponds to one such version.
   `copy_program`, `pg_sleep`, advisory locks, `query_to_xml`, …). Legitimate analytics
   SQL is unaffected — a large false-positive corpus pins that. Enforcement is not
   bypassable via `--no-safety` (that flag only skips the semantic-model pass).
+- **Closed a dollar-quote statement-stacking bypass in that gate.** A `'` inside a
+  Postgres/Snowflake/DuckDB `$$…$$` (or `$tag$…$tag$`) string desynced the literal
+  stripper and could smuggle a second statement (`SELECT $$'$$ ; DROP TABLE x -- '`)
+  past the multi-statement check. The gate now neutralizes comments and string /
+  dollar literals in a single lexer-faithful pass (first-opened construct wins), and
+  also blocks sequence writes (`setval`/`nextval`) and server/replication control
+  (`pg_stat_reset*`, `pg_switch_wal`, `pg_drop_replication_slot`, …). The guard module
+  is also now packaged in the built wheel (it was missing from `py-modules`, which
+  would have broken `import sql_guard` in an installed/containerized deploy).
 
 ## [0.3.6] — 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,10 @@ below corresponds to one such version.
   Postgres/Snowflake/DuckDB `$$…$$` (or `$tag$…$tag$`) string desynced the literal
   stripper and could smuggle a second statement (`SELECT $$'$$ ; DROP TABLE x -- '`)
   past the multi-statement check. The gate now neutralizes comments and string /
-  dollar literals in a single lexer-faithful pass (first-opened construct wins), and
-  also blocks sequence writes (`setval`/`nextval`) and server/replication control
+  dollar literals in a single lexer-faithful pass (first-opened construct wins),
+  refuses dialect-ambiguous MySQL comment forms (a bare `--x` and executable
+  `/*! … */` comments), and also blocks sequence writes (`setval`/`nextval`) and
+  server/replication control
   (`pg_stat_reset*`, `pg_switch_wal`, `pg_drop_replication_slot`, …). The guard module
   is also now packaged in the built wheel (it was missing from `py-modules`, which
   would have broken `import sql_guard` in an installed/containerized deploy).

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -44,7 +44,7 @@ server = [
 package-dir = { "" = "src" }
 # Flat top-level modules (not under a parent package) — listed explicitly so the import
 # names stay flat regardless of disk layout.
-py-modules = ["agami_paths", "execute_sql", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "model_deploy", "deploy_preflight", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
+py-modules = ["agami_paths", "execute_sql", "sql_guard", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "model_deploy", "deploy_preflight", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
 packages = ["semantic_model"]
 
 [tool.setuptools.package-data]

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -29,6 +29,7 @@ Drivers (install only what you need):
 
 Exit codes:
     0  — success, CSV on stdout
+    1  — SQL rejected by the read-only guard (kind="permission" JSON on stderr)
     2  — usage / config error (missing credentials, bad profile, etc.)
     3  — driver missing for the configured db type
     4  — connection / authentication failed

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -31,7 +31,13 @@ _MAX_SQL_CHARS = 50_000
 # second `$`), so those pass through untouched. `_neutralize` finds the matching
 # close tag itself (a backreference can't express "same literal tag" inside the
 # single-pass scan cleanly, so the scan does the find).
-_DOLLAR_OPEN_RE = re.compile(r"\$(?:[A-Za-z_]\w*)?\$")
+#
+# `\w*` accepts digit-led tags (`$1$`) too, which Postgres itself rejects (a real
+# tag follows identifier rules and can't start with a digit). Being STRICTER than
+# the grammar here is deliberate: treating any `$…$`-delimited span as an opaque
+# literal only ever neutralizes *more*, so it can never hide a token the database
+# would execute — it just refuses to let a `$1$`-looking region desync the scan.
+_DOLLAR_OPEN_RE = re.compile(r"\$\w*\$")
 
 
 class _GuardReject(Exception):

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -34,6 +34,17 @@ _MAX_SQL_CHARS = 50_000
 _DOLLAR_OPEN_RE = re.compile(r"\$(?:[A-Za-z_]\w*)?\$")
 
 
+class _GuardReject(Exception):
+    """Raised from the scan when SQL uses a construct whose meaning is
+    dialect-ambiguous and therefore cannot be neutralized safely with one lexer
+    (see the MySQL comment forms in `_neutralize`). Carries the caller-facing reason.
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
 def _neutralize(sql: str) -> str:
     """Blank out comments and string / dollar-quoted literals, and drop the quote
     delimiters of double-quoted identifiers (keeping their content), in a SINGLE
@@ -62,12 +73,27 @@ def _neutralize(sql: str) -> str:
     while i < n:
         two = sql[i : i + 2]
         if two == "--":  # line comment — ends at CR or LF (PG scanner ends at either)
+            # MySQL/MariaDB only treat `--` as a comment when the next char is
+            # whitespace/EOL/EOF; `--0` there parses as `- -0`, so blanking it (PG's
+            # rule) would hide a following `;DROP`. The two dialects genuinely
+            # disagree, so refuse the ambiguous form rather than pick one.
+            nxt = sql[i + 2] if i + 2 < n else ""
+            if nxt and nxt not in " \t\r\n\f":
+                raise _GuardReject(
+                    "an inline '--' comment must be followed by whitespace "
+                    "(bare '--x' is a comment in Postgres but an operator in MySQL)"
+                )
             j = i + 2
             while j < n and sql[j] not in "\r\n":
                 j += 1
             out.append(" ")
             i = j
         elif two == "/*":  # block comment
+            # `/*! ... */` (and versioned `/*!NNNNN ... */`) is a MySQL *executable*
+            # comment — the server runs its body as live SQL. Blanking it as an
+            # ordinary comment would smuggle whatever it contains past every check.
+            if sql[i + 2 : i + 3] == "!":
+                raise _GuardReject("MySQL executable comments ('/*! ... */') are not allowed")
             end = sql.find("*/", i + 2)
             i = n if end == -1 else end + 2
             out.append(" ")
@@ -201,6 +227,8 @@ def check_read_only(sql: str | None) -> str | None:
     Rejection ladder (each step has its own message so the caller can correct):
       0. Empty SQL
       1. SQL longer than `_MAX_SQL_CHARS`
+      1b. Dialect-ambiguous comment form (bare `--x`, MySQL `/*! ... */`) — raised
+          from `_neutralize` because it can't be neutralized safely with one lexer
       2. Multi-statement (any `;` outside literals/comments, except one trailing `;`)
       3. Doesn't open with SELECT or WITH (leading `(` tolerated)
       4. Contains a forbidden keyword (DML/DDL/TCL/session/pub-sub/lock/prepared/INTO)
@@ -220,7 +248,10 @@ def check_read_only(sql: str | None) -> str | None:
     # identifiers (`"pg_sleep"(10)` -> `pg_sleep(10)`), in one lexer-faithful pass so
     # nothing hidden inside a literal or comment can reach the checks below. See
     # `_neutralize` for why a single scan is required rather than layered regexes.
-    stripped = _neutralize(sql).strip()
+    try:
+        stripped = _neutralize(sql).strip()
+    except _GuardReject as reject:
+        return reject.reason
 
     # Allow exactly one trailing `;`. Any other `;` indicates a second statement —
     # the classic statement-stacking bypass (`COMMIT; DROP SCHEMA public CASCADE`).

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -132,11 +132,15 @@ def _neutralize(sql: str) -> str:
             out.append("".join(buf))
             i = j
         elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)
+            # Only a `$tag$` with a MATCHING close delimiter is a literal we can blank.
+            # An unterminated opener must NOT swallow to EOF — that would hide a trailing
+            # `; DROP ...` from the multi-statement check (fail-open). Treating it as a
+            # bare `$` instead leaves everything after it visible, so the scan fails safe
+            # (the DB rejects an unterminated dollar-quote anyway).
             m = _DOLLAR_OPEN_RE.match(sql, i)
-            if m:
-                tag = m.group(0)
-                close = sql.find(tag, m.end())
-                i = n if close == -1 else close + len(tag)
+            close = sql.find(m.group(0), m.end()) if m else -1
+            if m and close != -1:
+                i = close + len(m.group(0))
                 out.append(" ")
             else:
                 out.append("$")

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -26,23 +26,94 @@ import re
 # analytics SQL fits in ~10KB; 50KB is conservative.
 _MAX_SQL_CHARS = 50_000
 
-# Match SQL comments (line `--` and block `/* */`).
-# CRITICAL: callers MUST sub with a SINGLE SPACE, never with empty string.
-# Replacing with empty welds adjacent tokens together (`SELECT/**/INTO` ->
-# `SELECTINTO`) and defeats the `\b` word-boundary in every downstream regex.
-#
-# Line comments stop at `\r` OR `\n` — Postgres' scanner ends `--` at either.
-# Stopping only at `\n` is exploitable: `SELECT 1 --x\r;DROP TABLE y\n` would be
-# scrubbed to `SELECT 1 ` by a `[^\n]*`-only regex (the `\r;DROP...` is eaten as
-# part of the comment), masking a multi-statement attack.
-_SQL_COMMENT_RE = re.compile(r"--[^\r\n]*|/\*.*?\*/", re.DOTALL)
+# Opening delimiter of a Postgres / Snowflake / DuckDB dollar-quoted string —
+# `$$` or a tagged `$name$`. A positional parameter (`$1`) is NOT an opener (no
+# second `$`), so those pass through untouched. `_neutralize` finds the matching
+# close tag itself (a backreference can't express "same literal tag" inside the
+# single-pass scan cleanly, so the scan does the find).
+_DOLLAR_OPEN_RE = re.compile(r"\$(?:[A-Za-z_]\w*)?\$")
 
-# Single-quoted string literals so `;` / keywords inside them don't trip the
-# deny-list. PG / Redshift / Snowflake all support doubled-quote escaping inside
-# literals. Double-quoted IDENTIFIERS are handled separately (the gate strips the
-# quote chars via `.replace('"', '')` so `"pg_sleep"(10)` reduces to `pg_sleep(10)`
-# and the dangerous-function regex catches it).
-_SQL_SINGLE_QUOTED_RE = re.compile(r"'(?:''|[^'])*'")
+
+def _neutralize(sql: str) -> str:
+    """Blank out comments and string / dollar-quoted literals, and drop the quote
+    delimiters of double-quoted identifiers (keeping their content), in a SINGLE
+    left-to-right pass so the FIRST-opened construct wins — exactly how the database
+    lexer resolves them.
+
+    A stack of independent regex subs (one per construct) CANNOT do this: whichever
+    regex runs first is blind to the others, so a `'` inside a `$$...$$` body, or a
+    `$$` inside a `-- ...` comment, desyncs it and can smuggle an injected
+    `; DROP ...` past the multi-statement check. The scan below never desyncs
+    because at each position it commits to whatever opens there and skips to that
+    construct's own close. Under-matching (an unterminated literal running to EOF)
+    only ever fails *safe* — a stray `;` stays visible and trips the guard.
+
+    Only this analysis copy is transformed; the ORIGINAL sql is what executes.
+    Neutralized spans collapse to a single space (never empty — welding tokens like
+    `SELECT/**/INTO` -> `SELECTINTO` would defeat the `\\b` word boundaries below).
+
+    Escapes: `''` inside a single-quoted literal and `""` inside a double-quoted
+    identifier are treated as doubled-delimiter escapes (standard SQL). Backslash is
+    deliberately NOT an escape here — engines disagree (MySQL yes, standard PG no),
+    and not honoring it can only stop a literal *early* (fail safe), never late.
+    """
+    out: list[str] = []
+    i, n = 0, len(sql)
+    while i < n:
+        two = sql[i : i + 2]
+        if two == "--":  # line comment — ends at CR or LF (PG scanner ends at either)
+            j = i + 2
+            while j < n and sql[j] not in "\r\n":
+                j += 1
+            out.append(" ")
+            i = j
+        elif two == "/*":  # block comment
+            end = sql.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            out.append(" ")
+        elif sql[i] == "'":  # single-quoted string literal
+            j = i + 1
+            while j < n:
+                if sql[j] == "'":
+                    if j + 1 < n and sql[j + 1] == "'":  # doubled '' escape
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            out.append(" ")
+            i = j
+        elif sql[i] == '"':  # double-quoted identifier — keep content, drop quotes
+            j, buf = i + 1, []
+            while j < n:
+                if sql[j] == '"':
+                    if j + 1 < n and sql[j + 1] == '"':  # doubled "" escape
+                        buf.append('"')
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                buf.append(sql[j])
+                j += 1
+            # A pathological identifier like "a;b" reduces to a;b and trips the
+            # multi-statement check — a deliberate, safe-direction hardening choice.
+            out.append("".join(buf))
+            i = j
+        elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)
+            m = _DOLLAR_OPEN_RE.match(sql, i)
+            if m:
+                tag = m.group(0)
+                close = sql.find(tag, m.end())
+                i = n if close == -1 else close + len(tag)
+                out.append(" ")
+            else:
+                out.append("$")
+                i += 1
+        else:
+            out.append(sql[i])
+            i += 1
+    return "".join(out)
+
 
 # Allowed opening keyword. `WITH` covers CTEs whose final clause is a SELECT.
 # Leading `(` / whitespace is tolerated so a parenthesized set operation —
@@ -99,9 +170,18 @@ _DANGEROUS_FN_RE = re.compile(
     r"dblink\w*|"
     # Shell out via COPY
     r"copy_program|"
+    # Sequence mutation — `setval`/`nextval` WRITE (advance / reset a sequence),
+    # a real data change that starts with SELECT and so slips the keyword deny.
+    r"nextval|setval|"
     # Backend / process control
     r"pg_terminate_backend|pg_cancel_backend|pg_reload_conf|"
     r"pg_rotate_logfile|pg_logfile_rotate|"
+    # Server / replication / stats control — reset monitoring counters, force a WAL
+    # switch, or drop a replication slot (can break downstream replication). Same
+    # side-effecting family as the log/conf calls above. `pg_stat_reset\w*` covers
+    # `pg_stat_reset_shared` / `_single_table_counters` / etc.
+    r"pg_stat_reset\w*|pg_stat_statements_reset|pg_switch_wal|"
+    r"pg_create_restore_point|pg_drop_replication_slot|pg_replication_slot_advance|"
     # Session-state mutation that bypasses the `SET` keyword deny.
     r"set_config|current_setting|"
     # Session-survival advisory locks — survive connection return and can DoS.
@@ -136,19 +216,11 @@ def check_read_only(sql: str | None) -> str | None:
             "Real analytics SQL fits well under this."
         )
 
-    # CRITICAL: strip string literals BEFORE comments. The reverse order is
-    # exploitable — `SELECT '--'; DROP TABLE x` has `--` inside a literal, but the
-    # comment regex would otherwise eat from the `--` through end-of-line (taking
-    # the injected `; DROP ...` with it) and the multi-statement check would pass.
-    # Replacing literals first kills any embedded `--` / `/*` before the comment
-    # regex runs.
-    #
-    # Then strip PG-quoted identifier delimiters (`"`) so `"pg_sleep"(10)` reduces
-    # to `pg_sleep(10)` and the dangerous-function regex catches it. The trade-off:
-    # a pathological column named `"a;b"` ends up as `a;b` and trips the
-    # multi-statement check — a deliberate hardening choice.
-    stripped = _SQL_COMMENT_RE.sub(" ", _SQL_SINGLE_QUOTED_RE.sub("''", sql))
-    stripped = stripped.replace('"', "").strip()
+    # Blank out comments and string / dollar literals, and unwrap double-quoted
+    # identifiers (`"pg_sleep"(10)` -> `pg_sleep(10)`), in one lexer-faithful pass so
+    # nothing hidden inside a literal or comment can reach the checks below. See
+    # `_neutralize` for why a single scan is required rather than layered regexes.
+    stripped = _neutralize(sql).strip()
 
     # Allow exactly one trailing `;`. Any other `;` indicates a second statement —
     # the classic statement-stacking bypass (`COMMIT; DROP SCHEMA public CASCADE`).

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -29,6 +29,7 @@ Drivers (install only what you need):
 
 Exit codes:
     0  — success, CSV on stdout
+    1  — SQL rejected by the read-only guard (kind="permission" JSON on stderr)
     2  — usage / config error (missing credentials, bad profile, etc.)
     3  — driver missing for the configured db type
     4  — connection / authentication failed

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -31,7 +31,13 @@ _MAX_SQL_CHARS = 50_000
 # second `$`), so those pass through untouched. `_neutralize` finds the matching
 # close tag itself (a backreference can't express "same literal tag" inside the
 # single-pass scan cleanly, so the scan does the find).
-_DOLLAR_OPEN_RE = re.compile(r"\$(?:[A-Za-z_]\w*)?\$")
+#
+# `\w*` accepts digit-led tags (`$1$`) too, which Postgres itself rejects (a real
+# tag follows identifier rules and can't start with a digit). Being STRICTER than
+# the grammar here is deliberate: treating any `$…$`-delimited span as an opaque
+# literal only ever neutralizes *more*, so it can never hide a token the database
+# would execute — it just refuses to let a `$1$`-looking region desync the scan.
+_DOLLAR_OPEN_RE = re.compile(r"\$\w*\$")
 
 
 class _GuardReject(Exception):

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -34,6 +34,17 @@ _MAX_SQL_CHARS = 50_000
 _DOLLAR_OPEN_RE = re.compile(r"\$(?:[A-Za-z_]\w*)?\$")
 
 
+class _GuardReject(Exception):
+    """Raised from the scan when SQL uses a construct whose meaning is
+    dialect-ambiguous and therefore cannot be neutralized safely with one lexer
+    (see the MySQL comment forms in `_neutralize`). Carries the caller-facing reason.
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
 def _neutralize(sql: str) -> str:
     """Blank out comments and string / dollar-quoted literals, and drop the quote
     delimiters of double-quoted identifiers (keeping their content), in a SINGLE
@@ -62,12 +73,27 @@ def _neutralize(sql: str) -> str:
     while i < n:
         two = sql[i : i + 2]
         if two == "--":  # line comment — ends at CR or LF (PG scanner ends at either)
+            # MySQL/MariaDB only treat `--` as a comment when the next char is
+            # whitespace/EOL/EOF; `--0` there parses as `- -0`, so blanking it (PG's
+            # rule) would hide a following `;DROP`. The two dialects genuinely
+            # disagree, so refuse the ambiguous form rather than pick one.
+            nxt = sql[i + 2] if i + 2 < n else ""
+            if nxt and nxt not in " \t\r\n\f":
+                raise _GuardReject(
+                    "an inline '--' comment must be followed by whitespace "
+                    "(bare '--x' is a comment in Postgres but an operator in MySQL)"
+                )
             j = i + 2
             while j < n and sql[j] not in "\r\n":
                 j += 1
             out.append(" ")
             i = j
         elif two == "/*":  # block comment
+            # `/*! ... */` (and versioned `/*!NNNNN ... */`) is a MySQL *executable*
+            # comment — the server runs its body as live SQL. Blanking it as an
+            # ordinary comment would smuggle whatever it contains past every check.
+            if sql[i + 2 : i + 3] == "!":
+                raise _GuardReject("MySQL executable comments ('/*! ... */') are not allowed")
             end = sql.find("*/", i + 2)
             i = n if end == -1 else end + 2
             out.append(" ")
@@ -201,6 +227,8 @@ def check_read_only(sql: str | None) -> str | None:
     Rejection ladder (each step has its own message so the caller can correct):
       0. Empty SQL
       1. SQL longer than `_MAX_SQL_CHARS`
+      1b. Dialect-ambiguous comment form (bare `--x`, MySQL `/*! ... */`) — raised
+          from `_neutralize` because it can't be neutralized safely with one lexer
       2. Multi-statement (any `;` outside literals/comments, except one trailing `;`)
       3. Doesn't open with SELECT or WITH (leading `(` tolerated)
       4. Contains a forbidden keyword (DML/DDL/TCL/session/pub-sub/lock/prepared/INTO)
@@ -220,7 +248,10 @@ def check_read_only(sql: str | None) -> str | None:
     # identifiers (`"pg_sleep"(10)` -> `pg_sleep(10)`), in one lexer-faithful pass so
     # nothing hidden inside a literal or comment can reach the checks below. See
     # `_neutralize` for why a single scan is required rather than layered regexes.
-    stripped = _neutralize(sql).strip()
+    try:
+        stripped = _neutralize(sql).strip()
+    except _GuardReject as reject:
+        return reject.reason
 
     # Allow exactly one trailing `;`. Any other `;` indicates a second statement —
     # the classic statement-stacking bypass (`COMMIT; DROP SCHEMA public CASCADE`).

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -132,11 +132,15 @@ def _neutralize(sql: str) -> str:
             out.append("".join(buf))
             i = j
         elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)
+            # Only a `$tag$` with a MATCHING close delimiter is a literal we can blank.
+            # An unterminated opener must NOT swallow to EOF — that would hide a trailing
+            # `; DROP ...` from the multi-statement check (fail-open). Treating it as a
+            # bare `$` instead leaves everything after it visible, so the scan fails safe
+            # (the DB rejects an unterminated dollar-quote anyway).
             m = _DOLLAR_OPEN_RE.match(sql, i)
-            if m:
-                tag = m.group(0)
-                close = sql.find(tag, m.end())
-                i = n if close == -1 else close + len(tag)
+            close = sql.find(m.group(0), m.end()) if m else -1
+            if m and close != -1:
+                i = close + len(m.group(0))
                 out.append(" ")
             else:
                 out.append("$")

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -26,23 +26,94 @@ import re
 # analytics SQL fits in ~10KB; 50KB is conservative.
 _MAX_SQL_CHARS = 50_000
 
-# Match SQL comments (line `--` and block `/* */`).
-# CRITICAL: callers MUST sub with a SINGLE SPACE, never with empty string.
-# Replacing with empty welds adjacent tokens together (`SELECT/**/INTO` ->
-# `SELECTINTO`) and defeats the `\b` word-boundary in every downstream regex.
-#
-# Line comments stop at `\r` OR `\n` — Postgres' scanner ends `--` at either.
-# Stopping only at `\n` is exploitable: `SELECT 1 --x\r;DROP TABLE y\n` would be
-# scrubbed to `SELECT 1 ` by a `[^\n]*`-only regex (the `\r;DROP...` is eaten as
-# part of the comment), masking a multi-statement attack.
-_SQL_COMMENT_RE = re.compile(r"--[^\r\n]*|/\*.*?\*/", re.DOTALL)
+# Opening delimiter of a Postgres / Snowflake / DuckDB dollar-quoted string —
+# `$$` or a tagged `$name$`. A positional parameter (`$1`) is NOT an opener (no
+# second `$`), so those pass through untouched. `_neutralize` finds the matching
+# close tag itself (a backreference can't express "same literal tag" inside the
+# single-pass scan cleanly, so the scan does the find).
+_DOLLAR_OPEN_RE = re.compile(r"\$(?:[A-Za-z_]\w*)?\$")
 
-# Single-quoted string literals so `;` / keywords inside them don't trip the
-# deny-list. PG / Redshift / Snowflake all support doubled-quote escaping inside
-# literals. Double-quoted IDENTIFIERS are handled separately (the gate strips the
-# quote chars via `.replace('"', '')` so `"pg_sleep"(10)` reduces to `pg_sleep(10)`
-# and the dangerous-function regex catches it).
-_SQL_SINGLE_QUOTED_RE = re.compile(r"'(?:''|[^'])*'")
+
+def _neutralize(sql: str) -> str:
+    """Blank out comments and string / dollar-quoted literals, and drop the quote
+    delimiters of double-quoted identifiers (keeping their content), in a SINGLE
+    left-to-right pass so the FIRST-opened construct wins — exactly how the database
+    lexer resolves them.
+
+    A stack of independent regex subs (one per construct) CANNOT do this: whichever
+    regex runs first is blind to the others, so a `'` inside a `$$...$$` body, or a
+    `$$` inside a `-- ...` comment, desyncs it and can smuggle an injected
+    `; DROP ...` past the multi-statement check. The scan below never desyncs
+    because at each position it commits to whatever opens there and skips to that
+    construct's own close. Under-matching (an unterminated literal running to EOF)
+    only ever fails *safe* — a stray `;` stays visible and trips the guard.
+
+    Only this analysis copy is transformed; the ORIGINAL sql is what executes.
+    Neutralized spans collapse to a single space (never empty — welding tokens like
+    `SELECT/**/INTO` -> `SELECTINTO` would defeat the `\\b` word boundaries below).
+
+    Escapes: `''` inside a single-quoted literal and `""` inside a double-quoted
+    identifier are treated as doubled-delimiter escapes (standard SQL). Backslash is
+    deliberately NOT an escape here — engines disagree (MySQL yes, standard PG no),
+    and not honoring it can only stop a literal *early* (fail safe), never late.
+    """
+    out: list[str] = []
+    i, n = 0, len(sql)
+    while i < n:
+        two = sql[i : i + 2]
+        if two == "--":  # line comment — ends at CR or LF (PG scanner ends at either)
+            j = i + 2
+            while j < n and sql[j] not in "\r\n":
+                j += 1
+            out.append(" ")
+            i = j
+        elif two == "/*":  # block comment
+            end = sql.find("*/", i + 2)
+            i = n if end == -1 else end + 2
+            out.append(" ")
+        elif sql[i] == "'":  # single-quoted string literal
+            j = i + 1
+            while j < n:
+                if sql[j] == "'":
+                    if j + 1 < n and sql[j + 1] == "'":  # doubled '' escape
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            out.append(" ")
+            i = j
+        elif sql[i] == '"':  # double-quoted identifier — keep content, drop quotes
+            j, buf = i + 1, []
+            while j < n:
+                if sql[j] == '"':
+                    if j + 1 < n and sql[j + 1] == '"':  # doubled "" escape
+                        buf.append('"')
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                buf.append(sql[j])
+                j += 1
+            # A pathological identifier like "a;b" reduces to a;b and trips the
+            # multi-statement check — a deliberate, safe-direction hardening choice.
+            out.append("".join(buf))
+            i = j
+        elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)
+            m = _DOLLAR_OPEN_RE.match(sql, i)
+            if m:
+                tag = m.group(0)
+                close = sql.find(tag, m.end())
+                i = n if close == -1 else close + len(tag)
+                out.append(" ")
+            else:
+                out.append("$")
+                i += 1
+        else:
+            out.append(sql[i])
+            i += 1
+    return "".join(out)
+
 
 # Allowed opening keyword. `WITH` covers CTEs whose final clause is a SELECT.
 # Leading `(` / whitespace is tolerated so a parenthesized set operation —
@@ -99,9 +170,18 @@ _DANGEROUS_FN_RE = re.compile(
     r"dblink\w*|"
     # Shell out via COPY
     r"copy_program|"
+    # Sequence mutation — `setval`/`nextval` WRITE (advance / reset a sequence),
+    # a real data change that starts with SELECT and so slips the keyword deny.
+    r"nextval|setval|"
     # Backend / process control
     r"pg_terminate_backend|pg_cancel_backend|pg_reload_conf|"
     r"pg_rotate_logfile|pg_logfile_rotate|"
+    # Server / replication / stats control — reset monitoring counters, force a WAL
+    # switch, or drop a replication slot (can break downstream replication). Same
+    # side-effecting family as the log/conf calls above. `pg_stat_reset\w*` covers
+    # `pg_stat_reset_shared` / `_single_table_counters` / etc.
+    r"pg_stat_reset\w*|pg_stat_statements_reset|pg_switch_wal|"
+    r"pg_create_restore_point|pg_drop_replication_slot|pg_replication_slot_advance|"
     # Session-state mutation that bypasses the `SET` keyword deny.
     r"set_config|current_setting|"
     # Session-survival advisory locks — survive connection return and can DoS.
@@ -136,19 +216,11 @@ def check_read_only(sql: str | None) -> str | None:
             "Real analytics SQL fits well under this."
         )
 
-    # CRITICAL: strip string literals BEFORE comments. The reverse order is
-    # exploitable — `SELECT '--'; DROP TABLE x` has `--` inside a literal, but the
-    # comment regex would otherwise eat from the `--` through end-of-line (taking
-    # the injected `; DROP ...` with it) and the multi-statement check would pass.
-    # Replacing literals first kills any embedded `--` / `/*` before the comment
-    # regex runs.
-    #
-    # Then strip PG-quoted identifier delimiters (`"`) so `"pg_sleep"(10)` reduces
-    # to `pg_sleep(10)` and the dangerous-function regex catches it. The trade-off:
-    # a pathological column named `"a;b"` ends up as `a;b` and trips the
-    # multi-statement check — a deliberate hardening choice.
-    stripped = _SQL_COMMENT_RE.sub(" ", _SQL_SINGLE_QUOTED_RE.sub("''", sql))
-    stripped = stripped.replace('"', "").strip()
+    # Blank out comments and string / dollar literals, and unwrap double-quoted
+    # identifiers (`"pg_sleep"(10)` -> `pg_sleep(10)`), in one lexer-faithful pass so
+    # nothing hidden inside a literal or comment can reach the checks below. See
+    # `_neutralize` for why a single scan is required rather than layered regexes.
+    stripped = _neutralize(sql).strip()
 
     # Allow exactly one trailing `;`. Any other `;` indicates a second statement —
     # the classic statement-stacking bypass (`COMMIT; DROP SCHEMA public CASCADE`).

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -430,6 +430,11 @@ def test_red_team_unicode_whitespace_does_not_bypass_deny(sql: str) -> None:
         # digit), so the raw payload is a DB syntax error — but the scan still treats
         # any `$…$` span as opaque, so a `'` inside can't desync it and expose the `;`.
         r"SELECT $1$'$1$ ; DROP TABLE users -- '",
+        # An UNTERMINATED `$tag$` opener must not blank to EOF and swallow the trailing
+        # `; DROP ...` (a fail-open the `$…$`-as-opaque broadening introduced): with no
+        # matching close tag, the `;` stays visible and trips the guard.
+        r"SELECT 1 AS $tag$; DROP TABLE users",
+        r"SELECT 1 $$x ; DROP TABLE users",
         # A `$$` that OPENS inside a line comment must not be treated as a real
         # dollar-quote and swallow the statement that follows the newline.
         "SELECT 1 --$$\n;DROP TABLE x--$$",

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -426,6 +426,10 @@ def test_red_team_unicode_whitespace_does_not_bypass_deny(sql: str) -> None:
         r"SELECT $$'$$ ; DROP TABLE users -- '",
         r"SELECT $tag$'$tag$ ; DELETE FROM accounts -- '",
         r"SELECT $$won't$$ ; CREATE TABLE evil(x int) -- '",
+        # Numeric-tag `$1$` is not a real PG dollar-quote (tags can't start with a
+        # digit), so the raw payload is a DB syntax error — but the scan still treats
+        # any `$…$` span as opaque, so a `'` inside can't desync it and expose the `;`.
+        r"SELECT $1$'$1$ ; DROP TABLE users -- '",
         # A `$$` that OPENS inside a line comment must not be treated as a real
         # dollar-quote and swallow the statement that follows the newline.
         "SELECT 1 --$$\n;DROP TABLE x--$$",
@@ -558,6 +562,9 @@ def test_red_team_stacked_keywords(sql: str) -> None:
         "SELECT $$plain label$$ AS note FROM stats",
         "SELECT $tag$O'Brien$tag$ AS name",
         "SELECT $$multi\nline\ntext$$ AS body FROM docs",
+        # ----- Positional parameters ($1, $2) are NOT dollar-quote openers -----
+        "SELECT id, name FROM users WHERE id = $1",
+        "SELECT * FROM orders WHERE customer_id = $1 AND status = $2",
     ],
 )
 def test_false_positive_guard_legitimate_analytics_sql(sql: str) -> None:

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -294,6 +294,17 @@ def test_rejects_select_into_write_path(sql: str) -> None:
         "SELECT pg_terminate_backend(123)",
         "SELECT pg_cancel_backend(123)",
         "SELECT pg_reload_conf()",
+        # Sequence mutation — real writes that open with SELECT.
+        "SELECT setval('users_id_seq', 100)",
+        "SELECT nextval('order_seq')",
+        # Server / replication / stats control.
+        "SELECT pg_stat_reset()",
+        "SELECT pg_stat_reset_shared('bgwriter')",
+        "SELECT pg_stat_statements_reset()",
+        "SELECT pg_switch_wal()",
+        "SELECT pg_create_restore_point('x')",
+        "SELECT pg_drop_replication_slot('s')",
+        "SELECT pg_replication_slot_advance('s', '0/0')",
         # Post-audit additions.
         "SELECT set_config('statement_timeout', '0', false)",
         "SELECT current_setting('statement_timeout')",
@@ -407,16 +418,23 @@ def test_red_team_unicode_whitespace_does_not_bypass_deny(sql: str) -> None:
 @pytest.mark.parametrize(
     "sql",
     [
-        # Dollar-quoted strings are NOT stripped — their contents stay visible to the
-        # deny-list. Conservative rejection on pathological cases is intentional.
-        "SELECT $$;DROP TABLE x;$$",
-        "SELECT $$pg_sleep(10)$$",
-        "SELECT $tag$DROP TABLE x$tag$",
+        # Dollar-quote statement stacking. A `'` inside a `$$...$$` / `$tag$...$tag$`
+        # body used to desync the single-quote stripper and smuggle a real second
+        # statement past the multi-statement check. The lexer-faithful scan
+        # neutralizes the whole dollar body, so the injected `;` stays visible and is
+        # blocked. (Regression: arbitrary statement execution regardless of DB role.)
+        r"SELECT $$'$$ ; DROP TABLE users -- '",
+        r"SELECT $tag$'$tag$ ; DELETE FROM accounts -- '",
+        r"SELECT $$won't$$ ; CREATE TABLE evil(x int) -- '",
+        # A `$$` that OPENS inside a line comment must not be treated as a real
+        # dollar-quote and swallow the statement that follows the newline.
+        "SELECT 1 --$$\n;DROP TABLE x--$$",
+        # A DO-block is procedural, not a SELECT — rejected on the opening-keyword check.
         "DO $$ BEGIN DELETE FROM users; END $$",
     ],
 )
-def test_red_team_dollar_quoted_conservatively_rejected(sql: str) -> None:
-    assert check_read_only(sql) is not None, f"Dollar-quoted bypass: {sql!r}"
+def test_red_team_dollar_quoted_stacking_blocked(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"Dollar-quote stacking NOT blocked: {sql!r}"
 
 
 @pytest.mark.parametrize(
@@ -503,6 +521,11 @@ def test_red_team_stacked_keywords(sql: str) -> None:
         "SELECT DISTINCT ON (customer_id) customer_id, created_at, amount FROM orders ORDER BY customer_id, created_at DESC",
         # ----- generate_series -----
         "SELECT d::date FROM generate_series('2026-01-01'::date, '2026-12-31'::date, INTERVAL '1 day') AS d",
+        # ----- Dollar-quoted string CONSTANTS (a value, not executable code). The
+        # keywords/`;` inside are inert data; blocking these was an old false positive. -----
+        "SELECT $$plain label$$ AS note FROM stats",
+        "SELECT $tag$O'Brien$tag$ AS name",
+        "SELECT $$multi\nline\ntext$$ AS body FROM docs",
     ],
 )
 def test_false_positive_guard_legitimate_analytics_sql(sql: str) -> None:

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -440,6 +440,38 @@ def test_red_team_dollar_quoted_stacking_blocked(sql: str) -> None:
 @pytest.mark.parametrize(
     "sql",
     [
+        # MySQL/MariaDB `--` is a comment ONLY when followed by whitespace; `--0` is
+        # `- -0`, so blanking it PG-style would hide the stacked `;DROP`. Refuse the
+        # dialect-ambiguous form.
+        "SELECT 1--0;DROP TABLE users",
+        "SELECT 1--x\nUNION SELECT 2",
+        # MySQL executable comments run their body as live SQL server-side.
+        "SELECT 1/*!;DROP TABLE t*/",
+        "SELECT 1/*!50000 ;DROP TABLE t*/",
+        "SELECT * FROM t /*!UNION SELECT * FROM secrets*/",
+    ],
+)
+def test_red_team_mysql_comment_lexing_blocked(sql: str) -> None:
+    assert check_read_only(sql) is not None, f"MySQL comment bypass NOT blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # The whitespace-led `--` comment is a comment in BOTH dialects — must pass.
+        "SELECT 1 -- 0;DROP\n",
+        "SELECT 1 --\tvalue FROM t",
+        # A plain `/* ... */` block (not `/*!`) stays a normal comment.
+        "SELECT 1 /* note */ FROM t",
+    ],
+)
+def test_unambiguous_comments_still_pass(sql: str) -> None:
+    assert check_read_only(sql) is None, f"Legit comment wrongly rejected: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
         "SELECT 1; SET statement_timeout = 0; SELECT 2",
         "SELECT pg_sleep(10) FROM dual",
         "WITH x AS (LISTEN ch) SELECT 1",


### PR DESCRIPTION
## Summary

Fast-follow to #84 addressing two must-fix review findings before any release cuts. The guard from #84 is a genuine improvement, but a review pass found a statement-stacking bypass and a packaging break that would ship a broken import.

## Changes

- **Dollar-quote statement-stacking bypass (critical).** A `'` inside a Postgres/Snowflake/DuckDB dollar-quoted string (`$$…$$` or `$tag$…$tag$`) desynced the single-quote stripper, letting a second statement slip past the multi-statement check:
  ```
  SELECT $$'$$ ; DROP TABLE users -- '     (guard returned None → let through)
  ```
  Verified exploitable against the merged guard. Replaced the layered comment/literal regex subs with a single **lexer-faithful left-to-right scan** (`_neutralize`) so the *first-opened* construct wins — closing the whole desync class (dollar-in-quote, and `$$`-opened-inside-a-comment ordering). This is the "engine-aware literal stripping" the layered regexes couldn't do.
- **Extended dangerous-function deny-list.** Sequence writes (`setval`/`nextval`) and server/replication/stats control (`pg_stat_reset*`, `pg_switch_wal`, `pg_create_restore_point`, `pg_drop_replication_slot`, `pg_replication_slot_advance`) — same side-effecting family as the already-blocked `pg_reload_conf`.
- **Packaging break.** `sql_guard` was missing from `py-modules`, so the built wheel / GHCR image would `ModuleNotFoundError` on `import sql_guard` at the executor chokepoint (masked in CI by the editable install). Added it; **verified the built wheel now ships `sql_guard.py`**.
- **Docstring.** Documented exit code `1` (guard rejection) in `execute_sql`.

## Scope notes / follow-ups (not in this PR)

- The dangerous-function list is inherently **Postgres/Redshift-shaped**. Other engines have their own primitives (MySQL `LOAD_FILE`/`SLEEP`, SQL Server `xp_cmdshell`/`OPENROWSET`, Oracle `UTL_FILE`/`UTL_HTTP`). The **engine-agnostic** guarantees (SELECT/WITH-only, single-statement, no `INTO`) protect all dialects; the cross-engine backstop remains the **read-only DB role** (#82). A per-engine function deny-list is a separate, larger effort.
- BigQuery triple-quoted `'''…'''`/`"""…"""` and Oracle `q'[…]'` literals are other instances of the same desync class — worth covering if those drivers get wired to the executor.

## Test plan

- New: dollar-quote stacking PoCs (previously bypassed, now blocked) + the new dangerous functions.
- Legit dollar-quoted **string constants** (`SELECT $$label$$ …`) moved into the false-positive corpus — they select a *value*, not code, so blocking them was an old false positive.
- Full gate green: **1290 passed**, ruff clean, gitleaks clean. Plugin `lib/` copy synced (drift check passes).

## Checklist

- [x] Tests added for the bypass + new functions; false-positive corpus updated
- [x] Full gate green (ruff + pytest + gitleaks)
- [x] Vendored `plugins/agami/lib/` copy in sync
- [x] Wheel-packaging of `sql_guard` verified

Follow-up to #84.