### PR TITLE
Fix: list_datasources returns empty on every self-hosted / served deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`list_datasources` no longer reports empty on a self-hosted server.** On a
+  served deployment the warehouse/model is reached through the store, and the local
+  `credentials` file never ships to the container — but `list_datasources` was the
+  one tool still reading only that file, so it always returned "No profiles found …
+  run agami-connect", even while `get_datasource_schema` and `execute_sql` worked
+  against the deployed model. Because clients are told to call it first, they'd
+  conclude nothing was connected. It now enumerates the served models from the store
+  (the same seam every other tool already uses), and only falls back to the
+  credentials file for the local plugin.
+
 ### Security
 
 - **Hardened the read-only `execute_sql` gate.** SQL execution now runs through a

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -144,11 +144,13 @@ def list_datasources(store: Store) -> list[str]:
     return [r["datasource"] for r in rows]
 
 
-def count_model_tables(store: Store, datasource: str) -> int:
-    """How many modeled tables the served datasource has — a cheap COUNT for the datasource
-    listing, so `list_datasources` doesn't have to rebuild the whole Organization just to size it."""
-    rows = store.query("SELECT count(*) AS n FROM model_table WHERE datasource = ?", (datasource,))
-    return int(rows[0]["n"]) if rows else 0
+def model_table_counts(store: Store) -> dict[str, int]:
+    """`{datasource: table_count}` for every served datasource, in ONE grouped query — so the
+    datasource listing sizes itself without a per-datasource round trip (no N+1) and without
+    rebuilding the whole Organization. A datasource with no modeled tables simply won't appear in
+    the map; the caller defaults it to 0."""
+    rows = store.query("SELECT datasource, count(*) AS n FROM model_table GROUP BY datasource")
+    return {r["datasource"]: int(r["n"]) for r in rows}
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -144,6 +144,13 @@ def list_datasources(store: Store) -> list[str]:
     return [r["datasource"] for r in rows]
 
 
+def count_model_tables(store: Store, datasource: str) -> int:
+    """How many modeled tables the served datasource has — a cheap COUNT for the datasource
+    listing, so `list_datasources` doesn't have to rebuild the whole Organization just to size it."""
+    rows = store.query("SELECT count(*) AS n FROM model_table WHERE datasource = ?", (datasource,))
+    return int(rows[0]["n"]) if rows else 0
+
+
 # ---------------------------------------------------------------------------
 # Memory (ORGANIZATION.md / USER_MEMORY.md) + model_version — served from the DB too, so a DB-only
 # deploy reads NO files at runtime (get_datasource_schema's domain context + the receipt's version
@@ -391,11 +398,13 @@ def _group_turns(calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
         # user_question, so they'd mask the real question that the execute_sql did report. Earliest-with-
         # one stays drift-proof (a later call's drifted question can't win over the first real one).
         question = next((c["user_question"] for c in tc if c.get("user_question")), None)
-        turns.append({
-            "question": question,
-            "started": tc[0]["ts"],
-            "calls": tc,
-        })
+        turns.append(
+            {
+                "question": question,
+                "started": tc[0]["ts"],
+                "calls": tc,
+            }
+        )
     return turns
 
 
@@ -419,8 +428,13 @@ def list_sessions(store: Store, *, limit: int = 500) -> list[dict[str, Any]]:
         key = (r["actor"], r["thread_id"]) if r["thread_id"] else r["id"]
         s = sessions.get(key)
         if s is None:
-            s = {"key": key, "thread_id": r["thread_id"], "actor": r["actor"],
-                 "datasource": r["datasource"], "calls": []}
+            s = {
+                "key": key,
+                "thread_id": r["thread_id"],
+                "actor": r["actor"],
+                "datasource": r["datasource"],
+                "calls": [],
+            }
             sessions[key] = s
             order.append(key)
         s["calls"].append(r)

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -322,13 +322,14 @@ def tool_list_datasources(_args: dict[str, Any]) -> str:
     store = Store.from_env()
     if store is not None:
         try:
-            from model_store import count_model_tables, list_datasources
+            from model_store import list_datasources, model_table_counts
 
+            counts = model_table_counts(store)  # one grouped query, not one COUNT per datasource
             out = [
                 {
                     "datasource": ds,
                     "database_type": _served_db_type(ds),
-                    "table_count": count_model_tables(store, ds),
+                    "table_count": counts.get(ds, 0),
                     "model_present": True,
                     "is_active": ds == active,
                 }

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -182,6 +182,7 @@ def _db_type_for(profile: str, creds: dict[str, dict[str, str]]) -> str:
 # Read-only SQL guard (mirrors shared/sql-generation-rules.md → Safety Rules)
 # ---------------------------------------------------------------------------
 
+
 def check_read_only(sql: str) -> str | None:
     """Return None if the SQL is a safe single read-only statement, else a reason string.
 
@@ -307,10 +308,49 @@ def _resolve_receipt(profile: str, sql: str) -> dict | None:
 
 
 def tool_list_datasources(_args: dict[str, Any]) -> str:
-    """Local analog of Ask Agami `list_organizations`: enumerate local profiles."""
+    """Analog of Ask Agami `list_organizations`: enumerate the datasources this deployment serves.
+
+    Two backends behind one seam, exactly like `_load_org` / `_load_memory`: a served deployment
+    (AGAMI_DB_URL set) reads the models from the store — the credentials file never ships to the
+    container — while the local skill reads the on-disk profiles. Before this seam existed, the
+    tool only ever read the credentials file, so it reported "no datasources" on every self-hosted
+    server even with a model deployed and querying fine (get_datasource_schema / execute_sql work
+    because they already went through the store)."""
+    active = resolve_profile()
+    from store import Store  # stdlib-light; the DB driver is imported lazily inside
+
+    store = Store.from_env()
+    if store is not None:
+        try:
+            from model_store import count_model_tables, list_datasources
+
+            out = [
+                {
+                    "datasource": ds,
+                    "database_type": _served_db_type(ds),
+                    "table_count": count_model_tables(store, ds),
+                    "model_present": True,
+                    "is_active": ds == active,
+                }
+                for ds in list_datasources(store)
+                if ds  # skip the "" sentinel row install-global memory keys on
+            ]
+        finally:
+            store.close()
+        if out:
+            return json.dumps({"datasources": out, "active_datasource": active}, indent=2)
+        return json.dumps(
+            {
+                "datasources": [],
+                "note": "No models deployed to this server yet. Load one with the deploy's model "
+                "loader (model_deploy scans <artifacts_dir>/*/org.yaml).",
+            },
+            indent=2,
+        )
+
+    # Local skill path: enumerate the credentials-file profiles + their on-disk models.
     creds = _credentials_sections()
     artifacts = resolve_artifacts_dir()
-    active = resolve_profile()
     out = []
     for profile in sorted(creds.keys()):
         pdir = artifacts / profile
@@ -339,6 +379,16 @@ def tool_list_datasources(_args: dict[str, Any]) -> str:
             indent=2,
         )
     return json.dumps({"datasources": out, "active_datasource": active}, indent=2)
+
+
+def _served_db_type(datasource: str) -> str:
+    """Best-effort database-type label for a served datasource. The store holds the model, not the
+    warehouse credentials, so derive the type from the `DATASOURCE_URL[__<datasource>]` scheme the
+    executor already resolves. Display-only ("" when no DSN is set — the model still serves)."""
+    from execute_sql import _env_datasource_dsn  # sibling module; no import cycle
+
+    dsn = _env_datasource_dsn(datasource)
+    return _db_type_for(datasource, {datasource: {"url": dsn}}) if dsn else ""
 
 
 def _read_text(path: Path) -> str | None:
@@ -994,7 +1044,9 @@ def record_tool_call(
             "success": success,
             "error_kind": error_kind,
             "user_question": args.get("user_question"),
-            "agent_query": args.get("raw_query"),  # the existing arg is the agent's framing of the query
+            "agent_query": args.get(
+                "raw_query"
+            ),  # the existing arg is the agent's framing of the query
             "thread_id": args.get("thread_id"),
             "correlation_id": args.get("correlation_id"),  # the turn (one user question)
         }

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -333,7 +333,7 @@ def tool_list_datasources(_args: dict[str, Any]) -> str:
                     "is_active": ds == active,
                 }
                 for ds in list_datasources(store)
-                if ds  # skip the "" sentinel row install-global memory keys on
+                if ds  # defensive: only real, named datasources (never an empty name)
             ]
         finally:
             store.close()

--- a/tests/test_admin_model.py
+++ b/tests/test_admin_model.py
@@ -234,6 +234,37 @@ def test_list_datasources_is_sorted(env):
     s.close()
 
 
+def test_tool_list_datasources_reads_the_served_store(env):
+    """Regression: on a served deploy (AGAMI_DB_URL set) the credentials file never ships, so the
+    tool must enumerate the deployed models from the store instead of reporting empty. Previously it
+    read only the credentials INI and returned {"datasources": [], "note": "...credentials file..."}
+    on every self-hosted server, even while get_datasource_schema / execute_sql worked."""
+    import json
+
+    import tools
+
+    _seed(env, "SALES_DATA")
+    result = json.loads(tools.tool_list_datasources({}))
+
+    assert [d["datasource"] for d in result["datasources"]] == ["SALES_DATA"]
+    entry = result["datasources"][0]
+    assert entry["model_present"] is True
+    assert entry["table_count"] >= 1  # ORG seeds `orders` + `products`
+    assert "note" not in result  # the "run agami-connect" note must NOT fire when a model is served
+
+
+def test_tool_list_datasources_served_but_empty_gives_a_deploy_hint(env):
+    """A served deployment with no model yet returns an honest 'deploy a model' note — not the
+    local 'run the agami-connect skill' one, which doesn't apply on a server."""
+    import json
+
+    import tools
+
+    result = json.loads(tools.tool_list_datasources({}))
+    assert result["datasources"] == []
+    assert "model_deploy" in result["note"]
+
+
 # --- gating + empty state ----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

A self-hoster reported that `list_datasources` always returns `{"datasources": [], "note": "No profiles found in your credentials file. Run the agami-connect skill first."}` on a served deployment — even when a model is deployed and `get_datasource_schema` / `execute_sql` work fine against it. Because agent clients are told to call `list_datasources` first, they conclude nothing is connected and never query.

## Root cause

`tool_list_datasources` was the one product tool still enumerating **only** from the local credentials INI (`_credentials_sections()` → `<artifacts_dir>/local/credentials`). That file never ships to a served container:
- `prepare_deploy.py` excludes `local/` from the staged bundle
- the compose mounts only `${AGAMI_ARTIFACTS_DIR}:/artifacts:ro` (no `local/` bind)
- the entrypoint writes no credentials file — the warehouse is supplied via `DATASOURCE_URL`

So `_credentials_sections()` returns `{}` and the tool reports empty for **every** self-hosted deployment. Meanwhile the other tools already read through the store seam (`Store.from_env()` → `model_store.load_organization`), which is why they work.

## Fix

Mirror the exact two-backend seam `_load_org` / `_load_memory` already use:
- **Served (`AGAMI_DB_URL` set):** enumerate from the store — `model_store.list_datasources(store)` for names, a new cheap `model_store.count_model_tables(store, ds)` for sizing, `model_present=True`, and a best-effort `database_type` derived from the `DATASOURCE_URL[__<datasource>]` scheme (the store holds the model, not warehouse creds).
- **Local plugin (no `AGAMI_DB_URL`):** unchanged — the credentials-file enumeration.
- **Served but no model yet:** an honest "deploy a model (`model_deploy`)" hint instead of the local "run agami-connect" one.

Output shape is unchanged (still satisfies the `ListDatasourcesResult` contract — the roundtrip test covers it).

## Test plan

- `test_tool_list_datasources_reads_the_served_store` — seeds a model into a served sqlite store, asserts the datasource is listed with `model_present` + a non-empty `table_count` and **no** spurious "credentials file" note (the regression).
- `test_tool_list_datasources_served_but_empty_gives_a_deploy_hint` — served store, no model → the deploy hint.
- Local-path behavior and the contract roundtrip are unchanged.
- Full gate green (1279 passed, ruff + gitleaks clean).

## Notes

- `tools.py` / `model_store.py` aren't vendored into `plugins/agami/lib/`, so no `sync-lib` needed — this is a server-side path.
- No new capability/surface; a bug fix to an existing MCP tool.