### PR TITLE
Release v0.3.7: bump package + plugin to 0.3.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
-## [Unreleased]
+## [0.3.7] — 2026-07-06
 
 ### Added
 
@@ -21,6 +21,14 @@ below corresponds to one such version.
   `CREATE USER` / `GRANT SELECT` SQL for every supported dialect (Postgres/Redshift,
   MySQL, Snowflake, SQL Server, Oracle, Databricks, Trino, BigQuery). Ask agami for
   "the read-only grant" to get the exact SQL for your database.
+
+### Changed
+
+- **Self-host compose caps container log growth.** Every service now uses the
+  `json-file` driver with `max-size: 10m` / `max-file: 3` (≤30 MB per container), so
+  a long-running deploy on a small VM can't silently fill the disk — no VM-side
+  `daemon.json` step needed. Also silenced a harmless `CLOUDFLARE_TUNNEL_TOKEN … not
+  set` warning on non-tunnel deploys.
 
 ### Fixed
 
@@ -216,6 +224,7 @@ First version tracked in this changelog. Earlier history lives in the git log.
   other clients — stdio, no auth, no network.
 - Fan-trap / chasm-trap pre-flight that refuses to silently double-count.
 
+[0.3.7]: https://github.com/AgamiAI/agami-core/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/AgamiAI/agami-core/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/AgamiAI/agami-core/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/AgamiAI/agami-core/compare/v0.3.3...v0.3.4

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.6"
+version = "0.3.7"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary

Cuts **v0.3.7**. Bumps the version-of-truth in all four files (`packages/agami-core/pyproject.toml`, `.claude-plugin/marketplace.json` ×2, `plugins/agami/.claude-plugin/plugin.json`) and rolls `[Unreleased]` → `[0.3.7]` in the changelog. Merging this + creating the GitHub Release triggers the GHCR image + PyPI publishes.

## What's in this release (all already merged to main)

**Fixed**
- **`list_datasources` returned empty on every self-hosted server** (#86) — it read only the local credentials file, which never ships to a served container; it now enumerates the deployed models from the store. *(This is the fix the self-hoster reported.)*

**Security**
- **Read-only `execute_sql` guard hardening** (#84, #85) — single guard at the shared executor (stdio + HTTP + skills + cron); closed a dollar-quote statement-stacking bypass, refuse dialect-ambiguous MySQL comment forms, block sequence/replication-control functions, and **packaged `sql_guard` in the wheel** (was missing from `py-modules` — would have broken `import sql_guard` in the container).

**Added**
- **Read-only DB user guidance** (#82) — `/agami-connect` + `/agami-deploy` recommend a read-only user, with copy-paste `GRANT SELECT` per dialect.

**Changed**
- **Serverless least-privilege runtime-identity docs** (#83).
- **Compose caps container log growth** (#81) — `json-file` 10m×3 per service; silenced the `CLOUDFLARE_TUNNEL_TOKEN` warning.

## Checklist

- [x] Version bumped in all 4 files to 0.3.7
- [x] `[Unreleased]` rolled to `[0.3.7]` + compare link added
- [x] Full gate green (1306 passed)

## After merge

Create the **GitHub Release `v0.3.7`** → `release-image.yml` publishes `ghcr.io/agamiai/agami-core:0.3.7` / `:0.3` / `:latest` and `release-pypi.yml` publishes to PyPI. Then self-hosters on the default `AGAMI_IMAGE_TAG=latest` just re-run `./deploy.sh` (pull + up) to get the fix.