### PR TITLE
OAuth refresh-token grant — durable claude.ai sessions (Spec: ACE-033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [Unreleased]
+
+### Added
+
+- **OAuth refresh tokens — no more hourly re-login on the self-hosted server.** The token
+  endpoint now issues a `refresh_token` and supports the `refresh_token` grant (RFC 6749 §6),
+  so a connected client (claude.ai) silently renews the short-lived access token instead of
+  redoing the full login every hour. Refresh tokens **rotate** on each use with **reuse
+  detection** (replaying a rotated/stolen token revokes the whole family), are stored **hashed,
+  never in plaintext**, and are revocable. Access tokens stay short-lived (1h). Both lifetimes are
+  now env-configurable (`AGAMI_ACCESS_TOKEN_TTL` / `AGAMI_REFRESH_TOKEN_TTL`, seconds) with the
+  same defaults when unset (access 1h, refresh 30-day idle). No action needed on upgrade — the
+  new `oauth_refresh_token` table migrates in automatically on boot.
+
 ## [0.3.7] — 2026-07-06
 
 ### Added

--- a/deploy/agami.env.example
+++ b/deploy/agami.env.example
@@ -40,3 +40,9 @@ AGAMI_ADMIN_PASSWORD=
 
 # Only for the `tunnel` profile:
 # CLOUDFLARE_TUNNEL_TOKEN=
+
+# Optional: OAuth token lifetimes in SECONDS (unset = the defaults below). The access token is
+# short-lived; the refresh token silently renews it, so a connected client (claude.ai) isn't forced
+# to re-login when it expires. Leave these alone unless you specifically want to tune them.
+# AGAMI_ACCESS_TOKEN_TTL=3600        # access JWT lifetime (default 1 hour)
+# AGAMI_REFRESH_TOKEN_TTL=2592000    # refresh token idle lifetime (default 30 days)

--- a/migrations/core/010_oauth_refresh.sql
+++ b/migrations/core/010_oauth_refresh.sql
@@ -1,0 +1,22 @@
+-- Refresh tokens for the OAuth provider — long-lived, rotating, revocable renewal of the
+-- short-lived access JWTs (RFC 6749 §6). Without this a client (claude.ai) had to redo the full
+-- login every time the 1h access token expired; now it silently mints new access tokens.
+--
+-- Only the sha256 HASH of each token is stored (never the plaintext), so a DB read can't mint a
+-- token. Rotation: each successful refresh revokes the presented token and issues a new one in the
+-- same `family`; presenting an already-revoked token (a replay of a rotated/stolen token) revokes
+-- the whole family — the OAuth 2.1 reuse-detection posture for public clients. Portable SQL (sqlite
+-- + postgres), keyed by an app-minted value like the rest of the schema.
+
+CREATE TABLE oauth_refresh_token (
+    token_hash TEXT PRIMARY KEY,               -- sha256 hex of the opaque refresh token
+    family     TEXT NOT NULL,                  -- rotation lineage; reuse of a revoked token kills it
+    client_id  TEXT,                           -- the client the token was issued to (bound on refresh)
+    username   TEXT NOT NULL,                  -- the principal the token renews
+    expires_at TEXT NOT NULL,                  -- absolute idle-expiry; rotation carries it forward
+    revoked    INTEGER NOT NULL DEFAULT 0,     -- set on rotation, logout, or family compromise
+    created    TEXT NOT NULL
+);
+
+CREATE INDEX oauth_refresh_token_family ON oauth_refresh_token (family);
+CREATE INDEX oauth_refresh_token_username ON oauth_refresh_token (username);

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -67,6 +67,7 @@ def _actor_from_scope(scope: dict, auth: AuthProvider) -> str | None:
             return getattr(revalidated, "subject", None) if revalidated is not None else None
     return None
 
+
 # The brand assets (logo, provider icons, favicon) served at /static — packaged alongside this module.
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
 
@@ -121,9 +122,7 @@ def _unauthenticated(base: str, request: Request | None = None) -> Response:
         "Access-Control-Expose-Headers": "WWW-Authenticate",
     }
     if request is not None and "text/html" in (request.headers.get("accept") or ""):
-        return HTMLResponse(
-            admin.mcp_landing_body_html(base), status_code=401, headers=headers
-        )
+        return HTMLResponse(admin.mcp_landing_body_html(base), status_code=401, headers=headers)
     return JSONResponse({"error": "Not authenticated"}, status_code=401, headers=headers)
 
 
@@ -246,7 +245,7 @@ async def _auth_server(request: Request) -> JSONResponse:
             "token_endpoint": f"{base}/oauth/token",
             "registration_endpoint": f"{base}/oauth/register",
             "response_types_supported": ["code"],
-            "grant_types_supported": ["authorization_code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
             "code_challenge_methods_supported": ["S256"],
         },
         headers={"Access-Control-Allow-Origin": "*"},
@@ -314,7 +313,9 @@ def build_app() -> Starlette:
     # cookie), so fail fast with a clear message instead. (Set this to the public https URL even when
     # TLS terminates at a proxy — the browser↔proxy hop is what must be https.)
     if not base.startswith("https://"):
-        raise RuntimeError("PUBLIC_BASE_URL must be https:// (OAuth + the Secure admin cookie need TLS).")
+        raise RuntimeError(
+            "PUBLIC_BASE_URL must be https:// (OAuth + the Secure admin cookie need TLS)."
+        )
     bootstrap_paths()
     auth_provider = _build_auth_provider()
     session_manager = StreamableHTTPSessionManager(
@@ -354,7 +355,9 @@ def build_app() -> Starlette:
                     store.commit()
                 except Exception:  # noqa: BLE001 — a concurrent boot won the seed; not fatal
                     store.conn.rollback()
-                    _log.warning("admin seed skipped (already seeded or a concurrent boot won the race)")
+                    _log.warning(
+                        "admin seed skipped (already seeded or a concurrent boot won the race)"
+                    )
             finally:
                 store.close()
         async with session_manager.run():

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -47,8 +47,8 @@ _CODE_TTL = timedelta(minutes=10)  # authorization codes are short-lived
 
 def _ttl_from_env(var: str, default: timedelta) -> timedelta:
     """A token lifetime in seconds from `var`, else `default`. A missing / non-numeric / non-positive
-    value falls back to the default — a bad knob can never make a token live *longer* than intended
-    (it just ignores the garbage), so the fail-safe direction is the secure one."""
+    value falls back to the default — so a typo or garbage can't accidentally zero out or blank the
+    lifetime. A valid positive value is honored as-is; tuning the lifetime is the operator's call."""
     raw = os.environ.get(var, "").strip()
     if not raw:
         return default

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -47,16 +47,16 @@ _CODE_TTL = timedelta(minutes=10)  # authorization codes are short-lived
 
 def _ttl_from_env(var: str, default: timedelta) -> timedelta:
     """A token lifetime in seconds from `var`, else `default`. A missing / non-numeric / non-positive
-    value falls back to the default — so a typo or garbage can't accidentally zero out or blank the
-    lifetime. A valid positive value is honored as-is; tuning the lifetime is the operator's call."""
-    raw = os.environ.get(var, "").strip()
-    if not raw:
-        return default
+    / out-of-range value all fall back to the default — so a typo or garbage can't zero out, blank, or
+    overflow the lifetime. A valid positive value is honored as-is; tuning it is the operator's call."""
     try:
-        seconds = int(raw)
-    except ValueError:
+        seconds = int(os.environ.get(var, "").strip())
+        if seconds <= 0:
+            return default
+        return timedelta(seconds=seconds)
+    except (ValueError, OverflowError):
+        # non-numeric / empty (ValueError) or absurdly large (OverflowError from timedelta) → default
         return default
-    return timedelta(seconds=seconds) if seconds > 0 else default
 
 
 def _access_ttl() -> timedelta:
@@ -489,8 +489,13 @@ def _grant_refresh_token(store: Store, form: dict[str, str]) -> Response:
     if row is None:
         return _oauth_error("invalid_grant", "refresh token is invalid")
     if row["revoked"]:
-        # A revoked token being presented == a rotated/stolen token replayed → burn the whole family
-        # so a thief and the victim both lose it (one re-login is the accepted cost of theft detection).
+        # We got here because the token was ALREADY revoked when we read it — i.e. it was rotated (or
+        # stolen) and is being replayed *after* that rotation committed. Burn the whole family so a
+        # thief and the victim both lose it. NOTE this is a different case from a truly-concurrent
+        # double-use (two requests that both read revoked=0): that loser never reaches here — it's
+        # caught by the atomic rowcount guard below and gets a plain invalid_grant, no family kill. A
+        # client that loses a rotation response and retries the old token DOES land here — one re-login
+        # is the accepted cost of theft detection (see ACE-033 Decisions; OAuth 2.1 reuse detection).
         store.execute(
             "UPDATE oauth_refresh_token SET revoked = 1 WHERE family = ?", (row["family"],)
         )

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -43,7 +43,33 @@ if TYPE_CHECKING:
     from oidc import Identity  # for type hints only — runtime imports oidc lazily (egress module)
 
 _CODE_TTL = timedelta(minutes=10)  # authorization codes are short-lived
-_JWT_TTL = timedelta(hours=1)
+
+
+def _ttl_from_env(var: str, default: timedelta) -> timedelta:
+    """A token lifetime in seconds from `var`, else `default`. A missing / non-numeric / non-positive
+    value falls back to the default — a bad knob can never make a token live *longer* than intended
+    (it just ignores the garbage), so the fail-safe direction is the secure one."""
+    raw = os.environ.get(var, "").strip()
+    if not raw:
+        return default
+    try:
+        seconds = int(raw)
+    except ValueError:
+        return default
+    return timedelta(seconds=seconds) if seconds > 0 else default
+
+
+def _access_ttl() -> timedelta:
+    """Access-token (JWT) lifetime — short by design; a leaked one expires fast. Default 1h."""
+    return _ttl_from_env("AGAMI_ACCESS_TOKEN_TTL", timedelta(hours=1))
+
+
+def _refresh_ttl() -> timedelta:
+    """Refresh-token lifetime — the *idle* window (an actively-refreshing session rotates forward
+    indefinitely). Default 30 days."""
+    return _ttl_from_env("AGAMI_REFRESH_TOKEN_TTL", timedelta(days=30))
+
+
 # Claude's fixed OAuth callback (the connector redirects here after authorize). The .com host is the
 # announced future move; allow both so the connection survives the switch.
 _CLAUDE_CALLBACKS = (
@@ -84,7 +110,7 @@ def issue_jwt(subject: str) -> str:
         "sub": subject,
         "iss": public_base_url(),
         "iat": int(now.timestamp()),
-        "exp": int((now + _JWT_TTL).timestamp()),
+        "exp": int((now + _access_ttl()).timestamp()),
     }
     return jwt.encode(payload, _signing_secret(), algorithm="HS256")
 
@@ -343,53 +369,153 @@ def _issue_authorization_code(
     return RedirectResponse(f"{redirect_uri}?{query}", status_code=302)
 
 
-async def token(request: Request) -> Response:
-    """Exchange an authorization code + PKCE verifier for a self-signed JWT. Enforces single-use,
-    expiry, redirect match, and PKCE — any failure is a 400 with no token in the body."""
-    form = await _form(request)
-    if form.get("grant_type") != "authorization_code":
-        return _oauth_error("unsupported_grant_type", "only authorization_code is supported")
+def _hash_token(token: str) -> str:
+    """Refresh tokens are stored as their sha256 hex, never in plaintext — a DB read can't mint one."""
+    return hashlib.sha256(token.encode()).hexdigest()
 
+
+def _issue_refresh_token(
+    store: Store, *, client_id: str, username: str, family: str | None = None
+) -> str:
+    """Mint + persist (hash only) a refresh token for `username`, in `family` (a fresh lineage when
+    None). The caller commits. Returns the plaintext token — the only place it ever exists."""
+    token = secrets.token_urlsafe(32)
+    store.execute(
+        "INSERT INTO oauth_refresh_token (token_hash, family, client_id, username, expires_at, "
+        "revoked, created) VALUES (?, ?, ?, ?, ?, 0, ?)",
+        (
+            _hash_token(token),
+            family or secrets.token_urlsafe(16),
+            client_id,
+            username,
+            (_now() + _refresh_ttl()).isoformat(),
+            _now().isoformat(),
+        ),
+    )
+    return token
+
+
+def _token_response(
+    store: Store, *, username: str, client_id: str, family: str | None
+) -> JSONResponse:
+    """The shared token body: a fresh access JWT + a fresh/rotated refresh token. Commits the
+    refresh-token write together with whatever the caller already staged (code burn / rotate)."""
+    refresh_token = _issue_refresh_token(
+        store, client_id=client_id, username=username, family=family
+    )
+    store.commit()
+    return JSONResponse(
+        {
+            "access_token": issue_jwt(username),
+            "token_type": "Bearer",
+            "expires_in": int(_access_ttl().total_seconds()),
+            "refresh_token": refresh_token,
+        }
+    )
+
+
+async def token(request: Request) -> Response:
+    """The OAuth token endpoint — dispatch by grant. `authorization_code` exchanges a code (+ PKCE)
+    for an access JWT + a refresh token; `refresh_token` renews without re-login (RFC 6749 §6)."""
+    form = await _form(request)
+    grant = form.get("grant_type")
     store = _open_store()
     if store is None:
         return _oauth_error("server_error", "no datastore configured", status=500)
     try:
-        rows = store.query("SELECT * FROM oauth_state WHERE code = ?", (form.get("code", ""),))
-        row = rows[0] if rows else None
-        if row is None or row["used"]:
-            return _oauth_error("invalid_grant", "code is invalid or already used")
-        if _now().isoformat() > row["expires_at"]:
-            return _oauth_error("invalid_grant", "code has expired")
-        if form.get("redirect_uri", "") != (row["redirect_uri"] or ""):
-            return _oauth_error("invalid_grant", "redirect_uri mismatch")
-        if not _verify_pkce(form.get("code_verifier", ""), row["code_challenge"]):
-            return _oauth_error("invalid_grant", "PKCE verification failed")
-        # Confirm we can sign (secret present AND strong enough) BEFORE burning the code, so a
-        # misconfigured server doesn't consume the code on a request it can't fulfil.
-        try:
-            _signing_secret()
-        except RuntimeError:
-            return _oauth_error("server_error", "token signing is not configured", status=500)
-
-        # Single-use, atomically: only the request that flips used 0→1 may issue a token. The
-        # conditional UPDATE + rowcount check closes the read-then-write race two concurrent
-        # exchanges would otherwise win together (double-issued JWTs for one code).
-        burned = store.execute(
-            "UPDATE oauth_state SET used = 1 WHERE code = ? AND used = 0", (row["code"],)
-        )
-        store.commit()
-        if burned.rowcount != 1:
-            return _oauth_error("invalid_grant", "code is invalid or already used")
-        access_token = issue_jwt(row["username"])
-        return JSONResponse(
-            {
-                "access_token": access_token,
-                "token_type": "Bearer",
-                "expires_in": int(_JWT_TTL.total_seconds()),
-            }
+        if grant == "authorization_code":
+            return _grant_authorization_code(store, form)
+        if grant == "refresh_token":
+            return _grant_refresh_token(store, form)
+        return _oauth_error(
+            "unsupported_grant_type", "only authorization_code and refresh_token are supported"
         )
     finally:
         store.close()
+
+
+def _grant_authorization_code(store: Store, form: dict[str, str]) -> Response:
+    """Exchange an authorization code + PKCE verifier for a token pair. Enforces single-use, expiry,
+    redirect match, and PKCE — any failure is a 400 with no token in the body."""
+    rows = store.query("SELECT * FROM oauth_state WHERE code = ?", (form.get("code", ""),))
+    row = rows[0] if rows else None
+    if row is None or row["used"]:
+        return _oauth_error("invalid_grant", "code is invalid or already used")
+    if _now().isoformat() > row["expires_at"]:
+        return _oauth_error("invalid_grant", "code has expired")
+    if form.get("redirect_uri", "") != (row["redirect_uri"] or ""):
+        return _oauth_error("invalid_grant", "redirect_uri mismatch")
+    if not _verify_pkce(form.get("code_verifier", ""), row["code_challenge"]):
+        return _oauth_error("invalid_grant", "PKCE verification failed")
+    # Confirm we can sign (secret present AND strong enough) BEFORE burning the code, so a
+    # misconfigured server doesn't consume the code on a request it can't fulfil.
+    try:
+        _signing_secret()
+    except RuntimeError:
+        return _oauth_error("server_error", "token signing is not configured", status=500)
+
+    # Single-use, atomically: only the request that flips used 0→1 may issue a token. The
+    # conditional UPDATE + rowcount check closes the read-then-write race two concurrent exchanges
+    # would otherwise win together (double-issued tokens for one code). Committed with the refresh
+    # insert in _token_response, so code-burn and token issuance are one transaction.
+    burned = store.execute(
+        "UPDATE oauth_state SET used = 1 WHERE code = ? AND used = 0", (row["code"],)
+    )
+    if burned.rowcount != 1:
+        store.commit()
+        return _oauth_error("invalid_grant", "code is invalid or already used")
+    return _token_response(
+        store, username=row["username"], client_id=row["client_id"] or "", family=None
+    )
+
+
+def _grant_refresh_token(store: Store, form: dict[str, str]) -> Response:
+    """Renew an access token from a refresh token (RFC 6749 §6), rotating the refresh token: the
+    presented token is revoked and a successor issued in the same family. Reuse of an already-revoked
+    token (a replay of a rotated/stolen token) revokes the whole family — OAuth 2.1 reuse detection."""
+    presented = form.get("refresh_token", "")
+    if not presented:
+        return _oauth_error("invalid_request", "refresh_token is required")
+    # Confirm we can sign BEFORE mutating a token row, mirroring the auth-code path.
+    try:
+        _signing_secret()
+    except RuntimeError:
+        return _oauth_error("server_error", "token signing is not configured", status=500)
+
+    rows = store.query(
+        "SELECT * FROM oauth_refresh_token WHERE token_hash = ?", (_hash_token(presented),)
+    )
+    row = rows[0] if rows else None
+    if row is None:
+        return _oauth_error("invalid_grant", "refresh token is invalid")
+    if row["revoked"]:
+        # A revoked token being presented == a rotated/stolen token replayed → burn the whole family
+        # so a thief and the victim both lose it (one re-login is the accepted cost of theft detection).
+        store.execute(
+            "UPDATE oauth_refresh_token SET revoked = 1 WHERE family = ?", (row["family"],)
+        )
+        store.commit()
+        return _oauth_error("invalid_grant", "refresh token has been revoked")
+    if _now().isoformat() > row["expires_at"]:
+        return _oauth_error("invalid_grant", "refresh token has expired")
+    # Bind to the issuing client when the client sends one — RFC 6749 §6 doesn't require client_id
+    # for a public client, so a missing one is allowed (the token secret + hash-at-rest are the gate).
+    client_id = form.get("client_id", "")
+    if client_id and client_id != (row["client_id"] or ""):
+        return _oauth_error("invalid_grant", "client mismatch")
+
+    # Rotate atomically: only the request that flips revoked 0→1 may renew (closes the double-rotate
+    # race); a loser here gets a plain invalid_grant, NOT family revocation (it's a race, not a replay).
+    burned = store.execute(
+        "UPDATE oauth_refresh_token SET revoked = 1 WHERE token_hash = ? AND revoked = 0",
+        (row["token_hash"],),
+    )
+    if burned.rowcount != 1:
+        store.commit()
+        return _oauth_error("invalid_grant", "refresh token is invalid")
+    return _token_response(
+        store, username=row["username"], client_id=row["client_id"] or "", family=row["family"]
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/agami/skills/agami-deploy/bundle/agami.env.example
+++ b/plugins/agami/skills/agami-deploy/bundle/agami.env.example
@@ -39,3 +39,9 @@ AGAMI_ADMIN_PASSWORD=
 
 # Only for the `tunnel` profile:
 # CLOUDFLARE_TUNNEL_TOKEN=
+
+# Optional: OAuth token lifetimes in SECONDS (unset = the defaults below). The access token is
+# short-lived; the refresh token silently renews it, so a connected client (claude.ai) isn't forced
+# to re-login when it expires. Leave these alone unless you specifically want to tune them.
+# AGAMI_ACCESS_TOKEN_TTL=3600        # access JWT lifetime (default 1 hour)
+# AGAMI_REFRESH_TOKEN_TTL=2592000    # refresh token idle lifetime (default 30 days)

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -418,3 +418,165 @@ def test_non_jwt_bearer_is_rejected_when_signing_secret_set(env):
         json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
     )
     assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Refresh-token grant (ACE-033) — silent renewal of the short-lived access JWT, with rotation +
+# reuse-detection so a connected client (claude.ai) isn't forced to re-login every hour.
+# ---------------------------------------------------------------------------
+
+
+def _token_pair(client: TestClient) -> dict:
+    """Run the full authorization-code exchange and return the token body (access + refresh)."""
+    code = _authorize_code(client)
+    r = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": VERIFIER,
+            "redirect_uri": REDIRECT,
+        },
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _refresh(client: TestClient, refresh_token: str, *, client_id: str = "cid") -> dict:
+    r = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+        },
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_authorization_code_issues_a_refresh_token(env):
+    c = TestClient(mcp_http.build_app())
+    body = _token_pair(c)
+    assert body["refresh_token"]  # the code exchange now returns a refresh token
+    assert body["token_type"] == "Bearer" and body["expires_in"] == 3600
+
+
+def test_refresh_grant_rotates_and_renews(env):
+    c = TestClient(mcp_http.build_app())
+    first = _token_pair(c)
+    second = _refresh(c, first["refresh_token"])
+    # a fresh, verifiable access JWT for the same subject
+    claims = jwt.decode(second["access_token"], SECRET, algorithms=["HS256"], issuer=BASE)
+    assert claims["sub"] == "admin"
+    # rotation: a NEW refresh token, different from the one presented
+    assert second["refresh_token"] and second["refresh_token"] != first["refresh_token"]
+    # the successor keeps renewing (the chain works)
+    third = _refresh(c, second["refresh_token"])
+    assert third["refresh_token"] and third["refresh_token"] != second["refresh_token"]
+
+
+def test_refresh_token_reuse_revokes_the_family(env):
+    c = TestClient(mcp_http.build_app())
+    first = _token_pair(c)
+    second = _refresh(c, first["refresh_token"])  # rotates → `first` is now revoked
+    # replaying the revoked (old) token is treated as a stolen-token replay → rejected
+    replay = c.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": first["refresh_token"]},
+    )
+    assert replay.status_code == 400 and replay.json()["error"] == "invalid_grant"
+    # ...and the whole family is now dead: the previously-valid successor stops working too
+    dead = c.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": second["refresh_token"]},
+    )
+    assert dead.status_code == 400
+
+
+def test_refresh_rejects_missing_unknown_and_wrong_client(env):
+    c = TestClient(mcp_http.build_app())
+    # missing / unknown token
+    assert c.post("/oauth/token", data={"grant_type": "refresh_token"}).status_code == 400
+    assert (
+        c.post(
+            "/oauth/token", data={"grant_type": "refresh_token", "refresh_token": "nope"}
+        ).status_code
+        == 400
+    )
+    first = _token_pair(c)
+    # a wrong client_id (when one is supplied) is rejected — and does NOT rotate the token
+    wrong = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": first["refresh_token"],
+            "client_id": "someone-else",
+        },
+    )
+    assert wrong.status_code == 400 and wrong.json()["error"] == "invalid_grant"
+    # the token still works with the right client (the failed attempt didn't burn it)
+    assert _refresh(c, first["refresh_token"])["access_token"]
+
+
+def test_refresh_token_expiry_is_enforced(env):
+    c = TestClient(mcp_http.build_app())
+    first = _token_pair(c)
+    s = Store.from_env()
+    try:
+        s.execute(
+            "UPDATE oauth_refresh_token SET expires_at = ? WHERE revoked = 0",
+            ("2000-01-01T00:00:00+00:00",),
+        )
+        s.commit()
+    finally:
+        s.close()
+    expired = c.post(
+        "/oauth/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": first["refresh_token"],
+            "client_id": "cid",
+        },
+    )
+    assert expired.status_code == 400 and expired.json()["error"] == "invalid_grant"
+
+
+def test_refresh_token_is_stored_hashed_not_plaintext(env):
+    import oauth_server
+
+    c = TestClient(mcp_http.build_app())
+    rt = _token_pair(c)["refresh_token"]
+    s = Store.from_env()
+    try:
+        stored = [r["token_hash"] for r in s.query("SELECT token_hash FROM oauth_refresh_token")]
+    finally:
+        s.close()
+    assert rt not in stored  # never the plaintext
+    assert oauth_server._hash_token(rt) in stored  # the sha256 hash is what's persisted
+
+
+def test_metadata_advertises_refresh_grant(env):
+    c = TestClient(mcp_http.build_app())
+    meta = c.get("/.well-known/oauth-authorization-server").json()
+    assert meta["grant_types_supported"] == ["authorization_code", "refresh_token"]
+
+
+def test_token_ttls_are_env_configurable_and_fail_safe(env, monkeypatch):
+    from datetime import timedelta
+
+    import oauth_server
+
+    monkeypatch.delenv("AGAMI_ACCESS_TOKEN_TTL", raising=False)
+    monkeypatch.delenv("AGAMI_REFRESH_TOKEN_TTL", raising=False)
+    assert oauth_server._access_ttl() == timedelta(hours=1)  # defaults
+    assert oauth_server._refresh_ttl() == timedelta(days=30)
+
+    monkeypatch.setenv("AGAMI_ACCESS_TOKEN_TTL", "1800")  # explicit override
+    assert oauth_server._access_ttl() == timedelta(seconds=1800)
+    for bad in ("not-a-number", "0", "-5", ""):  # garbage / non-positive → default (fail-safe)
+        monkeypatch.setenv("AGAMI_ACCESS_TOKEN_TTL", bad)
+        assert oauth_server._access_ttl() == timedelta(hours=1)
+
+    monkeypatch.setenv("AGAMI_ACCESS_TOKEN_TTL", "1800")  # and the override reaches the wire
+    assert _token_pair(TestClient(mcp_http.build_app()))["expires_in"] == 1800

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -574,7 +574,8 @@ def test_token_ttls_are_env_configurable_and_fail_safe(env, monkeypatch):
 
     monkeypatch.setenv("AGAMI_ACCESS_TOKEN_TTL", "1800")  # explicit override
     assert oauth_server._access_ttl() == timedelta(seconds=1800)
-    for bad in ("not-a-number", "0", "-5", ""):  # garbage / non-positive → default (fail-safe)
+    # garbage / non-positive / out-of-range (would overflow timedelta) → default (fail-safe, no crash)
+    for bad in ("not-a-number", "0", "-5", "", "999999999999999"):
         monkeypatch.setenv("AGAMI_ACCESS_TOKEN_TTL", bad)
         assert oauth_server._access_ttl() == timedelta(hours=1)
 

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -491,7 +491,7 @@ def test_refresh_token_reuse_revokes_the_family(env):
         "/oauth/token",
         data={"grant_type": "refresh_token", "refresh_token": second["refresh_token"]},
     )
-    assert dead.status_code == 400
+    assert dead.status_code == 400 and dead.json()["error"] == "invalid_grant"
 
 
 def test_refresh_rejects_missing_unknown_and_wrong_client(env):


### PR DESCRIPTION
## Summary

Spec: ACE-033 (F2 app-auth). The self-hosted server issued a **1h access JWT and nothing else** — no refresh token, the token endpoint only accepted `authorization_code`, and the metadata advertised only that grant. So claude.ai had to redo the **full OAuth login every hour**. This adds the refresh-token grant (RFC 6749 §6) so it silently renews.

## Changes

- **Issue a `refresh_token`** on the `authorization_code` grant; add the **`refresh_token` grant** — mints a fresh access JWT and **rotates** the refresh token (revoke presented, issue successor in the same family).
- **Reuse detection (OAuth 2.1 for public clients):** replaying an already-revoked (rotated/stolen) refresh token **revokes the whole family**.
- **Storage:** new `oauth_refresh_token` table (migration `010`) — **sha256 hash only, never plaintext**; bound to `username` + issuing `client_id`; revocable; **auto-migrated on boot** (no manual step).
- **Metadata** advertises `["authorization_code", "refresh_token"]`; access tokens stay short-lived (1h).
- **Env-configurable lifetimes** (`AGAMI_ACCESS_TOKEN_TTL` / `AGAMI_REFRESH_TOKEN_TTL`, seconds) with defaults when unset (access 1h, refresh **30-day idle**) — closes the "baked-in, no knob" gap; a bad value fails safe to the default. Documented in both `agami.env.example` copies.

## Test plan

8 assertions in `tests/test_oauth_server.py`, mapping the spec's acceptance criteria: issue-on-code · rotation+renew (new JWT, `sub` preserved, new≠old refresh) · reuse→family revocation (sibling dies) · missing/unknown/wrong-client → `invalid_grant` · expiry enforced · **hash-not-plaintext** storage · metadata · TTL override + fail-safe-to-default. The `authorization_code` path (single-use, PKCE, expiry, redirect-match, signing precheck) is unchanged — existing OAuth tests pass untouched. Full gate green (**1314 passed**).

## Review

Ran `/review` incl. mandatory **security-review** (high lane): **0 must-fix**. Confirmed rotation atomicity, family-revocation (`WHERE family=?`, committed), hash-at-rest, check ordering, full parameterization, and grant isolation on both sqlite + postgres; the auth-code path is byte-for-byte preserved. Two review nits (docstring accuracy, one test assertion) folded in.

## Decisions (from the spec)

- 30-day refresh **idle** window (active sessions rotate forward indefinitely), access stays 1h — owner decision.
- Rotation + reuse detection over static tokens — OAuth 2.1 posture; tradeoff (a lost rotation response → one re-login) accepted for theft detection.
- `client_id` binding lenient on refresh (RFC 6749 §6 doesn't require it for public clients) so claude.ai's refresh can't break on a missing param; the token secret + hash-at-rest are the real gate.

## Checklist

- [x] Tests for every acceptance criterion; no existing test weakened
- [x] Full gate green (ruff + pytest + gitleaks)
- [x] Migration portable (sqlite + postgres), auto-applied on boot
- [x] Security-review passed (high lane), findings dispositioned
- [x] Generic — no customer names/data

Ships in **v0.3.8**; the self-hosted server picks it up via `./deploy.sh` (table migrates in automatically).