### PR TITLE
Release v0.3.8: bump package + plugin to 0.3.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
-## [Unreleased]
+## [0.3.8] — 2026-07-06
 
 ### Added
 
@@ -238,6 +238,7 @@ First version tracked in this changelog. Earlier history lives in the git log.
   other clients — stdio, no auth, no network.
 - Fan-trap / chasm-trap pre-flight that refuses to silently double-count.
 
+[0.3.8]: https://github.com/AgamiAI/agami-core/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/AgamiAI/agami-core/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/AgamiAI/agami-core/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/AgamiAI/agami-core/compare/v0.3.4...v0.3.5

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.7"
+version = "0.3.8"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary

Cuts **v0.3.8**. Bumps the version-of-truth in all four files and rolls `[Unreleased]` → `[0.3.8]`. Merging this + creating the GitHub Release triggers the GHCR image + PyPI publishes.

## What's in this release (already merged to main)

**Added**
- **OAuth refresh tokens (#88, ACE-033)** — the token endpoint issues a `refresh_token` and supports the `refresh_token` grant (RFC 6749 §6), so claude.ai silently renews the short-lived access token instead of the full login every hour. Rotation + reuse-detection, hash-at-rest, revocable; access stays 1h; lifetimes env-configurable with defaults. The `oauth_refresh_token` table migrates in automatically on boot.
- **Client-binding fix (#89)** — the refresh bind check is enforced only when both sides present a `client_id`, so a client that authorized without one can still refresh.

## Checklist

- [x] Version bumped in all 4 files to 0.3.8
- [x] `[Unreleased]` rolled to `[0.3.8]` + compare link
- [x] Full gate green (1315 passed)

## After merge

Create the **GitHub Release `v0.3.8`** → publishes `ghcr.io/agamiai/agami-core:0.3.8` / `:0.3` / `:latest` + PyPI. The self-hosted server then picks it up via `./deploy.sh` — the refresh-token table migrates in on boot, so the hourly re-login just stops (no re-onboarding).