### PR TITLE
feat(safety): scope execute_sql to semantic-model tables

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -728,6 +728,16 @@ def _model_safety(sql: str, profile: str, area: str | None):
         sys.stderr.write(f"[agami] could not load semantic model; skipping safety pass: {e}\n")
         return sql, None
 
+    # Table-scope guard — a query may only reference tables the semantic model
+    # declares; any other table in the connected database is refused. Runs FIRST
+    # so the fan/chasm and sensitive checks below only evaluate in-scope tables.
+    ts = RT.check_table_scope(sql, org)
+    if ts.action == "refuse":
+        json.dump({"error": {"kind": "table_out_of_scope", "tables": ts.offending_tables,
+                             "reason": ts.reason, "suggestion": ts.suggestion}}, sys.stderr)
+        sys.stderr.write("\n")
+        return sql, 1
+
     pf = RT.pre_flight_check(sql, org)
     if pf.risk and pf.action == "refuse":
         json.dump({"error": {"kind": "preflight_refused", "risk": pf.risk,

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -480,6 +480,81 @@ def check_sensitive_projection(sql: str, org: Organization) -> SensitiveCheckRes
     )
 
 
+# ---------------------------------------------------------------------------
+# Table-scope guard
+#
+# Enforced in the SAME shared safety pass as the fan/chasm pre-flight and the
+# sensitive-column guard (execute_sql.py:_model_safety), so EVERY entry point
+# that runs SQL through the engine only ever touches tables the semantic model
+# declares — a query referencing any other table in the connected database is
+# refused, by construction rather than by each LLM obeying a prose rule. This is
+# table-level scoping only; which columns of a modeled table may be projected is
+# the sensitive-projection guard's job.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TableScopeResult:
+    action: str  # "allow" | "refuse"
+    offending_tables: list[str] = field(default_factory=list)  # bare names not in the model
+    reason: str = ""
+    suggestion: Optional[str] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"action": self.action, "offending_tables": self.offending_tables,
+                "reason": self.reason, "suggestion": self.suggestion}
+
+
+def check_table_scope(sql: str, org: Organization) -> TableScopeResult:
+    """Refuse a query that references a table not declared in the semantic model.
+
+    Only *physical* table references count: CTE names (defined by WITH) and
+    derived/subquery aliases are not tables and are never treated as undeclared.
+    Matching is on the bare table name, case-insensitively (unquoted identifiers
+    fold case in Postgres and friends), against the model's declared tables via
+    `_model_table_index`, whose keys already exclude review_state='rejected'
+    tables (dropped at load time) — so an excluded table is correctly refused.
+
+    Degrades to allow when sqlglot is unavailable or the SQL doesn't parse (the
+    same posture as the fan/chasm and sensitive gates; the upstream read-only
+    guard already rejects multi-statement / DDL input). A model with zero
+    declared tables also allows — there is nothing to scope against.
+    """
+    if not _HAVE_SQLGLOT:
+        return TableScopeResult("allow")
+    allow = {name.lower() for name in _model_table_index(org)}
+    if not allow:
+        return TableScopeResult("allow")
+    try:
+        tree = sqlglot.parse_one(sql, error_level="ignore")
+    except Exception:
+        return TableScopeResult("allow")
+    if tree is None or not isinstance(tree, exp.Select):
+        return TableScopeResult("allow")
+
+    cte_names = {c.alias_or_name.lower() for c in tree.find_all(exp.CTE)}
+    offending: set[str] = set()
+    for tbl in tree.find_all(exp.Table):
+        name = tbl.name
+        if not name or name.lower() in cte_names:
+            continue  # a CTE reference, not a physical table
+        if name.lower() not in allow:
+            offending.add(name)
+    if not offending:
+        return TableScopeResult("allow")
+
+    tables = sorted(offending)
+    return TableScopeResult(
+        "refuse",
+        offending_tables=tables,
+        reason="query references table(s) not in the semantic model: "
+               + ", ".join(tables)
+               + " — only tables declared in the model may be queried.",
+        suggestion="Add the table to the model (agami-connect / '/agami-model'), "
+                   "or remove it from the query.",
+    )
+
+
 def _cardinality_index(org: Organization) -> list[Relationship]:
     rels: list[Relationship] = []
     for sa in org.subject_areas:

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -728,6 +728,16 @@ def _model_safety(sql: str, profile: str, area: str | None):
         sys.stderr.write(f"[agami] could not load semantic model; skipping safety pass: {e}\n")
         return sql, None
 
+    # Table-scope guard — a query may only reference tables the semantic model
+    # declares; any other table in the connected database is refused. Runs FIRST
+    # so the fan/chasm and sensitive checks below only evaluate in-scope tables.
+    ts = RT.check_table_scope(sql, org)
+    if ts.action == "refuse":
+        json.dump({"error": {"kind": "table_out_of_scope", "tables": ts.offending_tables,
+                             "reason": ts.reason, "suggestion": ts.suggestion}}, sys.stderr)
+        sys.stderr.write("\n")
+        return sql, 1
+
     pf = RT.pre_flight_check(sql, org)
     if pf.risk and pf.action == "refuse":
         json.dump({"error": {"kind": "preflight_refused", "risk": pf.risk,

--- a/tests/test_table_scope_gate.py
+++ b/tests/test_table_scope_gate.py
@@ -1,0 +1,102 @@
+"""Table-scope guard: a query may only reference tables the semantic model declares.
+
+Runs in the SAME shared safety pass as the fan/chasm pre-flight and the sensitive
+gate (execute_sql.py:_model_safety), so every engine entry point refuses a query
+that touches a table outside the model — not just whichever path obeyed a prose
+rule. Only physical table refs count; CTE names and derived-subquery aliases are
+not tables. Excluded (review_state='rejected') tables are dropped by the loader,
+so they never reach `_model_table_index` and land in the same "not declared →
+refuse" path exercised here via undeclared names.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as rt  # noqa: E402
+
+
+def _scope_org():
+    """Org declaring exactly two tables: orders, customers."""
+    def _t(name):
+        return m.Table(name=name, schema="public", storage_connection="c", grain=["id"],
+                       description=name, columns=[m.Column(name="id", type="integer")])
+    return m.Organization(organization="Shop",
+                          subject_areas=[m.SubjectArea(name="sales",
+                              tables_defined=[_t("orders"), _t("customers")])])
+
+
+def test_declared_table_allowed():
+    assert rt.check_table_scope("SELECT * FROM orders", _scope_org()).action == "allow"
+
+
+def test_undeclared_table_refused():
+    res = rt.check_table_scope("SELECT * FROM sqlite_master", _scope_org())
+    assert res.action == "refuse"
+    assert res.offending_tables == ["sqlite_master"]
+    assert "sqlite_master" in res.reason
+
+
+def test_join_all_declared_allowed():
+    res = rt.check_table_scope(
+        "SELECT * FROM orders o JOIN customers c ON o.customer_id = c.id", _scope_org())
+    assert res.action == "allow"
+
+
+def test_join_with_undeclared_refused_lists_only_bad_one():
+    res = rt.check_table_scope(
+        "SELECT * FROM orders o JOIN payments p ON p.order_id = o.id", _scope_org())
+    assert res.action == "refuse"
+    assert res.offending_tables == ["payments"]
+
+
+def test_cte_reference_allowed():
+    # `t` is a CTE name, not a physical table — must not be flagged.
+    res = rt.check_table_scope(
+        "WITH t AS (SELECT * FROM orders) SELECT * FROM t", _scope_org())
+    assert res.action == "allow"
+
+
+def test_cte_body_referencing_undeclared_refused():
+    res = rt.check_table_scope(
+        "WITH t AS (SELECT * FROM secret_table) SELECT * FROM t", _scope_org())
+    assert res.action == "refuse"
+    assert res.offending_tables == ["secret_table"]
+
+
+def test_subquery_alias_allowed():
+    # derived-table alias `x` is not a table; the inner `orders` is declared.
+    res = rt.check_table_scope("SELECT * FROM (SELECT id FROM orders) x", _scope_org())
+    assert res.action == "allow"
+
+
+def test_schema_qualified_declared_allowed():
+    assert rt.check_table_scope("SELECT * FROM public.orders", _scope_org()).action == "allow"
+
+
+def test_case_insensitive_match():
+    assert rt.check_table_scope("SELECT * FROM ORDERS", _scope_org()).action == "allow"
+
+
+def test_empty_model_allows():
+    org = m.Organization(organization="Empty", subject_areas=[m.SubjectArea(name="s")])
+    assert rt.check_table_scope("SELECT * FROM anything", org).action == "allow"
+
+
+def test_non_select_degrades_to_allow():
+    # Non-SELECT is the upstream read-only guard's job; this gate defers (allow).
+    assert rt.check_table_scope("DELETE FROM orders", _scope_org()).action == "allow"
+
+
+def test_unparseable_degrades_to_allow():
+    assert rt.check_table_scope("SELECT FROM WHERE ((", _scope_org()).action == "allow"


### PR DESCRIPTION
## Problem

`execute_sql` will run a read-only `SELECT` against **any** table in the connected database. The semantic model was consulted only for the trust receipt (unmapped tables silently omitted), join-trap detection, sensitive-column projection, and default filters — none of which restrict *which tables a query may reference*. So a query could read a table the model never declared, and it would succeed.

## Change

Add a deterministic **table-scope gate** to the shared model-safety pass so a query run through the engine may only reference tables the semantic model declares. Any other table is refused.

- **`runtime.check_table_scope(sql, org)`** — parses with sqlglot (already a dependency), collects physical table references, and matches them (bare name, case-insensitive) against `_model_table_index`. **CTE names and derived-subquery aliases are excluded** — they aren't physical tables. Excluded (`review_state='rejected'`) tables are dropped by the loader, so they fall into the same "not declared → refuse" path.
- **`execute_sql._model_safety`** — wired in as the **first** gate (before fan/chasm and sensitive), reusing the exit-1 + stderr-JSON refusal mechanism, so it surfaces to the MCP client exactly like `preflight_refused` / `sensitive_columns`. **No `tools.py` change.**
- **Enforcement: refuse-always**, no env toggle. Only the existing `--no-safety` operator flag bypasses it (same as the other model-safety gates).

## Reach (matches the existing model-safety guards)

This lives in the model-safety pass alongside the fan/chasm and sensitive-column guards, so it inherits their reach: it runs where the **full package** is importable (pip-installed / self-hosted MCP server — the `agami-deploy` team path) and **no-ops in the stdlib-only vendored plugin slice** (`runtime.py` is intentionally not vendored). Not expanding that architecture here.

## Degrade posture

Allows (does not block) when sqlglot is unavailable, the SQL doesn't parse, or the model declares no tables — identical to the fan/chasm and sensitive gates. The upstream read-only guard already rejects multi-statement / DDL input.

## Vendored copy

`plugins/agami/lib/execute_sql.py` regenerated via `uv run dev.py sync-lib` (drift check `test_vendored_lib_matches_source` passes).

## Tests

- `tests/test_table_scope_gate.py` — 12 unit tests: declared/undeclared, join with undeclared (lists only the bad one), CTE reference, CTE body reading an undeclared table, subquery alias, schema-qualified, case-insensitive, empty model, non-SELECT/unparseable degrade.
- Full suite: **1327 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)