### PR TITLE
Remove the log_feedback tool from agami-core

### DIFF
--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -255,7 +255,7 @@ Written by `agami-connect` Phase 0a on first run; updated by `agami-model` (its 
 ### `<artifacts_dir>/local/query_log.jsonl`
 
 ```jsonl
-{"ts":"2026-05-07T15:14:00Z","question":"how many orders shipped in May","sql":"SELECT ...","row_count":4,"execution_ms":250,"tier":"cli","risk":"LOW","error_kind":null,"feedback":"good","chart_path":"/Users/me/.agami/charts/20260507-141500.html"}
+{"ts":"2026-05-07T15:14:00Z","question":"how many orders shipped in May","sql":"SELECT ...","row_count":4,"execution_ms":250,"tier":"cli","risk":"LOW","error_kind":null,"chart_path":"/Users/me/.agami/charts/20260507-141500.html"}
 ```
 
 Fields per line:
@@ -271,7 +271,6 @@ Fields per line:
 | `tier`           | enum             | Connection method that ran the query: `cli` (native CLI), `duckdb`, `python` (Python driver). Field name is `tier` for backward-compatibility with v1.0 logs.                   |
 | `risk`           | enum             | `LOW` / `MEDIUM` / `HIGH` (large-table risk classifier)                                                                                                                         |
 | `error_kind`     | enum or null     | Set when execution failed; one of the 9 classifier kinds                                                                                                                        |
-| `feedback`       | enum or null     | `good` / `bad` / null (set retroactively by follow-up signals)                                                                                                                  |
 | `chart_path`     | string or null   | Absolute path of the HTML report from Phase 4e, or null if the query returned a 1×1 scalar that didn't get a report. Read by `query-database`'s reopen-intent flow (Phase 2a.1) |
 | `tables_used`    | array of strings | Qualified `<schema>.<table>` names the SQL FROMs/JOINs. For two-pass retrieval (Phase 2b large mode), this is what Pass 1 picked; for small mode, parsed from the SQL.          |
 | `retrieval_mode` | enum             | `small` or `large` — which Phase 2b branch ran. Useful for tuning the 50-table threshold.                                                                                       |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -20,7 +20,7 @@ your AI client  ──spawns──▶  python3 -m mcp_harness   (stdio child pro
 
 ## What it exposes
 
-Five tools, mirroring the hosted connector so the client experience is identical:
+Four tools, mirroring the hosted connector so the client experience is identical:
 
 | Tool | What it does |
 |---|---|
@@ -28,7 +28,6 @@ Five tools, mirroring the hosted connector so the client experience is identical
 | `get_datasource_schema` | Return the semantic model: the subject-area index, full per-table detail for requested `dataset_names`, plus `ORGANIZATION.md` / `USER_MEMORY.md`. |
 | `get_prompt_examples` | Return the curated `examples.yaml` few-shot library. |
 | `execute_sql` | Run **one read-only** `SELECT` / `WITH...SELECT` locally and return `{columns, rows, row_count, ...}`. DML/DDL/multi-statement are rejected. |
-| `log_feedback` | Append thumbs-up/down to `<artifacts_dir>/local/feedback.jsonl`. |
 
 The NL→SQL *intelligence* stays on the client side (the model generates SQL from
 the schema + examples these tools return) — exactly as with the hosted connector.

--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -1,8 +1,8 @@
-"""Shared pydantic contracts for the 5 product tools.
+"""Shared pydantic contracts for the 4 product tools.
 
 These pin the **data shapes** the product tools exchange — `list_datasources`,
-`get_datasource_schema`, `get_prompt_examples`, `execute_sql` (incl. the trust `receipt`),
-`log_feedback` — plus the `ActivitySink` log records, so downstream consumers build against
+`get_datasource_schema`, `get_prompt_examples`, `execute_sql` (incl. the trust `receipt`)
+— plus the `ActivitySink` log records, so downstream consumers build against
 fixed shapes instead of inventing their own.
 
 Source of truth = the **existing** local tool I/O in `mcp_harness.py` (the JSON each tool emits)
@@ -54,13 +54,6 @@ class ExecuteSqlRequest(_Contract):
     area: str | None = None
     raw_query: str | None = None
     max_rows: int | None = None
-
-
-class LogFeedbackRequest(_Contract):
-    raw_query: str
-    rating: str
-    notes: str | None = None
-    datasource: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -186,17 +179,6 @@ class ExecuteSqlResult(_Contract):
 
 
 # ---------------------------------------------------------------------------
-# log_feedback
-# ---------------------------------------------------------------------------
-
-
-class LogFeedbackResult(_Contract):
-    ok: bool
-    rating: str
-    logged_to: str
-
-
-# ---------------------------------------------------------------------------
 # ActivitySink payloads (the existing _append_jsonl records in mcp_harness)
 # ---------------------------------------------------------------------------
 
@@ -208,15 +190,6 @@ class QueryExecutionRecord(_Contract):
     row_count: int
     source: str
     question: str | None = None  # the user's NL question (may be absent)
-
-
-class FeedbackRecord(_Contract):
-    ts: str
-    profile: str
-    question: str
-    rating: str
-    source: str
-    notes: str | None = None
 
 
 class ToolCallRecord(_Contract):

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -300,7 +300,7 @@ def select_examples(
 
 
 class DbActivitySink:
-    """Write `query_executions` + `feedback` to the DB (one class, any backend the Store opens —
+    """Write `query_executions` + `tool_calls` to the DB (one class, any backend the Store opens —
     not a Postgres/SQLite pair). Conforms structurally to the `ports.ActivitySink` Protocol; the
     server's single execute_sql chokepoint logs one row per query through it."""
 
@@ -318,22 +318,6 @@ class DbActivitySink:
                 record.question,
                 record.sql,
                 record.row_count,
-                record.source,
-            ),
-        )
-        self._store.commit()
-
-    def record_feedback(self, record: Any) -> None:
-        self._store.execute(
-            "INSERT INTO feedback (id, ts, datasource, question, rating, notes, source) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                uuid4().hex,
-                record.ts,
-                record.profile,
-                record.question,
-                record.rating,
-                record.notes,
                 record.source,
             ),
         )

--- a/packages/agami-core/src/oss_adapters.py
+++ b/packages/agami-core/src/oss_adapters.py
@@ -15,7 +15,7 @@ import json
 from pathlib import Path
 
 import agami_paths
-from contracts import FeedbackRecord, QueryExecutionRecord
+from contracts import QueryExecutionRecord
 from ports import GovernanceVerdict, Org, Principal
 
 
@@ -32,26 +32,19 @@ def _append_jsonl(path: Path, record: dict) -> bool:
 
 
 class FileActivitySink:
-    """Default ``ActivitySink`` — appends query/feedback records to the same jsonl files the local
+    """Default ``ActivitySink`` — appends query-execution records to the same jsonl files the local
     skill uses (``<artifacts_dir>/local/...``). A Postgres adapter can replace this."""
 
-    def __init__(self, query_log: Path | None = None, feedback_log: Path | None = None) -> None:
+    def __init__(self, query_log: Path | None = None) -> None:
         # Resolve lazily by default (the artifacts dir may not be bootstrapped at construction);
         # paths can be injected for testing.
         self._query_log = query_log
-        self._feedback_log = feedback_log
 
     def _query_log_path(self) -> Path:
         return self._query_log or agami_paths.query_log_path()
 
-    def _feedback_log_path(self) -> Path:
-        return self._feedback_log or (agami_paths.local_dir() / "feedback.jsonl")
-
     def record_query_execution(self, record: QueryExecutionRecord) -> None:
         _append_jsonl(self._query_log_path(), record.model_dump())
-
-    def record_feedback(self, record: FeedbackRecord) -> None:
-        _append_jsonl(self._feedback_log_path(), record.model_dump())
 
 
 class SingleTenantOrgResolver:

--- a/packages/agami-core/src/ports.py
+++ b/packages/agami-core/src/ports.py
@@ -3,7 +3,7 @@
 agami-core keeps one MCP implementation across deployments; deployment-specific behavior is
 swapped at the composition root through these ports, never by forking a tool:
 
-  - ``ActivitySink``     — where query/feedback records go (file by default)
+  - ``ActivitySink``     — where query-execution records go (file by default)
   - ``OrgResolver``      — single vs multi tenancy as a config flag, not a schema fork
   - ``AuthProvider``     — bearer token → principal (presence by default)
   - ``GovernancePolicy`` — warn-only by default; enforcement is a paid concern
@@ -14,7 +14,7 @@ product runs out of the box); a downstream consumer supplies its own.
 
 The seam value types (``Org`` / ``Principal`` / ``GovernanceVerdict``) are stdlib dataclasses, not
 pydantic models, so this module imports with **zero dependencies** — a consumer can depend on the
-seams without pulling the model deps. The wire shapes that need validation (the 5-tool I/O) live
+seams without pulling the model deps. The wire shapes that need validation (the 4-tool I/O) live
 in ``contracts`` (pydantic). Each type is kept minimal — only what a default adapter or a
 consumer needs.
 """
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     # consumer that needs only the seams) import without the pydantic model deps. With
     # `from __future__ import annotations` the method annotations are lazy strings, and
     # @runtime_checkable only checks method *names*, so isinstance() works without these.
-    from contracts import FeedbackRecord, QueryExecutionRecord
+    from contracts import QueryExecutionRecord
 
 # ---------------------------------------------------------------------------
 # Seam value types (minimal — a consumer extends them when it needs more)
@@ -71,12 +71,10 @@ class GovernanceVerdict:
 class ActivitySink(Protocol):
     """Sink for runtime activity, written through the single ``execute_sql`` chokepoint.
 
-    OSS default = the file/jsonl writer (keeps the local skill working). Record shapes are the
-    local log records (``contracts.QueryExecutionRecord`` / ``FeedbackRecord``)."""
+    OSS default = the file/jsonl writer (keeps the local skill working). Record shape is the
+    local log record (``contracts.QueryExecutionRecord``)."""
 
     def record_query_execution(self, record: QueryExecutionRecord) -> None: ...
-
-    def record_feedback(self, record: FeedbackRecord) -> None: ...
 
 
 @runtime_checkable

--- a/packages/agami-core/src/semantic_model/curate.py
+++ b/packages/agami-core/src/semantic_model/curate.py
@@ -313,7 +313,7 @@ def _trust(obj) -> dict:
 def _metric_item(area: Optional[str], mm) -> dict:
     # Fields match the review-items vocabulary (entity_type) AND the dashboard
     # ITEMS_JSON contract (rule_1, signals, extra_lines, …) so the card renders the
-    # calculation and the feedback generator emits `by <email> role=` for sign-off.
+    # calculation and the review block emits `by <email> role=` for sign-off.
     binding_lines = [{"label": d, "text": sql} for d, sql in (mm.bindings or {}).items()]
     primary_sql = next(iter((mm.bindings or {}).values()), "")
     return {"kind": "metric", "entity_type": "metric", "rule": 1, "rule_1": True,

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -1,7 +1,7 @@
 """Backend-portable store — the thin DB layer the hosted server serves from.
 
 A shared/multi-instance server can't keep state in local files, so the model + prompt examples are
-served from a database and query logs/feedback are written to it. The backend is **Postgres in
+served from a database and query logs are written to it. The backend is **Postgres in
 production** (cloud-neutral, networked, multi-instance-safe), but the schema + queries are kept
 **portable** so the same code runs on **SQLite** — which is what the test suite uses (no DB service
 needed in CI) and is fine for a small single-instance self-host.

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -6,11 +6,11 @@ The shared MCP tool registry + implementations — one impl, both transports.
 entrypoint (`mcp_harness`) and the HTTP entrypoint (`mcp_http`) advertise, so a client sees the
 same surface and behavior whether it connects over stdio (Claude Desktop) or HTTP (claude.ai).
 
-The surface is the **5 product tools**: `list_datasources`, `get_datasource_schema` (adaptive),
-`get_prompt_examples`, `execute_sql`, `log_feedback`.
+The surface is the **4 product tools**: `list_datasources`, `get_datasource_schema` (adaptive),
+`get_prompt_examples`, `execute_sql`.
 
 Design constraints (match the rest of agami):
-  - The execute_sql + log_feedback tools are pure-stdlib. The model-backed tools import the
+  - The execute_sql tool is pure-stdlib. The model-backed tools import the
     `semantic_model` package (Pydantic) lazily and surface a clear "install the model deps" error
     if it's absent — so execution still works on a bare install.
   - **No data leaves the machine.** SQL is executed locally by shelling out to `execute_sql` (the
@@ -41,7 +41,6 @@ AGAMI_LOCAL = agami_paths.local_dir()
 CREDENTIALS_PATH = agami_paths.credentials_path()
 CONFIG_PATH = agami_paths.config_path()
 QUERY_LOG = agami_paths.query_log_path()
-FEEDBACK_LOG = AGAMI_LOCAL / "feedback.jsonl"
 TOOL_CALL_LOG = AGAMI_LOCAL / "tool_calls.jsonl"
 
 SERVER_NAME = "agami"
@@ -61,7 +60,7 @@ def server_version() -> str:
         return "0.0.0"
 
 
-# Client-facing usage guidance, surfaced by both transports. Describes the 5-tool flow;
+# Client-facing usage guidance, surfaced by both transports. Describes the 4-tool flow;
 # no save_correction (that's a skill operation, not on the MCP surface).
 SERVER_INSTRUCTIONS = (
     "agami local datasource agent. The NL→SQL intelligence runs on your side; these tools provide "
@@ -92,13 +91,12 @@ def bootstrap_paths() -> None:
     installs never create ~/.agami, so the migration is a no-op once there's nothing to move (it's
     a backward-compat shim, safe to drop in a later cleanup). Every entrypoint calls this so the
     paths reflect the resolved (possibly migrated) artifacts dir."""
-    global AGAMI_LOCAL, CREDENTIALS_PATH, CONFIG_PATH, QUERY_LOG, FEEDBACK_LOG, TOOL_CALL_LOG
+    global AGAMI_LOCAL, CREDENTIALS_PATH, CONFIG_PATH, QUERY_LOG, TOOL_CALL_LOG
     agami_paths.bootstrap()
     AGAMI_LOCAL = agami_paths.local_dir()
     CREDENTIALS_PATH = agami_paths.credentials_path()
     CONFIG_PATH = agami_paths.config_path()
     QUERY_LOG = agami_paths.query_log_path()
-    FEEDBACK_LOG = AGAMI_LOCAL / "feedback.jsonl"
     TOOL_CALL_LOG = AGAMI_LOCAL / "tool_calls.jsonl"
 
 
@@ -915,35 +913,6 @@ def tool_execute_sql(args: dict[str, Any]) -> str:
     return json.dumps(result, indent=2, default=str)
 
 
-def tool_log_feedback(args: dict[str, Any]) -> str:
-    """Local analog of Ask Agami `log_feedback`: append to <artifacts_dir>/local/feedback.jsonl."""
-    raw_query = args.get("raw_query")
-    rating = args.get("rating")
-    if not raw_query or not rating:
-        return json.dumps(
-            {"error": {"kind": "other", "remediation": "raw_query and rating are required."}}
-        )
-    norm = str(rating).strip().lower()
-    good = {"good", "positive", "thumbs_up", "👍", "up", "yes"}
-    bad = {"bad", "negative", "thumbs_down", "👎", "down", "no"}
-    rating_value = "Good" if norm in good else "Bad" if norm in bad else str(rating)
-    logged = _record_feedback(
-        {
-            "ts": _now_iso(),
-            "profile": resolve_profile(args.get("datasource")),
-            "question": raw_query,
-            "rating": rating_value,
-            "notes": args.get("notes"),
-            "source": "mcp_server",
-        }
-    )
-    if logged is None:
-        return json.dumps(
-            {"error": {"kind": "other", "remediation": f"Could not write {FEEDBACK_LOG}."}}
-        )
-    return json.dumps({"ok": True, "rating": rating_value, "logged_to": logged})
-
-
 def _now_iso() -> str:
     # Avoid Date.now-style nondeterminism concerns: use UTC wall clock here is fine
     # (this is a long-running server process, not a replayed workflow).
@@ -979,27 +948,6 @@ def _record_query(rec: dict[str, Any]) -> None:
         DbActivitySink(store).record_query_execution(QueryExecutionRecord(**rec))
     except Exception:
         pass  # best-effort: never fail the query because logging failed
-    finally:
-        store.close()
-
-
-def _record_feedback(rec: dict[str, Any]) -> str | None:
-    """Record feedback through the DB sink (AGAMI_DB_URL) or the local jsonl. Returns where it
-    landed ('database' or the file path), or None if the write failed (feedback is the user's
-    explicit action, so a failure surfaces — unlike incidental query logging). Closes the store."""
-    from store import Store
-
-    store = Store.from_env()
-    if store is None:
-        return str(FEEDBACK_LOG) if _append_jsonl(FEEDBACK_LOG, rec) else None
-    try:
-        from contracts import FeedbackRecord
-        from model_store import DbActivitySink
-
-        DbActivitySink(store).record_feedback(FeedbackRecord(**rec))
-        return "database"
-    except Exception:
-        return None
     finally:
         store.close()
 
@@ -1227,33 +1175,6 @@ TOOLS: dict[str, dict[str, Any]] = {
                 "max_rows": {"type": "integer", "description": "Row cap (clamped 1–10000)."},
             },
             "required": ["sql"],
-            "additionalProperties": False,
-        },
-    },
-    "log_feedback": {
-        "handler": tool_log_feedback,
-        "description": (
-            "Record thumbs-up/down feedback for a question to the local feedback.jsonl. "
-            "Local analog of the hosted log_feedback."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "raw_query": {"type": "string", "description": "The NL question the user asked."},
-                "rating": {
-                    "type": "string",
-                    "description": "good/bad (also accepts positive/negative/👍/👎).",
-                },
-                "notes": {"type": "string", "description": "Optional free-text comment."},
-                "datasource": {
-                    "type": "string",
-                    "description": "Profile name; defaults to the active profile.",
-                },
-                "user_question": _USER_QUESTION_PROP,
-                "thread_id": _THREAD_ID_PROP,
-                "correlation_id": _CORRELATION_ID_PROP,
-            },
-            "required": ["raw_query", "rating"],
             "additionalProperties": False,
         },
     },

--- a/plugins/agami/skills/agami-query/SKILL.md
+++ b/plugins/agami/skills/agami-query/SKILL.md
@@ -88,7 +88,7 @@ The model is the semantic-model tree at `<artifacts_dir>/<profile>/` (`org.yaml`
 
 **Don't run a separate existence probe either** (no `ls org.yaml`, and never probe for the plugin's own scripts — `sm`, `execute_sql.py`, `semantic_model/` always ship with the plugin). That same first `sm areas` call doubles as the check: model present → you get the map; absent → the CLI returns `{"error":"no_model"}` with **exit code 3** → invoke `agami-connect` and stop.
 
-Drive everything through the CLI — the `sm` wrapper resolves the interpreter + deps. (These granular steps are CLI operations; on the MCP surface they're folded into the smart `get_datasource_schema`, which advertises the 5 product tools — so don't invoke the steps below as MCP tools.)
+Drive everything through the CLI — the `sm` wrapper resolves the interpreter + deps. (These granular steps are CLI operations; on the MCP surface they're folded into the smart `get_datasource_schema`, which advertises the 4 product tools — so don't invoke the steps below as MCP tools.)
 
 ```bash
 ROOT="<artifacts_dir>/<profile>"

--- a/plugins/agami/skills/agami-serve/SKILL.md
+++ b/plugins/agami/skills/agami-serve/SKILL.md
@@ -10,7 +10,7 @@ You are setting up the local agami **MCP server** so the user can query their
 database from the **Claude Desktop app** (or any client that reads a
 `claude_desktop_config.json`-style file). This is the local mirror of the hosted
 "Ask Agami" connector: same tool surface (`list_datasources`,
-`get_datasource_schema`, `get_prompt_examples`, `execute_sql`, `log_feedback`),
+`get_datasource_schema`, `get_prompt_examples`, `execute_sql`),
 but backed by the user's local model + local execution. Everything stays on the
 machine; the server is stdio-only, has no auth, and makes no network call.
 

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -388,7 +388,7 @@ def test_all_tools_expose_thread_and_correlation_ids():
     import tools
 
     for name in ("list_datasources", "get_datasource_schema", "get_prompt_examples",
-                 "execute_sql", "log_feedback"):
+                 "execute_sql"):
         props = tools.TOOLS[name]["inputSchema"]["properties"]
         assert "thread_id" in props and "correlation_id" in props, name
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,4 +1,4 @@
-"""The 5-tool pydantic contracts mirror the existing local tool I/O.
+"""The 4-tool pydantic contracts mirror the existing local tool I/O.
 
 The load-bearing check: a real sample of each tool's **current** stdio output parses into its
 contract and dumps back **without loss** — proving the contracts match the local,
@@ -17,9 +17,7 @@ from contracts import (  # noqa: E402
     DatasourceSchemaResult,
     ErrorResult,
     ExecuteSqlResult,
-    FeedbackRecord,
     ListDatasourcesResult,
-    LogFeedbackResult,
     PromptExamplesResult,
     QueryExecutionRecord,
 )
@@ -121,15 +119,6 @@ def test_execute_sql_error_roundtrip():
     assert _roundtrip(ErrorResult, sample) == sample
 
 
-def test_log_feedback_roundtrip():
-    sample = {
-        "ok": True,
-        "rating": "Good",
-        "logged_to": "/home/you/agami-artifacts/local/feedback.jsonl",
-    }
-    assert _roundtrip(LogFeedbackResult, sample) == sample
-
-
 def test_activity_sink_records_roundtrip():
     q = {
         "ts": "2026-06-25T00:00:00Z",
@@ -140,15 +129,6 @@ def test_activity_sink_records_roundtrip():
         "source": "mcp_server",
     }
     assert _roundtrip(QueryExecutionRecord, q) == q
-    f = {
-        "ts": "2026-06-25T00:00:01Z",
-        "profile": "acme",
-        "question": "how many orders?",
-        "rating": "Good",
-        "notes": "spot on",
-        "source": "mcp_server",
-    }
-    assert _roundtrip(FeedbackRecord, f) == f
 
 
 def test_contracts_tolerate_richer_payload_losslessly():

--- a/tests/test_db_activity_sink.py
+++ b/tests/test_db_activity_sink.py
@@ -1,4 +1,4 @@
-"""The DB write path — execute_sql/log_feedback log to the DB when AGAMI_DB_URL is set (Slice D).
+"""The DB write path — execute_sql logs to the DB when AGAMI_DB_URL is set (Slice D).
 
 `DbActivitySink` conforms to the `ports.ActivitySink` Protocol by shape (no inheritance) and is
 backend-agnostic (one class — SQLite here, Postgres in prod). The local jsonl path is unchanged
@@ -6,8 +6,6 @@ when AGAMI_DB_URL is unset.
 """
 
 from __future__ import annotations
-
-import json
 
 import pytest
 
@@ -60,19 +58,6 @@ def test_record_query_writes_one_row(tmp_path, monkeypatch):
     ]
 
 
-def test_log_feedback_writes_to_db(tmp_path, monkeypatch):
-    url = _fresh_db(tmp_path)
-    monkeypatch.setenv("AGAMI_DB_URL", url)
-    out = json.loads(
-        tools.tool_log_feedback({"raw_query": "how many?", "rating": "good", "datasource": "main"})
-    )
-    assert out["ok"] is True and out["logged_to"] == "database"
-    s = Store.connect(url)
-    rows = s.query("SELECT datasource, question, rating FROM feedback")
-    s.close()
-    assert rows == [{"datasource": "main", "question": "how many?", "rating": "Good"}]
-
-
 def test_record_query_is_best_effort_on_db_error(tmp_path, monkeypatch):
     # AGAMI_DB_URL points at a DB with NO migrations applied, so the INSERT into query_executions
     # fails. _record_query must swallow it — a logging failure can't break a successful query.
@@ -89,10 +74,3 @@ def test_record_query_is_best_effort_on_db_error(tmp_path, monkeypatch):
             "source": "mcp_server",
         }
     )
-
-
-def test_local_jsonl_path_unchanged_when_db_unset(tmp_path, monkeypatch):
-    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
-    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
-    out = json.loads(tools.tool_log_feedback({"raw_query": "q", "rating": "bad"}))
-    assert out["ok"] is True and out["logged_to"].endswith("feedback.jsonl")  # still the file

--- a/tests/test_mcp_harness.py
+++ b/tests/test_mcp_harness.py
@@ -226,14 +226,14 @@ def test_initialize_and_tools_list():
     for token in ("examples-first", "receipt", "review_state"):
         assert token in instr, token
 
-    # The MCP surface is exactly the 5 product tools on stdio (mirrored by HTTP). The granular
+    # The MCP surface is exactly the 4 product tools on stdio (mirrored by HTTP). The granular
     # traversal tools / identify_entity / pre_flight_check / save_correction are deliberately NOT
     # MCP tools (subsumed / folded / skill-operations) — asserted here so the omission can't
     # silently regress. See tests/test_tools_registry.py for the cross-transport assertion.
     tools = {t["name"] for t in by_id[2]["result"]["tools"]}
     assert tools == {
         "list_datasources", "get_datasource_schema",
-        "get_prompt_examples", "execute_sql", "log_feedback",
+        "get_prompt_examples", "execute_sql",
     }
 
 

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -22,7 +22,6 @@ PRODUCT_TOOLS = {
     "get_datasource_schema",
     "get_prompt_examples",
     "execute_sql",
-    "log_feedback",
 }
 
 
@@ -163,8 +162,8 @@ def test_mcp_bare_path_is_not_307_redirected(base_url):
     assert bare.status_code == slashed.status_code  # parity with the trailing-slash form
 
 
-def test_http_tools_list_is_the_same_five(base_url):
-    """Authed end-to-end: initialize → tools/list over HTTP returns exactly the 5 product tools —
+def test_http_tools_list_is_the_same_four(base_url):
+    """Authed end-to-end: initialize → tools/list over HTTP returns exactly the 4 product tools —
     the same surface stdio advertises (mirrored, not forked)."""
     headers = {
         "Authorization": "Bearer present",

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -370,7 +370,7 @@ def test_build_app_fails_fast_on_present_but_weak_signing_secret(env, monkeypatc
 
 def test_end_to_end_oauth_then_mcp_tools_list(env):
     # The whole point: a token minted via the OAuth flow is accepted by the transport, and the
-    # tools/list comes back with exactly the 5 product tools.
+    # tools/list comes back with exactly the 4 product tools.
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
@@ -404,7 +404,6 @@ def test_end_to_end_oauth_then_mcp_tools_list(env):
         "get_datasource_schema",
         "get_prompt_examples",
         "execute_sql",
-        "log_feedback",
     }
 
 

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -89,12 +89,11 @@ def test_warn_only_governance_never_blocks():
 
 
 def test_file_activity_sink_writes_jsonl(tmp_path):
-    from contracts import FeedbackRecord, QueryExecutionRecord
+    from contracts import QueryExecutionRecord
     from oss_adapters import FileActivitySink
 
     ql = tmp_path / "query.jsonl"
-    fl = tmp_path / "feedback.jsonl"
-    sink = FileActivitySink(query_log=ql, feedback_log=fl)
+    sink = FileActivitySink(query_log=ql)
 
     sink.record_query_execution(
         QueryExecutionRecord(
@@ -106,18 +105,6 @@ def test_file_activity_sink_writes_jsonl(tmp_path):
             source="mcp_server",
         )
     )
-    sink.record_feedback(
-        FeedbackRecord(
-            ts="2026-06-25T00:00:01Z",
-            profile="acme",
-            question="how many?",
-            rating="Good",
-            notes=None,
-            source="mcp_server",
-        )
-    )
 
     qrec = json.loads(ql.read_text().splitlines()[0])
     assert qrec["profile"] == "acme" and qrec["row_count"] == 1 and qrec["source"] == "mcp_server"
-    frec = json.loads(fl.read_text().splitlines()[0])
-    assert frec["rating"] == "Good" and frec["question"] == "how many?"

--- a/tests/test_tools_registry.py
+++ b/tests/test_tools_registry.py
@@ -1,7 +1,7 @@
 """The shared TOOLS registry — one impl, both transports.
 
 Both the stdio entrypoint (mcp_harness) and the HTTP entrypoint (mcp_http) import the SAME
-`tools.TOOLS` object, so the surface can't drift. These assert the surface is exactly the 5
+`tools.TOOLS` object, so the surface can't drift. These assert the surface is exactly the 4
 product tools, the dropped tools are gone, and the registry the two transports share is identical.
 """
 
@@ -15,11 +15,11 @@ PRODUCT_TOOLS = {
     "get_datasource_schema",
     "get_prompt_examples",
     "execute_sql",
-    "log_feedback",
 }
-# Subsumed by the smart get_datasource_schema / folded / internal / skill-operation — deliberately
-# NOT on the MCP surface of either transport.
+# Subsumed by the smart get_datasource_schema / folded / internal / skill-operation, or (log_feedback)
+# simply removed from the surface. Deliberately NOT on the MCP surface of either transport.
 DROPPED_FROM_MCP = {
+    "log_feedback",
     "list_subject_areas",
     "get_subject_area_bundle",
     "get_table_context",
@@ -29,7 +29,7 @@ DROPPED_FROM_MCP = {
 }
 
 
-def test_surface_is_exactly_the_five_product_tools():
+def test_surface_is_exactly_the_four_product_tools():
     assert set(tools.TOOLS) == PRODUCT_TOOLS
 
 


### PR DESCRIPTION
## What

Subtractive refactor of the MCP tool surface — removes the `log_feedback` tool and everything wired to it:

- **tools.py** — `tool_log_feedback`, the `log_feedback` entry in the `TOOLS` registry, `_record_feedback`, and the `FEEDBACK_LOG` constant.
- **contracts.py** — `LogFeedbackRequest`, `LogFeedbackResult`, `FeedbackRecord`.
- **model_store.py** — `DbActivitySink.record_feedback`.
- **ports.py / oss_adapters.py / store.py / curate.py** — the `ActivitySink.record_feedback` member, the `FileActivitySink` feedback path/param, and stray references, so no dangling symbol or import remains.

The MCP surface is now the **4 product tools** (`list_datasources`, `get_datasource_schema`, `get_prompt_examples`, `execute_sql`).

## Left intentionally in place

- **The `feedback` table** — `migrations/core/002_runtime.sql` is **untouched**; the table is still created (empty, unused). Dropping it is destructive and out of scope. `test_schema.py` still asserts it exists.
- **`query_executions`** and its sink — unchanged.

## Not touched (different feature — flagging to avoid confusion)

The `/agami-model` dashboard's **"Generate feedback for Claude"** back-channel (parsed by `parse_model_feedback.py`) is a separate feature that happens to share the word "feedback." Its tests (`test_model_feedback.py`) and its docs (`usage.md`, `trust-layer.md`) are deliberately **left as-is**.

## Verification

- `rg -i "feedback" packages/agami-core/src` -> **zero** hits.
- `TOOLS` no longer contains `log_feedback`; imports resolve clean.
- Full suite: **1312 passed**; ruff check + format clean; gitleaks clean.
- Diff is subtractive: 29 insertions / 219 deletions across 18 files.