### PR TITLE
feat(safety): SELECT * ban + column-scope guard for execute_sql

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -738,6 +738,24 @@ def _model_safety(sql: str, profile: str, area: str | None):
         sys.stderr.write("\n")
         return sql, 1
 
+    # SELECT * ban — force every projected column to be named, so the column-scope
+    # guard below can check what is actually returned (and nothing hides behind *).
+    star = RT.check_no_select_star(sql)
+    if star.action == "refuse":
+        json.dump({"error": {"kind": "select_star",
+                             "reason": star.reason, "suggestion": star.suggestion}}, sys.stderr)
+        sys.stderr.write("\n")
+        return sql, 1
+
+    # Column-scope guard — a column that binds to a declared table must be one that
+    # table declares (a hallucinated column, or a physical column the model excluded).
+    cs = RT.check_column_scope(sql, org)
+    if cs.action == "refuse":
+        json.dump({"error": {"kind": "column_out_of_scope", "columns": cs.columns,
+                             "reason": cs.reason, "suggestion": cs.suggestion}}, sys.stderr)
+        sys.stderr.write("\n")
+        return sql, 1
+
     pf = RT.pre_flight_check(sql, org)
     if pf.risk and pf.action == "refuse":
         json.dump({"error": {"kind": "preflight_refused", "risk": pf.risk,

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -664,14 +664,28 @@ def check_column_scope(sql: str, org: Organization) -> ColumnScopeResult:
             p = p.parent
         return p
 
+    def _select_chain(node):
+        """Enclosing selects innermost -> outermost (alias visibility + correlation)."""
+        chain, p = [], node
+        while p is not None:
+            if isinstance(p, exp.Select):
+                chain.append(p)
+            p = p.parent
+        return chain
+
     # Resolve scoping PER enclosing SELECT, keyed by object identity — exp nodes hash
     # by structure, so two identical set-operation arms would collide on the node
-    # itself. For each select we track the physical tables it reads directly, and
-    # whether it also reads from a CTE ref / derived subquery (in which case a bare
-    # column we can't match may legitimately be that source's output → fail-open).
-    alias_to_table: dict[str, str] = {}    # alias/name -> bare physical table (global; for qualified refs)
-    direct_phys: dict[int, set[str]] = {}  # id(select) -> {bare physical table read directly}
-    has_derived: dict[int, bool] = {}      # id(select) -> reads a CTE ref / derived subquery directly
+    # itself. SQL table aliases AND select-list output names are per-SELECT (an inner
+    # scope can reuse a name), so they are never flattened into one global map — that
+    # would let an inner alias validate an outer column against the wrong table, or an
+    # inner `AS x` mask an unrelated outer column `x`. For each select we track the
+    # physical tables it reads directly (alias -> bare table), its output aliases, and
+    # whether it reads from a CTE ref / derived subquery (→ a bare column we can't
+    # match may be that source's output, so fail-open).
+    alias_by_select: dict[int, dict[str, str]] = {}  # id(select) -> {alias -> bare physical table}
+    direct_phys: dict[int, set[str]] = {}            # id(select) -> {bare physical table read directly}
+    has_derived: dict[int, bool] = {}                # id(select) -> reads a CTE ref / derived subquery directly
+    output_by_select: dict[int, set[str]] = {}       # id(select) -> {select-list output alias}
     for tbl in tree.find_all(exp.Table):
         name = (tbl.name or "").lower()
         if not name:
@@ -681,8 +695,8 @@ def check_column_scope(sql: str, org: Organization) -> ColumnScopeResult:
             if sel is not None:
                 has_derived[id(sel)] = True  # `FROM <cte>` is a derived source for this select
             continue
-        alias_to_table[tbl.alias_or_name.lower()] = name
         if sel is not None:
+            alias_by_select.setdefault(id(sel), {})[tbl.alias_or_name.lower()] = name
             direct_phys.setdefault(id(sel), set()).add(name)
     for sq in tree.find_all(exp.Subquery):
         # a derived table in FROM/JOIN (NOT a WHERE/scalar subquery, which adds no columns to its select)
@@ -690,9 +704,12 @@ def check_column_scope(sql: str, org: Organization) -> ColumnScopeResult:
             sel = _enclosing_select(sq)
             if sel is not None:
                 has_derived[id(sel)] = True
-
-    # select-list output names (`AS x`) are aliases, not base columns
-    output_aliases = {a.alias.lower() for a in tree.find_all(exp.Alias) if a.alias}
+    for al in tree.find_all(exp.Alias):
+        if not al.alias:
+            continue
+        sel = _enclosing_select(al)
+        if sel is not None:
+            output_by_select.setdefault(id(sel), set()).add(al.alias.lower())
 
     offending: set[str] = set()
     for col in tree.find_all(exp.Column):
@@ -700,17 +717,25 @@ def check_column_scope(sql: str, org: Organization) -> ColumnScopeResult:
         if not name:
             continue
         lname = name.lower()
+        chain = _select_chain(col)
+        sel = chain[0] if chain else None
         if col.table:
-            phys = alias_to_table.get(col.table.lower())
+            # resolve the qualifier within the column's own scope, walking outward:
+            # a correlated ref sees ancestor aliases; an inner alias shadows an outer.
+            qual = col.table.lower()
+            phys = None
+            for s in chain:
+                phys = alias_by_select.get(id(s), {}).get(qual)
+                if phys is not None:
+                    break
             if phys is None:
                 continue  # qualified by a CTE/derived alias — validated at its own source
             if phys in declared and lname not in declared[phys]:
                 offending.add(f"{phys}.{name}")
             continue
         # unqualified: judge against the tables its own SELECT reads directly
-        if lname in output_aliases:
-            continue  # a select-list output alias, not a base column
-        sel = _enclosing_select(col)
+        if sel is not None and lname in output_by_select.get(id(sel), set()):
+            continue  # a select-list output alias of THIS select, not a base column
         local = {t for t in direct_phys.get(id(sel), set()) if t in declared} if sel is not None else set()
         if any(lname in declared[t] for t in local):
             continue  # declared on a table this select reads (possibly ambiguous — don't false-reject)

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -529,7 +529,11 @@ def check_table_scope(sql: str, org: Organization) -> TableScopeResult:
         tree = sqlglot.parse_one(sql, error_level="ignore")
     except Exception:
         return TableScopeResult("allow")
-    if tree is None or not isinstance(tree, exp.Select):
+    # A set operation (UNION/INTERSECT/EXCEPT) parses to exp.Union, not exp.Select,
+    # so gate on "contains a SELECT" rather than "is a SELECT" — otherwise every
+    # set-operation arm would bypass the guard. A non-SELECT statement has no SELECT
+    # node and still degrades to allow (the upstream read-only guard owns those).
+    if tree is None or tree.find(exp.Select) is None:
         return TableScopeResult("allow")
 
     cte_names = {c.alias_or_name.lower() for c in tree.find_all(exp.CTE)}
@@ -551,6 +555,180 @@ def check_table_scope(sql: str, org: Organization) -> TableScopeResult:
                + ", ".join(tables)
                + " — only tables declared in the model may be queried.",
         suggestion="Add the table to the model (agami-connect / '/agami-model'), "
+                   "or remove it from the query.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# SELECT * ban + column-scope guard
+#
+# Companions to the table-scope guard, enforced in the same _model_safety pass.
+# The star ban forces every projected column to be named; the column-scope guard
+# then refuses any column that binds to a declared table but is not one that table
+# declares (a hallucinated column, or a physical column the model excluded). Both
+# run AFTER check_table_scope, so every physical table in scope is known-declared.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StarCheckResult:
+    action: str  # "allow" | "refuse"
+    reason: str = ""
+    suggestion: Optional[str] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"action": self.action, "reason": self.reason, "suggestion": self.suggestion}
+
+
+def check_no_select_star(sql: str) -> StarCheckResult:
+    """Refuse a query whose projection list contains `*` or `t.*`.
+
+    A star defeats column-level scoping (an undeclared column hides behind it) and
+    stops `check_column_scope` from validating what is actually returned, so every
+    projected column must be named. Applies to EVERY select in the tree — outer
+    query, subqueries, CTE bodies, and set-operation (UNION/…) arms — so a star
+    can't hide one level down. `COUNT(*)` and other `agg(*)` are fine: the star sits
+    inside the aggregate, so the projection itself is not a star.
+
+    Degrades to allow when sqlglot is unavailable, the SQL doesn't parse, or it is
+    not a SELECT-bearing statement (the upstream read-only guard owns non-SELECTs).
+    """
+    if not _HAVE_SQLGLOT:
+        return StarCheckResult("allow")
+    try:
+        tree = sqlglot.parse_one(sql, error_level="ignore")
+    except Exception:
+        return StarCheckResult("allow")
+    if tree is None or tree.find(exp.Select) is None:
+        return StarCheckResult("allow")
+    for select in tree.find_all(exp.Select):
+        for proj in select.expressions:
+            if isinstance(proj, exp.Star) or (isinstance(proj, exp.Column) and isinstance(proj.this, exp.Star)):
+                return StarCheckResult(
+                    "refuse",
+                    reason="query uses SELECT * — every column must be named so it can be "
+                           "checked against the semantic model.",
+                    suggestion="List the columns explicitly instead of '*'.",
+                )
+    return StarCheckResult("allow")
+
+
+@dataclass
+class ColumnScopeResult:
+    action: str  # "allow" | "refuse"
+    columns: list[str] = field(default_factory=list)  # offending "table.column" / "column"
+    reason: str = ""
+    suggestion: Optional[str] = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"action": self.action, "columns": self.columns,
+                "reason": self.reason, "suggestion": self.suggestion}
+
+
+def check_column_scope(sql: str, org: Organization) -> ColumnScopeResult:
+    """Refuse a query that references a column not declared on the table it binds to.
+
+    Strict where a column visibly binds to a declared physical table — qualified by
+    that table (or its alias), or the single in-scope declared table for a bare
+    column; fail-open where the column comes from a CTE/subquery output or a
+    select-list alias we can't attribute to a physical table. This mirrors the
+    table-scope and fan/chasm gates' degrade-to-allow posture, so legitimate complex
+    SQL never false-refuses, while the common hallucinated-column case (including
+    columns inside a CTE/subquery body, which bind directly to their physical table)
+    is still caught. Matching is case-insensitive (unquoted identifiers fold case),
+    consistent with `check_table_scope`. Runs AFTER the table-scope + star gates, so
+    every physical table in scope is known-declared and no `*` remains.
+
+    Degrades to allow when sqlglot is unavailable, the SQL doesn't parse, it is not
+    a SELECT, or the model declares no columns.
+    """
+    if not _HAVE_SQLGLOT:
+        return ColumnScopeResult("allow")
+    colidx = _column_index(org)
+    if not colidx:
+        return ColumnScopeResult("allow")
+    try:
+        tree = sqlglot.parse_one(sql, error_level="ignore")
+    except Exception:
+        return ColumnScopeResult("allow")
+    if tree is None or tree.find(exp.Select) is None:
+        return ColumnScopeResult("allow")
+
+    # case-insensitive declared-column index: lower(table) -> {lower(column)}
+    declared = {t.lower(): {c.lower() for c in cols} for t, cols in colidx.items()}
+    cte_names = {c.alias_or_name.lower() for c in tree.find_all(exp.CTE)}
+
+    def _enclosing_select(node):
+        p = node.parent
+        while p is not None and not isinstance(p, exp.Select):
+            p = p.parent
+        return p
+
+    # Resolve scoping PER enclosing SELECT, keyed by object identity — exp nodes hash
+    # by structure, so two identical set-operation arms would collide on the node
+    # itself. For each select we track the physical tables it reads directly, and
+    # whether it also reads from a CTE ref / derived subquery (in which case a bare
+    # column we can't match may legitimately be that source's output → fail-open).
+    alias_to_table: dict[str, str] = {}    # alias/name -> bare physical table (global; for qualified refs)
+    direct_phys: dict[int, set[str]] = {}  # id(select) -> {bare physical table read directly}
+    has_derived: dict[int, bool] = {}      # id(select) -> reads a CTE ref / derived subquery directly
+    for tbl in tree.find_all(exp.Table):
+        name = (tbl.name or "").lower()
+        if not name:
+            continue
+        sel = _enclosing_select(tbl)
+        if name in cte_names:
+            if sel is not None:
+                has_derived[id(sel)] = True  # `FROM <cte>` is a derived source for this select
+            continue
+        alias_to_table[tbl.alias_or_name.lower()] = name
+        if sel is not None:
+            direct_phys.setdefault(id(sel), set()).add(name)
+    for sq in tree.find_all(exp.Subquery):
+        # a derived table in FROM/JOIN (NOT a WHERE/scalar subquery, which adds no columns to its select)
+        if isinstance(sq.parent, (exp.From, exp.Join)):
+            sel = _enclosing_select(sq)
+            if sel is not None:
+                has_derived[id(sel)] = True
+
+    # select-list output names (`AS x`) are aliases, not base columns
+    output_aliases = {a.alias.lower() for a in tree.find_all(exp.Alias) if a.alias}
+
+    offending: set[str] = set()
+    for col in tree.find_all(exp.Column):
+        name = col.name
+        if not name:
+            continue
+        lname = name.lower()
+        if col.table:
+            phys = alias_to_table.get(col.table.lower())
+            if phys is None:
+                continue  # qualified by a CTE/derived alias — validated at its own source
+            if phys in declared and lname not in declared[phys]:
+                offending.add(f"{phys}.{name}")
+            continue
+        # unqualified: judge against the tables its own SELECT reads directly
+        if lname in output_aliases:
+            continue  # a select-list output alias, not a base column
+        sel = _enclosing_select(col)
+        local = {t for t in direct_phys.get(id(sel), set()) if t in declared} if sel is not None else set()
+        if any(lname in declared[t] for t in local):
+            continue  # declared on a table this select reads (possibly ambiguous — don't false-reject)
+        if sel is not None and has_derived.get(id(sel), False):
+            continue  # fail-open: may be an output column of this select's CTE/derived source
+        if not local:
+            continue  # no declared physical table in this scope to judge against — fail-open
+        offending.add(name)
+
+    if not offending:
+        return ColumnScopeResult("allow")
+    cols = sorted(offending)
+    return ColumnScopeResult(
+        "refuse",
+        columns=cols,
+        reason="query references column(s) not in the semantic model: " + ", ".join(cols)
+               + " — only columns declared on the model's tables may be queried.",
+        suggestion="Add the column to the model (agami-connect / '/agami-model'), "
                    "or remove it from the query.",
     )
 

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -427,6 +427,26 @@ def _direct_from_tables(tree: "exp.Select") -> set[str]:
     return names
 
 
+def _output_selects(node: "exp.Expression") -> list["exp.Select"]:
+    """The SELECTs whose projection reaches the query OUTPUT: the top-level SELECT, or
+    — for a set operation (UNION / INTERSECT / EXCEPT) — every arm.
+
+    sqlglot parses `A UNION B` to an exp.SetOperation, NOT an exp.Select, so a gate
+    that inspects only `isinstance(tree, exp.Select)` silently skips every set-operation
+    arm (the bypass this closes for the sensitive-projection and fan/chasm gates, mirroring
+    the table-scope fix). Nested subquery / CTE SELECTs are excluded on purpose: their
+    projections feed an enclosing query, not the final result, so a sensitive column a
+    WHERE-subquery projects but the outer query only filters on is not exposed and must
+    not be refused."""
+    if isinstance(node, exp.Select):
+        return [node]
+    if isinstance(node, exp.SetOperation):  # base of Union / Intersect / Except
+        return _output_selects(node.this) + _output_selects(node.expression)
+    if isinstance(node, (exp.Subquery, exp.Paren)):  # `(SELECT …) UNION (SELECT …)`
+        return _output_selects(node.this) if node.this is not None else []
+    return []
+
+
 def check_sensitive_projection(sql: str, org: Organization) -> SensitiveCheckResult:
     """Refuse a query that PROJECTS a `sensitive` column's raw values; allow the
     column in COUNT, filters, GROUP BY, and joins. Degrades to allow when sqlglot
@@ -440,32 +460,35 @@ def check_sensitive_projection(sql: str, org: Organization) -> SensitiveCheckRes
         tree = sqlglot.parse_one(sql, error_level="ignore")
     except Exception:
         return SensitiveCheckResult("allow")
-    if tree is None or not isinstance(tree, exp.Select):
+    # A set operation (UNION/INTERSECT/EXCEPT) parses to exp.SetOperation, not
+    # exp.Select — gate on "contains a SELECT" and scan every OUTPUT-bearing arm, else
+    # `… UNION SELECT ssn FROM customers` would project a sensitive column past this gate.
+    if tree is None or tree.find(exp.Select) is None:
         return SensitiveCheckResult("allow")
 
-    scope = _tables_in_scope(tree)
-    direct = _direct_from_tables(tree)
     offending: set[str] = set()
-
-    for proj in tree.expressions:
-        # (a) a raw projection of a sensitive column, not protected by COUNT
-        for col in proj.find_all(exp.Column):
-            if col.name not in allnames or _count_protects(col):
-                continue
-            tbl = _resolve_col_table(col, scope)
-            if tbl is None:
-                offending.add(col.name)  # ambiguous + sensitive somewhere → conservative
-            elif tbl in by_table and col.name in by_table[tbl]:
-                offending.add(f"{tbl}.{col.name}")
-            # same-named column on a non-sensitive table → not offending
-        # (b) `*` / `t.*` that would expand a directly-FROM'd table holding sensitive cols
-        is_star = isinstance(proj, exp.Star) or (isinstance(proj, exp.Column) and isinstance(proj.this, exp.Star))
-        if is_star:
-            qualifier = proj.table if isinstance(proj, exp.Column) else None
-            tables = {scope.get(qualifier, qualifier)} if qualifier else direct
-            for tbl in tables:
-                for c in sorted(by_table.get(tbl, set())):
-                    offending.add(f"{tbl}.{c}")
+    for sel in _output_selects(tree):
+        scope = _tables_in_scope(sel)
+        direct = _direct_from_tables(sel)
+        for proj in sel.expressions:
+            # (a) a raw projection of a sensitive column, not protected by COUNT
+            for col in proj.find_all(exp.Column):
+                if col.name not in allnames or _count_protects(col):
+                    continue
+                tbl = _resolve_col_table(col, scope)
+                if tbl is None:
+                    offending.add(col.name)  # ambiguous + sensitive somewhere → conservative
+                elif tbl in by_table and col.name in by_table[tbl]:
+                    offending.add(f"{tbl}.{col.name}")
+                # same-named column on a non-sensitive table → not offending
+            # (b) `*` / `t.*` that would expand a directly-FROM'd table holding sensitive cols
+            is_star = isinstance(proj, exp.Star) or (isinstance(proj, exp.Column) and isinstance(proj.this, exp.Star))
+            if is_star:
+                qualifier = proj.table if isinstance(proj, exp.Column) else None
+                tables = {scope.get(qualifier, qualifier)} if qualifier else direct
+                for tbl in tables:
+                    for c in sorted(by_table.get(tbl, set())):
+                        offending.add(f"{tbl}.{c}")
 
     if not offending:
         return SensitiveCheckResult("allow")
@@ -790,16 +813,37 @@ def _many_side_facing_one(rels: list[Relationship], table: str, dim: str) -> boo
 
 
 def pre_flight_check(sql: str, org: Organization) -> PreFlightResult:
-    """Detect fan-trap / chasm-trap and decide rewrite-vs-refuse-vs-allow."""
+    """Detect fan-trap / chasm-trap and decide rewrite-vs-refuse-vs-allow.
+
+    A set operation (UNION/INTERSECT/EXCEPT) parses to exp.SetOperation, not exp.Select;
+    each arm is analyzed on its own and a trap in ANY arm refuses the whole query. Arms
+    are not auto-rewritten (splicing a rewrite into one arm of a set operation is out of
+    scope), so a rewriteable arm-trap becomes a refuse. Degrades to allow when sqlglot is
+    unavailable, the SQL doesn't parse, or it contains no SELECT."""
     if not _HAVE_SQLGLOT:
         return PreFlightResult(None, "allow", sql, reason="sqlglot unavailable; skipped")
     try:
         tree = sqlglot.parse_one(sql, error_level="ignore")
     except Exception as e:
         return PreFlightResult(None, "allow", sql, reason=f"unparseable; skipped ({e})")
-    if tree is None or not isinstance(tree, exp.Select):
-        return PreFlightResult(None, "allow", sql, reason="not a SELECT; skipped")
+    if tree is None or tree.find(exp.Select) is None:
+        return PreFlightResult(None, "allow", sql, reason="no SELECT; skipped")
+    if isinstance(tree, exp.Select):
+        return _preflight_select(tree, org, sql, allow_rewrite=True)
+    # Set operation: analyze each arm; a trap in any arm inflates that arm's aggregate.
+    for arm in _output_selects(tree):
+        res = _preflight_select(arm, org, arm.sql(), allow_rewrite=False)
+        if res.risk and res.action == "refuse":
+            # tie the arm's diagnosis back to the full set-operation query
+            return PreFlightResult(res.risk, "refuse", sql, reason=res.reason,
+                                   suggestion=res.suggestion, triggering_joins=res.triggering_joins)
+    return PreFlightResult(None, "allow", sql, reason="no fan/chasm or aggregation issue in any arm")
 
+
+def _preflight_select(tree: "exp.Select", org: Organization, sql: str, allow_rewrite: bool) -> PreFlightResult:
+    """Fan/chasm + aggregation-semantics analysis of a SINGLE SELECT. `sql` is that
+    select's own text (used for the join rewrite + messages). When `allow_rewrite` is
+    False (a set-operation arm), a rewriteable fan trap is refused, not rewritten."""
     rels = _cardinality_index(org)
     tables_in_scope = _tables_in_scope(tree)  # alias -> table
     table_set = set(tables_in_scope.values())
@@ -854,7 +898,7 @@ def pre_flight_check(sql: str, org: Organization) -> PreFlightResult:
         # AND the SELECT is aggregation-only (no raw rows).
         many_aliases = {a for a, t in tables_in_scope.items() if t in many_tables}
         referenced_elsewhere = _tables_referenced_outside_from(tree, tables_in_scope) & many_tables
-        if not has_raw_columns and not referenced_elsewhere:
+        if allow_rewrite and not has_raw_columns and not referenced_elsewhere:
             rewritten = _drop_fanout_joins(sql, many_aliases | many_tables)
             if rewritten and rewritten.strip() != sql.strip():
                 return PreFlightResult(

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -738,6 +738,24 @@ def _model_safety(sql: str, profile: str, area: str | None):
         sys.stderr.write("\n")
         return sql, 1
 
+    # SELECT * ban — force every projected column to be named, so the column-scope
+    # guard below can check what is actually returned (and nothing hides behind *).
+    star = RT.check_no_select_star(sql)
+    if star.action == "refuse":
+        json.dump({"error": {"kind": "select_star",
+                             "reason": star.reason, "suggestion": star.suggestion}}, sys.stderr)
+        sys.stderr.write("\n")
+        return sql, 1
+
+    # Column-scope guard — a column that binds to a declared table must be one that
+    # table declares (a hallucinated column, or a physical column the model excluded).
+    cs = RT.check_column_scope(sql, org)
+    if cs.action == "refuse":
+        json.dump({"error": {"kind": "column_out_of_scope", "columns": cs.columns,
+                             "reason": cs.reason, "suggestion": cs.suggestion}}, sys.stderr)
+        sys.stderr.write("\n")
+        return sql, 1
+
     pf = RT.pre_flight_check(sql, org)
     if pf.risk and pf.action == "refuse":
         json.dump({"error": {"kind": "preflight_refused", "risk": pf.risk,

--- a/tests/test_column_scope_adversarial.py
+++ b/tests/test_column_scope_adversarial.py
@@ -151,6 +151,30 @@ def test_quoted_identifier_undeclared_refused():
 
 
 # ===========================================================================
+# Per-SELECT scope correctness (regressions for the global-map bugs)
+# ===========================================================================
+
+def test_alias_reused_across_scopes_resolves_locally():
+    # `o` aliases orders in the outer query and customers in the correlated
+    # subquery. A global alias map would resolve outer `o.amount` against the wrong
+    # table (last-write-wins) and false-refuse; per-select resolution keeps it valid.
+    res = rt.check_column_scope(
+        "SELECT o.amount FROM orders o "
+        "WHERE EXISTS (SELECT 1 FROM customers o WHERE o.id = 1)", _scope_org())
+    assert res.action == "allow"
+
+
+def test_nested_output_alias_does_not_mask_outer_column():
+    # An inner `AS bogus` must NOT let an unrelated outer `bogus` slip through. A
+    # global output-alias set would skip the outer column; per-select scoping refuses.
+    res = rt.check_column_scope(
+        "SELECT bogus FROM orders WHERE id IN (SELECT id AS bogus FROM customers)",
+        _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["bogus"]
+
+
+# ===========================================================================
 # Documented accepted fail-opens -> allow (the intended boundary)
 # ===========================================================================
 

--- a/tests/test_column_scope_adversarial.py
+++ b/tests/test_column_scope_adversarial.py
@@ -1,0 +1,182 @@
+"""Adversarial suite for the SELECT * ban + column-scope guard.
+
+Each case is an attempt to slip an undeclared column or a `*` past the gate. A
+green happy-path suite (test_column_scope_gate.py) does NOT prove the gate holds
+against evasion — these do. Cases fall into four groups:
+
+  * star-ban evasion            -> must refuse (kind: select_star)
+  * column-scope evasion        -> must refuse (kind: column_out_of_scope)
+  * documented accepted fail-open -> asserts *allow*, so a future narrowing of the
+                                    boundary is a conscious, test-breaking decision
+  * upstream-owned              -> asserts a different layer already catches it
+
+The set-operation cases (UNION arm) are the regressions that prove the fix for the
+`parse_one -> exp.Union is not exp.Select` bypass that also affected check_table_scope.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as rt  # noqa: E402
+
+
+def _scope_org():
+    """Org declaring orders(id, amount, customer_id, status) + customers(id, name, region)."""
+    def _t(name, cols):
+        return m.Table(name=name, schema="public", storage_connection="c", grain=["id"],
+                       description=name,
+                       columns=[m.Column(name=c, type=typ) for c, typ in cols])
+    orders = _t("orders", [("id", "integer"), ("amount", "decimal"),
+                           ("customer_id", "integer"), ("status", "string")])
+    customers = _t("customers", [("id", "integer"), ("name", "string"), ("region", "string")])
+    return m.Organization(organization="Shop",
+                          subject_areas=[m.SubjectArea(name="sales",
+                              tables_defined=[orders, customers])])
+
+
+# ===========================================================================
+# Star-ban evasion -> must refuse
+# ===========================================================================
+
+STAR_EVASIONS = [
+    "SELECT id FROM (SELECT * FROM orders) x",            # star hidden in a subquery
+    "WITH t AS (SELECT * FROM orders) SELECT id FROM t",  # star hidden in a CTE body
+    "SELECT id FROM orders UNION SELECT * FROM customers",  # star in a set-operation arm
+    "SELECT o.* FROM orders o",                            # qualified star
+    "SELECT (SELECT * FROM customers LIMIT 1) FROM orders",  # star in a scalar subquery
+    "SELECT/**/ * FROM orders",                            # comment obfuscation
+    "select * from orders",                                # lowercase
+]
+
+
+@pytest.mark.parametrize("sql", STAR_EVASIONS)
+def test_star_evasion_refused(sql):
+    assert rt.check_no_select_star(sql).action == "refuse"
+
+
+# COUNT(*) / agg(*) must NOT be over-blocked by the star ban.
+@pytest.mark.parametrize("sql", [
+    "SELECT COUNT(*) FROM orders",
+    "SELECT COUNT(DISTINCT id) FROM orders",
+    "SELECT status, COUNT(*) AS n FROM orders GROUP BY status",
+])
+def test_aggregate_star_allowed(sql):
+    assert rt.check_no_select_star(sql).action == "allow"
+
+
+# ===========================================================================
+# Column-scope evasion -> must refuse
+# ===========================================================================
+
+# An undeclared column smuggled into a non-SELECT clause.
+CLAUSE_SMUGGLES = [
+    "SELECT id FROM orders WHERE bogus > 1",
+    "SELECT id FROM orders GROUP BY bogus",
+    "SELECT customer_id, SUM(amount) FROM orders GROUP BY customer_id HAVING SUM(bogus) > 0",
+    "SELECT id FROM orders ORDER BY bogus",
+    "SELECT o.id FROM orders o JOIN customers c ON o.bogus = c.id",
+]
+
+
+@pytest.mark.parametrize("sql", CLAUSE_SMUGGLES)
+def test_undeclared_column_in_any_clause_refused(sql):
+    assert rt.check_column_scope(sql, _scope_org()).action == "refuse"
+
+
+# An undeclared column wrapped in an expression / function / window.
+EXPR_WRAPS = [
+    "SELECT UPPER(bogus) FROM orders",
+    "SELECT amount + bogus FROM orders",
+    "SELECT SUM(bogus) FROM orders",
+    "SELECT CASE WHEN bogus > 0 THEN 1 ELSE 0 END FROM orders",
+    "SELECT ROW_NUMBER() OVER (ORDER BY bogus) FROM orders",
+]
+
+
+@pytest.mark.parametrize("sql", EXPR_WRAPS)
+def test_undeclared_column_in_expression_refused(sql):
+    assert rt.check_column_scope(sql, _scope_org()).action == "refuse"
+
+
+def test_alias_masquerade_refused():
+    # The OUTPUT alias `id` is declared, but the underlying `bogus` is not — we
+    # validate the underlying column, not the alias it is renamed to.
+    res = rt.check_column_scope("SELECT bogus AS id FROM orders", _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["bogus"]
+
+
+def test_undeclared_column_in_union_arm_refused():
+    res = rt.check_column_scope(
+        "SELECT id FROM orders UNION SELECT bogus FROM customers", _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["bogus"]
+
+
+def test_correlated_subquery_qualified_smuggle_refused():
+    # `o.bogus` is qualified to the physical `orders` — caught regardless of the
+    # surrounding subquery.
+    res = rt.check_column_scope(
+        "SELECT o.id FROM orders o "
+        "WHERE EXISTS (SELECT 1 FROM customers c WHERE c.id = o.bogus)", _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["orders.bogus"]
+
+
+def test_undeclared_column_alongside_where_subquery_refused():
+    # A WHERE/IN subquery adds no columns to the outer select's scope, so a bare
+    # undeclared column in the outer query is still caught.
+    res = rt.check_column_scope(
+        "SELECT bogus FROM orders WHERE id IN (SELECT id FROM customers)", _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["bogus"]
+
+
+def test_quoted_identifier_undeclared_refused():
+    # Documents the case-insensitive-match behavior: a quoted undeclared name is
+    # still refused.
+    res = rt.check_column_scope('SELECT "BOGUS" FROM orders', _scope_org())
+    assert res.action == "refuse"
+
+
+# ===========================================================================
+# Documented accepted fail-opens -> allow (the intended boundary)
+# ===========================================================================
+
+def test_fail_open_derived_alias_qualified_column():
+    # `x.whatever` is qualified by a derived-table alias, not a physical table —
+    # validated at the subquery's own body; the outer reference is not re-checked.
+    res = rt.check_column_scope(
+        "SELECT x.whatever FROM (SELECT id AS whatever FROM orders) x", _scope_org())
+    assert res.action == "allow"
+
+
+def test_fail_open_cte_shadowing_table_name():
+    # A CTE named after a real table shadows it; its body defines its own columns,
+    # so the outer reference traces to no physical table (DB is the backstop).
+    res = rt.check_column_scope(
+        "WITH orders AS (SELECT 1 AS bogus) SELECT bogus FROM orders", _scope_org())
+    assert res.action == "allow"
+
+
+# ===========================================================================
+# Upstream-owned -> a different layer catches it
+# ===========================================================================
+
+def test_multistatement_stacking_caught_by_read_only_guard():
+    # Column smuggled into a stacked second statement is rejected before
+    # _model_safety runs, by the read-only guard.
+    import sql_guard
+    assert sql_guard.check_read_only(
+        "SELECT id FROM orders; SELECT * FROM secret") is not None

--- a/tests/test_column_scope_gate.py
+++ b/tests/test_column_scope_gate.py
@@ -1,0 +1,166 @@
+"""SELECT * ban + column-scope guard: a projected/referenced column must be named
+and declared on the table it binds to.
+
+Enforced in the SAME shared safety pass as the table-scope and sensitive gates
+(execute_sql.py:_model_safety), so every engine entry point refuses a query that
+names an undeclared column — not just whichever path obeyed a prose rule. Posture:
+strict where a column binds to a declared physical table; fail-open on
+CTE/subquery-output and select-list-alias columns. The evasion attempts and the
+documented fail-open boundary live in test_column_scope_adversarial.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as rt  # noqa: E402
+
+
+def _scope_org():
+    """Org declaring orders(id, amount, customer_id, status) + customers(id, name, region)."""
+    def _t(name, cols):
+        return m.Table(name=name, schema="public", storage_connection="c", grain=["id"],
+                       description=name,
+                       columns=[m.Column(name=c, type=typ) for c, typ in cols])
+    orders = _t("orders", [("id", "integer"), ("amount", "decimal"),
+                           ("customer_id", "integer"), ("status", "string")])
+    customers = _t("customers", [("id", "integer"), ("name", "string"), ("region", "string")])
+    return m.Organization(organization="Shop",
+                          subject_areas=[m.SubjectArea(name="sales",
+                              tables_defined=[orders, customers])])
+
+
+# --- SELECT * ban ----------------------------------------------------------
+
+def test_select_star_refused():
+    assert rt.check_no_select_star("SELECT * FROM orders").action == "refuse"
+
+
+def test_qualified_star_refused():
+    assert rt.check_no_select_star("SELECT o.* FROM orders o").action == "refuse"
+
+
+def test_named_columns_allowed():
+    assert rt.check_no_select_star("SELECT id, amount FROM orders").action == "allow"
+
+
+def test_count_star_allowed():
+    # COUNT(*) is not a projection-level star.
+    assert rt.check_no_select_star("SELECT COUNT(*) FROM orders").action == "allow"
+
+
+def test_star_non_select_degrades_to_allow():
+    # Non-SELECT is the upstream read-only guard's job; this gate defers (allow).
+    assert rt.check_no_select_star("DELETE FROM orders").action == "allow"
+
+
+def test_star_unparseable_degrades_to_allow():
+    assert rt.check_no_select_star("SELECT FROM WHERE ((").action == "allow"
+
+
+# --- column-scope: declared columns pass -----------------------------------
+
+def test_declared_columns_allowed():
+    assert rt.check_column_scope("SELECT id, amount FROM orders", _scope_org()).action == "allow"
+
+
+def test_qualified_declared_column_allowed():
+    assert rt.check_column_scope("SELECT o.amount FROM orders o", _scope_org()).action == "allow"
+
+
+def test_join_column_from_each_side_allowed():
+    res = rt.check_column_scope(
+        "SELECT o.amount, c.name FROM orders o JOIN customers c ON o.customer_id = c.id",
+        _scope_org())
+    assert res.action == "allow"
+
+
+def test_join_ambiguous_but_declared_allowed():
+    # `id` exists on both tables — declared, so allow (don't false-reject on ambiguity).
+    res = rt.check_column_scope(
+        "SELECT id FROM orders o JOIN customers c ON o.customer_id = c.id", _scope_org())
+    assert res.action == "allow"
+
+
+def test_declared_column_in_where_and_group_allowed():
+    res = rt.check_column_scope(
+        "SELECT status, COUNT(*) FROM orders WHERE amount > 0 GROUP BY status", _scope_org())
+    assert res.action == "allow"
+
+
+# --- column-scope: undeclared columns refused ------------------------------
+
+def test_undeclared_column_refused():
+    res = rt.check_column_scope("SELECT bogus FROM orders", _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["bogus"]
+    assert "bogus" in res.reason
+
+
+def test_qualified_undeclared_column_refused():
+    res = rt.check_column_scope("SELECT o.bogus FROM orders o", _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["orders.bogus"]
+
+
+def test_undeclared_column_in_where_refused():
+    res = rt.check_column_scope("SELECT id FROM orders WHERE bogus > 1", _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["bogus"]
+
+
+def test_cte_body_undeclared_column_refused():
+    # `bogus` binds directly to the physical `orders` inside the CTE body -> caught.
+    res = rt.check_column_scope(
+        "WITH t AS (SELECT bogus FROM orders) SELECT id FROM t", _scope_org())
+    assert res.action == "refuse"
+    assert res.columns == ["bogus"]
+
+
+# --- column-scope: legitimate complex SQL passes ---------------------------
+
+def test_cte_output_column_allowed():
+    res = rt.check_column_scope(
+        "WITH t AS (SELECT id, amount FROM orders) SELECT id, amount FROM t", _scope_org())
+    assert res.action == "allow"
+
+
+def test_subquery_derived_column_allowed():
+    res = rt.check_column_scope(
+        "SELECT x.total FROM (SELECT SUM(amount) AS total FROM orders) x", _scope_org())
+    assert res.action == "allow"
+
+
+def test_select_list_alias_reuse_allowed():
+    res = rt.check_column_scope(
+        "SELECT amount AS a FROM orders ORDER BY a", _scope_org())
+    assert res.action == "allow"
+
+
+def test_case_insensitive_match():
+    assert rt.check_column_scope("SELECT ID, AMOUNT FROM orders", _scope_org()).action == "allow"
+
+
+# --- column-scope: degrade-to-allow ----------------------------------------
+
+def test_column_empty_model_allows():
+    org = m.Organization(organization="Empty", subject_areas=[m.SubjectArea(name="s")])
+    assert rt.check_column_scope("SELECT anything FROM whatever", org).action == "allow"
+
+
+def test_column_non_select_degrades_to_allow():
+    assert rt.check_column_scope("DELETE FROM orders", _scope_org()).action == "allow"
+
+
+def test_column_unparseable_degrades_to_allow():
+    assert rt.check_column_scope("SELECT FROM WHERE ((", _scope_org()).action == "allow"

--- a/tests/test_sample_database.py
+++ b/tests/test_sample_database.py
@@ -230,6 +230,28 @@ def test_sensitive_projection_allows_aggregate_filter_and_nonsensitive():
         assert RT.check_sensitive_projection(sql, org).action == "allow", sql
 
 
+def test_sensitive_projection_refuses_set_operation_arm():
+    """A sensitive column projected in ANY set-operation arm is refused. A UNION parses
+    to exp.SetOperation (not exp.Select), so a gate that only inspects the root SELECT
+    would let `SELECT id … UNION SELECT email …` slip PII straight past the gate."""
+    org = L.load_organization(MODEL_DIR)
+    for sql in [
+        "SELECT id FROM customers UNION SELECT email FROM customers",
+        "SELECT full_name FROM customers UNION ALL SELECT email FROM customers",
+        "SELECT id FROM customers INTERSECT SELECT email FROM customers",
+        "(SELECT id FROM customers) UNION (SELECT email FROM customers)",
+    ]:
+        assert RT.check_sensitive_projection(sql, org).action == "refuse", sql
+
+
+def test_sensitive_projection_allows_union_of_nonsensitive():
+    """A set operation whose every arm projects only non-sensitive columns still passes —
+    the arm-walking fix must not over-refuse a clean UNION."""
+    org = L.load_organization(MODEL_DIR)
+    sql = "SELECT id FROM customers UNION SELECT country FROM customers"
+    assert RT.check_sensitive_projection(sql, org).action == "allow", sql
+
+
 @pytest.fixture
 def wired_artifacts(tmp_path):
     """A temp artifacts dir wired to the sample exactly as Phase 0s does."""

--- a/tests/test_semantic_model_runtime.py
+++ b/tests/test_semantic_model_runtime.py
@@ -67,6 +67,26 @@ def test_explicit_cross_product_allowed():
     assert pf.action == "allow" and pf.risk is None
 
 
+def test_fan_trap_in_a_set_operation_arm_is_refused():
+    """A fan/chasm trap in ANY set-operation arm refuses the whole query. The set
+    operation parses to exp.SetOperation, so gating on isinstance(tree, exp.Select) would
+    skip every arm. Arms are not auto-rewritten, so a would-be auto_rewrite fan trap
+    (see test_fan_trap_auto_rewrite) becomes a refuse when it sits inside a UNION arm."""
+    org = _sales_org()
+    fan = ("SELECT SUM(orders.total_amount) FROM orders "
+           "JOIN order_items ON order_items.order_id = orders.id")
+    pf = rt.pre_flight_check(f"SELECT 1 AS n UNION ALL {fan}", org)
+    assert pf.risk == "fan_trap" and pf.action == "refuse"
+
+
+def test_clean_set_operation_passes_preflight():
+    """A set operation with no trapped arm still passes — arm-walking must not over-refuse."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(
+        "SELECT id FROM orders UNION SELECT id FROM customers", org)
+    assert pf.action == "allow" and pf.risk is None
+
+
 def test_aggregating_many_side_is_allowed():
     # aggregating the MANY side (order_items) is legitimate, not a fan trap
     org = _sales_org()

--- a/tests/test_table_scope_gate.py
+++ b/tests/test_table_scope_gate.py
@@ -93,6 +93,21 @@ def test_empty_model_allows():
     assert rt.check_table_scope("SELECT * FROM anything", org).action == "allow"
 
 
+def test_set_operation_arm_scoped():
+    # A UNION parses to exp.Union, not exp.Select: the guard must still scope every
+    # arm (regression for the set-operation bypass), not blanket-allow.
+    res = rt.check_table_scope(
+        "SELECT id FROM orders UNION SELECT id FROM secret_table", _scope_org())
+    assert res.action == "refuse"
+    assert res.offending_tables == ["secret_table"]
+
+
+def test_set_operation_all_declared_allowed():
+    res = rt.check_table_scope(
+        "SELECT id FROM orders UNION ALL SELECT id FROM customers", _scope_org())
+    assert res.action == "allow"
+
+
 def test_non_select_degrades_to_allow():
     # Non-SELECT is the upstream read-only guard's job; this gate defers (allow).
     assert rt.check_table_scope("DELETE FROM orders", _scope_org()).action == "allow"


### PR DESCRIPTION
Follow-up to #91 (table-scope gate). Adds two companion refuse checks to the shared `_model_safety` pass so every engine entry point (CLI + MCP `execute_sql`) rejects a query that names an **undeclared column** or uses **`SELECT *`** — not just whichever path obeyed a prose rule.

## What changed

**`runtime.py` (single-source):**
- **`check_no_select_star(sql)`** — refuses a projection-level `*` / `t.*` in **any** select (outer, subquery, CTE body, set-operation arm). `COUNT(*)` and other `agg(*)` still pass (the star sits inside the aggregate, not the projection). A star defeats column-level scoping, so we force every projected column to be named.
- **`check_column_scope(sql, org)`** — a column that binds to a declared physical table must be one that table declares. **Strict** where a column visibly binds to a physical table (per-enclosing-SELECT scoping, case-insensitive, consistent with `check_table_scope`); **fail-open** on CTE/subquery-output and select-list-alias columns we can't attribute — matching the gate's degrade-to-allow posture, so legitimate complex SQL never false-refuses. Still catches hallucinated columns, **including inside CTE/subquery bodies** (they bind directly to their physical table).

**`execute_sql.py` (`_model_safety`):** both checks wired in right after `check_table_scope`, before the fan/chasm + sensitive checks. New error kinds: `select_star`, `column_out_of_scope` (exit 1). Re-vendored byte-identical to `plugins/agami/lib/execute_sql.py`.

## Set-operation bypass (also fixes #91's gate)

Surfaced while writing the adversarial tests: `sqlglot.parse_one("… UNION …")` returns `exp.Union`, **not** `exp.Select`, so the `not isinstance(tree, exp.Select) → allow` short-circuit made **every UNION/INTERSECT/EXCEPT arm skip the guard**. `check_table_scope` (merged in #91) had the same hole — a `SELECT id FROM orders UNION SELECT id FROM secret_table` bypassed table-scope. All three checks now gate on *"contains a SELECT"* and walk every arm. Regression test added to `test_table_scope_gate.py`.

## Tests (full suite: 1376 passed)

- `tests/test_column_scope_gate.py` — star ban, column-scope happy path, legit CTE/subquery/alias, degrade-to-allow.
- `tests/test_column_scope_adversarial.py` — star evasion (subquery/CTE/UNION-arm/`t.*`/comment-obfuscation), column evasion (every clause, expression/window wraps, **alias masquerade**, UNION arm, correlated subquery, `COUNT(*)` not over-blocked), **documented accepted fail-opens** (derived-alias-qualified, CTE-shadows-table — asserted `allow` so a future narrowing is a conscious decision), and the upstream-owned multi-statement case.
- `tests/test_table_scope_gate.py` — UNION-arm regression.

Also verified end-to-end through `_model_safety`: correct exit codes, error kinds, and ordering (table-scope → star → column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)