### PR TITLE
Accept per-field `service_account` in BigQuery credentials

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -183,6 +183,14 @@ def _load_credentials(profile: str) -> dict[str, str]:
 
     section = {k: (v.strip() if isinstance(v, str) else v) for k, v in cfg[profile].items()}
 
+    # Accept the friendlier `service_account` / `credentials_path` spellings in the
+    # per-field form too — the BigQuery executor reads `service_account_path`, and the
+    # DSN parser already treats all three as equivalent. Without this, a per-field
+    # `service_account = ...` would be silently ignored (falling back to ADC).
+    for alias in ("service_account", "credentials_path"):
+        if section.get(alias) and not section.get("service_account_path"):
+            section["service_account_path"] = section[alias]
+
     # If the profile has `url = ...` (e.g. a Supabase / Neon / RDS DSN), parse it
     # and merge with any per-field overrides (sslmode, etc.) defined alongside.
     if "url" in section and section["url"]:

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -183,6 +183,14 @@ def _load_credentials(profile: str) -> dict[str, str]:
 
     section = {k: (v.strip() if isinstance(v, str) else v) for k, v in cfg[profile].items()}
 
+    # Accept the friendlier `service_account` / `credentials_path` spellings in the
+    # per-field form too — the BigQuery executor reads `service_account_path`, and the
+    # DSN parser already treats all three as equivalent. Without this, a per-field
+    # `service_account = ...` would be silently ignored (falling back to ADC).
+    for alias in ("service_account", "credentials_path"):
+        if section.get(alias) and not section.get("service_account_path"):
+            section["service_account_path"] = section[alias]
+
     # If the profile has `url = ...` (e.g. a Supabase / Neon / RDS DSN), parse it
     # and merge with any per-field overrides (sslmode, etc.) defined alongside.
     if "url" in section and section["url"]:

--- a/tests/test_env_credentials.py
+++ b/tests/test_env_credentials.py
@@ -108,39 +108,49 @@ def test_no_env_falls_through_to_the_file(monkeypatch, tmp_path):
 
 # --- per-field BigQuery: service_account alias normalizes to the path key ---
 
-def test_bigquery_service_account_alias_normalizes_in_file(monkeypatch, tmp_path):
-    """A per-field `service_account = ...` maps to `service_account_path` (what the
-    BigQuery executor reads) — the friendlier spelling must not be silently ignored."""
+def _bq_creds(tmp_path, *extra_lines):
+    """Write a minimal BigQuery credentials file (chmod 600) with the given extra
+    per-field lines, and return its path — the per-field form these tests exercise."""
     creds = tmp_path / "credentials"
     creds.write_text(
-        "[gcp]\ntype = bigquery\nproject = my-proj\n"
-        "service_account = /abs/path/key.json\n",
+        "[gcp]\ntype = bigquery\nproject = my-proj\n" + "".join(f"{ln}\n" for ln in extra_lines),
         encoding="utf-8",
     )
     import os
     if os.name == "posix":
         creds.chmod(0o600)
-    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", creds)
-
-    out = _load_credentials("gcp")
-    assert out["service_account_path"] == "/abs/path/key.json"
+    return creds
 
 
-def test_bigquery_explicit_service_account_path_is_not_clobbered(monkeypatch, tmp_path):
-    """If both `service_account_path` and the alias appear, the explicit path wins."""
-    creds = tmp_path / "credentials"
-    creds.write_text(
-        "[gcp]\ntype = bigquery\nproject = my-proj\n"
-        "service_account_path = /explicit/key.json\n"
-        "service_account = /alias/key.json\n",
-        encoding="utf-8",
+@pytest.mark.parametrize("alias", ["service_account", "credentials_path"])
+def test_bigquery_alias_normalizes_to_path_key(monkeypatch, tmp_path, alias):
+    """Both per-field spellings (`service_account`, `credentials_path`) map to
+    `service_account_path` (what the BigQuery executor reads) — the friendlier
+    spellings the docs use must not be silently ignored (falling back to ADC)."""
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", _bq_creds(tmp_path, f"{alias} = /abs/path/key.json"))
+
+    assert _load_credentials("gcp")["service_account_path"] == "/abs/path/key.json"
+
+
+def test_bigquery_explicit_service_account_path_wins_over_alias(monkeypatch, tmp_path):
+    """When both the explicit `service_account_path` and an alias appear, the explicit
+    path wins and the alias does NOT clobber it — pins the `not …get(...)` guard, which
+    without it would let the alias overwrite the explicitly-set path."""
+    monkeypatch.setattr(
+        execute_sql,
+        "CREDENTIALS_PATH",
+        _bq_creds(tmp_path, "service_account_path = /explicit/key.json", "service_account = /alias/key.json"),
     )
-    import os
-    if os.name == "posix":
-        creds.chmod(0o600)
-    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", creds)
 
     assert _load_credentials("gcp")["service_account_path"] == "/explicit/key.json"
+
+
+def test_bigquery_empty_alias_falls_through_to_adc(monkeypatch, tmp_path):
+    """An empty `service_account =` must not synthesize a `service_account_path` — it
+    stays unset so the client falls back to ADC, rather than loading a key from ''."""
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", _bq_creds(tmp_path, "service_account ="))
+
+    assert "service_account_path" not in _load_credentials("gcp")
 
 
 # --- neither source → an error that names both -----------------------------

--- a/tests/test_env_credentials.py
+++ b/tests/test_env_credentials.py
@@ -106,6 +106,43 @@ def test_no_env_falls_through_to_the_file(monkeypatch, tmp_path):
     assert out["host"] == "filehost" and out["type"] == "postgres"
 
 
+# --- per-field BigQuery: service_account alias normalizes to the path key ---
+
+def test_bigquery_service_account_alias_normalizes_in_file(monkeypatch, tmp_path):
+    """A per-field `service_account = ...` maps to `service_account_path` (what the
+    BigQuery executor reads) — the friendlier spelling must not be silently ignored."""
+    creds = tmp_path / "credentials"
+    creds.write_text(
+        "[gcp]\ntype = bigquery\nproject = my-proj\n"
+        "service_account = /abs/path/key.json\n",
+        encoding="utf-8",
+    )
+    import os
+    if os.name == "posix":
+        creds.chmod(0o600)
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", creds)
+
+    out = _load_credentials("gcp")
+    assert out["service_account_path"] == "/abs/path/key.json"
+
+
+def test_bigquery_explicit_service_account_path_is_not_clobbered(monkeypatch, tmp_path):
+    """If both `service_account_path` and the alias appear, the explicit path wins."""
+    creds = tmp_path / "credentials"
+    creds.write_text(
+        "[gcp]\ntype = bigquery\nproject = my-proj\n"
+        "service_account_path = /explicit/key.json\n"
+        "service_account = /alias/key.json\n",
+        encoding="utf-8",
+    )
+    import os
+    if os.name == "posix":
+        creds.chmod(0o600)
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", creds)
+
+    assert _load_credentials("gcp")["service_account_path"] == "/explicit/key.json"
+
+
 # --- neither source → an error that names both -----------------------------
 
 def test_missing_both_sources_names_env_and_file(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## What

A per-field `service_account = /path/key.json` line in a BigQuery credentials profile was **silently ignored** — the executor reads `service_account_path`, so the client fell back to Application Default Credentials instead of using the key. The docs use the shorter `service_account` spelling, making this an easy footgun.

`_load_credentials` now normalizes the `service_account` / `credentials_path` aliases to `service_account_path` for the per-field INI form — matching what `_parse_dsn` already does for the `url = bigquery://...?service_account=...` form. An explicit `service_account_path` still wins if both are present.

## Why

The three spellings were already equivalent in the DSN path but not the per-field path — inconsistent, and the inconsistency failed closed (fell back to ADC) with no error, so users couldn't tell why their key wasn't used.

## Changes

- `packages/agami-core/src/execute_sql.py` — alias normalization in `_load_credentials` (source of truth).
- `plugins/agami/lib/execute_sql.py` — re-synced vendored copy (`dev.py sync-lib`); drift check passes.
- `tests/test_env_credentials.py` — two tests: alias normalizes from the file; explicit `service_account_path` isn't clobbered.

## Test plan

- `uv run dev.py check` — full suite green (1326 passed), ruff + gitleaks + lib-drift all pass.
- New tests cover both the alias-maps and explicit-wins cases.

## Customer-safety

No real names/data/credentials — neutral `my-proj` / `/abs/path/key.json` placeholders only.