### PR TITLE
docs: correctness + plain-English sweep; OIDC→paid; one deploy path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,12 @@ Prefer the raw tools? `dev.py` is only a wrapper — the equivalents are below.
 
 ### Tests on their own
 
-The suite needs `pydantic`, `pyyaml`, and `sqlglot` to import the semantic-model code (DB-driver
-tests skip cleanly without a database). `uvx` pulls them in for the run:
+The suite imports the `agami-core` library, so install it editable with its `[model,server]` extras
+(that pulls in `pydantic` / `pyyaml` / `sqlglot` plus the server deps; DB-driver tests skip cleanly
+without a database). `uvx` wires it up for the run:
 
 ```bash
-uvx --with pytest-cov --with pydantic --with pyyaml --with sqlglot pytest tests/ -q
+uvx --with pytest-cov --with-editable "packages/agami-core[model,server]" pytest tests/ -q
 ```
 
 The privacy test (`tests/test_privacy_no_network.py`) is a contract: no shipped script may make a
@@ -70,8 +71,8 @@ no test exercises) — the quickest way to confirm a change is tested, regardles
 Under the hood that's:
 
 ```bash
-uvx --with pytest-cov --with pydantic --with pyyaml --with sqlglot \
-  pytest tests/ -q --cov=plugins --cov-report=xml
+uvx --with pytest-cov --with-editable "packages/agami-core[model,server]" \
+  pytest tests/ -q --cov=plugins --cov=packages/agami-core/src --cov-report=xml
 uvx diff-cover coverage.xml --compare-branch=origin/main
 ```
 
@@ -96,7 +97,7 @@ So: **bump the version on any commit that changes user-visible behavior.**
 
 ### When to bump what
 
-The version lives in three files. They should always match:
+The version lives in **three places across two files**. They must always match:
 
 - `.claude-plugin/marketplace.json` — `metadata.version` and `plugins[0].version`
 - `plugins/agami/.claude-plugin/plugin.json` — `version`

--- a/README.md
+++ b/README.md
@@ -87,35 +87,28 @@ the model from scratch so I can see it work"** the first time. Either way it tak
 a few minutes — it's the demo of *how* the receipts you saw in step 3 are earned.
 Full flow: [docs/usage.md](docs/usage.md).
 
-### Real database
+### Your own database
 
-When you're ready to connect your own database:
+Connecting your database is a short back-and-forth with agami — you fill in one
+template, and it handles the rest:
 
-```bash
-# 1. Run connect — picks your DB type, writes a credentials template (first run only)
-/agami-connect
+1. **Start setup.** Run `/agami-connect` (or just say *"connect to my database"*).
+   agami asks which database you use, has you name the connection, and writes a
+   credentials template for you to fill in.
+2. **Fill in the template.** Open the file agami points you to, add your connection
+   details, and save it — leave the filename as-is. agami only ever runs **read-only**
+   queries, so a read-only database user is all it needs; ask agami for *"the read-only
+   grant"* and it gives you the exact SQL to create one.
+3. **Say *"introspect my database"*** (or just *"continue"*). agami takes it from there:
+   it locks the file down for you (no manual `chmod`), reads your schema, builds the
+   semantic model, and seeds a few validated example queries. You don't move or rename
+   anything.
+4. **Ask a question** — *"how many orders did we ship last month?"*
 
-# 2. Fill in the template, then save + lock it down
-#    (agami only runs read-only queries, so use a read-only DB user if you can —
-#     ask agami for "the read-only grant" to get the exact GRANT SQL)
-$EDITOR <artifacts_dir>/local/credentials.example
-mv <artifacts_dir>/local/credentials.example <artifacts_dir>/local/credentials
-chmod 600 <artifacts_dir>/local/credentials
-
-# 3. Re-run connect to introspect: build the semantic model + seed examples
-/agami-connect
-
-# 4. Ask a question
-how many orders did we ship last month?
-```
-
-`/agami-connect` is one-stop: it picks up missing credentials, introspects the
-live DB, computes confidence on every entity, auto-approves the high-signal ones
-(FK joins, DBA-commented fields, structural names), gates a metric sign-off
-*before* generating seed examples, and leaves the low-confidence long tail in an
-optional panel that self-approves as you query. Full flow:
-[docs/usage.md](docs/usage.md). Credentials per dialect:
-[docs/credentials.md](docs/credentials.md).
+That's the whole setup. Along the way agami scores its confidence in every join and
+entity, auto-approves the clear ones (real foreign keys, well-named columns), and asks
+you to sign off the judgment calls. Full walkthrough: [docs/usage.md](docs/usage.md).
+Connection details for each database: [docs/credentials.md](docs/credentials.md).
 
 ## Install
 
@@ -217,10 +210,10 @@ It gathers your hostname and admin identity, writes `docker-compose.yml` + a fil
 (referencing the published `ghcr.io/agamiai/agami-core` image — no clone, no build), and either runs
 `docker compose up` locally or prints the exact VM steps and the shareable `/mcp` URL.
 
-- **Step-by-step deploy (VM, DNS, TLS, the variants — Cloudflare Tunnel, managed Postgres, Cloud Run):
-  [deploy/README.md](deploy/README.md).**
-- Env-var contract, the `pip install "agami-core[server]"` path, and Google / Microsoft (OIDC) login:
-  [docs/self-hosting.md](docs/self-hosting.md).
+**The full step-by-step — VM, DNS/TLS, and every variant (Cloudflare Tunnel, managed Postgres,
+Cloud Run) — is in [deploy/README.md](deploy/README.md).** (Prefer to wire it up by hand instead of
+using the bundle? The [manual install + environment-variable reference](docs/self-hosting.md) covers
+that.) Admins sign in with a password; teammates get per-user access to `/mcp`.
 
 It's cloud-neutral (a VM + Postgres, or a serverless platform + managed Postgres), configured entirely
 by environment variables, and **LLM-free + zero-egress by default**. Self-hosting this for people
@@ -235,7 +228,7 @@ by environment variables, and **LLM-free + zero-egress by default**. Self-hostin
 - [Format spec](docs/format-spec.md) — the semantic-model layout + a worked example
 - [MCP server](docs/mcp-server.md) — use agami from Claude Desktop
 - [Deploy a shared team server](deploy/README.md) — the Docker bundle, step-by-step (VM, DNS/TLS, variants)
-- [Self-hosting reference](docs/self-hosting.md) — the HTTP server, env-var contract, OIDC login
+- [Self-hosting reference](docs/self-hosting.md) — manual (non-Docker) install + the environment-variable reference
 - [Troubleshooting & uninstall](docs/troubleshooting.md)
 - [Fair-code vs hosted](docs/open-vs-hosted.md) · [Privacy](docs/privacy.md)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -90,6 +90,6 @@ database. Nothing else. Never the platform default.
   endpoint, so keep that identity scoped to only what the deployment needs (or block the container's route to
   metadata) — the same least-privilege rule, one level down.
 
-This is defense-in-depth **alongside** the read-only `DATASOURCE_URL` database user and the app-layer
-SELECT-only enforcement: the read-only user limits database damage; a least-privilege runtime identity
-limits cloud-account damage.
+Think of it as two separate safety nets that work together: the **read-only database user** limits what
+a breach could do to your data, and a **least-privilege runtime identity** limits what it could do to
+your cloud account. Keep both.

--- a/deploy/agami.env.example
+++ b/deploy/agami.env.example
@@ -8,15 +8,12 @@ COMPOSE_PROFILES=bundled-db,edge
 # Point a DNS A-record at this VM, or use the `tunnel` profile for a name without a public IP.
 PUBLIC_BASE_URL=https://agami.your-domain.example
 
-# The admin (identity = email; gates the /admin console). Set at least one auth method below.
+# The admin (identity = email; gates the /admin console), signing in with a password.
 AGAMI_ADMIN_USERNAME=you@example.com
 AGAMI_ADMIN_FIRST_NAME=Alex
 AGAMI_ADMIN_LAST_NAME=Kim
-# Type a strong password here by hand, then save (leave blank only if you set AGAMI_ADMIN_PROVIDER instead).
+# Type a strong password here by hand, then save.
 AGAMI_ADMIN_PASSWORD=
-# AGAMI_ADMIN_PROVIDER=google            # or microsoft — also set the matching OIDC client:
-# AGAMI_OIDC_GOOGLE_CLIENT_ID=
-# AGAMI_OIDC_GOOGLE_CLIENT_SECRET=
 
 # The WAREHOUSE the model queries — its connection DSN. This is a CREDENTIAL: type it here by hand and
 # never share it in chat. The scheme picks the type (postgresql:// mysql:// redshift:// snowflake://…);

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -3,9 +3,11 @@
 `agami` reads database connection details from `<artifacts_dir>/local/credentials`.
 Same pattern as `~/.aws/credentials`, `~/.dbt/profiles.yml`, `~/.pgpass`.
 
-`/agami-connect` creates a template at `<artifacts_dir>/local/credentials.example`
-on first run (its Phase 0a). Edit it and save as
-`<artifacts_dir>/local/credentials`:
+The first time you connect, `/agami-connect` writes a template at
+`<artifacts_dir>/local/credentials.example`. Fill in your connection details, save it
+(leave the filename as-is), then say *"introspect my database"* — agami moves it to
+`<artifacts_dir>/local/credentials` and locks it down for you. You don't rename or
+`chmod` anything by hand. A filled-in file looks like this:
 
 ```ini
 [default]
@@ -17,14 +19,10 @@ user     = myuser
 password = mypassword
 ```
 
-Then **make it readable only by you**:
-
-```bash
-chmod 600 <artifacts_dir>/local/credentials
-```
-
-`agami` refuses to read the file unless it's `chmod 600` — the same protection
-`ssh` uses for private keys.
+`agami` refuses to read the file unless it's readable only by you (`chmod 600`, the
+same protection `ssh` uses for private keys) — which is why agami sets that for you. If
+you ever create the file by hand instead, run `chmod 600 <artifacts_dir>/local/credentials`
+yourself.
 
 ## Use a read-only user
 
@@ -129,5 +127,5 @@ The skill picks the first available connection method, in this order:
 | **DuckDB** universal binary | `duckdb` on `PATH` (covers Postgres / MySQL / SQLite, not Snowflake / BigQuery) | `brew install duckdb` (or [duckdb.org](https://duckdb.org/)) |
 | **Python driver** (fallback) | Python + `psycopg2-binary` / `pymysql` / `snowflake-connector-python` / `google-cloud-bigquery` | `pip install psycopg2-binary pymysql snowflake-connector-python google-cloud-bigquery` |
 
-`/agami-connect` Phase 0a tells you exactly what to install for your OS if nothing
-is detected.
+If none of these is on your machine, `/agami-connect` notices during setup and offers
+to install what's needed for your OS — you don't have to work it out yourself.

--- a/docs/install/claude-code-cli.md
+++ b/docs/install/claude-code-cli.md
@@ -70,11 +70,11 @@ Try invoking it:
 /agami-connect
 ```
 
-On first run, the skill detects there are no credentials and walks you through the DB-type picker, then writes a `<artifacts_dir>/local/credentials.example` template you fill in. (No separate `/agami-init` — the setup flow lives in `/agami-connect` Phase 0a.)
+On first run, the skill sees there are no credentials, walks you through the DB-type picker, and writes a `<artifacts_dir>/local/credentials.example` template for you to fill in. (There's no separate `/agami-init` — setup lives inside `/agami-connect`.)
 
 ## 6. Set up credentials
 
-`agami-connect` Phase 0a writes a template at `<artifacts_dir>/local/credentials.example`. Edit it with your DB connection, save as `<artifacts_dir>/local/credentials`, run `chmod 600 <artifacts_dir>/local/credentials`. See the [main README's "Setup credentials" section](../../README.md#setup-credentials) for format.
+`/agami-connect` writes a template at `<artifacts_dir>/local/credentials.example` the first time you connect. Fill in your connection details, save it (leave the filename as-is), then say *"introspect my database"* — agami moves it into place and locks it down (`chmod 600`) for you; you don't move or `chmod` anything by hand. Full format and per-database fields: [docs/credentials.md](../credentials.md).
 
 ## Updating
 

--- a/docs/install/claude-code-cursor.md
+++ b/docs/install/claude-code-cursor.md
@@ -37,11 +37,11 @@ Try a skill in the Claude pane chat input:
 /agami-connect
 ```
 
-If you haven't set up credentials yet, the skill walks you through the DB-type picker and writes `<artifacts_dir>/local/credentials.example` for you to fill in. (No separate `/agami-init` — its setup flow was folded into `/agami-connect` Phase 0a.)
+If you haven't set up credentials yet, the skill walks you through the DB-type picker and writes `<artifacts_dir>/local/credentials.example` for you to fill in. (There's no separate `/agami-init` — setup lives inside `/agami-connect`.)
 
 ## 5. Set up credentials
 
-Same as the CLI / VS Code: edit `<artifacts_dir>/local/credentials.example`, save as `<artifacts_dir>/local/credentials`, `chmod 600`. See the [main README's "Setup credentials" section](../../README.md#setup-credentials).
+Same as the CLI / VS Code: agami writes `<artifacts_dir>/local/credentials.example`, you fill it in and save it, then say *"introspect my database"* — agami moves it into place and locks it down (`chmod 600`) for you. Format and per-database fields: [docs/credentials.md](../credentials.md).
 
 ## Cursor-specific notes
 

--- a/docs/install/claude-code-vscode.md
+++ b/docs/install/claude-code-vscode.md
@@ -39,13 +39,11 @@ Try a skill in the Claude pane chat input:
 /agami-connect
 ```
 
-If you haven't set up credentials yet, the skill walks you through the DB-type picker and writes `<artifacts_dir>/local/credentials.example` for you to fill in. (No separate `/agami-init` — its setup flow was folded into `/agami-connect` Phase 0a.)
+If you haven't set up credentials yet, the skill walks you through the DB-type picker and writes `<artifacts_dir>/local/credentials.example` for you to fill in. (There's no separate `/agami-init` — setup lives inside `/agami-connect`.)
 
 ## 5. Set up credentials
 
-Same as the CLI: edit `<artifacts_dir>/local/credentials.example`, save as `<artifacts_dir>/local/credentials`, `chmod 600`. See the [main README's "Setup credentials" section](../../README.md#setup-credentials).
-
-The terminal-side `chmod` works identically — the skill's `init` flow walks you through it via Bash inside the Claude pane.
+Same as the CLI: agami writes `<artifacts_dir>/local/credentials.example`, you fill it in and save it, then say *"introspect my database"* — agami moves it into place and locks it down (`chmod 600`) for you, all through Bash inside the Claude pane. Format and per-database fields: [docs/credentials.md](../credentials.md).
 
 ## VS Code-specific notes
 

--- a/docs/open-vs-hosted.md
+++ b/docs/open-vs-hosted.md
@@ -17,6 +17,9 @@ Run agami on your own machines, for your own people (multi-user included):
 - **Corrections** + the `examples.yaml` few-shot library.
 - The **local MCP server** (`agami serve`) — stdio, no auth, no network.
   See [mcp-server.md](mcp-server.md).
+- The **self-hosted team server** (`/agami-deploy`) — an HTTPS MCP server your whole
+  org connects to, with a password-protected admin console and per-user access to the
+  query surface. See [deploy/README.md](../deploy/README.md).
 
 ## Paid — the hosted cloud
 
@@ -24,8 +27,11 @@ For teams that need it served, and for serving people **outside** your organizat
 
 - A **multi-tenant model registry** over a remote MCP endpoint.
 - **Shared, governed** examples + context across a team.
+- **Feedback capture**: user corrections and query feedback rolled into the shared
+  model and evals.
 - **Continuous evals**: scheduled runs, regression alerting, golden-dataset management.
-- **CI-gated deploys** and org-scale governance (SSO, RBAC, audit).
+- **Single sign-on (Google / Microsoft)** and org-scale governance (**RBAC**, audit).
+- **CI-gated deploys**.
 
 Moving from local to hosted is a **backend swap** — the local server and the hosted
 connector expose the same tools, so you point at a different backend, not a new product.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,12 +1,42 @@
 # Privacy
 
-The short version: **your data never leaves your machine.** `agami` is a Claude Code skill that runs locally — credentials, schema, query results, and corrections all live in `<artifacts_dir>/local/` and `~/agami-artifacts/` on your laptop. There is no agami server in the loop, no telemetry, no opt-in, no opt-out. The runtime is silent.
+**The short version:** agami runs no server of its own, has no telemetry, and makes no network calls. Your credentials, semantic model, query results, charts, and exports all stay in local files on your machine.
 
-This page documents what stays on your machine, what we'd never send anywhere even hypothetically, and how the one outbound interaction (the post-install GitHub-star ask) works.
+But agami works *through* an AI assistant — Claude Code, or Claude Desktop / claude.ai via the local MCP server — and that assistant is what turns your question into SQL. So the assistant sends the model provider (Anthropic, under its terms) the things any AI assistant would need: your question, the part of your semantic model it's reasoning over, the SQL, and the results it shows you. That's inherent to using an LLM — not something agami adds. This page is precise about who sees what.
 
 ---
 
-## What `agami` keeps local
+## agami itself sends nothing
+
+There is no outbound network call in agami's own code — no telemetry, no analytics, no install ping, no agami server in the loop. You can grep the source: there is no `curl` / `requests.post` / socket call in any skill or script path, and a test (`tests/test_privacy_no_network.py`) fails the build if any script introduces one.
+
+So none of this is ever collected, transmitted, or logged **by agami**:
+
+- Your credentials, database hostnames, IPs, ports, tokens
+- File paths, environment variables, working-directory contents, git history
+- Email addresses, machine IDs, hardware fingerprints, stack traces, error logs
+- Any usage counts or events — there is nothing to opt out of, because there's nothing there
+
+---
+
+## What your AI client sends to the model
+
+Because agami writes SQL *with* an LLM, your AI client passes the model what it needs to do that. When you run agami inside Claude Code / Claude Desktop / claude.ai, that means Anthropic's API receives:
+
+- your natural-language question,
+- the slice of your **semantic model** it's working from — table and column names, descriptions, and metric definitions (the governed model agami built, not your whole database),
+- the SQL agami generates, and
+- the result rows the assistant shows you.
+
+This is how every AI coding or analysis assistant works; agami neither adds nor removes it. What agami *does* do is keep that surface as small and controlled as possible:
+
+- **You decide what the model can see.** The semantic model is the only schema the LLM works from — never a live connection to your database. Exclude any table or column you don't want queried, and mark columns `sensitive` so their raw values are never projected (they can still be counted or filtered).
+- **Execution stays on your machine.** agami runs the generated SQL against your database locally. Your **database credentials and connection never go to the model** — only the model context above and the rows you'd see anyway.
+- **Want nothing to leave at all?** Point your client — or a [self-hosted deploy](open-vs-hosted.md) — at a local or self-hosted model, and even the question and model context stay on your own infrastructure.
+
+---
+
+## What agami keeps local
 
 Every byte agami reads or writes stays on your machine:
 
@@ -17,7 +47,7 @@ Every byte agami reads or writes stays on your machine:
 - **Examples library** (`<artifacts_dir>/<profile>/examples.yaml`)
 - **Organization context** (`<artifacts_dir>/<profile>/ORGANIZATION.md`) — your description of what the database represents, domain terminology
 - **User memory** (`<artifacts_dir>/USER_MEMORY.md`) — your cross-database preferences
-- **Query results** (everything Claude shows you)
+- **Query results** (everything the assistant shows you)
 - **Query log** (`<artifacts_dir>/local/query_log.jsonl`) — your personal record of every query you ran
 - **Charts** (`<artifacts_dir>/local/charts/<profile>/<ts>.html`)
 - **CSV exports** (`<artifacts_dir>/local/exports/<profile>/<ts>.csv`)
@@ -30,55 +60,22 @@ The skill never reads files outside those paths, with one carve-out: your DB too
 
 ---
 
-## What agami never sends anywhere
+## The GitHub-star prompt is not a network call
 
-There is no outbound network call from the skill code, period. To be explicit, the following categories are never collected, transmitted, or logged by agami:
-
-- Query text (the NL question or the generated SQL)
-- Schema content (table names, column names, descriptions, sample data)
-- Result rows or any subset thereof
-- Database hostnames, IPs, ports, credentials
-- File paths beyond `<artifacts_dir>/local/` and `<artifacts_dir>/`
-- Email addresses, names, IPs, MAC addresses, machine IDs, hardware fingerprints
-- Stack traces, log lines, error messages
-- Working directory contents, environment variables, git history
-- Anything from `<artifacts_dir>/local/credentials`, the artifacts dir, charts, exports, or the query log
-
-You can grep the source — there is no `curl` / `requests.post` / network call in any skill or script code path. A test (`tests/test_privacy_no_network.py`) enforces this: any script that introduces a network-egress primitive fails the build.
-
----
-
-## The one outbound interaction: GitHub-star ask
-
-After your first successful query, the `agami-query` skill asks once whether you want to star the repo on GitHub. This is a chat-side `AskUserQuestion` modal with three options:
-
-- **Yes — open GitHub now** — runs `open https://github.com/AgamiAI/agami-core` (or platform equivalent), which hands the URL to your OS. Your browser handles it from there.
-- **Maybe later** — closes the prompt; we never ask again.
-- **Already starred — thank you!** — closes the prompt; we never ask again.
-
-Nothing about your response leaves your machine. agami has no signal-collection on the GitHub side — we don't observe whether you actually star, and a star is public information anyway. The decision is recorded in `<artifacts_dir>/local/.optins` so the ask doesn't repeat. To re-prompt: `rm <artifacts_dir>/local/.optins` and ask any agami skill a question.
-
-That's the entire outbound surface: opening one well-known URL in your browser when you click "Yes." No background network calls, no opt-in telemetry, no analytics events.
+After your first successful query, `agami-query` asks once, in chat, whether you'd like to star the repo. It's just a prompt — choosing **Yes** runs `open https://github.com/AgamiAI/agami-core` (or the platform equivalent), handing that URL to your browser; your browser does the rest. agami sends nothing and never learns whether you actually starred (a star is public anyway). **Maybe later** and **Already starred** dismiss it for good. The choice is recorded in `<artifacts_dir>/local/.optins` so it doesn't repeat; to see it again, `rm <artifacts_dir>/local/.optins`.
 
 ---
 
 ## The optional local MCP server keeps the same guarantee
 
-`agami serve` (`python -m mcp_harness`, in `packages/agami-core/src/mcp_harness.py`) lets you
-use agami from Claude Code / Claude Desktop. It changes nothing about this privacy posture:
+`agami serve` (`python -m mcp_harness`, in `packages/agami-core/src/mcp_harness.py`) lets you use agami from Claude Desktop. It changes nothing about the posture above:
 
-- It speaks the MCP **stdio** transport — a child process of your AI client,
-  reading/writing OS pipes. It **never binds a network port** and makes **no
-  network call**. `tests/test_mcp_harness.py` enforces this (the source is
-  asserted to contain no socket/http/urllib/requests primitives).
-- It reads only the same local paths listed above and executes SQL locally via
-  `execute_sql.py`. Only the rows you'd see anyway are returned to your client.
-- It has **no authentication** because it needs none: the trust boundary is your
-  OS user account. (Networked, authenticated, multi-user serving is the hosted
-  product — see [open-vs-hosted.md](open-vs-hosted.md).)
+- It speaks the MCP **stdio** transport — a child process of your AI client, reading/writing OS pipes. It **never binds a network port** and makes **no network call** of its own. `tests/test_mcp_harness.py` enforces this (the source is asserted to contain no socket/http/urllib/requests primitives).
+- It reads only the local paths listed above and executes SQL locally via `execute_sql.py`. Only the rows you'd see anyway are returned to your client. (What that client then sends to the model is the same as the section above — it's still an LLM assistant.)
+- It has **no authentication** because it needs none: the trust boundary is your OS user account. (Networked, authenticated, multi-user serving is the [self-hosted team server](open-vs-hosted.md).)
 
 ---
 
 ## No telemetry
 
-agami has **no telemetry** — no usage counts, no events, no install ping, no opt-in or opt-out. Earlier 0.x builds kept a vestigial (never-deployed, never-invoked) telemetry sample client + Cloudflare endpoint in the repo as historical artifacts; those were removed entirely. There is no network call anywhere in the codebase, and `tests/test_privacy_no_network.py` fails the build if any script introduces one. If a future agami version ever added telemetry, it would be opt-in with a full privacy doc — never a silent re-enable.
+agami has **no telemetry** — no usage counts, no events, no install ping, no opt-in or opt-out. Earlier 0.x builds kept a vestigial (never-deployed, never-invoked) telemetry sample client + endpoint in the repo as historical artifacts; those were removed entirely. There is no network call anywhere in agami's codebase, and `tests/test_privacy_no_network.py` fails the build if any script introduces one. If a future version ever added telemetry, it would be opt-in with a full privacy doc — never a silent re-enable.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,16 +1,16 @@
 # Privacy
 
-**The short version:** agami runs no server of its own, has no telemetry, and makes no network calls. Your credentials, semantic model, query results, charts, and exports all stay in local files on your machine.
+**The short version:** used the normal way — as a skill inside Claude Code, or the local stdio server in Claude Desktop — agami makes no network calls of its own and has no telemetry. Your credentials, semantic model, query results, charts, and exports all stay in local files on your machine. (The self-hosted team server is a network service you deliberately stand up for your org — a separate, opt-in deployment, covered near the end.)
 
 But agami works *through* an AI assistant — Claude Code, or Claude Desktop / claude.ai via the local MCP server — and that assistant is what turns your question into SQL. So the assistant sends the model provider (Anthropic, under its terms) the things any AI assistant would need: your question, the part of your semantic model it's reasoning over, the SQL, and the results it shows you. That's inherent to using an LLM — not something agami adds. This page is precise about who sees what.
 
 ---
 
-## agami itself sends nothing
+## The local path makes no network calls
 
-There is no outbound network call in agami's own code — no telemetry, no analytics, no install ping, no agami server in the loop. You can grep the source: there is no `curl` / `requests.post` / socket call in any skill or script path, and a test (`tests/test_privacy_no_network.py`) fails the build if any script introduces one.
+When you use agami locally — the skill scripts plus the on-machine library (the SQL executor and the stdio MCP server) — there is no outbound network call of any kind: no telemetry, no analytics, no install ping. `tests/test_privacy_no_network.py` enforces this: it scans every shipped skill script and the local library modules and fails the build if one gains a `curl` / `requests.post` / socket call. (It deliberately excludes the two **server** modules, `mcp_http` and `oidc` — the self-hosted team server *is* a network service by design; that's the opt-in deploy covered below, not the local path.)
 
-So none of this is ever collected, transmitted, or logged **by agami**:
+So none of this is ever collected, transmitted, or logged by the local agami path:
 
 - Your credentials, database hostnames, IPs, ports, tokens
 - File paths, environment variables, working-directory contents, git history
@@ -73,6 +73,12 @@ After your first successful query, `agami-query` asks once, in chat, whether you
 - It speaks the MCP **stdio** transport — a child process of your AI client, reading/writing OS pipes. It **never binds a network port** and makes **no network call** of its own. `tests/test_mcp_harness.py` enforces this (the source is asserted to contain no socket/http/urllib/requests primitives).
 - It reads only the local paths listed above and executes SQL locally via `execute_sql.py`. Only the rows you'd see anyway are returned to your client. (What that client then sends to the model is the same as the section above — it's still an LLM assistant.)
 - It has **no authentication** because it needs none: the trust boundary is your OS user account. (Networked, authenticated, multi-user serving is the [self-hosted team server](open-vs-hosted.md).)
+
+---
+
+## The self-hosted team server (opt-in)
+
+If you [deploy the team server](../deploy/README.md) so your org can share one model, that server *is* a network service by design — it serves your model to your team over HTTPS. Your data still stays in your environment: it holds only the semantic model (never a live database connection), runs SQL locally against your own warehouse, and is **zero-egress by default**. Single sign-on — which would call an identity provider — is a hosted-tier feature, so a self-hosted server makes no outbound call of its own at all.
 
 ---
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -45,11 +45,11 @@ and the other tools just read the model. Nothing leaves your environment.
 | `AGAMI_DB_URL` | yes (server) | The store: `postgresql://…` in prod, `sqlite://…` for a small/local run. `APP_DATABASE_URL` is accepted as an alias for the cloud-platform convention (`AGAMI_DB_URL` wins if both are set). Unset ⇒ the local file path. |
 | `PUBLIC_BASE_URL` | yes (server) | Backs OAuth/MCP discovery + the `WWW-Authenticate` resource URL. Set it explicitly — it can't be auto-detected behind a proxy/LB; the server fails fast at startup if it's missing. |
 | `AGAMI_ORG_ID` | no | The single configured org id (default `local`). The server is single-tenant by default. |
-| `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its own session JWTs with. When set, the server validates real tokens (the admin password login flow); unset ⇒ the bearer-presence local default. |
+| `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its session JWTs with — this is what turns on **real per-user login** (admin password + per-user `/mcp` OAuth). **Required for any internet-facing deploy;** the `/agami-deploy` bundle generates and persists it for you. Unset ⇒ a local bearer-presence default only (single-user, not per-user). |
 
-Admins sign in to `/admin` with a **username and password**; team members get per-user OAuth on `/mcp`.
-Single sign-on (Google / Microsoft) is part of the hosted cloud — see
-[what's free vs hosted](open-vs-hosted.md).
+So on a real deploy (signing secret set — the bundle does this for you), admins sign in to `/admin` with a
+**username and password**, and each team member authenticates individually to `/mcp`. Single sign-on
+(Google / Microsoft) is part of the hosted cloud — see [what's free vs hosted](open-vs-hosted.md).
 
 > **Serverless note:** on a managed-container platform (Cloud Run, ECS/Fargate, Container Apps) the server
 > runs under a cloud identity — scope it to a dedicated least-privilege one, not the platform default. See

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,14 +1,15 @@
-# Self-hosting the team server
+# Self-hosting: manual install & configuration reference
 
-Beyond the local single-player setup, agami ships an **HTTP MCP server** so a team can point their
-Claude at one shared, governed model. It's **cloud-neutral** — a VM + Postgres, or a stateless
-platform (Cloud Run / Container Apps) + managed Postgres. No GCP service is required to boot: no
-Cloud SQL connector, no Secret Manager, no Cloud Logging (a regression test enforces this).
+> **Most people should not read this page.** The one-command path — [**deploy/README.md**](../deploy/README.md),
+> driven by the `/agami-deploy` skill — writes a ready-to-run Docker bundle (docker-compose + Caddy
+> auto-TLS + a filled `.env`) from the published image `ghcr.io/agamiai/agami-core`, no clone and no
+> build. This page is the **by-hand alternative and the environment-variable reference** — for when you
+> want to run the server without the bundle (a bare `pip install`, a serverless platform, etc.).
 
-> **The easy path:** the **`/agami-deploy`** skill writes a ready-to-run bundle (docker-compose +
-> Caddy auto-TLS + a filled `.env`) that pulls the published image `ghcr.io/agamiai/agami-core` — no
-> clone, no build. See [deploy/README.md](../deploy/README.md). The manual steps below are for when
-> you'd rather wire it up yourself.
+agami's **HTTP MCP server** lets a team point their Claude at one shared, governed model. It's
+**cloud-neutral** — a VM + Postgres, or a stateless platform (Cloud Run / Container Apps) + managed
+Postgres. No GCP service is required to boot: no Cloud SQL connector, no Secret Manager, no Cloud
+Logging (a regression test enforces this).
 
 ## Install
 
@@ -44,24 +45,15 @@ and the other tools just read the model. Nothing leaves your environment.
 | `AGAMI_DB_URL` | yes (server) | The store: `postgresql://…` in prod, `sqlite://…` for a small/local run. `APP_DATABASE_URL` is accepted as an alias for the cloud-platform convention (`AGAMI_DB_URL` wins if both are set). Unset ⇒ the local file path. |
 | `PUBLIC_BASE_URL` | yes (server) | Backs OAuth/MCP discovery + the `WWW-Authenticate` resource URL. Set it explicitly — it can't be auto-detected behind a proxy/LB; the server fails fast at startup if it's missing. |
 | `AGAMI_ORG_ID` | no | The single configured org id (default `local`). The server is single-tenant by default. |
-| `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its own session JWTs with. When set, the server validates real tokens (the password / OIDC login flow); unset ⇒ the bearer-presence local default. |
+| `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its own session JWTs with. When set, the server validates real tokens (the admin password login flow); unset ⇒ the bearer-presence local default. |
+
+Admins sign in to `/admin` with a **username and password**; team members get per-user OAuth on `/mcp`.
+Single sign-on (Google / Microsoft) is part of the hosted cloud — see
+[what's free vs hosted](open-vs-hosted.md).
 
 > **Serverless note:** on a managed-container platform (Cloud Run, ECS/Fargate, Container Apps) the server
 > runs under a cloud identity — scope it to a dedicated least-privilege one, not the platform default. See
 > [Runtime identity on serverless platforms](../deploy/README.md#runtime-identity-on-serverless-platforms).
 
-## Optional: social login (OIDC)
-
-"Sign in with Google / Microsoft" is **off by default**. Configure a provider's client id/secret to
-enable it (the option is hidden when unset; username/password still works):
-
-| Variable | Provider | Notes |
-|----------|----------|-------|
-| `AGAMI_OIDC_GOOGLE_CLIENT_ID` / `_SECRET` | Google | requires `email_verified` |
-| `AGAMI_OIDC_MICROSOFT_CLIENT_ID` / `_SECRET` | Microsoft | also set `AGAMI_OIDC_MICROSOFT_TENANT` to a **pinned** tenant id (not `common`/`organizations`) — the tenant is the trust boundary |
-| `AGAMI_PUBLIC_SIGNUP` | — | default off. When on, an unknown verified email self-provisions a **demo** account — intended only for a dedicated "Try for free" instance whose data is non-sensitive. Leave off for any real deployment (it's onboarded-only: an admin must add the user first). |
-
-**Egress note:** OIDC is the one feature where the **hosted** server reaches out — it calls the
-identity provider to verify a login. Everything else stays local. If you want a strictly no-egress
-deployment, leave OIDC unconfigured (or run the local stdio server, `python -m mcp_harness`); the
-skill and the query path never make a network call regardless.
+The serving path stays **LLM-free and zero-egress**: the client is the brain, `execute_sql` runs SQL
+against your own database, and nothing leaves your environment.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,10 +1,10 @@
 # Self-hosting: manual install & configuration reference
 
-> **Most people should not read this page.** The one-command path — [**deploy/README.md**](../deploy/README.md),
-> driven by the `/agami-deploy` skill — writes a ready-to-run Docker bundle (docker-compose + Caddy
-> auto-TLS + a filled `.env`) from the published image `ghcr.io/agamiai/agami-core`, no clone and no
-> build. This page is the **by-hand alternative and the environment-variable reference** — for when you
-> want to run the server without the bundle (a bare `pip install`, a serverless platform, etc.).
+> **Deploying agami? Start with [deploy/README.md](../deploy/README.md).** The `/agami-deploy` skill
+> writes a ready-to-run Docker bundle there (docker-compose + Caddy auto-TLS + a filled `.env`) from the
+> published image `ghcr.io/agamiai/agami-core` — no clone, no build. **This page is the reference** for
+> the pieces that bundle sets for you: the manual (non-Docker) `pip install` path, and the full list of
+> environment variables — handy for a serverless platform or a hand-rolled setup.
 
 agami's **HTTP MCP server** lets a team point their Claude at one shared, governed model. It's
 **cloud-neutral** — a VM + Postgres, or a stateless platform (Cloud Run / Container Apps) + managed


### PR DESCRIPTION
Follow-up to the README sweep (#95), from a close read of the docs. Everything here was verified against the actual skill/code, not guessed.

## Correctness fixes
- **Connect flow was wrong** in README + `docs/credentials.md` + `docs/install/*`. agami **promotes the filled template and `chmod 600`s it itself**, and you trigger introspection by saying *"introspect my database"* / *"continue"* — there is no manual `mv`/`chmod` and no second `/agami-connect` run. Corrected everywhere; dropped internal "Phase 0a" references; fixed a **broken link** (`README.md#setup-credentials` didn't exist → now `docs/credentials.md`).
- **privacy.md overclaimed.** "Your data never leaves your machine" isn't right — agami runs *through* Claude, so the AI client (Claude Code / Desktop / claude.ai) sends the model your question, semantic model, SQL, and results. Rewrote to separate *"agami itself sends nothing"* (no server, no telemetry) from *"what your AI client sends to the model."* Reframed the GitHub-star prompt as **not a network call**.
- **CONTRIBUTING.md had stale commands that actually fail.** The documented raw `pytest` invocation errors with `ImportError: cannot import name 'models' from 'semantic_model'` after the package move — corrected to `--with-editable packages/agami-core[model,server]` (and added `--cov=packages/agami-core/src`). Fixed "the version lives in three files" (three strings across **two** files).
- **deploy/README.md**: rewrote the confusing defense-in-depth sentence in plain English.

## Product decisions applied
- **OIDC / SSO is paid-only.** Removed "sign in with Google/Microsoft" from the free self-host docs and the `agami.env.example` bundle template (password admin only). `open-vs-hosted.md` now lists SSO under the hosted tier, adds the requested **feedback-capture** item, and surfaces the **free self-hosted team server**.
  - ⚠️ **Follow-up (code, not this PR):** the server still honors `AGAMI_OIDC_*` env vars — gating that in the community build needs a separate code change. Flagging so docs and behavior converge.
- **One deploy path.** `deploy/README.md` is the single paved path; `docs/self-hosting.md` is retitled as the **manual / environment-variable reference** it links to, and the README points at one path instead of two.

## Scope / safety
- Docs + the `deploy/agami.env.example` template only — **no plugin behavior change, no version bump** needed.
- Full local gate green (`uv run dev.py check`: whole suite + ruff + gitleaks, incl. deploy tests). All relative links across the 11 changed files resolve.
- No real names/data/credentials.