### PR TITLE
docs: basic single-provider SSO is free; Enterprise SSO (per-org/SAML/SCIM) is paid

### DIFF
--- a/deploy/agami.env.example
+++ b/deploy/agami.env.example
@@ -8,12 +8,17 @@ COMPOSE_PROFILES=bundled-db,edge
 # Point a DNS A-record at this VM, or use the `tunnel` profile for a name without a public IP.
 PUBLIC_BASE_URL=https://agami.your-domain.example
 
-# The admin (identity = email; gates the /admin console), signing in with a password.
+# The admin (identity = email; gates the /admin console). Set at least one auth method below.
 AGAMI_ADMIN_USERNAME=you@example.com
 AGAMI_ADMIN_FIRST_NAME=Alex
 AGAMI_ADMIN_LAST_NAME=Kim
-# Type a strong password here by hand, then save.
+# Type a strong password here by hand, then save (or use single sign-on instead — uncomment below).
 AGAMI_ADMIN_PASSWORD=
+# Optional: sign in with one Google or Microsoft account instead of a password. Basic single-provider
+# SSO is free; per-org (multi-tenant) SSO, SAML, and SCIM are hosted Enterprise SSO.
+# AGAMI_ADMIN_PROVIDER=google            # or microsoft — also set the matching OIDC client:
+# AGAMI_OIDC_GOOGLE_CLIENT_ID=
+# AGAMI_OIDC_GOOGLE_CLIENT_SECRET=
 
 # The WAREHOUSE the model queries — its connection DSN. This is a CREDENTIAL: type it here by hand and
 # never share it in chat. The scheme picks the type (postgresql:// mysql:// redshift:// snowflake://…);

--- a/deploy/agami.env.example
+++ b/deploy/agami.env.example
@@ -14,11 +14,16 @@ AGAMI_ADMIN_FIRST_NAME=Alex
 AGAMI_ADMIN_LAST_NAME=Kim
 # Type a strong password here by hand, then save (or use single sign-on instead — uncomment below).
 AGAMI_ADMIN_PASSWORD=
-# Optional: sign in with one Google or Microsoft account instead of a password. Basic single-provider
-# SSO is free; per-org (multi-tenant) SSO, SAML, and SCIM are hosted Enterprise SSO.
-# AGAMI_ADMIN_PROVIDER=google            # or microsoft — also set the matching OIDC client:
+# Optional: sign in with a single Google or Microsoft provider instead of a password. Basic
+# single-provider SSO is free; per-org (multi-tenant) SSO, SAML, and SCIM are hosted Enterprise SSO.
+# AGAMI_ADMIN_PROVIDER=google            # or microsoft — also set the matching OIDC client below:
+#   Google:
 # AGAMI_OIDC_GOOGLE_CLIENT_ID=
 # AGAMI_OIDC_GOOGLE_CLIENT_SECRET=
+#   Microsoft (instead of Google):
+# AGAMI_OIDC_MICROSOFT_CLIENT_ID=
+# AGAMI_OIDC_MICROSOFT_CLIENT_SECRET=
+# AGAMI_OIDC_MICROSOFT_TENANT=           # pin ONE tenant id (not 'common'/'organizations')
 
 # The WAREHOUSE the model queries — its connection DSN. This is a CREDENTIAL: type it here by hand and
 # never share it in chat. The scheme picks the type (postgresql:// mysql:// redshift:// snowflake://…);

--- a/docs/open-vs-hosted.md
+++ b/docs/open-vs-hosted.md
@@ -19,7 +19,8 @@ Run agami on your own machines, for your own people (multi-user included):
   See [mcp-server.md](mcp-server.md).
 - The **self-hosted team server** (`/agami-deploy`) — an HTTPS MCP server your whole
   org connects to, with a password-protected admin console and per-user access to the
-  query surface. See [deploy/README.md](../deploy/README.md).
+  query surface. Basic **single sign-on** (one Google or Microsoft account) is included.
+  See [deploy/README.md](../deploy/README.md).
 
 ## Paid — the hosted cloud
 
@@ -30,7 +31,9 @@ For teams that need it served, and for serving people **outside** your organizat
 - **Feedback capture**: user corrections and query feedback rolled into the shared
   model and evals.
 - **Continuous evals**: scheduled runs, regression alerting, golden-dataset management.
-- **Single sign-on (Google / Microsoft)** and org-scale governance (**RBAC**, audit).
+- **Enterprise SSO**: per-org (multi-tenant) identity, **SAML**, and **SCIM**
+  provisioning — plus org-scale governance (**RBAC**, audit). (Basic single-provider
+  SSO is free, above.)
 - **CI-gated deploys**.
 
 Moving from local to hosted is a **backend swap** — the local server and the hosted

--- a/docs/open-vs-hosted.md
+++ b/docs/open-vs-hosted.md
@@ -18,8 +18,8 @@ Run agami on your own machines, for your own people (multi-user included):
 - The **local MCP server** (`agami serve`) — stdio, no auth, no network.
   See [mcp-server.md](mcp-server.md).
 - The **self-hosted team server** (`/agami-deploy`) — an HTTPS MCP server your whole
-  org connects to, with a password-protected admin console and per-user access to the
-  query surface. Basic **single sign-on** (one Google or Microsoft account) is included.
+  org connects to, with an admin console (sign in with a password or a single Google /
+  Microsoft **SSO** provider) and per-user access to the query surface.
   See [deploy/README.md](../deploy/README.md).
 
 ## Paid — the hosted cloud

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -78,7 +78,7 @@ After your first successful query, `agami-query` asks once, in chat, whether you
 
 ## The self-hosted team server (opt-in)
 
-If you [deploy the team server](../deploy/README.md) so your org can share one model, that server *is* a network service by design — it serves your model to your team over HTTPS. Your data still stays in your environment: it holds only the semantic model (never a live database connection), runs SQL locally against your own warehouse, and is **zero-egress by default**. Single sign-on — which would call an identity provider — is a hosted-tier feature, so a self-hosted server makes no outbound call of its own at all.
+If you [deploy the team server](../deploy/README.md) so your org can share one model, that server *is* a network service by design — it serves your model to your team over HTTPS. Your data still stays in your environment: it holds only the semantic model (never a live database connection), runs SQL locally against your own warehouse, and is **zero-egress by default**. The one thing that reaches out is **single sign-on**, if you turn it on: to verify a login the server calls Google/Microsoft (the identity provider). Leave SSO off — the default — and it makes no outbound call of its own.
 
 ---
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -54,8 +54,9 @@ So on a real deploy (signing secret set — the bundle does this for you), admin
 
 Instead of a password, the admin can sign in with **one** Google or Microsoft account. Set
 `AGAMI_ADMIN_PROVIDER=google` (or `microsoft`) and that provider's OIDC client — for Google,
-`AGAMI_OIDC_GOOGLE_CLIENT_ID` + `AGAMI_OIDC_GOOGLE_CLIENT_SECRET`; for Microsoft, the `MICROSOFT` vars plus
-`AGAMI_OIDC_MICROSOFT_TENANT` pinned to a single tenant id. It's off unless configured, and this basic
+`AGAMI_OIDC_GOOGLE_CLIENT_ID` + `AGAMI_OIDC_GOOGLE_CLIENT_SECRET`; for Microsoft,
+`AGAMI_OIDC_MICROSOFT_CLIENT_ID` + `AGAMI_OIDC_MICROSOFT_CLIENT_SECRET` plus `AGAMI_OIDC_MICROSOFT_TENANT`
+pinned to a single tenant id. It's off unless configured, and this basic
 single-provider login is **free**. Per-org (multi-tenant) SSO, SAML, and SCIM are hosted **Enterprise SSO**
 — see [what's free vs hosted](open-vs-hosted.md).
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -48,12 +48,21 @@ and the other tools just read the model. Nothing leaves your environment.
 | `AGAMI_SIGNING_SECRET` | yes (auth) | ≥32-byte secret the server signs its session JWTs with — this is what turns on **real per-user login** (admin password + per-user `/mcp` OAuth). **Required for any internet-facing deploy;** the `/agami-deploy` bundle generates and persists it for you. Unset ⇒ a local bearer-presence default only (single-user, not per-user). |
 
 So on a real deploy (signing secret set — the bundle does this for you), admins sign in to `/admin` with a
-**username and password**, and each team member authenticates individually to `/mcp`. Single sign-on
-(Google / Microsoft) is part of the hosted cloud — see [what's free vs hosted](open-vs-hosted.md).
+**username and password**, and each team member authenticates individually to `/mcp`.
+
+### Optional: single sign-on (Google / Microsoft)
+
+Instead of a password, the admin can sign in with **one** Google or Microsoft account. Set
+`AGAMI_ADMIN_PROVIDER=google` (or `microsoft`) and that provider's OIDC client — for Google,
+`AGAMI_OIDC_GOOGLE_CLIENT_ID` + `AGAMI_OIDC_GOOGLE_CLIENT_SECRET`; for Microsoft, the `MICROSOFT` vars plus
+`AGAMI_OIDC_MICROSOFT_TENANT` pinned to a single tenant id. It's off unless configured, and this basic
+single-provider login is **free**. Per-org (multi-tenant) SSO, SAML, and SCIM are hosted **Enterprise SSO**
+— see [what's free vs hosted](open-vs-hosted.md).
 
 > **Serverless note:** on a managed-container platform (Cloud Run, ECS/Fargate, Container Apps) the server
 > runs under a cloud identity — scope it to a dedicated least-privilege one, not the platform default. See
 > [Runtime identity on serverless platforms](../deploy/README.md#runtime-identity-on-serverless-platforms).
 
-The serving path stays **LLM-free and zero-egress**: the client is the brain, `execute_sql` runs SQL
-against your own database, and nothing leaves your environment.
+The serving path is **LLM-free and zero-egress by default**: the client is the brain, `execute_sql` runs SQL
+against your own database, and nothing leaves your environment. (The one exception is single sign-on, if you
+turn it on — the server calls Google/Microsoft to verify a login.)


### PR DESCRIPTION
Corrects the OIDC free/paid line from #96. **No code change** — `oidc.py` stays in agami-core untouched.

## Why
The agami-hosted **F6-enterprise-sso** feature spec is explicit about the boundary, and #96 got it wrong:

> "the Google/Microsoft login *mechanism* (the OIDC handshake) **ALREADY SHIPS free in agami-core** (`oidc.py`; ACE-006, shipped 2026-06-26) and is **REUSED** via the AuthProvider port… the **free single-tenant, single-provider path is byte-identical** to today."
> "**authentication is free, Enterprise SSO + org-scoped identity is paid.**"

So:
- **Free (agami-core):** basic **single-tenant, single-provider** Google/Microsoft OIDC login.
- **Paid (agami-hosted):** **Enterprise SSO** — per-org/multi-tenant identity + **SAML** + **SCIM**, behind the `is_enabled(org, feature)` entitlements gate (AH-004).

#96 filed *all* SSO under "paid" and stripped the free single-provider option — which contradicts F6 and would have undercut the hosted feature that reuses core's `oidc.py`. Also: removing `oidc.py` from core is **not** an option — the paid feature reuses it ("reused, not rebuilt").

## Changes (docs + deploy template only)
- **`agami.env.example`** — restore the optional (free) `AGAMI_ADMIN_PROVIDER` / `AGAMI_OIDC_*` single-provider login, labeled free vs. the hosted Enterprise tier.
- **`self-hosting.md`** — brief "Optional: single sign-on" note (free, single provider); caveat the zero-egress line (SSO, if enabled, calls the IdP).
- **`open-vs-hosted.md`** — basic single sign-on now under **Free**; the paid bullet is **Enterprise SSO** (per-org, SAML, SCIM) + RBAC/audit.
- **`privacy.md`** — fix the team-server section: SSO, if turned on, makes one outbound call to the IdP; it's not "hosted-only."

## Verification
- **No code touched** (`oidc.py` and the server unchanged) — kept as the shared/reused mechanism per F6.
- Free/paid SSO wording is now consistent across all four files; all links resolve.
- `uv run dev.py check` green (suite + ruff + gitleaks, incl. deploy tests).