### PR TITLE
feat(store): migration-overlay seam — layer extra migration roots on core

### DIFF
--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -38,6 +38,21 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+# Extra migration roots layered on top of migrations/core. A consumer registers its root here at
+# boot so the mcp_http lifespan's `run_migrations()` (no args) applies it — no call-site edit.
+_MIGRATION_OVERLAYS: list[Path] = []
+
+
+def register_migration_overlay(path: Path) -> None:
+    """Register an extra migration root, applied AFTER migrations/core in registration order.
+
+    Lets a consumer overlay its own tables without editing core's tree. Roots should have
+    distinct directory names — the name namespaces their tracking ids so an overlay file can't
+    collide with a core file on the schema_migrations primary key."""
+    if path not in _MIGRATION_OVERLAYS:
+        _MIGRATION_OVERLAYS.append(path)
+
+
 class Store:
     """A DB-API connection + its dialect, with portable execute/query helpers.
 
@@ -109,8 +124,16 @@ class Store:
 
     # --- migrations ---------------------------------------------------------
 
-    def run_migrations(self, migrations_dir: Path | None = None) -> list[str]:
-        """Apply un-applied `NNN_*.sql` in order; return the filenames newly applied. Idempotent.
+    def run_migrations(
+        self, migrations_dir: Path | None = None, overlay_dirs: list[Path] | None = None
+    ) -> list[str]:
+        """Apply un-applied `NNN_*.sql` in order; return the tracking ids newly applied. Idempotent.
+
+        Applies `migrations/core` first, then any overlay roots in order — a consumer layers
+        its own tables on top of core without editing core's tree. `overlay_dirs` overrides the
+        registered overlays (`register_migration_overlay`); pass `[]` to force core-only. Core ids stay
+        the bare filename (so already-migrated DBs are byte-identical); overlay ids are namespaced by
+        their root's name, so a core and an overlay file with the same name can't collide on the pk.
 
         On Postgres a **session advisory lock** brackets the read-applied + apply so that when several
         instances boot together (e.g. Cloud Run) exactly one migrates and the rest wait, then re-read the
@@ -118,6 +141,10 @@ class Store:
         collide on the `schema_migrations` primary key. SQLite is single-writer, so the lock is a no-op.
         A failing migration propagates (fail-closed: a half-migrated schema must not serve)."""
         migrations_dir = migrations_dir or MIGRATIONS_DIR
+        overlays = overlay_dirs if overlay_dirs is not None else list(_MIGRATION_OVERLAYS)
+        # (namespace, root): core is un-namespaced (bare ids, backwards-compatible); each overlay is
+        # namespaced by its directory name so its ids can't collide with core's on the pk.
+        roots = [("", migrations_dir)] + [(root.name, root) for root in overlays]
         # pg_advisory_lock (session-level, NOT released by commit) — must use the session variant so the
         # per-migration commits in the loop below don't drop it mid-apply.
         locked = self.dialect == "postgres"
@@ -130,16 +157,18 @@ class Store:
             self.commit()
             applied = {r["id"] for r in self.query("SELECT id FROM schema_migrations")}
             ran: list[str] = []
-            for path in sorted(migrations_dir.glob("*.sql")):
-                if path.name in applied:
-                    continue
-                self._run_script(path.read_text())
-                self.execute(
-                    "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
-                    (path.name, _now_iso()),
-                )
-                self.commit()
-                ran.append(path.name)
+            for namespace, root in roots:
+                for path in sorted(root.glob("*.sql")):
+                    mid = f"{namespace}:{path.name}" if namespace else path.name
+                    if mid in applied:
+                        continue
+                    self._run_script(path.read_text())
+                    self.execute(
+                        "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+                        (mid, _now_iso()),
+                    )
+                    self.commit()
+                    ran.append(mid)
         except Exception:
             if locked:
                 # A failed migration leaves the psycopg2 connection in an aborted-transaction state, so roll

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -50,6 +50,10 @@ def register_migration_overlay(path: Path) -> None:
     have a distinct, non-empty directory name — the name namespaces its tracking ids so an overlay
     file can't collide with a core file on the schema_migrations primary key; `run_migrations`
     raises on an empty or duplicated overlay name."""
+    # Normalize first so different spellings of one dir (relative/absolute/symlinked) dedupe here
+    # rather than slipping through as duplicate roots that the run_migrations namespace guard then
+    # rejects. resolve() doesn't require the path to exist (strict=False); run_migrations checks that.
+    path = path.resolve()
     if path not in _MIGRATION_OVERLAYS:
         _MIGRATION_OVERLAYS.append(path)
 
@@ -144,6 +148,12 @@ class Store:
         A failing migration propagates (fail-closed: a half-migrated schema must not serve)."""
         migrations_dir = migrations_dir or MIGRATIONS_DIR
         overlays = overlay_dirs if overlay_dirs is not None else list(_MIGRATION_OVERLAYS)
+        # A registered overlay that doesn't exist (or isn't a directory) would silently apply nothing —
+        # `glob` on a bad path yields an empty iterator — so a misconfigured overlay would be skipped
+        # with no signal. Fail fast so the misconfig is loud rather than an unmigrated schema.
+        not_dirs = [str(root) for root in overlays if not root.is_dir()]
+        if not_dirs:
+            raise ValueError(f"overlay migration root is not a directory: {not_dirs}")
         # Overlay tracking ids are namespaced by the root's directory name. Fail fast (before any lock
         # or DDL) if a name is empty — an empty name falls back to a BARE id that collides with core —
         # or duplicated across overlays — two roots would then map distinct files to the same id. Left

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -46,9 +46,10 @@ _MIGRATION_OVERLAYS: list[Path] = []
 def register_migration_overlay(path: Path) -> None:
     """Register an extra migration root, applied AFTER migrations/core in registration order.
 
-    Lets a consumer overlay its own tables without editing core's tree. Roots should have
-    distinct directory names — the name namespaces their tracking ids so an overlay file can't
-    collide with a core file on the schema_migrations primary key."""
+    Lets a consumer overlay its own tables without editing core's tree. Each overlay root must
+    have a distinct, non-empty directory name — the name namespaces its tracking ids so an overlay
+    file can't collide with a core file on the schema_migrations primary key; `run_migrations`
+    raises on an empty or duplicated overlay name."""
     if path not in _MIGRATION_OVERLAYS:
         _MIGRATION_OVERLAYS.append(path)
 
@@ -134,6 +135,7 @@ class Store:
         registered overlays (`register_migration_overlay`); pass `[]` to force core-only. Core ids stay
         the bare filename (so already-migrated DBs are byte-identical); overlay ids are namespaced by
         their root's name, so a core and an overlay file with the same name can't collide on the pk.
+        Overlay roots must have distinct, non-empty directory names — this raises `ValueError` otherwise.
 
         On Postgres a **session advisory lock** brackets the read-applied + apply so that when several
         instances boot together (e.g. Cloud Run) exactly one migrates and the rest wait, then re-read the
@@ -142,6 +144,20 @@ class Store:
         A failing migration propagates (fail-closed: a half-migrated schema must not serve)."""
         migrations_dir = migrations_dir or MIGRATIONS_DIR
         overlays = overlay_dirs if overlay_dirs is not None else list(_MIGRATION_OVERLAYS)
+        # Overlay tracking ids are namespaced by the root's directory name. Fail fast (before any lock
+        # or DDL) if a name is empty — an empty name falls back to a BARE id that collides with core —
+        # or duplicated across overlays — two roots would then map distinct files to the same id. Left
+        # unchecked, either surfaces mid-apply as a schema_migrations pk violation or a skipped migration.
+        namespaces = [root.name for root in overlays]
+        if "" in namespaces:
+            raise ValueError(
+                "overlay migration root has an empty directory name; give each overlay a distinct name"
+            )
+        dupes = sorted({n for n in namespaces if namespaces.count(n) > 1})
+        if dupes:
+            raise ValueError(
+                f"overlay migration roots share a directory name: {dupes}; names must be distinct"
+            )
         # (namespace, root): core is un-namespaced (bare ids, backwards-compatible); each overlay is
         # namespaced by its directory name so its ids can't collide with core's on the pk.
         roots = [("", migrations_dir)] + [(root.name, root) for root in overlays]

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -177,3 +177,89 @@ def test_startup_is_fail_closed_on_migration_error(env, monkeypatch):
     with pytest.raises(RuntimeError, match="migration blew up"):
         with TestClient(mcp_http.build_app()):
             pass
+
+
+# --- migration overlays (extra roots layered on top of migrations/core) ------
+
+
+def test_no_overlay_keeps_bare_core_ids(tmp_path):
+    # Default path (no overlay) is byte-identical to today: core ids are bare filenames.
+    core = tmp_path / "core"
+    _write_migration(core, "001_core.sql", "CREATE TABLE core_a (a INTEGER);")
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    ran = s.run_migrations(core, overlay_dirs=[])
+    s.close()
+    assert ran == ["001_core.sql"]  # no namespace prefix on core
+
+
+def test_overlay_applies_core_then_overlay_and_is_idempotent(tmp_path):
+    core = tmp_path / "core"
+    ov = tmp_path / "ov_a"
+    _write_migration(core, "001_core.sql", "CREATE TABLE core_b (a INTEGER);")
+    _write_migration(ov, "001_a.sql", "CREATE TABLE t_a (b INTEGER);")
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    first = s.run_migrations(core, overlay_dirs=[ov])
+    second = s.run_migrations(core, overlay_dirs=[ov])  # nothing pending now
+    ids = {r["id"] for r in s.query("SELECT id FROM schema_migrations")}
+    s.close()
+    assert first == ["001_core.sql", "ov_a:001_a.sql"]  # core first, then overlay
+    assert second == []  # idempotent
+    assert {"001_core.sql", "ov_a:001_a.sql"} <= ids
+
+
+def test_same_filename_in_core_and_overlay_does_not_collide(tmp_path):
+    # Core and an overlay both ship 001_init.sql — namespaced overlay ids keep them distinct on the pk.
+    core = tmp_path / "core"
+    ov = tmp_path / "ov_b"
+    _write_migration(core, "001_init.sql", "CREATE TABLE core_init (a INTEGER);")
+    _write_migration(ov, "001_init.sql", "CREATE TABLE ov_init (b INTEGER);")
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    ran = s.run_migrations(core, overlay_dirs=[ov])
+    tables = {r["name"] for r in s.query("SELECT name FROM sqlite_master WHERE type='table'")}
+    s.close()
+    assert ran == ["001_init.sql", "ov_b:001_init.sql"]  # both applied, distinct ids
+    assert {"core_init", "ov_init"} <= tables  # both DDLs actually ran (no skip-on-collision)
+
+
+def test_overlay_added_after_core_resumes(tmp_path):
+    # An overlay registered AFTER core was already migrated lands on the next run (resume-safe).
+    core = tmp_path / "core"
+    ov = tmp_path / "ov_c"
+    _write_migration(core, "001_core.sql", "CREATE TABLE core_c (a INTEGER);")
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    s.run_migrations(core, overlay_dirs=[])  # core only, first
+    _write_migration(ov, "001_c.sql", "CREATE TABLE t_c (b INTEGER);")
+    ran = s.run_migrations(core, overlay_dirs=[ov])  # core skipped, overlay is new
+    s.close()
+    assert ran == ["ov_c:001_c.sql"]
+
+
+def test_overlays_apply_in_the_given_order(tmp_path):
+    core = tmp_path / "core"
+    ov1 = tmp_path / "ov_1"
+    ov2 = tmp_path / "ov_2"
+    _write_migration(core, "001_core.sql", "CREATE TABLE core_d (a INTEGER);")
+    _write_migration(ov1, "001_one.sql", "CREATE TABLE one (a INTEGER);")
+    _write_migration(ov2, "001_two.sql", "CREATE TABLE two (a INTEGER);")
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    ran = s.run_migrations(core, overlay_dirs=[ov1, ov2])
+    s.close()
+    assert ran == ["001_core.sql", "ov_1:001_one.sql", "ov_2:001_two.sql"]  # core → ov1 → ov2
+
+
+def test_register_migration_overlay_is_used_by_no_arg_run(tmp_path, monkeypatch):
+    # The mcp_http lifespan calls run_migrations() with no args — a registered overlay must apply.
+    import store as store_mod
+
+    monkeypatch.setattr(store_mod, "_MIGRATION_OVERLAYS", [])  # isolate the module global
+    core = tmp_path / "core"
+    ov = tmp_path / "ov_reg"
+    _write_migration(core, "001_core.sql", "CREATE TABLE core_e (a INTEGER);")
+    _write_migration(ov, "001_reg.sql", "CREATE TABLE reg (a INTEGER);")
+    store_mod.register_migration_overlay(ov)
+    store_mod.register_migration_overlay(ov)  # dedup: registering twice is a no-op
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    ran = s.run_migrations(core)  # overlay_dirs defaults to the registered list
+    s.close()
+    assert store_mod._MIGRATION_OVERLAYS == [ov]  # deduped
+    assert ran == ["001_core.sql", "ov_reg:001_reg.sql"]  # the registered overlay applied

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -263,3 +263,33 @@ def test_register_migration_overlay_is_used_by_no_arg_run(tmp_path, monkeypatch)
     s.close()
     assert store_mod._MIGRATION_OVERLAYS == [ov]  # deduped
     assert ran == ["001_core.sql", "ov_reg:001_reg.sql"]  # the registered overlay applied
+
+
+def test_duplicate_overlay_namespace_raises(tmp_path):
+    # Two overlay roots with the SAME basename share a namespace → fail fast, no partial apply.
+    core = tmp_path / "core"
+    a_ov = tmp_path / "a" / "ov"
+    b_ov = tmp_path / "b" / "ov"
+    _write_migration(core, "001_core.sql", "CREATE TABLE core_f (a INTEGER);")
+    _write_migration(a_ov, "001_a.sql", "CREATE TABLE t_a (a INTEGER);")
+    _write_migration(b_ov, "001_b.sql", "CREATE TABLE t_b (a INTEGER);")
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    with pytest.raises(ValueError, match="share a directory name"):
+        s.run_migrations(core, overlay_dirs=[a_ov, b_ov])
+    tables = {r["name"] for r in s.query("SELECT name FROM sqlite_master WHERE type='table'")}
+    s.close()
+    assert "t_a" not in tables and "t_b" not in tables  # nothing applied
+    assert "schema_migrations" not in tables  # guard runs before the tracking table is created
+
+
+def test_empty_overlay_namespace_raises(tmp_path):
+    # An overlay root with an empty directory name (a filesystem root) would produce BARE ids that
+    # collide with core — reject it before touching the filesystem.
+    core = tmp_path / "core"
+    _write_migration(core, "001_core.sql", "CREATE TABLE core_g (a INTEGER);")
+    root_like = Path(tmp_path.anchor)  # .name == "" (filesystem root)
+    assert root_like.name == ""  # precondition
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    with pytest.raises(ValueError, match="empty directory name"):
+        s.run_migrations(core, overlay_dirs=[root_like])
+    s.close()

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -261,7 +261,7 @@ def test_register_migration_overlay_is_used_by_no_arg_run(tmp_path, monkeypatch)
     s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
     ran = s.run_migrations(core)  # overlay_dirs defaults to the registered list
     s.close()
-    assert store_mod._MIGRATION_OVERLAYS == [ov]  # deduped
+    assert store_mod._MIGRATION_OVERLAYS == [ov.resolve()]  # deduped + normalized on registration
     assert ran == ["001_core.sql", "ov_reg:001_reg.sql"]  # the registered overlay applied
 
 
@@ -293,3 +293,28 @@ def test_empty_overlay_namespace_raises(tmp_path):
     with pytest.raises(ValueError, match="empty directory name"):
         s.run_migrations(core, overlay_dirs=[root_like])
     s.close()
+
+
+def test_nonexistent_overlay_root_raises(tmp_path):
+    # A registered overlay that isn't a directory would silently apply nothing (glob yields empty);
+    # fail fast instead so the misconfiguration is loud.
+    core = tmp_path / "core"
+    _write_migration(core, "001_core.sql", "CREATE TABLE core_h (a INTEGER);")
+    s = Store.connect("sqlite://" + str(tmp_path / "db.sqlite"))
+    with pytest.raises(ValueError, match="not a directory"):
+        s.run_migrations(core, overlay_dirs=[tmp_path / "does_not_exist"])
+    s.close()
+
+
+def test_register_overlay_normalizes_path(tmp_path, monkeypatch):
+    # Different spellings of the same directory dedupe on registration (normalized via resolve()),
+    # so they don't slip through as duplicate roots the namespace guard would then reject.
+    import store as store_mod
+
+    monkeypatch.setattr(store_mod, "_MIGRATION_OVERLAYS", [])
+    ov = tmp_path / "a" / "ov"
+    _write_migration(ov, "001_x.sql", "CREATE TABLE t_x (a INTEGER);")
+    alt = tmp_path / "a" / "ov" / ".." / "ov"  # different spelling, same dir after resolve()
+    store_mod.register_migration_overlay(ov)
+    store_mod.register_migration_overlay(alt)
+    assert store_mod._MIGRATION_OVERLAYS == [ov.resolve()]  # collapsed to one


### PR DESCRIPTION
## Summary

Lets the migration runner apply **additional migration roots** on top of `migrations/core`, in deterministic order, so a downstream consumer can add its own tables **without editing core's migration tree**. Additive and **no-op by default**.

## Changes

- **`Store.run_migrations(migrations_dir=None, overlay_dirs=None)`** — applies core first, then each overlay root in order.
- **`register_migration_overlay(path)`** — registers an overlay root so the no-arg `run_migrations()` call in the `mcp_http` lifespan picks it up, with **no call-site edit**.
- Overlay tracking ids are **namespaced by the root's directory name**, so a core and an overlay file with the same filename can't collide on the `schema_migrations` primary key. Core ids stay bare filenames.

## Backwards compatibility

- With no overlays, a run applies **exactly** `migrations/core` — already-migrated DBs are **byte-identical** (core ids unchanged).
- Both existing call sites (`mcp_http` lifespan, `model_deploy`) are unchanged no-arg calls.
- The Postgres advisory-lock bracket, fail-closed rollback, and per-migration commit are preserved.

## Correctness

Idempotent (a second run is a no-op), **order-deterministic** (core → overlay-1 → overlay-2 …), collision-safe via namespacing, and resume-safe (overlays recorded in `schema_migrations` like core migrations).

## Tests

`tests/test_auto_migrate.py` adds: bare-core-ids on the no-overlay path, core-then-overlay + idempotency, deterministic ordering, same-filename collision avoidance, resume after a later-added overlay, and the registered-overlay no-arg path. `ruff` clean; the migration suite passes in isolation.
