### PR TITLE
Release v0.3.9: bump package + plugin to 0.3.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.8",
+    "version": "0.3.9",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,7 @@ First version tracked in this changelog. Earlier history lives in the git log.
   other clients — stdio, no auth, no network.
 - Fan-trap / chasm-trap pre-flight that refuses to silently double-count.
 
+[0.3.9]: https://github.com/AgamiAI/agami-core/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/AgamiAI/agami-core/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/AgamiAI/agami-core/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/AgamiAI/agami-core/compare/v0.3.5...v0.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.3.9] — 2026-07-10
+
+### Added
+
+- **Composition seams for downstream extension (no-op by default).**
+  `mcp_http.create_app(extra_tools={}, adapters=None)` lets a downstream consumer add MCP tools and
+  inject the `ports.py` adapters without forking or monkeypatching core, and `tools.register(...)`
+  adds a tool to the shared registry with a duplicate-name guard. An existing deploy is unaffected —
+  `create_app()` with no arguments behaves exactly as before, and `execute_sql`'s schema is unchanged.
+  (#100)
+- **Migration-overlay seam.** The store can layer additional migration roots on top of core's, so a
+  downstream package can ship its own migrations alongside agami-core's (empty/duplicate namespaces
+  and non-directory roots are rejected). No change for a default install. (#101)
+
 ## [0.3.8] — 2026-07-06
 
 ### Added

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.8"
+version = "0.3.9"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Version bump to **0.3.9** across all four locations (pyproject, marketplace.json ×2, plugin.json) + CHANGELOG.

### What ships in 0.3.9
- **#100** — `create_app(extra_tools, adapters)` + `tools.register(...)` composition seam for the HTTP server (additive, no-op by default).
- **#101** — migration-overlay seam on the store (additive, no-op by default).

### Why patch, not minor
Both are internal `packages/agami-core` composition seams for downstream consumers — no new skill, DB, or flag, and **no user-visible plugin behavior change**. Per CONTRIBUTING that's the patch bucket; pre-1.0 patch-for-additive is the norm.

### Release mechanism (after merge)
Publishing the GitHub Release `v0.3.9` triggers `release-pypi.yml` (PyPI trusted publish; verifies the tag matches pyproject `0.3.9`) and `release-image.yml` (ghcr image). Tag must equal `0.3.9`.