### PR TITLE
ACE-048: offload blocking work off the event loop + uvicorn worker factory

### DIFF
--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -32,6 +32,7 @@ model = [
 # install so the local executor/skill stay stdlib-lean — only a hosted deployment installs it.
 server = [
   "mcp>=1.2",
+  "anyio>=4",           # async_offload.run_blocking offloads blocking work off the loop (ACE-048)
   "uvicorn>=0.30",
   "psycopg2-binary>=2.9",
   "argon2-cffi>=23",

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -44,7 +44,7 @@ server = [
 package-dir = { "" = "src" }
 # Flat top-level modules (not under a parent package) — listed explicitly so the import
 # names stay flat regardless of disk layout.
-py-modules = ["agami_paths", "execute_sql", "sql_guard", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "model_deploy", "deploy_preflight", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
+py-modules = ["agami_paths", "async_offload", "execute_sql", "sql_guard", "mcp_harness", "mcp_http", "tools", "ports", "contracts", "oss_adapters", "store", "model_store", "model_deploy", "deploy_preflight", "oauth_server", "oidc", "passwords", "user_store", "admin", "ui", "onboarding"]
 packages = ["semantic_model"]
 
 [tool.setuptools.package-data]

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -21,6 +21,7 @@ from urllib.parse import quote
 import jwt
 import ui
 import user_store
+from async_offload import run_blocking
 
 # Reuse the OAuth provider's shared HS256 secret accessor + store opener + the admin OIDC-start handler
 # so the admin surface signs with the same key, reads the same datastore, and runs the same hardened
@@ -235,7 +236,7 @@ def _call_card(c: dict[str, Any]) -> str:
         body = ""
     ds = ui.esc(c.get("datasource") or "—")
     lat = (str(c["execution_ms"]) + " ms") if c.get("execution_ms") is not None else ""
-    rows_bit = f' · {c["row_count"]} rows' if c.get("row_count") is not None else ""
+    rows_bit = f" · {c['row_count']} rows" if c.get("row_count") is not None else ""
     return (
         '<div style="border-top:1px solid var(--line);padding:9px 0 11px">'
         f"{head}{body}"
@@ -569,16 +570,12 @@ async def admin_login(request: Request) -> Response:
     # Email is the identity: normalize the typed address (trim + lowercase) so login is
     # case-insensitive and matches the normalized username the seed stored.
     typed = form.get("username", "").strip().lower()
-    store = _open_store()
-    try:
-        principal = (
-            user_store.authenticate(store, typed, form.get("password", ""))
-            if store is not None
-            else None
-        )
-    finally:
-        if store is not None:
-            store.close()
+    # The whole credential check (DB reads + the ~50-100 ms argon2 verify) runs off the event loop in a worker
+    # thread with its OWN Store, so an admin login never freezes concurrent requests and no loop-thread Store is
+    # shared across threads (ACE-048). No datastore configured → None → the generic "invalid" re-render below.
+    principal = await run_blocking(
+        user_store.authenticate_with_own_store, typed, form.get("password", "")
+    )
     if principal is None:
         # Same generic message for wrong password, unknown user, or disabled — no enumeration oracle.
         # Keep the social button on the re-render so a failed password attempt doesn't hide it.

--- a/packages/agami-core/src/async_offload.py
+++ b/packages/agami-core/src/async_offload.py
@@ -1,0 +1,24 @@
+"""Offload blocking work off the asyncio event loop (ACE-048).
+
+The hosted HTTP server runs on a single asyncio worker, so a synchronous argon2 verify (~50-100 ms), an
+OIDC token exchange (up to a 10 s timeout), or a per-tool-call audit INSERT run directly on the loop would
+freeze every other in-flight request. `run_blocking` hands such a call to a worker thread so the loop stays
+responsive. A leaf module (no agami imports) so any handler can use it without an import cycle.
+
+anyio ships with Starlette/uvicorn (the `[server]` extra). `to_thread.run_sync` is positional-only, so we
+wrap in `functools.partial` to carry keyword arguments (e.g. `exchange_code(p, code=..., redirect_uri=...)`).
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, TypeVar
+
+from anyio import to_thread
+
+_T = TypeVar("_T")
+
+
+async def run_blocking(fn: Callable[..., _T], /, *args: object, **kwargs: object) -> _T:
+    """Run a blocking sync callable in a worker thread, keeping the event loop free for other requests."""
+    return await to_thread.run_sync(functools.partial(fn, *args, **kwargs))

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import admin
 import onboarding
 import user_store
+from async_offload import run_blocking
 from oss_adapters import (
     FileActivitySink,
     PresenceAuthProvider,
@@ -304,8 +305,12 @@ def build_server(registry: dict | None = None):
             raised = True
             raise
         finally:
+            # The per-call audit write opens a fresh Store + INSERT + close; run it off the event loop so
+            # it doesn't add DB latency to every tool call on the loop (ACE-048). `_actor_ctx.get()` is read
+            # here (on the loop) and passed in. Still best-effort — a logging failure never breaks the tool.
             try:
-                record_tool_call(
+                await run_blocking(
+                    record_tool_call,
                     name=name,
                     arguments=arguments,
                     result_text=result_text,
@@ -445,7 +450,12 @@ def main() -> int:
     public_base_url()  # fail fast if unset
     host = os.environ.get("HOST", "127.0.0.1")
     port = int(os.environ.get("PORT", "8000"))
-    uvicorn.run(build_app(), host=host, port=port)
+    # Bind via the import-string factory (not a built instance) so `WORKERS=N` can fork N worker processes —
+    # uvicorn re-imports `build_app` in each worker (ACE-048). Multi-worker is safe: session state is stateless
+    # JWT + Postgres, boot migrations are guarded by a pg advisory lock (store.run_migrations), and the admin
+    # seed tolerates a concurrent-boot race (lifespan). WORKERS defaults to 1 (unchanged single-process behaviour).
+    workers = int(os.environ.get("WORKERS", "1"))
+    uvicorn.run("mcp_http:build_app", factory=True, host=host, port=port, workers=workers)
     return 0
 
 

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -26,12 +26,13 @@ from uuid import uuid4
 
 import jwt
 import ui
+from async_offload import run_blocking
 from ports import Principal
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from store import Store
 from user_store import (
-    authenticate,
+    authenticate_with_own_store,
     bind_oidc_subject,
     claim_pending_oidc,
     create_user,
@@ -323,7 +324,12 @@ async def authorize(request: Request) -> Response:
         if providers:
             return _login_form(form, providers=providers)
 
-        principal = authenticate(store, form.get("username", ""), form.get("password", ""))
+        # The whole credential check (DB reads + the ~50-100 ms argon2 verify) runs off the event loop so a
+        # login never freezes concurrent requests (ACE-048). It opens its OWN Store in the worker thread — the
+        # handler's loop-thread `store` (used above and below) is never shared across threads.
+        principal = await run_blocking(
+            authenticate_with_own_store, form.get("username", ""), form.get("password", "")
+        )
         if principal is None:
             return _login_form(form, error="Invalid username or password.", providers=providers)
 

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -632,7 +632,11 @@ async def oidc_start(request: Request) -> Response:
         },
         csrf,
     )
-    url = oidc.authorize_url(p, state=state, nonce=nonce, redirect_uri=_oidc_callback_uri())
+    # authorize_url resolves the IdP discovery doc (cached after the first call) — offload so a first-call
+    # network fetch doesn't freeze the loop (ACE-048).
+    url = await run_blocking(
+        oidc.authorize_url, p, state=state, nonce=nonce, redirect_uri=_oidc_callback_uri()
+    )
     resp = RedirectResponse(url, status_code=302)
     resp.set_cookie(
         _CSRF_COOKIE,
@@ -658,7 +662,11 @@ async def admin_oidc_start(request: Request) -> Response:
     nonce = secrets.token_urlsafe(16)
     csrf = secrets.token_urlsafe(16)
     state = _mint_oidc_state({"purpose": "admin_login", "provider": p.key, "nonce": nonce}, csrf)
-    url = oidc.authorize_url(p, state=state, nonce=nonce, redirect_uri=_oidc_callback_uri())
+    # authorize_url resolves the IdP discovery doc (cached after the first call) — offload so a first-call
+    # network fetch doesn't freeze the loop (ACE-048).
+    url = await run_blocking(
+        oidc.authorize_url, p, state=state, nonce=nonce, redirect_uri=_oidc_callback_uri()
+    )
     resp = RedirectResponse(url, status_code=302)
     resp.set_cookie(
         _CSRF_COOKIE,
@@ -689,8 +697,14 @@ async def oidc_callback(request: Request) -> Response:
     if not q.get("code"):
         return _oauth_error("invalid_request", "missing code")
     try:
-        id_token = oidc.exchange_code(p, code=q.get("code", ""), redirect_uri=_oidc_callback_uri())
-        identity = oidc.verify_id_token(p, id_token, nonce=claims.get("nonce", ""))
+        # The IdP token exchange (a network round-trip, up to a 10 s timeout) + the JWKS-backed ID-token
+        # verification run off the event loop so a slow/unreachable IdP never freezes other requests (ACE-048).
+        id_token = await run_blocking(
+            oidc.exchange_code, p, code=q.get("code", ""), redirect_uri=_oidc_callback_uri()
+        )
+        identity = await run_blocking(
+            oidc.verify_id_token, p, id_token, nonce=claims.get("nonce", "")
+        )
     except Exception:
         # Bad signature/aud/iss/sub/nonce/unverified-email/exchange error — all collapse to one verdict.
         return _oauth_error("access_denied", "OIDC verification failed", status=403)

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -189,6 +189,20 @@ def authenticate(store: Store, username: str, password: str) -> Principal | None
     return Principal(subject=username)
 
 
+def authenticate_with_own_store(username: str, password: str) -> Principal | None:
+    """`authenticate`, but opening (and closing) its OWN Store — so an async handler can run the whole
+    credential check (DB reads + the ~50-100 ms argon2 verify) in a worker thread via `run_blocking`
+    without sharing its event-loop Store across threads (SQLite forbids cross-thread connection use).
+    Returns None when no datastore is configured (the login handlers treat that as a failed login)."""
+    store = Store.from_env()
+    if store is None:
+        return None
+    try:
+        return authenticate(store, username, password)
+    finally:
+        store.close()
+
+
 def seed_admin_from_env(store: Store) -> str | None:
     """Seed the initial admin from the AGAMI_ADMIN_* env. Returns the seeded username (the email), or
     None if there's nothing to seed / the admin already exists.

--- a/tests/test_async_offload.py
+++ b/tests/test_async_offload.py
@@ -1,0 +1,61 @@
+"""ACE-048: run_blocking offloads a sync callable (with args AND kwargs) to a worker thread, and the
+uvicorn factory import string resolves so `WORKERS=N` can fork worker processes."""
+
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("anyio")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import anyio  # noqa: E402
+from async_offload import run_blocking  # noqa: E402
+
+
+def test_run_blocking_offloads_to_a_worker_thread_with_args_and_kwargs():
+    main_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+
+    def work(a, b, *, c):
+        seen["thread"] = threading.get_ident()
+        return (a, b, c)
+
+    async def _call():
+        # positional AND keyword args must both reach the callable (to_thread is positional-only, hence
+        # the functools.partial inside run_blocking).
+        return await run_blocking(work, 1, 2, c=3)
+
+    result = anyio.run(_call)
+    assert result == (1, 2, 3)
+    assert seen["thread"] != main_thread  # actually ran off the event-loop thread
+
+
+def test_run_blocking_propagates_the_callables_exception():
+    async def _call():
+        return await run_blocking(lambda: 1 // 0)
+
+    with pytest.raises(ZeroDivisionError):
+        anyio.run(_call)
+
+
+def test_uvicorn_factory_import_string_resolves(monkeypatch):
+    """`main()` binds uvicorn to the import string 'mcp_http:build_app' with factory=True — the callable
+    must resolve and produce a Starlette app so multi-worker forking works."""
+    pytest.importorskip("starlette")
+    pytest.importorskip("mcp")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://agami.example.test")
+
+    import importlib
+
+    from starlette.applications import Starlette
+
+    module_name, _, attr = "mcp_http:build_app".partition(":")
+    factory = getattr(importlib.import_module(module_name), attr)
+    assert callable(factory)
+    assert isinstance(factory(), Starlette)

--- a/tests/test_async_offload.py
+++ b/tests/test_async_offload.py
@@ -13,6 +13,11 @@ pytest.importorskip("anyio")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+# async_offload + mcp_http live in the packaged src tree, not the plugin scripts dir — add it so
+# this test imports them when run in isolation (matches the other server tests, e.g. test_admin).
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
 
 import anyio  # noqa: E402
 from async_offload import run_blocking  # noqa: E402


### PR DESCRIPTION
## Summary
Behaviour-preserving availability fix (audit **P3**, feature **F12**, **high/auth lane**). The single asyncio worker ran argon2 verify (~50–100 ms), OIDC token exchange (up to a 10 s timeout), and per-tool-call audit INSERTs **synchronously on the loop** → one login / callback / tool call froze all concurrent users. And `uvicorn.run(build_app(), …)` passed an app *instance*, so `--workers>1` was impossible. Now the blocking calls run **off-loop**, and uvicorn binds a **factory import-string** so `--workers=N` works.

## Changes
- New leaf `async_offload.run_blocking(fn, *args, **kwargs)` (`functools.partial` over `anyio.to_thread.run_sync`).
- **KDF:** login handlers (`oauth authorize`, `admin_login`) offload the credential check via a new `user_store.authenticate_with_own_store()` that opens its **own** Store in the worker thread — a loop-thread SQLite connection is thread-bound and can't cross threads. `authenticate` stays sync (20+ existing test callers unchanged).
- **OIDC:** `oidc_callback` offloads `exchange_code` + `verify_id_token`; `oidc_start`/`admin_oidc_start` offload `authorize_url`.
- **Audit:** `_call_tool`'s `finally` offloads `record_tool_call` (`actor` read on-loop, passed in). Still best-effort.
- **Factory:** `main()` → `uvicorn.run("mcp_http:build_app", factory=True, workers=WORKERS)` (`WORKERS` env, default 1). The boot-migration race is **already** handled by `store.run_migrations`' `pg_advisory_lock` (Cloud-Run multi-instance), and the admin seed tolerates the boot race — so no new lock was needed.

## Test plan
- `run_blocking` runs a sync fn with args **and** kwargs on a worker thread + propagates exceptions; the factory import-string `mcp_http:build_app` resolves to a Starlette app.
- **Behaviour-preserving proof:** all existing oauth/admin/OIDC/tool-call tests still pass (same auth outcomes + the timing-enumeration defense — the dummy-verify still runs, now off-thread).
- **Full gate green:** ruff + all tests + gitleaks + lib-drift (`uv run dev.py check`).

## Out of scope (per spec)
The query-subprocess event-loop block (known issue, parked ACE-028); a pooled/queued audit writer (the fresh-Store-per-call churn stays — follow-up); rate limiting (ACE-049, depends on this).

Spec: ACE-048