### PR TITLE
ACE-046: incremental curation validation + single-pass snapshot

### DIFF
--- a/packages/agami-core/src/semantic_model/curate.py
+++ b/packages/agami-core/src/semantic_model/curate.py
@@ -38,8 +38,9 @@ from .models import CrossSubjectAreaRelationship, Entity, Metric, Organization, 
 # Process-lived incremental-validation cache (ACE-046). Every curation write re-validates the whole
 # model; keyed by (area content + table registry) so an enrichment run — which edits one area at a
 # time — only re-runs the changed area's rules instead of the whole model on every edit. Safe to
-# share process-wide: entries are content-addressed, so a hit is always a byte-identical result.
-_VALIDATION_CACHE: dict = {}
+# share process-wide: entries are content-addressed, so a hit is always a byte-identical result;
+# `validate` self-bounds its size.
+_VALIDATION_CACHE: V.ValidationCache = {}
 
 # ---------------------------------------------------------------------------
 # Read views

--- a/packages/agami-core/src/semantic_model/curate.py
+++ b/packages/agami-core/src/semantic_model/curate.py
@@ -35,6 +35,12 @@ from .loader import _read_yaml as _load
 from .loader import load_organization
 from .models import CrossSubjectAreaRelationship, Entity, Metric, Organization, Relationship
 
+# Process-lived incremental-validation cache (ACE-046). Every curation write re-validates the whole
+# model; keyed by (area content + table registry) so an enrichment run — which edits one area at a
+# time — only re-runs the changed area's rules instead of the whole model on every edit. Safe to
+# share process-wide: entries are content-addressed, so a hit is always a byte-identical result.
+_VALIDATION_CACHE: dict = {}
+
 # ---------------------------------------------------------------------------
 # Read views
 # ---------------------------------------------------------------------------
@@ -434,7 +440,7 @@ def set_key_terminology(root: str | Path, terms: dict, *, merge: bool = True) ->
         odoc.pop("key_terminology", None)
     _dump(orgp, odoc)
     try:
-        vres = V.validate(load_organization(root, include_rejected=True))
+        vres = V.validate(load_organization(root, include_rejected=True), cache=_VALIDATION_CACHE)
         res.validated = vres.ok
         if not vres.ok:
             res.errors = vres.errors
@@ -472,7 +478,7 @@ def apply(root: str | Path, ops: list[dict], *, signer: Optional[str] = None,
     # validate the whole model after the batch
     try:
         org = load_organization(root, include_rejected=True)
-        vres = V.validate(org)
+        vres = V.validate(org, cache=_VALIDATION_CACHE)
         res.validated = vres.ok
         if not vres.ok:
             res.errors = vres.errors
@@ -774,7 +780,7 @@ def write_items(root: str | Path, area: str, kind: str, items: list[dict],
 
     # validate the whole model; revert the batch on any failure
     try:
-        vres = V.validate(load_organization(root, include_rejected=True))
+        vres = V.validate(load_organization(root, include_rejected=True), cache=_VALIDATION_CACHE)
         res.validated = vres.ok
         if not vres.ok:
             res.errors = vres.errors
@@ -842,7 +848,7 @@ def add_relationships(root: str | Path, *, intra: Optional[dict[str, list[dict]]
     if not res.applied:
         return res
     try:
-        vres = V.validate(load_organization(root, include_rejected=True))
+        vres = V.validate(load_organization(root, include_rejected=True), cache=_VALIDATION_CACHE)
         res.validated = vres.ok
         if not vres.ok:
             res.errors = vres.errors

--- a/packages/agami-core/src/semantic_model/snapshot.py
+++ b/packages/agami-core/src/semantic_model/snapshot.py
@@ -54,12 +54,14 @@ def _model_files(root: Path) -> list[Path]:
     return out
 
 
-def _hash_and_manifest(root: Path, files: list[Path]) -> tuple[str, dict[str, str]]:
-    """Read each model file ONCE and derive both outputs from the same bytes: the rolling
-    12-char model hash (path + bytes, in sorted order) and the per-file manifest shas. Folding
-    the manifest build into the hash pass is what drops a changed-model snapshot from two
-    whole-tree byte reads to one (ACE-046). Both outputs are byte-identical to computing them
-    separately."""
+def _hash_and_manifest(
+    root: Path, files: list[Path], *, want_manifest: bool = True
+) -> tuple[str, dict[str, str]]:
+    """Read each model file ONCE and derive the rolling 12-char model hash (path + bytes, in sorted
+    order) — and, when `want_manifest`, the per-file manifest shas from the same bytes. Folding the
+    manifest build into the hash pass is what drops a changed-model snapshot from two whole-tree byte
+    reads to one (ACE-046); the hash-only callers skip the extra per-file digest. Both outputs are
+    byte-identical to computing them separately."""
     h = hashlib.sha256()
     manifest: dict[str, str] = {}
     for p in files:
@@ -69,14 +71,15 @@ def _hash_and_manifest(root: Path, files: list[Path]) -> tuple[str, dict[str, st
         h.update(b"\0")
         h.update(data)
         h.update(b"\0")
-        manifest[rel] = hashlib.sha256(data).hexdigest()
+        if want_manifest:
+            manifest[rel] = hashlib.sha256(data).hexdigest()
     return h.hexdigest()[:12], manifest
 
 
 def compute_model_hash(root: str | os.PathLike) -> str:
     """12-char content hash over the model tree (path + bytes of each file)."""
     root = Path(root)
-    digest, _ = _hash_and_manifest(root, _model_files(root))
+    digest, _ = _hash_and_manifest(root, _model_files(root), want_manifest=False)
     return digest
 
 

--- a/packages/agami-core/src/semantic_model/snapshot.py
+++ b/packages/agami-core/src/semantic_model/snapshot.py
@@ -54,21 +54,30 @@ def _model_files(root: Path) -> list[Path]:
     return out
 
 
-def _file_sha(p: Path) -> str:
-    return hashlib.sha256(p.read_bytes()).hexdigest()
+def _hash_and_manifest(root: Path, files: list[Path]) -> tuple[str, dict[str, str]]:
+    """Read each model file ONCE and derive both outputs from the same bytes: the rolling
+    12-char model hash (path + bytes, in sorted order) and the per-file manifest shas. Folding
+    the manifest build into the hash pass is what drops a changed-model snapshot from two
+    whole-tree byte reads to one (ACE-046). Both outputs are byte-identical to computing them
+    separately."""
+    h = hashlib.sha256()
+    manifest: dict[str, str] = {}
+    for p in files:
+        rel = str(p.relative_to(root)).replace(os.sep, "/")
+        data = p.read_bytes()
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(data)
+        h.update(b"\0")
+        manifest[rel] = hashlib.sha256(data).hexdigest()
+    return h.hexdigest()[:12], manifest
 
 
 def compute_model_hash(root: str | os.PathLike) -> str:
     """12-char content hash over the model tree (path + bytes of each file)."""
     root = Path(root)
-    h = hashlib.sha256()
-    for p in _model_files(root):
-        rel = str(p.relative_to(root)).replace(os.sep, "/")
-        h.update(rel.encode("utf-8"))
-        h.update(b"\0")
-        h.update(p.read_bytes())
-        h.update(b"\0")
-    return h.hexdigest()[:12]
+    digest, _ = _hash_and_manifest(root, _model_files(root))
+    return digest
 
 
 def _snapshot_dirs_newest_first(snaps: Path) -> list[Path]:
@@ -99,7 +108,9 @@ def write_snapshot(root: str | os.PathLike) -> str | None:
         root = Path(root)
         if not (root / "org.yaml").exists():
             return None  # not a model root — nothing to snapshot
-        digest = compute_model_hash(root)
+        # One pass: the hash (to name the dir) and the manifest shas (written only on a new dir)
+        # come from a single read of each file, not two.
+        digest, manifest_files = _hash_and_manifest(root, _model_files(root))
         snaps = root / SNAPSHOT_DIR
         snaps.mkdir(exist_ok=True)
         d = snaps / digest
@@ -110,8 +121,7 @@ def write_snapshot(root: str | os.PathLike) -> str | None:
             manifest = {
                 "schema_version": 1,
                 "model_hash": digest,
-                "files": {str(p.relative_to(root)).replace(os.sep, "/"): _file_sha(p)
-                          for p in _model_files(root)},
+                "files": manifest_files,
             }
             (d / "manifest.json").write_text(
                 json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")

--- a/packages/agami-core/src/semantic_model/validator.py
+++ b/packages/agami-core/src/semantic_model/validator.py
@@ -124,6 +124,10 @@ def validate(org: Organization) -> ValidationResult:
     # doc's "defined once, TableRef'd from each subject area" pattern).
     org_tables = _org_tables(org)
     for sa in org.subject_areas:
+        # Build the area's {name: table} index once and share it across every check that needs it
+        # (entity mappings + each relationship's FK-type check), instead of rebuilding it per
+        # relationship — that per-rel rebuild was the O(R×T) cost this pass eliminates (ACE-046).
+        defined = _all_tables(sa)
         _check_subject_area_sizing(sa, res)
         _check_table_refs_resolve(sa, res, org_tables)
         _check_expose_column_groups(sa, res, org_tables)
@@ -131,9 +135,9 @@ def validate(org: Organization) -> ValidationResult:
         _check_default_filters_columns(sa, res)
         _check_value_transforms(sa, res)
         _check_choice_fields(sa, res)
-        _check_entity_mappings(sa, res)
+        _check_entity_mappings(sa, res, defined)
         for rel in sa.relationships:
-            _check_relationship(rel, sa, org, res, cross=False)
+            _check_relationship(rel, sa, org, res, cross=False, defined=defined)
 
     for rel in org.cross_subject_area_relationships:
         _check_cross_relationship(rel, org, res)
@@ -316,8 +320,9 @@ def _check_choice_fields(sa: SubjectArea, res: ValidationResult) -> None:
                     )
 
 
-def _check_entity_mappings(sa: SubjectArea, res: ValidationResult) -> None:
-    defined = _all_tables(sa)
+def _check_entity_mappings(
+    sa: SubjectArea, res: ValidationResult, defined: dict[str, Table]
+) -> None:
     for ent in sa.entities:
         for mp in ent.maps_to:
             table = defined.get(mp.table)
@@ -341,6 +346,7 @@ def _check_relationship(
     res: ValidationResult,
     *,
     cross: bool,
+    defined: dict[str, Table],
 ) -> None:
     # cardinality required (structural gate, check #17) — models enforces non-null,
     # re-assert the value domain here for a clear validator-level error too.
@@ -377,7 +383,7 @@ def _check_relationship(
         return  # user took explicit ownership; skip simple-form type check
 
     # FK type-compatibility on the simple form (Gap 3)
-    _check_fk_type_compat(rel, sa, res)
+    _check_fk_type_compat(rel, res, defined)
 
 
 def _check_cross_relationship(
@@ -398,8 +404,11 @@ def _check_cross_relationship(
             f"{rel.to_subject_area!r}",
         )
 
-    # trust-block parity + on: parse + cardinality (reuse intra checks)
-    _check_relationship(rel, sa_from or SubjectArea(name="<unknown>"), org, res, cross=True)
+    # trust-block parity + on: parse + cardinality (reuse intra checks). The FK-type check resolves
+    # against the FROM area's tables, exactly as before — the cross edge's to_table lives in another
+    # area, so it stays unresolved here (unchanged behaviour).
+    sa_for_rel = sa_from or SubjectArea(name="<unknown>")
+    _check_relationship(rel, sa_for_rel, org, res, cross=True, defined=_all_tables(sa_for_rel))
 
     # executable must match the endpoints' storage connections
     conn_from = _table_connection(sa_from, rel.from_table) if sa_from else None
@@ -583,8 +592,9 @@ def _check_metric_binding_columns(org: Organization, res: ValidationResult) -> N
 # ---------------------------------------------------------------------------
 
 
-def _check_fk_type_compat(rel: Relationship, sa: SubjectArea, res: ValidationResult) -> None:
-    defined = _all_tables(sa)
+def _check_fk_type_compat(
+    rel: Relationship, res: ValidationResult, defined: dict[str, Table]
+) -> None:
     from_t = defined.get(rel.from_table)
     to_t = defined.get(rel.to_table)
     if not (from_t and to_t and rel.from_column and rel.to_column):

--- a/packages/agami-core/src/semantic_model/validator.py
+++ b/packages/agami-core/src/semantic_model/validator.py
@@ -37,6 +37,7 @@ list[str] contract while adding structured findings for the review dashboard.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -113,9 +114,66 @@ class ValidationResult:
 # ---------------------------------------------------------------------------
 
 
-def validate(org: Organization) -> ValidationResult:
+# An incremental-validation cache (ACE-046): per-area findings keyed by everything a per-area rule
+# reads — the area's own content AND the org-wide table registry. An enrichment run passes one of
+# these across edits so only the edited area's rules re-run; a normal `validate(org)` (cache=None)
+# is unchanged. Because the key pins every input, a cache hit is byte-identical to recomputing.
+ValidationCache = dict
+
+
+def _sig(obj) -> str:
+    """Content hash of a model object (pydantic v2). Stable across loads of identical YAML."""
+    return hashlib.sha256(obj.model_dump_json().encode("utf-8")).hexdigest()
+
+
+def _org_tables_sig(org_tables: dict[str, Table]) -> str:
+    """Signature of the org-wide table registry — the ONLY cross-area input the per-area rules read
+    (`_check_table_refs_resolve` = table-name existence; `_check_expose_column_groups` = a referenced
+    table's column_groups). Folding it into every area's key means any table add/remove/rename
+    invalidates every cached area (a full revalidate), while a metric/entity/relationship edit —
+    which never touches tables — leaves it stable, so only the edited area re-runs."""
+    h = hashlib.sha256()
+    for name in sorted(org_tables):
+        h.update(name.encode("utf-8"))
+        h.update(b"\0")
+        h.update(org_tables[name].model_dump_json().encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def _validate_area(
+    sa: SubjectArea, org: Organization, org_tables: dict[str, Table]
+) -> list[Finding]:
+    """Run one area's per-area rule battery into its own result and return just its findings, so a
+    run cache can reuse them verbatim when the area (and the table registry) are unchanged."""
+    ares = ValidationResult()
+    # Build the area's {name: table} index once and share it across every check that needs it
+    # (entity mappings + each relationship's FK-type check), instead of rebuilding it per
+    # relationship — that per-rel rebuild was the O(R×T) cost this pass eliminates (ACE-046).
+    defined = _all_tables(sa)
+    _check_subject_area_sizing(sa, ares)
+    _check_table_refs_resolve(sa, ares, org_tables)
+    _check_expose_column_groups(sa, ares, org_tables)
+    _check_deep_table_column_groups(sa, ares)
+    _check_default_filters_columns(sa, ares)
+    _check_value_transforms(sa, ares)
+    _check_choice_fields(sa, ares)
+    _check_entity_mappings(sa, ares, defined)
+    for rel in sa.relationships:
+        _check_relationship(rel, sa, org, ares, cross=False, defined=defined)
+    return ares.findings
+
+
+def validate(org: Organization, *, cache: "ValidationCache | None" = None) -> ValidationResult:
     """Run every cross-cutting rule. Returns a ValidationResult (never raises on
-    a model-level problem — those surface as the model failing to parse upstream)."""
+    a model-level problem — those surface as the model failing to parse upstream).
+
+    When `cache` is supplied (an enrichment run reusing one dict across edits), each area's
+    per-area findings are memoized by (area name, area content, table-registry signature): only a
+    changed area re-runs its rules. The cross-area + org-level rules always run fresh — they are
+    cheap and can depend on any area. The result is identical to a full validate, because the key
+    pins every input a per-area rule reads. Default `cache=None` validates everything, so all other
+    callers are unchanged."""
     res = ValidationResult()
 
     _check_storage_connection_refs(org, res)
@@ -123,21 +181,21 @@ def validate(org: Organization) -> ValidationResult:
     # defined in another area (multi-membership without duplication — the design
     # doc's "defined once, TableRef'd from each subject area" pattern).
     org_tables = _org_tables(org)
+    reg_sig = _org_tables_sig(org_tables) if cache is not None else ""
     for sa in org.subject_areas:
-        # Build the area's {name: table} index once and share it across every check that needs it
-        # (entity mappings + each relationship's FK-type check), instead of rebuilding it per
-        # relationship — that per-rel rebuild was the O(R×T) cost this pass eliminates (ACE-046).
-        defined = _all_tables(sa)
-        _check_subject_area_sizing(sa, res)
-        _check_table_refs_resolve(sa, res, org_tables)
-        _check_expose_column_groups(sa, res, org_tables)
-        _check_deep_table_column_groups(sa, res)
-        _check_default_filters_columns(sa, res)
-        _check_value_transforms(sa, res)
-        _check_choice_fields(sa, res)
-        _check_entity_mappings(sa, res, defined)
-        for rel in sa.relationships:
-            _check_relationship(rel, sa, org, res, cross=False, defined=defined)
+        if cache is not None:
+            key = (sa.name, _sig(sa), reg_sig)
+            findings = cache.get(key)
+            if findings is None:
+                findings = _validate_area(sa, org, org_tables)
+                # Keep the cache bounded to ~one entry per area: drop this area's entries at prior
+                # content/registry signatures before storing the current one.
+                for stale in [k for k in cache if k[0] == sa.name and k != key]:
+                    del cache[stale]
+                cache[key] = findings
+        else:
+            findings = _validate_area(sa, org, org_tables)
+        res.findings.extend(findings)
 
     for rel in org.cross_subject_area_relationships:
         _check_cross_relationship(rel, org, res)

--- a/packages/agami-core/src/semantic_model/validator.py
+++ b/packages/agami-core/src/semantic_model/validator.py
@@ -118,7 +118,13 @@ class ValidationResult:
 # reads — the area's own content AND the org-wide table registry. An enrichment run passes one of
 # these across edits so only the edited area's rules re-run; a normal `validate(org)` (cache=None)
 # is unchanged. Because the key pins every input, a cache hit is byte-identical to recomputing.
-ValidationCache = dict
+# Key = (area name, area content sha, org-table-registry sha) → that area's findings.
+ValidationCache = dict[tuple[str, str, str], "list[Finding]"]
+
+# Hard ceiling so a long-lived process (e.g. the HTTP server) that validates many distinct models
+# through one shared cache can't grow it without bound. Content-addressed, so evicting an entry only
+# costs a cold recompute; we evict foreign-model areas first and never the current model's.
+_CACHE_MAX = 1024
 
 
 def _sig(obj) -> str:
@@ -139,6 +145,19 @@ def _org_tables_sig(org_tables: dict[str, Table]) -> str:
         h.update(org_tables[name].model_dump_json().encode("utf-8"))
         h.update(b"\0")
     return h.hexdigest()
+
+
+def _bound_cache(cache: ValidationCache, org: Organization) -> None:
+    """Cap total cache size for long-lived processes. Evict oldest entries for areas NOT in the
+    current model first (insertion order); never evict the current model's areas, so a single large
+    model doesn't thrash. Only triggers well past any real model's area count."""
+    if len(cache) <= _CACHE_MAX:
+        return
+    current = {sa.name for sa in org.subject_areas}
+    for k in [k for k in cache if k[0] not in current]:
+        if len(cache) <= _CACHE_MAX:
+            break
+        del cache[k]
 
 
 def _validate_area(
@@ -188,11 +207,12 @@ def validate(org: Organization, *, cache: "ValidationCache | None" = None) -> Va
             findings = cache.get(key)
             if findings is None:
                 findings = _validate_area(sa, org, org_tables)
-                # Keep the cache bounded to ~one entry per area: drop this area's entries at prior
-                # content/registry signatures before storing the current one.
+                # Drop this area's entries at prior content/registry signatures before storing the
+                # current one — keeps steady-state to ~one entry per area within a model.
                 for stale in [k for k in cache if k[0] == sa.name and k != key]:
                     del cache[stale]
                 cache[key] = findings
+                _bound_cache(cache, org)
         else:
             findings = _validate_area(sa, org, org_tables)
         res.findings.extend(findings)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,17 @@ def _reset_org_cache():
     yield
     tools._ORG_CACHE.clear()
     tools._current_org_ctx.set(None)
+
+
+@pytest.fixture(autouse=True)
+def _reset_validation_cache():
+    """The incremental-curation-validation cache (ACE-046) is module-global too; clear it around
+    each test so one test's cached per-area findings can't bleed into the next."""
+    try:
+        from semantic_model import curate
+    except Exception:
+        yield
+        return
+    curate._VALIDATION_CACHE.clear()
+    yield
+    curate._VALIDATION_CACHE.clear()

--- a/tests/test_ace046_incremental_curation.py
+++ b/tests/test_ace046_incremental_curation.py
@@ -248,3 +248,14 @@ def test_enrichment_validation_work_is_linear_not_quadratic(monkeypatch):
     # End-of-run parity: the incrementally-cached verdict equals a from-scratch full validate.
     final = _org(*areas)
     assert _findings_tuple(v.validate(final, cache=cache)) == _findings_tuple(v.validate(final))
+
+
+def test_cache_is_bounded_across_many_distinct_models(monkeypatch):
+    # A long-lived process validating many DISTINCT models through one shared cache must not grow
+    # without bound: foreign-model areas are evicted past the cap, so size stays bounded — while the
+    # current model's areas are always retained (correctness = a miss just recomputes).
+    monkeypatch.setattr(v, "_CACHE_MAX", 20)
+    cache: dict = {}
+    for i in range(200):  # 200 distinct single-area models → would be 200 entries unbounded
+        v.validate(_org(_area(f"model{i:03d}")), cache=cache)
+    assert len(cache) <= 20  # capped, not linear in the number of models seen

--- a/tests/test_ace046_incremental_curation.py
+++ b/tests/test_ace046_incremental_curation.py
@@ -23,7 +23,6 @@ from semantic_model import models as m  # noqa: E402
 from semantic_model import snapshot as S  # noqa: E402
 from semantic_model import validator as v  # noqa: E402
 
-
 # --------------------------------------------------------------------------- validator memoize
 
 
@@ -216,3 +215,36 @@ def test_table_change_forces_full_revalidate(monkeypatch):
     res2 = v.validate(org2, cache=cache)
     assert sorted(calls) == ["alpha", "beta", "gamma"]
     assert _findings_tuple(res2) == _findings_tuple(v.validate(org2))
+
+
+# --------------------------------------------------------------------------------- E2E (done bar)
+
+
+def test_enrichment_validation_work_is_linear_not_quadratic(monkeypatch):
+    # The done-bar decidably: simulate agami-connect enriching a 50-area model one area at a time,
+    # re-validating with a shared cache after each edit. Total per-area validations must grow
+    # LINEARLY with the number of edits (one changed area re-runs per edit), not quadratically
+    # (whole-model re-validate per edit). We count work, not wall-time, so it's not flaky.
+    N = 50
+    count = {"n": 0}
+    real = v._validate_area
+    monkeypatch.setattr(v, "_validate_area",
+                        lambda sa, org, ot: (count.__setitem__("n", count["n"] + 1),
+                                             real(sa, org, ot))[1])
+
+    areas = [_area(f"area{i:03d}") for i in range(N)]
+    cache: dict = {}
+
+    v.validate(_org(*areas), cache=cache)  # initial cold pass
+    assert count["n"] == N  # every area validated once
+
+    count["n"] = 0
+    for i in range(N):
+        areas[i] = _area(f"area{i:03d}", extra_rels=1)  # "enrich" area i (content only, no tables)
+        v.validate(_org(*areas), cache=cache)
+    assert count["n"] == N  # exactly one area re-validated per edit — LINEAR, not N*N
+    assert count["n"] < N * N  # emphatically not quadratic
+
+    # End-of-run parity: the incrementally-cached verdict equals a from-scratch full validate.
+    final = _org(*areas)
+    assert _findings_tuple(v.validate(final, cache=cache)) == _findings_tuple(v.validate(final))

--- a/tests/test_ace046_incremental_curation.py
+++ b/tests/test_ace046_incremental_curation.py
@@ -1,0 +1,141 @@
+"""ACE-046 — incremental curation validation + snapshot caching, all behaviour-preserving.
+
+Slice 1 here: `_all_tables(sa)` is built once per area (not once per relationship), and a snapshot
+write reads each model file once (not twice), with a byte-identical hash + manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import models as m  # noqa: E402
+from semantic_model import snapshot as S  # noqa: E402
+from semantic_model import validator as v  # noqa: E402
+
+
+# --------------------------------------------------------------------------- validator memoize
+
+
+def _col(name, type="integer"):
+    return m.Column(name=name, type=type)
+
+
+def _area_with_n_rels(name: str, n: int) -> m.SubjectArea:
+    """One area, two tables, and `n` identical compatible relationships between them — so the
+    per-relationship FK-type check runs n times but must consult a single shared table index."""
+    a = m.Table(name="a", schema="s", storage_connection="c", grain=["x"], description="d",
+                columns=[_col("x")])
+    b = m.Table(name="b", schema="s", storage_connection="c", grain=["y"], description="d",
+                columns=[_col("y")])
+    rels = [m.Relationship(from_table="a", to_table="b", from_column="x", to_column="y",
+                           relationship="many_to_one", confidence="inferred") for _ in range(n)]
+    refs = [m.TableRef(storage_connection="c", schema="s", table="a"),
+            m.TableRef(storage_connection="c", schema="s", table="b")]
+    return m.SubjectArea(name=name, tables=refs, tables_defined=[a, b], relationships=rels)
+
+
+def _org(*areas) -> m.Organization:
+    return m.Organization(organization="O",
+                          storage_connections=[m.StorageConnection(name="c", storage_type="PostgreSQL")],
+                          subject_areas=list(areas))
+
+
+def test_all_tables_built_once_per_area_not_per_relationship(monkeypatch):
+    # 5 relationships in one area would rebuild the table index 5× before ACE-046; now it's built
+    # once per area and shared. Count calls to _all_tables and assert it tracks area count, not R.
+    calls = {"n": 0}
+    real = v._all_tables
+
+    def counting(sa):
+        calls["n"] += 1
+        return real(sa)
+
+    monkeypatch.setattr(v, "_all_tables", counting)
+
+    v.validate(_org(_area_with_n_rels("one", 5)))
+    assert calls["n"] == 1  # one area → one build, regardless of the 5 relationships
+
+    calls["n"] = 0
+    v.validate(_org(_area_with_n_rels("one", 5), _area_with_n_rels("two", 3)))
+    assert calls["n"] == 2  # two areas → exactly two builds
+
+
+def test_memoized_validation_verdict_is_unchanged():
+    # Compatible FK types on every relationship → no fk_type findings; incompatible → a finding.
+    ok = v.validate(_org(_area_with_n_rels("one", 4)))
+    assert "fk_type_mismatch" not in {f.code for f in ok.findings}
+
+    bad_area = _area_with_n_rels("one", 1)
+    bad_area.tables_defined[1].columns = [_col("y", "string")]  # to_column now a type mismatch
+    bad = v.validate(_org(bad_area))
+    assert "fk_type_mismatch" in {f.code for f in bad.findings}
+
+
+# --------------------------------------------------------------------------- single-pass snapshot
+
+
+def _mini_model(root: Path) -> None:
+    (root / "subject_areas" / "a").mkdir(parents=True, exist_ok=True)
+    (root / "org.yaml").write_text("organization: t\nversion: 1\n", encoding="utf-8")
+    (root / "subject_areas" / "a" / "subject_area.yaml").write_text("name: a\n", encoding="utf-8")
+    (root / "subject_areas" / "a" / "note.yaml").write_text("k: v\n", encoding="utf-8")
+
+
+def _expected_hash_and_manifest(root: Path) -> tuple[str, dict[str, str]]:
+    """Independently recompute the rolling model hash + per-file shas, to prove the folded
+    single-pass computation is byte-identical to computing them separately."""
+    h = hashlib.sha256()
+    manifest: dict[str, str] = {}
+    for p in S._model_files(root):
+        rel = str(p.relative_to(root)).replace(os.sep, "/")
+        data = p.read_bytes()
+        h.update(rel.encode("utf-8")); h.update(b"\0"); h.update(data); h.update(b"\0")
+        manifest[rel] = hashlib.sha256(data).hexdigest()
+    return h.hexdigest()[:12], manifest
+
+
+def test_snapshot_reads_each_file_once(tmp_path, monkeypatch):
+    r = tmp_path / "m"
+    _mini_model(r)
+    model_files = {str(p.resolve()) for p in S._model_files(r)}
+
+    reads: dict[str, int] = {}
+    real_read = Path.read_bytes
+
+    def counting_read(self):
+        key = str(self.resolve())
+        if key in model_files:
+            reads[key] = reads.get(key, 0) + 1
+        return real_read(self)
+
+    monkeypatch.setattr(Path, "read_bytes", counting_read)
+    S.write_snapshot(r)  # a NEW snapshot — the case that used to read the whole tree twice
+
+    assert reads and all(n == 1 for n in reads.values())  # each model file read exactly once
+    assert set(reads) == model_files  # and every model file was read
+
+
+def test_snapshot_hash_and_manifest_are_byte_identical(tmp_path):
+    import json
+
+    r = tmp_path / "m"
+    _mini_model(r)
+    exp_hash, exp_manifest = _expected_hash_and_manifest(r)
+
+    digest = S.write_snapshot(r)
+    assert digest == exp_hash  # dir name == independently-computed rolling hash
+
+    manifest = json.loads((r / ".snapshots" / digest / "manifest.json").read_text())
+    assert manifest["model_hash"] == exp_hash
+    assert manifest["files"] == exp_manifest  # per-file shas byte-identical

--- a/tests/test_ace046_incremental_curation.py
+++ b/tests/test_ace046_incremental_curation.py
@@ -139,3 +139,80 @@ def test_snapshot_hash_and_manifest_are_byte_identical(tmp_path):
     manifest = json.loads((r / ".snapshots" / digest / "manifest.json").read_text())
     assert manifest["model_hash"] == exp_hash
     assert manifest["files"] == exp_manifest  # per-file shas byte-identical
+
+
+# ------------------------------------------------------------------ incremental validation (cache)
+
+
+def _area(name: str, *, ftype: str = "integer", extra_rels: int = 0) -> m.SubjectArea:
+    """An area with two uniquely-named tables (so table names don't collide across areas) and a
+    baseline FK relationship; `ftype` drives the FK type-compat verdict, `extra_rels` grows the
+    area's content without touching its tables."""
+    ta, tb = f"{name}_a", f"{name}_b"
+    a = m.Table(name=ta, schema="s", storage_connection="c", grain=["x"], description="d",
+                columns=[m.Column(name="x", type=ftype)])
+    b = m.Table(name=tb, schema="s", storage_connection="c", grain=["y"], description="d",
+                columns=[m.Column(name="y", type="integer")])
+    rels = [m.Relationship(from_table=ta, to_table=tb, from_column="x", to_column="y",
+                           relationship="many_to_one", confidence="inferred")
+            for _ in range(1 + extra_rels)]
+    refs = [m.TableRef(storage_connection="c", schema="s", table=ta),
+            m.TableRef(storage_connection="c", schema="s", table=tb)]
+    return m.SubjectArea(name=name, tables=refs, tables_defined=[a, b], relationships=rels)
+
+
+def _findings_tuple(res):
+    return [(f.severity, f.code, f.message) for f in res.findings]
+
+
+def test_cached_validate_is_identical_to_full_validate():
+    # A 3-area model, one area carrying an FK type mismatch → a real finding. The cached path must
+    # produce the exact same findings (same order, severity, code, message) as a full validate.
+    org = _org(_area("alpha"), _area("beta", ftype="string"), _area("gamma"))
+    full = v.validate(org)
+    cached = v.validate(org, cache={})
+    assert _findings_tuple(cached) == _findings_tuple(full)
+    assert "fk_type_mismatch" in {f.code for f in cached.findings}
+
+
+def test_only_the_changed_area_revalidates(monkeypatch):
+    calls: list[str] = []
+    real = v._validate_area
+
+    def spy(sa, org, org_tables):
+        calls.append(sa.name)
+        return real(sa, org, org_tables)
+
+    monkeypatch.setattr(v, "_validate_area", spy)
+
+    cache: dict = {}
+    org1 = _org(_area("alpha"), _area("beta"), _area("gamma"))
+    v.validate(org1, cache=cache)
+    assert calls == ["alpha", "beta", "gamma"]  # cold cache → all three run
+
+    # Same alpha + gamma content, beta grows by one relationship (no table change).
+    calls.clear()
+    org2 = _org(_area("alpha"), _area("beta", extra_rels=1), _area("gamma"))
+    res2 = v.validate(org2, cache=cache)
+    assert calls == ["beta"]  # only the edited area re-runs; alpha + gamma are cache hits
+    assert _findings_tuple(res2) == _findings_tuple(v.validate(org2))  # still correct
+
+
+def test_table_change_forces_full_revalidate(monkeypatch):
+    calls: list[str] = []
+    real = v._validate_area
+    monkeypatch.setattr(v, "_validate_area",
+                        lambda sa, org, ot: (calls.append(sa.name), real(sa, org, ot))[1])
+
+    cache: dict = {}
+    org1 = _org(_area("alpha"), _area("beta"), _area("gamma"))
+    v.validate(org1, cache=cache)
+    calls.clear()
+
+    # Add a column to alpha's table → the org-wide table registry changes → every area's key misses,
+    # so all three re-run even though beta/gamma are untouched (conservative, verdict-preserving).
+    org2 = _org(_area("alpha"), _area("beta"), _area("gamma"))
+    org2.subject_areas[0].tables_defined[0].columns.append(m.Column(name="z", type="integer"))
+    res2 = v.validate(org2, cache=cache)
+    assert sorted(calls) == ["alpha", "beta", "gamma"]
+    assert _findings_tuple(res2) == _findings_tuple(v.validate(org2))

--- a/tests/test_ace046_incremental_curation.py
+++ b/tests/test_ace046_incremental_curation.py
@@ -16,9 +16,12 @@ import pytest
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlglot")
 
+yaml = pytest.importorskip("yaml")
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
+from semantic_model import curate  # noqa: E402
 from semantic_model import models as m  # noqa: E402
 from semantic_model import snapshot as S  # noqa: E402
 from semantic_model import validator as v  # noqa: E402
@@ -93,7 +96,9 @@ def _mini_model(root: Path) -> None:
 
 def _expected_hash_and_manifest(root: Path) -> tuple[str, dict[str, str]]:
     """Independently recompute the rolling model hash + per-file shas, to prove the folded
-    single-pass computation is byte-identical to computing them separately."""
+    single-pass computation is byte-identical to computing them separately. Note: this pins the
+    hash/manifest *math*, not file *selection* — it reuses `_model_files` (unchanged in this diff),
+    so a bug in file discovery would be invisible here (covered elsewhere by the snapshot tests)."""
     h = hashlib.sha256()
     manifest: dict[str, str] = {}
     for p in S._model_files(root):
@@ -259,3 +264,73 @@ def test_cache_is_bounded_across_many_distinct_models(monkeypatch):
     for i in range(200):  # 200 distinct single-area models → would be 200 entries unbounded
         v.validate(_org(_area(f"model{i:03d}")), cache=cache)
     assert len(cache) <= 20  # capped, not linear in the number of models seen
+
+
+def test_bound_never_evicts_the_model_being_validated(monkeypatch):
+    # The invariant _bound_cache promises: the model CURRENTLY being validated keeps all its area
+    # entries even when the cache is over cap — only foreign-model areas are evicted. Pre-fill with
+    # foreign entries to the cap, then validate a 4-area model and assert all four survive.
+    monkeypatch.setattr(v, "_CACHE_MAX", 5)
+    cache: dict = {}
+    for i in range(5):
+        v.validate(_org(_area(f"foreign{i}")), cache=cache)
+    current = _org(_area("k0"), _area("k1"), _area("k2"), _area("k3"))
+    v.validate(current, cache=cache)
+    cached_names = {k[0] for k in cache}
+    assert {"k0", "k1", "k2", "k3"} <= cached_names  # every current-model area retained despite cap
+
+
+# ------------------------------------------------------------- curate.* wiring (the integration)
+
+
+def _write_two_area_model(root: Path) -> None:
+    """A real on-disk two-area model (sales, crm), each one valid table — the shape curate writes to.
+    Kept minimal so it validates cleanly and an enrichment write to one area is a real edit."""
+    (root / "datasources" / "c").mkdir(parents=True)
+    (root / "org.yaml").write_text(yaml.safe_dump({
+        "organization": "shop", "version": 1,
+        "storage_connections": [{"name": "c", "ref": "datasources/c/storage.yaml"}],
+        "subject_areas": ["subject_areas/sales", "subject_areas/crm"],
+    }))
+    (root / "datasources" / "c" / "storage.yaml").write_text(
+        yaml.safe_dump({"name": "c", "storage_type": "PostgreSQL"}))
+    for area, table in (("sales", "orders"), ("crm", "customers")):
+        (root / "subject_areas" / area / "tables").mkdir(parents=True)
+        (root / "subject_areas" / area / "metrics").mkdir(parents=True)
+        (root / "subject_areas" / area / "subject_area.yaml").write_text(yaml.safe_dump({
+            "name": area,
+            "tables": [{"storage_connection": "c", "schema": "public", "table": table}],
+        }))
+        (root / "subject_areas" / area / "tables" / f"{table}.yaml").write_text(yaml.safe_dump({
+            "name": table, "schema": "public", "storage_connection": "c", "grain": ["id"],
+            "description": table,
+            "columns": [{"name": "id", "type": "integer", "primary_key": True}],
+        }))
+
+
+def _metric_item(name: str, table: str) -> dict:
+    return {"name": name, "calculation": f"count of {table}", "bindings": {"PostgreSQL": "COUNT(*)"},
+            "source_tables": [table], "confidence": "inferred", "review_state": "unreviewed"}
+
+
+def test_curate_write_shares_the_validation_cache_across_calls(tmp_path, monkeypatch):
+    # The delivered behaviour: curate's write paths pass the shared _VALIDATION_CACHE, so across two
+    # enrichment writes only the CHANGED area re-validates. This guards the actual wiring — stripping
+    # `cache=_VALIDATION_CACHE` from curate makes the second call re-validate 'sales' and fails here.
+    _write_two_area_model(tmp_path)
+    curate._VALIDATION_CACHE.clear()
+
+    seen: list[str] = []
+    real = v._validate_area
+    monkeypatch.setattr(v, "_validate_area",
+                        lambda sa, org, ot: (seen.append(sa.name), real(sa, org, ot))[1])
+
+    res1 = curate.write_items(tmp_path, "sales", "metric", [_metric_item("m1", "orders")])
+    assert res1.validated and not res1.skipped, res1.skipped
+    assert set(seen) == {"sales", "crm"}   # cold shared cache → both areas validated
+    assert curate._VALIDATION_CACHE        # the shared cache was actually used (wiring present)
+
+    seen.clear()
+    res2 = curate.write_items(tmp_path, "crm", "metric", [_metric_item("m2", "customers")])
+    assert res2.validated and not res2.skipped, res2.skipped
+    assert seen == ["crm"]  # only the edited area re-runs; 'sales' served from the shared cache


### PR DESCRIPTION
**Spec:** ACE-046 (contract F12-runtime-scalability) · **Req:** REQ-017, REQ-001 · **Lane:** standard (local model-authoring; no auth, no egress)

## Summary
Curation/enrichment re-checked the **whole** model and re-fingerprinted the **whole** file tree after **every** edit, so enrichment of a large (50+ area) model grew super-linearly. This makes that work incremental **without changing any user-visible behaviour** — same verdicts, same snapshots, same git commits, same version stamps. Only the authoring/file path is touched; the query path is untouched. Depends on the shipped ACE-045.

## Changes
- **`validator.py` — incremental validation.** `validate(org, *, cache=None)` memoizes each area's findings keyed by `(area name, area-content sha, org-table-registry sha)`. Only a changed area re-runs its rules; cross-area + org-level rules always run fresh. The key pins **every** input a per-area rule reads (its own content + the table registry), so a cache hit is **byte-identical** to a full validate; any table add/remove/rename invalidates every area. `cache=None` (every existing caller) is unchanged. Self-bounds its size for long-lived processes.
- **`validator.py` — memoize `_all_tables(sa)`** once per area (threaded through the entity-mapping + per-relationship FK checks): the O(R×T) per-relationship rebuild → O(R+T).
- **`snapshot.py` — single-pass write.** Fold the manifest build into the hash pass so a changed-model snapshot reads each file **once**, not twice. Hash + manifest byte-identical (also closes a small TOCTOU between the two old reads).
- **`curate.py`** — the four write paths (`apply`/`write_items`/`set_key_terminology`/`add_relationships`) share a process-lived, content-addressed validation cache.

## Behaviour-preserving
Every verdict, snapshot hash, manifest, and git commit is identical to before — the changes only skip **redundant** recomputation. Validation stays the binding gate (a failure still reverts exactly as today). No new tables, no surface change, no network egress (`test_privacy_no_network` green).

## Tests
New `tests/test_ace046_incremental_curation.py`: `_all_tables` built once per area; snapshot reads each file once + byte-identical hash/manifest; cached validate == full validate; only the changed area re-runs; a table change forces full revalidate; cache bounded across many models; and an E2E asserting validation **work is linear, not N×N** across a 50-area enrichment with end-of-run parity.

## Review
Adversarial review found **no correctness bug** (could not construct a stale-verdict counterexample); its two nits (cache size bound, typed aliases) are dispositioned in the final commit.

## Checklist
- [x] `uv run dev.py check` green (ruff + full suite (1430) + gitleaks)
- [x] Spec-linked (`Spec: ACE-046` on every commit)
- [x] Behaviour-preserving; no weakened/deleted tests
- [x] No new egress; no auth/PII touched