### PR TITLE
ACE-047: O(1) name→table index for get_datasource_schema

### DIFF
--- a/packages/agami-core/src/semantic_model/loader.py
+++ b/packages/agami-core/src/semantic_model/loader.py
@@ -282,10 +282,10 @@ def _load_cross_metrics(root: Path, org_doc: dict) -> list[Metric]:
 @dataclass(frozen=True)
 class TableIndex:
     """O(1) name→Table lookup that reproduces `_find_table` EXACTLY, so the schema hot path stops
-    linear-scanning the whole model per table (ACE-047, scalability-audit finding P12). Match rule: a defined table's
-    name equals the query OR its bare form; on a name clash the first table in scan order wins;
-    area scoping and the TableRef multi-area fallback are preserved. Built once from the cached
-    model and threaded through get_table_context; byte-identical to the scan it replaces."""
+    linear-scanning the whole model per table (ACE-047, scalability-audit finding P12). Match rule:
+    a defined table's name equals the query OR its bare form; on a name clash the first table in
+    scan order wins; area scoping and the TableRef multi-area fallback are preserved. Built once
+    from the cached model and threaded through get_table_context; byte-identical to the scan."""
 
     org_wide: dict[str, tuple[Table, int]]           # t.name -> (table, global scan rank)
     per_area: dict[str, dict[str, tuple[Table, int]]]  # area -> {t.name -> (table, rank)}

--- a/packages/agami-core/src/semantic_model/loader.py
+++ b/packages/agami-core/src/semantic_model/loader.py
@@ -34,6 +34,7 @@ Nothing here imports Pydantic-free; the whole module is v2-only.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -278,7 +279,66 @@ def _load_cross_metrics(root: Path, org_doc: dict) -> list[Metric]:
 # ---------------------------------------------------------------------------
 
 
-def _find_table(org: Organization, table_name: str, area: Optional[str] = None) -> Optional[Table]:
+@dataclass(frozen=True)
+class TableIndex:
+    """O(1) name→Table lookup that reproduces `_find_table` EXACTLY, so the schema hot path stops
+    linear-scanning the whole model per table (ACE-047, audit P12). Match rule: a defined table's
+    name equals the query OR its bare form; on a name clash the first table in scan order wins;
+    area scoping and the TableRef multi-area fallback are preserved. Built once from the cached
+    model and threaded through get_table_context; byte-identical to the scan it replaces."""
+
+    org_wide: dict[str, tuple[Table, int]]           # t.name -> (table, global scan rank)
+    per_area: dict[str, dict[str, tuple[Table, int]]]  # area -> {t.name -> (table, rank)}
+    area_refs: dict[str, set[str]]                   # area -> {ref.table} for the fallback test
+
+    @staticmethod
+    def _pick(m: dict[str, tuple[Table, int]], query: str, bare: str) -> Optional[Table]:
+        # Return the earlier-in-scan-order table among a name-match and a bare-match — exactly what
+        # `_find_table`'s in-order `t.name == query or t.name == bare` scan would have returned.
+        a = m.get(query)
+        b = m.get(bare) if bare != query else None
+        if a and b:
+            return a[0] if a[1] <= b[1] else b[0]
+        return a[0] if a else (b[0] if b else None)
+
+    def find(self, table_name: str, area: Optional[str] = None) -> Optional[Table]:
+        bare = bare_name(table_name)
+        if area:
+            hit = self._pick(self.per_area.get(area, {}), table_name, bare)
+            if hit is not None:
+                return hit
+            refs = self.area_refs.get(area, set())
+            if table_name in refs or bare in refs:
+                return self._pick(self.org_wide, table_name, bare)
+            return None
+        return self._pick(self.org_wide, table_name, bare)
+
+
+def build_table_index(org: Organization) -> TableIndex:
+    """Build the O(1) name→Table index once per schema call (ACE-047). Scan order (areas, then
+    tables) matches `_find_table`, and first-occurrence-wins via setdefault keeps a clash resolving
+    identically."""
+    org_wide: dict[str, tuple[Table, int]] = {}
+    per_area: dict[str, dict[str, tuple[Table, int]]] = {}
+    area_refs: dict[str, set[str]] = {}
+    rank = 0
+    for sa in org.subject_areas:
+        amap: dict[str, tuple[Table, int]] = {}
+        for t in sa.tables_defined:
+            org_wide.setdefault(t.name, (t, rank))
+            amap.setdefault(t.name, (t, rank))
+            rank += 1
+        per_area[sa.name] = amap
+        area_refs[sa.name] = {ref.table for ref in sa.tables}
+    return TableIndex(org_wide=org_wide, per_area=per_area, area_refs=area_refs)
+
+
+def _find_table(
+    org: Organization, table_name: str, area: Optional[str] = None,
+    *, index: Optional[TableIndex] = None,
+) -> Optional[Table]:
+    if index is not None:
+        return index.find(table_name, area)
     bare = bare_name(table_name)
     areas = [org.subject_area(area)] if area else org.subject_areas
     for sa in areas:
@@ -307,6 +367,7 @@ def collect_default_filters(
     *,
     area: Optional[str] = None,
     params: Optional[dict[str, str]] = None,
+    index: Optional[TableIndex] = None,
 ) -> list[str]:
     """Union of default_filters for the in-scope tables, with :param substitution.
 
@@ -318,7 +379,7 @@ def collect_default_filters(
     out: list[str] = []
     seen: set[str] = set()
     for name in table_names:
-        table = _find_table(org, name, area)
+        table = _find_table(org, name, area, index=index)
         if table is None:
             continue
         alias = _table_alias(table.name)
@@ -380,18 +441,22 @@ def get_table_context(
     columns: Optional[list[str]] = None,
     include: Optional[list[str]] = None,
     params: Optional[dict[str, str]] = None,
+    index: Optional[TableIndex] = None,
 ) -> dict[str, Any]:
     """Compound context fetch — the primary mechanism for keeping inference rounds
     low. Returns columns (full detail for the requested set, honoring
     expose_column_groups), plus any of: default_filters, relationships, caveats,
     value_transforms, metrics.
+
+    Pass `index` (from `build_table_index`) to resolve tables in O(1) instead of a per-table linear
+    scan — used by the schema hot path on wide models (ACE-047). Behaviour is identical either way.
     """
     include = include or list(DEFAULT_CONTEXT_INCLUDE)
     sa = org.subject_area(area) if area else None
     result: dict[str, Any] = {"tables": {}}
 
     for name in tables:
-        table = _find_table(org, name, area)
+        table = _find_table(org, name, area, index=index)
         if table is None:
             result["tables"][name] = {"error": "not found in scope"}
             continue
@@ -415,7 +480,7 @@ def get_table_context(
             tinfo["caveats"] = table.caveats
         if "default_filters" in include:
             tinfo["default_filters"] = collect_default_filters(
-                org, [table.name], area=area, params=params
+                org, [table.name], area=area, params=params, index=index
             )
         if "performance_hints" in include and table.performance_hints:
             tinfo["performance_hints"] = table.performance_hints.model_dump(exclude_none=True)

--- a/packages/agami-core/src/semantic_model/loader.py
+++ b/packages/agami-core/src/semantic_model/loader.py
@@ -282,7 +282,7 @@ def _load_cross_metrics(root: Path, org_doc: dict) -> list[Metric]:
 @dataclass(frozen=True)
 class TableIndex:
     """O(1) name→Table lookup that reproduces `_find_table` EXACTLY, so the schema hot path stops
-    linear-scanning the whole model per table (ACE-047, audit P12). Match rule: a defined table's
+    linear-scanning the whole model per table (ACE-047, scalability-audit finding P12). Match rule: a defined table's
     name equals the query OR its bare form; on a name clash the first table in scan order wins;
     area scoping and the TableRef multi-area fallback are preserved. Built once from the cached
     model and threaded through get_table_context; byte-identical to the scan it replaces."""

--- a/packages/agami-core/src/semantic_model/loader.py
+++ b/packages/agami-core/src/semantic_model/loader.py
@@ -328,8 +328,11 @@ def build_table_index(org: Organization) -> TableIndex:
             org_wide.setdefault(t.name, (t, rank))
             amap.setdefault(t.name, (t, rank))
             rank += 1
-        per_area[sa.name] = amap
-        area_refs[sa.name] = {ref.table for ref in sa.tables}
+        # Area names are NOT enforced unique; `_find_table` resolves an area via
+        # `org.subject_area(area)`, which returns the FIRST area of that name — so the per-area maps
+        # must be first-wins too (setdefault), or a duplicate name would resolve the wrong area.
+        per_area.setdefault(sa.name, amap)
+        area_refs.setdefault(sa.name, {ref.table for ref in sa.tables})
     return TableIndex(org_wide=org_wide, per_area=per_area, area_refs=area_refs)
 
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -709,23 +709,20 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
 
     from semantic_model import loader as L
 
-    # Build the O(1) name→table index once for this call so the full-mode table assembly resolves
-    # each table by lookup instead of re-scanning the whole model per table (ACE-047).
-    index = L.build_table_index(org)
-
     requested = args.get("dataset_names") or []
     requested_mode = (args.get("mode") or "auto").lower()
     metrics = _all_metrics(org)
 
     if requested:
-        # Explicit table scope — full detail for the named tables, no budget downgrade.
+        # Explicit table scope — full detail for the named tables, no budget downgrade. Build the
+        # O(1) name→table index so this resolves each table by lookup, not a per-table rescan (P12).
         wanted = [str(n).split(".")[-1] for n in requested]
         result: dict[str, Any] = {
             "datasource": profile,
             "organization": org.description or None,
             "mode": "full",
             "requested_mode": requested_mode,
-            "tables": _table_contexts(org, wanted, L, index=index),
+            "tables": _table_contexts(org, wanted, L, index=L.build_table_index(org)),
             "metric_index": {n: (m.description or n) for n, (m, _a) in metrics.items()},
             "large_tables": _large_tables(org),
         }
@@ -737,6 +734,10 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
         )
         if mode not in _SCHEMA_MODE_DOWNGRADE:
             mode = "summary"
+        # Only full mode assembles the per-table `tables` block (the sole index consumer), and the
+        # loop only ever DOWNGRADES from full — so build the index iff we start at full, else the
+        # index-mode wide-model path (the one this optimizes) would pay a wasted O(tables) build.
+        index = L.build_table_index(org) if mode == "full" else None
         truncated = False
         while True:
             result = _schema_payload(org, profile, mode, matched, metrics, L, index=index)

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -607,8 +607,9 @@ def _large_tables(org) -> dict[str, int]:
     return out
 
 
-def _table_contexts(org, table_names: list[str], L) -> dict[str, Any]:
-    """Full get_table_context for the named tables, grouped back into a {name: ctx} map."""
+def _table_contexts(org, table_names: list[str], L, index=None) -> dict[str, Any]:
+    """Full get_table_context for the named tables, grouped back into a {name: ctx} map. `index`
+    (from L.build_table_index) resolves tables in O(1) instead of a per-table linear scan (ACE-047)."""
     area_of = {t.name: sa.name for sa in org.subject_areas for t in sa.tables_defined}
     by_area: dict[str | None, list[str]] = {}
     for t in table_names:
@@ -620,13 +621,15 @@ def _table_contexts(org, table_names: list[str], L) -> dict[str, Any]:
             tbls,
             area=area,
             include=["default_filters", "relationships", "caveats", "value_transforms", "metrics"],
+            index=index,
         )
         contexts.update(ctx.get("tables", {}))
     return contexts
 
 
 def _schema_payload(
-    org, profile: str, mode: str, matched: list[str], metrics: dict[str, tuple[Any, str | None]], L
+    org, profile: str, mode: str, matched: list[str], metrics: dict[str, tuple[Any, str | None]], L,
+    index=None,
 ) -> dict[str, Any]:
     """Build the structured schema payload at the given verbosity. `metric_index` + `large_tables`
     are always present (the never-hide net); `metrics` carries FULL detail for the matched set, or
@@ -665,7 +668,7 @@ def _schema_payload(
         ]
     if mode == "full":
         result["tables"] = _table_contexts(
-            org, [t.name for sa in org.subject_areas for t in sa.tables_defined], L
+            org, [t.name for sa in org.subject_areas for t in sa.tables_defined], L, index=index
         )
     # metrics in full: the matched set (a query/metric_names limits them); else every metric in
     # full mode (back-compat); else none (rely on metric_index).
@@ -706,6 +709,10 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
 
     from semantic_model import loader as L
 
+    # Build the O(1) name→table index once for this call so the full-mode table assembly resolves
+    # each table by lookup instead of re-scanning the whole model per table (ACE-047).
+    index = L.build_table_index(org)
+
     requested = args.get("dataset_names") or []
     requested_mode = (args.get("mode") or "auto").lower()
     metrics = _all_metrics(org)
@@ -718,7 +725,7 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
             "organization": org.description or None,
             "mode": "full",
             "requested_mode": requested_mode,
-            "tables": _table_contexts(org, wanted, L),
+            "tables": _table_contexts(org, wanted, L, index=index),
             "metric_index": {n: (m.description or n) for n, (m, _a) in metrics.items()},
             "large_tables": _large_tables(org),
         }
@@ -732,7 +739,7 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
             mode = "summary"
         truncated = False
         while True:
-            result = _schema_payload(org, profile, mode, matched, metrics, L)
+            result = _schema_payload(org, profile, mode, matched, metrics, L, index=index)
             if len(json.dumps(result, default=str)) <= _SCHEMA_CHAR_BUDGET:
                 break
             nxt = _SCHEMA_MODE_DOWNGRADE[mode]

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -715,7 +715,8 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
 
     if requested:
         # Explicit table scope — full detail for the named tables, no budget downgrade. Build the
-        # O(1) name→table index so this resolves each table by lookup, not a per-table rescan (P12).
+        # O(1) name→table index so this resolves each table by lookup, not a per-table rescan
+        # (scalability-audit finding P12).
         wanted = [str(n).split(".")[-1] for n in requested]
         result: dict[str, Any] = {
             "datasource": profile,
@@ -735,8 +736,9 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
         if mode not in _SCHEMA_MODE_DOWNGRADE:
             mode = "summary"
         # Only full mode assembles the per-table `tables` block (the sole index consumer), and the
-        # loop only ever DOWNGRADES from full — so build the index iff we start at full, else the
-        # index-mode wide-model path (the one this optimizes) would pay a wasted O(tables) build.
+        # loop only ever DOWNGRADES from full — so build the index iff we start at full, else a
+        # wide model that starts in `mode="index"` (the case this optimizes) would pay a wasted
+        # O(tables) index build it never uses.
         index = L.build_table_index(org) if mode == "full" else None
         truncated = False
         while True:

--- a/tests/test_ace047_schema_index.py
+++ b/tests/test_ace047_schema_index.py
@@ -54,12 +54,34 @@ def test_index_find_matches_linear_find_for_every_case():
         ("orders", None), ("sales.orders", None), ("customers", None), ("missing", None),
         ("orders", "alpha"), ("orders", "beta"), ("orders", "gamma"),  # gamma = TableRef fallback
         ("sales.orders", "beta"), ("customers", "gamma"), ("customers", "alpha"),
-        ("orders", "nosucharea"), ("", None),
+        ("orders", "nosucharea"), ("", None), ("orders", ""),  # "" area is falsy → org-wide
     ]
     for name, area in cases:
         linear = L._find_table(org, name, area)                 # the old scan
         viaidx = L._find_table(org, name, area, index=idx)      # the O(1) path
         assert viaidx is linear, f"index diverged from linear for ({name!r}, {area!r})"
+
+
+def test_index_matches_linear_with_duplicate_area_names():
+    # Area names are NOT enforced unique. `_find_table` resolves an area via subject_area(), which
+    # returns the FIRST area of that name — so the index's per-area maps must be first-wins too.
+    a1 = m.SubjectArea(name="sales", tables=[_ref("only_first")], tables_defined=[_tbl("only_first")])
+    a2 = m.SubjectArea(name="sales", tables=[_ref("only_second")], tables_defined=[_tbl("only_second")])
+    org = m.Organization(organization="O",
+                         storage_connections=[m.StorageConnection(name="c", storage_type="PostgreSQL")],
+                         subject_areas=[a1, a2])
+    idx = L.build_table_index(org)
+    for name in ("only_first", "only_second", "missing"):
+        assert L._find_table(org, name, "sales", index=idx) is L._find_table(org, name, "sales")
+
+
+def test_collect_default_filters_index_matches_linear():
+    org = _org_with_clash_and_fallback()
+    idx = L.build_table_index(org)
+    for area in (None, "alpha", "gamma"):
+        base = L.collect_default_filters(org, ["orders", "customers"], area=area)
+        withidx = L.collect_default_filters(org, ["orders", "customers"], area=area, index=idx)
+        assert withidx == base
 
 
 def test_get_table_context_byte_identical_with_and_without_index():

--- a/tests/test_ace047_schema_index.py
+++ b/tests/test_ace047_schema_index.py
@@ -1,0 +1,129 @@
+"""ACE-047 — get_datasource_schema O(1) table lookups (Slice 1).
+
+The name→table index must reproduce `_find_table` EXACTLY (area scoping, name-or-bare match,
+first-in-scan-order on a clash, TableRef fallback), and the whole schema payload must stay
+byte-identical whether the index is used or the old linear scan is.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import loader as L  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+
+
+def _tbl(name: str, cols=("id",)) -> m.Table:
+    return m.Table(name=name, schema="public", storage_connection="c", grain=["id"],
+                   description=f"{name} desc", columns=[m.Column(name=c, type="integer") for c in cols])
+
+
+def _ref(table: str) -> m.TableRef:
+    return m.TableRef(storage_connection="c", schema="public", table=table)
+
+
+def _org_with_clash_and_fallback() -> m.Organization:
+    # alpha defines a table literally named "orders"; beta defines one named "sales.orders" (bare
+    # "orders") — a name clash resolved by scan order. gamma REFERENCES orders (defined in alpha)
+    # via a TableRef but doesn't define it — the multi-area fallback case.
+    alpha = m.SubjectArea(name="alpha", tables=[_ref("orders")], tables_defined=[_tbl("orders")])
+    beta = m.SubjectArea(name="beta", tables=[_ref("sales.orders")],
+                         tables_defined=[_tbl("sales.orders")])
+    gamma = m.SubjectArea(name="gamma", tables=[_ref("customers"), _ref("orders")],
+                          tables_defined=[_tbl("customers")])
+    return m.Organization(organization="O",
+                          storage_connections=[m.StorageConnection(name="c", storage_type="PostgreSQL")],
+                          subject_areas=[alpha, beta, gamma])
+
+
+def test_index_find_matches_linear_find_for_every_case():
+    org = _org_with_clash_and_fallback()
+    idx = L.build_table_index(org)
+    # (name, area) matrix: exact names, bare/full, area-scoped, org-wide, the clash, the TableRef
+    # fallback (customers-area referencing orders), and misses.
+    cases = [
+        ("orders", None), ("sales.orders", None), ("customers", None), ("missing", None),
+        ("orders", "alpha"), ("orders", "beta"), ("orders", "gamma"),  # gamma = TableRef fallback
+        ("sales.orders", "beta"), ("customers", "gamma"), ("customers", "alpha"),
+        ("orders", "nosucharea"), ("", None),
+    ]
+    for name, area in cases:
+        linear = L._find_table(org, name, area)                 # the old scan
+        viaidx = L._find_table(org, name, area, index=idx)      # the O(1) path
+        assert viaidx is linear, f"index diverged from linear for ({name!r}, {area!r})"
+
+
+def test_get_table_context_byte_identical_with_and_without_index():
+    org = _org_with_clash_and_fallback()
+    idx = L.build_table_index(org)
+    names = ["orders", "customers", "sales.orders"]
+    for area in (None, "alpha", "gamma"):
+        base = L.get_table_context(org, names, area=area)
+        withidx = L.get_table_context(org, names, area=area, index=idx)
+        assert json.dumps(withidx, default=str) == json.dumps(base, default=str)
+
+
+# ---------------------------------------------------------------- tool-level byte identity
+
+
+def _write_model(root: Path, n_areas: int, tables_per_area: int, *, wide: bool, big: bool) -> None:
+    import yaml
+
+    (root / "datasources" / "c").mkdir(parents=True, exist_ok=True)
+    (root / "datasources" / "c" / "storage.yaml").write_text(
+        yaml.safe_dump({"name": "c", "storage_type": "PostgreSQL"}))
+    area_paths = []
+    for i in range(n_areas):
+        a = f"area{i}"
+        (root / "subject_areas" / a / "tables").mkdir(parents=True)
+        refs = []
+        for j in range(tables_per_area):
+            tname = f"t{i}_{j}"
+            refs.append({"storage_connection": "c", "schema": "public", "table": tname})
+            cols = [{"name": "id", "type": "integer", "primary_key": True}]
+            for k in range(10 if wide else 1):
+                cols.append({"name": f"col_{k}", "type": "decimal",
+                             "description": ("d" * 300) if wide else "x"})
+            tdoc = {"name": tname, "schema": "public", "storage_connection": "c", "grain": ["id"],
+                    "description": f"table {tname}", "columns": cols}
+            if big:
+                tdoc["performance_hints"] = {"estimated_row_count": 2_000_000}
+            (root / "subject_areas" / a / "tables" / f"{tname}.yaml").write_text(yaml.safe_dump(tdoc))
+        (root / "subject_areas" / a / "subject_area.yaml").write_text(
+            yaml.safe_dump({"name": a, "description": f"area {a}", "tables": refs}))
+        area_paths.append(f"subject_areas/{a}")
+    (root / "org.yaml").write_text(yaml.safe_dump(
+        {"organization": "acme", "version": 1,
+         "storage_connections": [{"name": "c", "ref": "datasources/c/storage.yaml"}],
+         "subject_areas": area_paths}))
+
+
+@pytest.mark.parametrize("build,args", [
+    (dict(n_areas=3, tables_per_area=4, wide=True, big=True), {"mode": "full"}),      # full
+    (dict(n_areas=30, tables_per_area=2, wide=False, big=False), {"mode": "auto"}),   # summary
+    (dict(n_areas=60, tables_per_area=1, wide=False, big=False), {"mode": "auto"}),   # index
+    (dict(n_areas=3, tables_per_area=8, wide=True, big=False), {"mode": "full"}),     # budget-downgrade
+    (dict(n_areas=3, tables_per_area=4, wide=True, big=False), {"dataset_names": ["t0_0", "t1_1"]}),
+])
+def test_tool_output_byte_identical_with_and_without_index(monkeypatch, tmp_path, build, args):
+    import tools
+
+    art = tmp_path / "art"
+    _write_model(art / "acme", **build)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+
+    with_index = tools.tool_get_datasource_schema({"datasource": "acme", **args})
+    # Force the old linear path everywhere by disabling the index, and compare byte-for-byte.
+    monkeypatch.setattr(L, "build_table_index", lambda org: None)
+    without_index = tools.tool_get_datasource_schema({"datasource": "acme", **args})
+
+    assert with_index == without_index

--- a/tests/test_ace047_schema_index.py
+++ b/tests/test_ace047_schema_index.py
@@ -127,3 +127,39 @@ def test_tool_output_byte_identical_with_and_without_index(monkeypatch, tmp_path
     without_index = tools.tool_get_datasource_schema({"datasource": "acme", **args})
 
     assert with_index == without_index
+
+
+def test_e2e_wide_model_all_lookups_via_index_and_linear_in_table_count(monkeypatch, tmp_path):
+    # The done-bar: on a 300-table model, full-mode assembly resolves EVERY table through the O(1)
+    # index (the linear scan is never entered), and the number of lookups is linear in the table
+    # count — not the O(tables^2) rescan the index replaces. Counts work, not wall-time (non-flaky).
+    import tools
+
+    n_tables = 300
+    art = tmp_path / "art"
+    _write_model(art / "acme", n_areas=10, tables_per_area=30, wide=False, big=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+
+    scan_calls = {"n": 0}
+    real_find_table = L._find_table
+
+    def counting_find_table(org, name, area=None, *, index=None):
+        if index is None:
+            scan_calls["n"] += 1  # a fall-through to the old linear scan
+        return real_find_table(org, name, area, index=index)
+
+    find_calls = {"n": 0}
+    real_index_find = L.TableIndex.find
+
+    def counting_index_find(self, name, area=None):
+        find_calls["n"] += 1
+        return real_index_find(self, name, area)
+
+    monkeypatch.setattr(L, "_find_table", counting_find_table)
+    monkeypatch.setattr(L.TableIndex, "find", counting_index_find)
+
+    tools.tool_get_datasource_schema({"datasource": "acme", "mode": "full"})
+
+    assert scan_calls["n"] == 0                    # no lookup fell back to the linear scan
+    assert find_calls["n"] >= n_tables             # every table was resolved
+    assert find_calls["n"] <= n_tables * 4         # a constant #lookups per table — LINEAR, not n^2


### PR DESCRIPTION
**Spec:** ACE-047 (contract F12-runtime-scalability) · **Req:** REQ-017, REQ-001 · **Lane:** standard (query-serving schema assembly; read-only, no auth, no egress)

## Summary
`get_datasource_schema` runs on model discovery every query session. Assembling **full** mode looked up each table with `_find_table`, which **scans the whole model per table** → O(tables²) on a wide model. This adds an O(1) name→table index so each lookup is instant. **Byte-identical output** — the LLM-facing modes, the 60 KB budget, the downgrade behavior, and the drill-in API are all unchanged; only the internal assembly is faster. Depends on the shipped ACE-045 (reuses the cached model). Ports cleanly to agami-hosted (downstream of the same load seam; storage-agnostic).

## Changes
- **`loader.py`** — `build_table_index(org)` → a `TableIndex` that reproduces `_find_table` **exactly**: area scoping, name-or-bare match, first-in-scan-order on a clash, first-wins on duplicate area names (mirrors `subject_area()`), and the TableRef multi-area fallback. Threaded as an opt-in `index=` through `_find_table` / `collect_default_filters` / `get_table_context` (default `None` = today's scan, so every other caller is untouched).
- **`tools.py`** — `tool_get_datasource_schema` builds the index once and passes it down the full-mode paths (the `dataset_names` branch and the sizing loop). Built **only when full mode is actually assembled** (its sole consumer), so the index-mode wide-model path pays nothing.

## Scope note (see spec Decisions)
Grounding showed the spec's original "incremental size estimate + 3→1 rebuilds" rested on a misread — the expensive per-table `tables` build already runs once, and an approximate size estimate would break byte-identity. So this ships as the **O(1) index only** (the real win); the sizing loop keeps its exact measurement. The former "reuse shared pieces" slice was dropped (low value, byte-order risk).

## Behaviour-preserving
Verified the index matches the linear `_find_table` for every case (clash, area-scope, TableRef fallback, duplicate area names, misses, empty area), and the **whole tool payload is byte-for-byte identical** with the index vs with it forced off, across full / summary / index / budget-downgrade / dataset_names.

## Tests
New `tests/test_ace047_schema_index.py`: index-vs-linear parity matrix (incl. the duplicate-area regression, verified to fail pre-fix), `get_table_context` + `collect_default_filters` byte-identity, tool-level byte-identity across all five payload shapes, and an E2E on a 300-table model proving **no lookup falls through to the linear scan** and lookups are **linear in the table count, not O(tables²)** (counted, non-flaky).

## Review
Adversarial + test-quality panel. Found 1 must-fix (the duplicate-area divergence — now fixed + regression-tested) and 2 nits (conditional build, extra coverage — both done). No silent-failure findings.

## Checklist
- [x] `uv run dev.py check` green (ruff + full suite + gitleaks)
- [x] Spec-linked (`Spec: ACE-047` on every commit)
- [x] Behaviour-preserving; no weakened/deleted tests
- [x] No new egress; no auth/PII touched