### PR TITLE
ACE-050: storage hygiene — overwrite-in-place tokens, clear spent codes, keep all logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [Unreleased]
+
+### Changed
+
+- **OAuth refresh-token storage is now configurable — default `overwrite` (ACE-050).**
+  `AGAMI_REFRESH_TOKEN_MODE` selects `overwrite` (default: each refresh UPDATEs the session's single
+  token row in place — one row per session, no growing heap of dead tokens) or `rotate` (the prior
+  behaviour: insert-new + revoke-old, keeping OAuth 2.1 **stolen-token reuse detection**, plus a
+  cleanup that prunes only already-expired revoked rows). **Upgrade note:** the new default
+  `overwrite` trades away reuse detection — a replayed stolen refresh token simply fails to
+  authenticate instead of revoking the whole family. A deployment that wants family-revocation must
+  set `AGAMI_REFRESH_TOKEN_MODE=rotate`. Also: used/expired one-time authorization codes are now
+  cleared at authorize, and the query/activity logs (`query_executions` / `tool_calls`) are
+  explicitly **retained** — never deleted by any default path — with a new `idx_query_executions_ts`
+  index to keep newest-first reads fast as history grows.
+
 ## [0.3.9] — 2026-07-10
 
 ### Added

--- a/deploy/agami.env.example
+++ b/deploy/agami.env.example
@@ -53,3 +53,6 @@ AGAMI_ADMIN_PASSWORD=
 # to re-login when it expires. Leave these alone unless you specifically want to tune them.
 # AGAMI_ACCESS_TOKEN_TTL=3600        # access JWT lifetime (default 1 hour)
 # AGAMI_REFRESH_TOKEN_TTL=2592000    # refresh token idle lifetime (default 30 days)
+# AGAMI_REFRESH_TOKEN_MODE=overwrite # refresh-token storage: overwrite (default: one row/session, no
+#                                    # dead-token heap; DROPS stolen-token reuse detection) OR rotate
+#                                    # (keeps OAuth 2.1 reuse detection + prunes expired revoked rows)

--- a/migrations/core/011_query_executions_ts.sql
+++ b/migrations/core/011_query_executions_ts.sql
@@ -1,0 +1,6 @@
+-- ACE-050: index query_executions by timestamp. The query log is RETAINED (never pruned — it's the
+-- user's history and the paid tier's eval fuel), so it must stay fast to read newest-first as it
+-- grows. Mirrors idx_tool_calls_ts on the activity log. IF NOT EXISTS: this index is added to an
+-- already-shipped table, so guard against a deployment that created it out of band.
+
+CREATE INDEX IF NOT EXISTS idx_query_executions_ts ON query_executions (ts);

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -358,6 +358,17 @@ async def authorize(request: Request) -> Response:
         store.close()
 
 
+def _cleanup_spent_codes(store: Store) -> None:
+    """Remove used or expired one-time authorization codes (ACE-050). They're single-use, short-lived
+    tickets — once used or past `expires_at` they carry no information and only pile up. Valid, unused
+    codes are untouched. Run opportunistically on the authorize chokepoint (no background job);
+    staged with the caller's commit."""
+    store.execute(
+        "DELETE FROM oauth_state WHERE used = 1 OR expires_at < ?",
+        (_now().isoformat(),),
+    )
+
+
 def _issue_authorization_code(
     store: Store,
     *,
@@ -370,6 +381,7 @@ def _issue_authorization_code(
     """Mint a fresh authorization code for an authenticated user and 302 back to the client. Shared
     by the password path and the OIDC callback so both resume the same OAuth token exchange."""
     code = secrets.token_urlsafe(32)
+    _cleanup_spent_codes(store)  # clear spent/expired tickets while we're here (ACE-050)
     store.execute(
         "INSERT INTO oauth_state (code, client_id, redirect_uri, code_challenge, username, "
         "expires_at, used, created) VALUES (?, ?, ?, ?, ?, ?, 0, ?)",

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -71,6 +71,19 @@ def _refresh_ttl() -> timedelta:
     return _ttl_from_env("AGAMI_REFRESH_TOKEN_TTL", timedelta(days=30))
 
 
+def _refresh_token_mode() -> str:
+    """How a refresh renews its token, config-selected (ACE-050) — both modes ship here, so
+    agami-hosted picks its mode by flag, never a fork:
+      - 'overwrite' (default): UPDATE the presented token's row in place → one row per session,
+        no heap of dead tokens. Trades away stolen-token reuse detection (a replayed old token just
+        finds no row → invalid_grant) — the accepted self-host tradeoff.
+      - 'rotate': INSERT-new + revoke-old (keeps reuse detection), plus a cleanup of only *expired*
+        revoked rows so it stops piling up. agami-hosted selects this.
+    An unknown / blank value falls back to the 'overwrite' default."""
+    mode = os.environ.get("AGAMI_REFRESH_TOKEN_MODE", "").strip().lower()
+    return mode if mode in {"overwrite", "rotate"} else "overwrite"
+
+
 # Claude's fixed OAuth callback (the connector redirects here after authorize). The .com host is the
 # announced future move; allow both so the connection survives the switch.
 _CLAUDE_CALLBACKS = (
@@ -401,15 +414,20 @@ def _issue_refresh_token(
     return token
 
 
-def _token_response(
-    store: Store, *, username: str, client_id: str, family: str | None
-) -> JSONResponse:
-    """The shared token body: a fresh access JWT + a fresh/rotated refresh token. Commits the
-    refresh-token write together with whatever the caller already staged (code burn / rotate)."""
-    refresh_token = _issue_refresh_token(
-        store, client_id=client_id, username=username, family=family
+def _cleanup_expired_revoked(store: Store) -> None:
+    """Prune only EXPIRED revoked refresh rows ('rotate' mode, ACE-050). A revoked row's sole
+    remaining purpose is stolen-token reuse detection, which can only fire inside the token's
+    validity window — once it's past `expires_at` the row is pure dead weight, so removing it loses
+    no theft signal while stopping the revoked-row heap from growing forever. Staged with the
+    caller's transaction (committed by `_token_response`)."""
+    store.execute(
+        "DELETE FROM oauth_refresh_token WHERE revoked = 1 AND expires_at < ?",
+        (_now().isoformat(),),
     )
-    store.commit()
+
+
+def _token_body(username: str, refresh_token: str) -> JSONResponse:
+    """The OAuth token response body: a fresh access JWT + the given refresh token."""
     return JSONResponse(
         {
             "access_token": issue_jwt(username),
@@ -418,6 +436,19 @@ def _token_response(
             "refresh_token": refresh_token,
         }
     )
+
+
+def _token_response(
+    store: Store, *, username: str, client_id: str, family: str | None
+) -> JSONResponse:
+    """The shared token body for the INSERT path (initial issue + 'rotate' refresh): mint a NEW
+    refresh row, then commit it together with whatever the caller already staged (code burn /
+    rotate / expired-revoked cleanup)."""
+    refresh_token = _issue_refresh_token(
+        store, client_id=client_id, username=username, family=family
+    )
+    store.commit()
+    return _token_body(username, refresh_token)
 
 
 async def token(request: Request) -> Response:
@@ -476,9 +507,11 @@ def _grant_authorization_code(store: Store, form: dict[str, str]) -> Response:
 
 
 def _grant_refresh_token(store: Store, form: dict[str, str]) -> Response:
-    """Renew an access token from a refresh token (RFC 6749 §6), rotating the refresh token: the
-    presented token is revoked and a successor issued in the same family. Reuse of an already-revoked
-    token (a replay of a rotated/stolen token) revokes the whole family — OAuth 2.1 reuse detection."""
+    """Renew an access token from a refresh token (RFC 6749 §6), replacing the presented token with a
+    successor. How that successor is persisted is set by `AGAMI_REFRESH_TOKEN_MODE` (ACE-050):
+    'overwrite' (default) updates the row in place (one row per session); 'rotate' revokes-old +
+    issues-new and keeps OAuth 2.1 reuse detection (a replay of a revoked token burns the family).
+    Validation (lookup, revoked/expiry/client checks) is identical for both."""
     presented = form.get("refresh_token", "")
     if not presented:
         return _oauth_error("invalid_request", "refresh_token is required")
@@ -520,8 +553,28 @@ def _grant_refresh_token(store: Store, form: dict[str, str]) -> Response:
     if client_id and stored_client and client_id != stored_client:
         return _oauth_error("invalid_grant", "client mismatch")
 
-    # Rotate atomically: only the request that flips revoked 0→1 may renew (closes the double-rotate
-    # race); a loser here gets a plain invalid_grant, NOT family revocation (it's a race, not a replay).
+    if _refresh_token_mode() == "overwrite":
+        # Overwrite in place: the presented row BECOMES the successor (new hash + expiry), so a
+        # session keeps exactly one row and no dead-token heap accumulates (ACE-050). The atomic
+        # `revoked = 0` guard still closes the double-rotate race. Reuse detection is forgone — a
+        # replayed old token now simply finds no row (invalid_grant), not a family burn.
+        new_token = secrets.token_urlsafe(32)
+        rotated = store.execute(
+            "UPDATE oauth_refresh_token SET token_hash = ?, expires_at = ? "
+            "WHERE token_hash = ? AND revoked = 0",
+            (_hash_token(new_token), (_now() + _refresh_ttl()).isoformat(), row["token_hash"]),
+        )
+        if rotated.rowcount != 1:
+            store.commit()
+            return _oauth_error("invalid_grant", "refresh token is invalid")
+        store.commit()
+        return _token_body(row["username"], new_token)
+
+    # 'rotate' mode: revoke the presented token and issue a successor in the same family, keeping the
+    # revoked row for stolen-token reuse detection. Atomic: only the request that flips revoked 0→1
+    # may renew (closes the double-rotate race); a loser here gets a plain invalid_grant, NOT family
+    # revocation (it's a race, not a replay). Prune only already-expired revoked rows so the heap
+    # stops growing without losing any live theft signal.
     burned = store.execute(
         "UPDATE oauth_refresh_token SET revoked = 1 WHERE token_hash = ? AND revoked = 0",
         (row["token_hash"],),
@@ -529,6 +582,7 @@ def _grant_refresh_token(store: Store, form: dict[str, str]) -> Response:
     if burned.rowcount != 1:
         store.commit()
         return _oauth_error("invalid_grant", "refresh token is invalid")
+    _cleanup_expired_revoked(store)
     return _token_response(
         store, username=row["username"], client_id=row["client_id"] or "", family=row["family"]
     )

--- a/plugins/agami/skills/agami-deploy/bundle/agami.env.example
+++ b/plugins/agami/skills/agami-deploy/bundle/agami.env.example
@@ -45,3 +45,6 @@ AGAMI_ADMIN_PASSWORD=
 # to re-login when it expires. Leave these alone unless you specifically want to tune them.
 # AGAMI_ACCESS_TOKEN_TTL=3600        # access JWT lifetime (default 1 hour)
 # AGAMI_REFRESH_TOKEN_TTL=2592000    # refresh token idle lifetime (default 30 days)
+# AGAMI_REFRESH_TOKEN_MODE=overwrite # refresh-token storage: overwrite (default: one row/session, no
+#                                    # dead-token heap; DROPS stolen-token reuse detection) OR rotate
+#                                    # (keeps OAuth 2.1 reuse detection + prunes expired revoked rows)

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -595,6 +595,50 @@ def test_ace050_authorize_clears_used_and_expired_codes(env):
         s.close()
 
 
+def test_ace050_query_executions_ts_index_exists(env):
+    # The retained query log is never pruned, so it must stay fast to read newest-first — index ts
+    # (migration 011). The test DB is sqlite, so check its catalog.
+    s = Store.from_env()
+    try:
+        idx = s.query(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_query_executions_ts'"
+        )
+        assert idx, "idx_query_executions_ts should be created by migration 011"
+    finally:
+        s.close()
+
+
+def test_ace050_hygiene_never_deletes_query_or_activity_logs(env):
+    # The headline guarantee: the hygiene paths (refresh rotation, authorize code cleanup) must NEVER
+    # touch the user-visible query/activity history. Seed both logs, run the hygiene chokepoints, and
+    # assert every seeded row survives.
+    c = TestClient(mcp_http.build_app())
+    s = Store.from_env()
+    try:
+        s.execute(
+            "INSERT INTO query_executions (id, ts, datasource, question, sql, row_count, source) "
+            "VALUES ('q1', ?, 'acme', 'q', 'SELECT 1', 1, 'mcp_server')",
+            ("2020-01-01T00:00:00+00:00",),
+        )
+        s.execute(
+            "INSERT INTO tool_calls (id, ts, tool_name, success) VALUES ('t1', ?, 'execute_sql', 1)",
+            ("2020-01-01T00:00:00+00:00",),
+        )
+        s.commit()
+    finally:
+        s.close()
+
+    pair = _token_pair(c)  # authorize (runs code cleanup) + issue
+    _refresh(c, pair["refresh_token"])  # refresh (runs token hygiene)
+
+    s = Store.from_env()
+    try:
+        assert s.query("SELECT id FROM query_executions WHERE id = 'q1'"), "query log must be retained"
+        assert s.query("SELECT id FROM tool_calls WHERE id = 't1'"), "activity log must be retained"
+    finally:
+        s.close()
+
+
 def test_refresh_rejects_missing_unknown_and_wrong_client(env):
     c = TestClient(mcp_http.build_app())
     # missing / unknown token

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -475,7 +475,10 @@ def test_refresh_grant_rotates_and_renews(env):
     assert third["refresh_token"] and third["refresh_token"] != second["refresh_token"]
 
 
-def test_refresh_token_reuse_revokes_the_family(env):
+def test_refresh_token_reuse_revokes_the_family(env, monkeypatch):
+    # Stolen-token reuse detection is a 'rotate'-mode feature (it needs the revoked old row to
+    # replay against); the 'overwrite' default forgoes it by design. Pin rotate for this test.
+    monkeypatch.setenv("AGAMI_REFRESH_TOKEN_MODE", "rotate")
     c = TestClient(mcp_http.build_app())
     first = _token_pair(c)
     second = _refresh(c, first["refresh_token"])  # rotates → `first` is now revoked
@@ -491,6 +494,73 @@ def test_refresh_token_reuse_revokes_the_family(env):
         data={"grant_type": "refresh_token", "refresh_token": second["refresh_token"]},
     )
     assert dead.status_code == 400 and dead.json()["error"] == "invalid_grant"
+
+
+def test_ace050_overwrite_default_keeps_one_row_and_kills_old_tokens(env):
+    # Default mode is 'overwrite': each refresh UPDATEs the session's single row in place, so no heap
+    # of dead tokens accumulates and every superseded token stops authenticating.
+    c = TestClient(mcp_http.build_app())
+    first = _token_pair(c)
+    second = _refresh(c, first["refresh_token"])
+    third = _refresh(c, second["refresh_token"])
+    assert third["refresh_token"] not in (first["refresh_token"], second["refresh_token"])
+
+    s = Store.from_env()
+    try:
+        n = s.query("SELECT COUNT(*) AS n FROM oauth_refresh_token")[0]["n"]
+        assert n == 1  # one row for the session, updated in place — no accumulation
+    finally:
+        s.close()
+
+    for stale in (first["refresh_token"], second["refresh_token"]):
+        r = c.post(
+            "/oauth/token",
+            data={"grant_type": "refresh_token", "refresh_token": stale, "client_id": "cid"},
+        )
+        assert r.status_code == 400 and r.json()["error"] == "invalid_grant"
+
+
+def test_ace050_rotate_mode_prunes_only_expired_revoked_rows(env, monkeypatch):
+    # 'rotate' keeps revoked rows for reuse detection but must prune the ones past expiry (dead
+    # weight — the theft signal is moot once the token could no longer authenticate anyway).
+    monkeypatch.setenv("AGAMI_REFRESH_TOKEN_MODE", "rotate")
+    c = TestClient(mcp_http.build_app())
+    pair = _token_pair(c)
+
+    s = Store.from_env()
+    try:
+        # Seed two revoked rows directly: one already expired, one still within its window.
+        for th, exp in (("expired_revoked", "2000-01-01T00:00:00+00:00"),
+                        ("live_revoked", "2999-01-01T00:00:00+00:00")):
+            s.execute(
+                "INSERT INTO oauth_refresh_token (token_hash, family, client_id, username, "
+                "expires_at, revoked, created) VALUES (?, 'fam', 'cid', 'admin', ?, 1, ?)",
+                (th, exp, "2000-01-01T00:00:00+00:00"),
+            )
+        s.commit()
+    finally:
+        s.close()
+
+    _refresh(c, pair["refresh_token"])  # a rotate refresh triggers the expired-revoked cleanup
+
+    s = Store.from_env()
+    try:
+        hashes = {r["token_hash"] for r in s.query("SELECT token_hash FROM oauth_refresh_token")}
+        assert "expired_revoked" not in hashes  # pruned
+        assert "live_revoked" in hashes  # kept — still inside its validity window
+    finally:
+        s.close()
+
+
+def test_ace050_refresh_mode_flag_default_and_validation(monkeypatch):
+    import oauth_server
+
+    monkeypatch.delenv("AGAMI_REFRESH_TOKEN_MODE", raising=False)
+    assert oauth_server._refresh_token_mode() == "overwrite"  # default
+    monkeypatch.setenv("AGAMI_REFRESH_TOKEN_MODE", "ROTATE")
+    assert oauth_server._refresh_token_mode() == "rotate"  # case-insensitive
+    monkeypatch.setenv("AGAMI_REFRESH_TOKEN_MODE", "garbage")
+    assert oauth_server._refresh_token_mode() == "overwrite"  # invalid → default
 
 
 def test_refresh_rejects_missing_unknown_and_wrong_client(env):

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -563,6 +563,38 @@ def test_ace050_refresh_mode_flag_default_and_validation(monkeypatch):
     assert oauth_server._refresh_token_mode() == "overwrite"  # invalid → default
 
 
+def test_ace050_authorize_clears_used_and_expired_codes(env):
+    # One-time codes are single-use, short-lived tickets; the authorize chokepoint prunes used or
+    # expired ones (spent tickets), but never a valid, unused code.
+    c = TestClient(mcp_http.build_app())
+    s = Store.from_env()
+    try:
+        seeded = [
+            ("used_code", "2999-01-01T00:00:00+00:00", 1),  # used → prune
+            ("expired_code", "2000-01-01T00:00:00+00:00", 0),  # expired → prune
+            ("valid_code", "2999-01-01T00:00:00+00:00", 0),  # valid + unused → keep
+        ]
+        for code, exp, used in seeded:
+            s.execute(
+                "INSERT INTO oauth_state (code, client_id, redirect_uri, code_challenge, username, "
+                "expires_at, used, created) VALUES (?, 'cid', ?, 'ch', 'admin', ?, ?, ?)",
+                (code, REDIRECT, exp, used, "2000-01-01T00:00:00+00:00"),
+            )
+        s.commit()
+    finally:
+        s.close()
+
+    _authorize_code(c)  # a fresh authorize runs the spent-code cleanup
+
+    s = Store.from_env()
+    try:
+        codes = {r["code"] for r in s.query("SELECT code FROM oauth_state")}
+        assert "used_code" not in codes and "expired_code" not in codes  # spent tickets pruned
+        assert "valid_code" in codes  # valid, unused code preserved
+    finally:
+        s.close()
+
+
 def test_refresh_rejects_missing_unknown_and_wrong_client(env):
     c = TestClient(mcp_http.build_app())
     # missing / unknown token

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -530,8 +530,10 @@ def test_ace050_rotate_mode_prunes_only_expired_revoked_rows(env, monkeypatch):
     s = Store.from_env()
     try:
         # Seed two revoked rows directly: one already expired, one still within its window.
-        for th, exp in (("expired_revoked", "2000-01-01T00:00:00+00:00"),
-                        ("live_revoked", "2999-01-01T00:00:00+00:00")):
+        for th, exp in (
+            ("expired_revoked", "2000-01-01T00:00:00+00:00"),
+            ("live_revoked", "2999-01-01T00:00:00+00:00"),
+        ):
             s.execute(
                 "INSERT INTO oauth_refresh_token (token_hash, family, client_id, username, "
                 "expires_at, revoked, created) VALUES (?, 'fam', 'cid', 'admin', ?, 1, ?)",


### PR DESCRIPTION
**Spec:** ACE-050 (contract F12) · **Req:** REQ-017, REQ-006 · **Lane:** HIGH (auth / credential storage) · depends on shipped ACE-033

## Summary
Three tables looked like they "grow forever," but only one is real garbage — dead refresh tokens. The query/activity logs are the user's history + the paid tier's fuel, so they're **explicitly retained**. This is **not** a log-delete job: it stops hoarding dead auth plumbing and keeps the logs.

## Changes
- **Refresh tokens — config-selected policy `AGAMI_REFRESH_TOKEN_MODE` (both modes in core, no fork):**
  - **`overwrite` (default):** on refresh, UPDATE the presented token's row in place (new hash + expiry) — **one row per session**, no dead-token heap. Atomic `WHERE token_hash=old AND revoked=0` + `rowcount==1` keeps the single-winner race guard. **Trade-off:** forgoes stolen-token reuse detection (a replayed old token just fails to auth) — the accepted self-host posture.
  - **`rotate`:** the prior behaviour (insert-new + revoke-old, keeping OAuth 2.1 family-revocation reuse detection) **plus** `_cleanup_expired_revoked` to prune only revoked rows past expiry (no live theft signal lost). agami-hosted selects this by flag.
- **One-time codes:** `_cleanup_spent_codes` clears used/expired `oauth_state` rows at the authorize chokepoint (no cron); valid unused codes untouched.
- **Logs retained:** `query_executions` / `tool_calls` are never deleted by any default path (verified none exist). New migration `011_query_executions_ts.sql` adds `idx_query_executions_ts` so newest-first admin reads stay fast.

## ⚠ Upgrade note (security posture)
The **default** is now `overwrite`, which **turns off stolen-token reuse detection**. A deployment that wants OAuth 2.1 family-revocation must set `AGAMI_REFRESH_TOKEN_MODE=rotate`. Surfaced in both `agami.env.example` templates + a CHANGELOG `[Unreleased]` entry.

## Open-core
Both modes ship in agami-core's `oauth_server`; agami-hosted just sets the flag — zero rewrite, zero fork (same "config, never fork" principle as the executor seam). No egress, no background job (cleanup is inline on existing chokepoints).

## Tests
`test_ace050_*` in test_oauth_server.py: overwrite → exactly one row + old tokens die; rotate prunes only *expired* revoked rows (a live revoked row survives); used/expired codes cleared but valid ones kept; `idx_query_executions_ts` exists; and the **headline guarantee** — the hygiene paths never delete query/activity logs (seeded history survives). The reuse-detection test is pinned to `rotate` (it's a rotate-only feature).

## Review
Security-review (mandatory, high-lane) + adversarial + test-quality panels. **No vulnerability found** — atomicity sound on SQLite + Postgres, expiry carry-forward correct, client-binding preserved, cleanups correctly scoped, all SQL parameterized. Dispositioned: the default-flip docs gap (fixed above). **Known follow-up:** a forced-concurrency test for the `rowcount==1` race guard (needs a concurrency harness; the rotate twin was already untested) — flagged, not shipped as a flaky test.

## Checklist
- [x] `uv run dev.py check` green (ruff + full suite + gitleaks)
- [x] Spec-linked (`Spec: ACE-050` on every commit)
- [x] High-lane: security-reviewed; upgrade note documented
- [x] No new egress; logs retained (no user-visible data deleted by default)