### PR TITLE
ACE-051: hosted guard reads model from DB + fails closed on a missing model

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -765,7 +765,18 @@ def _model_safety(sql: str, profile: str, area: str | None):
     try:
         from semantic_model import runtime as RT
     except Exception:
-        return sql, None  # model package not available -> no-op
+        # The model package (pydantic) isn't importable, so the guards can't run at all. On the
+        # hosted served path that is the same "can't guarantee safety" condition as a missing model
+        # — fail closed. Locally it stays a no-op (a bare install legitimately has no model). (The
+        # sqlglot-unavailable / unparseable-SQL degrade-to-allow is a distinct fail-open owned by
+        # ACE-037, not closed here.)
+        if _hosted():
+            json.dump({"error": {"kind": "model_unavailable", "reason":
+                       "semantic-model package not importable; refusing to run unguarded on the "
+                       "hosted server"}}, sys.stderr)
+            sys.stderr.write("\n")
+            return sql, 1
+        return sql, None  # local: model package not available -> no-op
 
     org = _resolve_guard_model(profile)
     if org is None:

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -711,30 +711,73 @@ def _write_cursor_csv(cur: Any) -> None:
             writer.writerow(row)
 
 
+def _hosted() -> bool:
+    """The served (hosted) path is signalled by a configured database — the same signal
+    `tools._load_org` / `Store.from_env` use. On it, a missing model is a safety failure (fail
+    closed); locally (no DB) a not-yet-built model legitimately means 'no model yet'."""
+    return bool(os.environ.get("AGAMI_DB_URL") or os.environ.get("APP_DATABASE_URL"))
+
+
+def _resolve_guard_model(profile: str):
+    """Resolve the semantic model for the safety pass, mirroring `tools._load_org` (ACE-051): from
+    the DB when one is configured (hosted — the `/artifacts` disk mount may be absent), else the
+    on-disk YAML (local). Returns an `Organization` or None if neither is available.
+
+    The DB import is lazy AND env-guarded on purpose: the local executor runs from a stdlib-lean
+    mirror that does not ship `store`/`model_store`, so we only reach for them when a DB is set.
+    Any DB-load failure degrades to disk rather than crashing the executor."""
+    from semantic_model import loader as L
+
+    if _hosted():
+        try:
+            from model_store import load_organization as _load_db
+            from store import Store
+
+            store = Store.from_env()
+            if store is not None:
+                try:
+                    org = _load_db(store, profile)
+                finally:
+                    store.close()
+                if org is not None:
+                    return org
+        except Exception as e:
+            sys.stderr.write(f"[agami] hosted model load from DB failed, trying disk: {e}\n")
+
+    root = Path(os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")) / profile
+    if (root / "org.yaml").exists():
+        try:
+            return L.load_organization(root)
+        except Exception as e:
+            sys.stderr.write(f"[agami] could not load semantic model from disk: {e}\n")
+    return None
+
+
 def _model_safety(sql: str, profile: str, area: str | None):
     """Semantic-model safety pass before execution: fan-trap / chasm-trap pre-flight
-    + default_filters auto-application, reading the model at <artifacts>/<profile>/.
+    + default_filters auto-application, over a model resolved from the DB (hosted) or disk (local).
 
     Returns (sql_to_run, exit_code). exit_code is None to continue, or an int to
-    short-circuit (a fan/chasm-trap refusal the caller must consume). Inert (returns
-    the SQL unchanged) when there is no model, or the model package isn't importable.
+    short-circuit (a refusal the caller must consume). Inert (returns the SQL unchanged) when the
+    model package isn't importable, or — on the LOCAL path only — when there is no model yet. On the
+    HOSTED path a model that can't be resolved fails closed (refuses), never runs unguarded (ACE-051).
     """
     try:
-        from semantic_model import loader as L
         from semantic_model import runtime as RT
     except Exception:
         return sql, None  # model package not available -> no-op
-    artifacts = Path(
-        os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")
-    )
-    root = artifacts / profile
-    if not (root / "org.yaml").exists():
-        return sql, None  # no model for this profile -> no-op
-    try:
-        org = L.load_organization(root)
-    except Exception as e:
-        sys.stderr.write(f"[agami] could not load semantic model; skipping safety pass: {e}\n")
-        return sql, None
+
+    org = _resolve_guard_model(profile)
+    if org is None:
+        if _hosted():
+            # Fail closed: a served query with no resolvable model must be refused, never run with
+            # the fan/chasm/scope/PII guards silently off.
+            json.dump({"error": {"kind": "model_unavailable", "reason":
+                       "no semantic model could be resolved (checked DB and disk); refusing to run "
+                       "unguarded on the hosted server"}}, sys.stderr)
+            sys.stderr.write("\n")
+            return sql, 1
+        return sql, None  # local: no model yet -> no-op (unchanged)
 
     # Build the shared guard context ONCE — parse the SQL + build each model index a single
     # time — and thread it through the battery below, instead of every guard re-parsing and

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -728,6 +728,11 @@ def _resolve_guard_model(profile: str):
     Any DB-load failure degrades to disk rather than crashing the executor."""
     from semantic_model import loader as L
 
+    # Any load failure below degrades to the next source (DB → disk → None), silently: a freeform
+    # error line here would (a) leak DB connection details from the exception and (b) precede the
+    # JSON refusal `_model_safety` emits when both sources are absent on hosted, breaking the
+    # single-JSON-object contract callers parse. The observable signal is the fail-closed refusal
+    # itself, not a diagnostic line.
     if _hosted():
         try:
             from model_store import load_organization as _load_db
@@ -741,15 +746,15 @@ def _resolve_guard_model(profile: str):
                     store.close()
                 if org is not None:
                     return org
-        except Exception as e:
-            sys.stderr.write(f"[agami] hosted model load from DB failed, trying disk: {e}\n")
+        except Exception:
+            pass  # DB unreachable/misconfigured -> fall through to disk
 
     root = Path(os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")) / profile
     if (root / "org.yaml").exists():
         try:
             return L.load_organization(root)
-        except Exception as e:
-            sys.stderr.write(f"[agami] could not load semantic model from disk: {e}\n")
+        except Exception:
+            pass  # unparseable/absent on disk -> None (hosted then fails closed)
     return None
 
 

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -765,7 +765,18 @@ def _model_safety(sql: str, profile: str, area: str | None):
     try:
         from semantic_model import runtime as RT
     except Exception:
-        return sql, None  # model package not available -> no-op
+        # The model package (pydantic) isn't importable, so the guards can't run at all. On the
+        # hosted served path that is the same "can't guarantee safety" condition as a missing model
+        # — fail closed. Locally it stays a no-op (a bare install legitimately has no model). (The
+        # sqlglot-unavailable / unparseable-SQL degrade-to-allow is a distinct fail-open owned by
+        # ACE-037, not closed here.)
+        if _hosted():
+            json.dump({"error": {"kind": "model_unavailable", "reason":
+                       "semantic-model package not importable; refusing to run unguarded on the "
+                       "hosted server"}}, sys.stderr)
+            sys.stderr.write("\n")
+            return sql, 1
+        return sql, None  # local: model package not available -> no-op
 
     org = _resolve_guard_model(profile)
     if org is None:

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -711,30 +711,73 @@ def _write_cursor_csv(cur: Any) -> None:
             writer.writerow(row)
 
 
+def _hosted() -> bool:
+    """The served (hosted) path is signalled by a configured database — the same signal
+    `tools._load_org` / `Store.from_env` use. On it, a missing model is a safety failure (fail
+    closed); locally (no DB) a not-yet-built model legitimately means 'no model yet'."""
+    return bool(os.environ.get("AGAMI_DB_URL") or os.environ.get("APP_DATABASE_URL"))
+
+
+def _resolve_guard_model(profile: str):
+    """Resolve the semantic model for the safety pass, mirroring `tools._load_org` (ACE-051): from
+    the DB when one is configured (hosted — the `/artifacts` disk mount may be absent), else the
+    on-disk YAML (local). Returns an `Organization` or None if neither is available.
+
+    The DB import is lazy AND env-guarded on purpose: the local executor runs from a stdlib-lean
+    mirror that does not ship `store`/`model_store`, so we only reach for them when a DB is set.
+    Any DB-load failure degrades to disk rather than crashing the executor."""
+    from semantic_model import loader as L
+
+    if _hosted():
+        try:
+            from model_store import load_organization as _load_db
+            from store import Store
+
+            store = Store.from_env()
+            if store is not None:
+                try:
+                    org = _load_db(store, profile)
+                finally:
+                    store.close()
+                if org is not None:
+                    return org
+        except Exception as e:
+            sys.stderr.write(f"[agami] hosted model load from DB failed, trying disk: {e}\n")
+
+    root = Path(os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")) / profile
+    if (root / "org.yaml").exists():
+        try:
+            return L.load_organization(root)
+        except Exception as e:
+            sys.stderr.write(f"[agami] could not load semantic model from disk: {e}\n")
+    return None
+
+
 def _model_safety(sql: str, profile: str, area: str | None):
     """Semantic-model safety pass before execution: fan-trap / chasm-trap pre-flight
-    + default_filters auto-application, reading the model at <artifacts>/<profile>/.
+    + default_filters auto-application, over a model resolved from the DB (hosted) or disk (local).
 
     Returns (sql_to_run, exit_code). exit_code is None to continue, or an int to
-    short-circuit (a fan/chasm-trap refusal the caller must consume). Inert (returns
-    the SQL unchanged) when there is no model, or the model package isn't importable.
+    short-circuit (a refusal the caller must consume). Inert (returns the SQL unchanged) when the
+    model package isn't importable, or — on the LOCAL path only — when there is no model yet. On the
+    HOSTED path a model that can't be resolved fails closed (refuses), never runs unguarded (ACE-051).
     """
     try:
-        from semantic_model import loader as L
         from semantic_model import runtime as RT
     except Exception:
         return sql, None  # model package not available -> no-op
-    artifacts = Path(
-        os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")
-    )
-    root = artifacts / profile
-    if not (root / "org.yaml").exists():
-        return sql, None  # no model for this profile -> no-op
-    try:
-        org = L.load_organization(root)
-    except Exception as e:
-        sys.stderr.write(f"[agami] could not load semantic model; skipping safety pass: {e}\n")
-        return sql, None
+
+    org = _resolve_guard_model(profile)
+    if org is None:
+        if _hosted():
+            # Fail closed: a served query with no resolvable model must be refused, never run with
+            # the fan/chasm/scope/PII guards silently off.
+            json.dump({"error": {"kind": "model_unavailable", "reason":
+                       "no semantic model could be resolved (checked DB and disk); refusing to run "
+                       "unguarded on the hosted server"}}, sys.stderr)
+            sys.stderr.write("\n")
+            return sql, 1
+        return sql, None  # local: no model yet -> no-op (unchanged)
 
     # Build the shared guard context ONCE — parse the SQL + build each model index a single
     # time — and thread it through the battery below, instead of every guard re-parsing and

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -728,6 +728,11 @@ def _resolve_guard_model(profile: str):
     Any DB-load failure degrades to disk rather than crashing the executor."""
     from semantic_model import loader as L
 
+    # Any load failure below degrades to the next source (DB → disk → None), silently: a freeform
+    # error line here would (a) leak DB connection details from the exception and (b) precede the
+    # JSON refusal `_model_safety` emits when both sources are absent on hosted, breaking the
+    # single-JSON-object contract callers parse. The observable signal is the fail-closed refusal
+    # itself, not a diagnostic line.
     if _hosted():
         try:
             from model_store import load_organization as _load_db
@@ -741,15 +746,15 @@ def _resolve_guard_model(profile: str):
                     store.close()
                 if org is not None:
                     return org
-        except Exception as e:
-            sys.stderr.write(f"[agami] hosted model load from DB failed, trying disk: {e}\n")
+        except Exception:
+            pass  # DB unreachable/misconfigured -> fall through to disk
 
     root = Path(os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")) / profile
     if (root / "org.yaml").exists():
         try:
             return L.load_organization(root)
-        except Exception as e:
-            sys.stderr.write(f"[agami] could not load semantic model from disk: {e}\n")
+        except Exception:
+            pass  # unparseable/absent on disk -> None (hosted then fails closed)
     return None
 
 

--- a/tests/test_ace051_fail_closed.py
+++ b/tests/test_ace051_fail_closed.py
@@ -71,7 +71,9 @@ def test_hosted_fail_closed_refuses_when_no_model(tmp_path, monkeypatch, capsys)
     from store import Store
 
     url = "sqlite://" + str(tmp_path / "empty.db")
-    Store.connect(url).run_migrations()
+    s = Store.connect(url)
+    s.run_migrations()
+    s.close()
     monkeypatch.setenv("AGAMI_DB_URL", url)
     monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_artifacts"))
 
@@ -138,7 +140,9 @@ def test_hosted_falls_back_to_disk_when_db_has_no_model(tmp_path, monkeypatch, c
     from store import Store
 
     url = "sqlite://" + str(tmp_path / "empty.db")
-    Store.connect(url).run_migrations()  # migrated, no model
+    s = Store.connect(url)
+    s.run_migrations()  # migrated, no model
+    s.close()
     _write_disk(tmp_path / "art" / "acme")
     monkeypatch.setenv("AGAMI_DB_URL", url)
     monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "art"))
@@ -156,6 +160,20 @@ def test_hosted_db_load_error_falls_back_to_disk(tmp_path, monkeypatch):
 
     sql, code = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
     assert code is None  # disk model resolved + guards passed the declared query
+
+
+def test_refusal_stderr_is_a_single_clean_json_object(tmp_path, monkeypatch, capsys):
+    # A DB that ERRORS on load + no disk model, on hosted → fail closed. The load failure must NOT
+    # write freeform diagnostics (which would precede the JSON refusal → mixed/unparseable stderr,
+    # and could leak DB connection details). stderr must be exactly one JSON refusal object.
+    monkeypatch.setenv("AGAMI_DB_URL", "postgres://user:pw@127.0.0.1:1/nope")  # unreachable → raises
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_disk"))  # no disk model either
+
+    _, code = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
+    assert code == 1
+    err = capsys.readouterr().err.strip()
+    assert json.loads(err)["error"]["kind"] == "model_unavailable"  # parses whole → single object
+    assert "127.0.0.1" not in err and "pw" not in err  # no connection details leaked
 
 
 def test_hosted_fail_closed_when_model_package_unimportable(tmp_path, monkeypatch, capsys):

--- a/tests/test_ace051_fail_closed.py
+++ b/tests/test_ace051_fail_closed.py
@@ -122,5 +122,58 @@ def test_disk_db_verdict_parity(tmp_path, monkeypatch, capsys):
         capsys.readouterr()
         return code
 
-    for sql in ("SELECT id FROM sqlite_master", "SELECT id FROM orders"):
-        assert verdict(hosted=True, sql=sql) == verdict(hosted=False, sql=sql)
+    # Query BOTH declared tables + an undeclared table + a bad column, so a lossy DB round-trip that
+    # drops a table (customers) or mangles a column can't hide behind identical verdicts.
+    for sql in (
+        "SELECT id FROM sqlite_master",   # undeclared table → refuse (both)
+        "SELECT id FROM orders",          # declared → allow (both)
+        "SELECT id FROM customers",       # the OTHER declared table → allow only if it survived
+        "SELECT nope FROM orders",        # undeclared column → refuse only if the column set survived
+    ):
+        assert verdict(hosted=True, sql=sql) == verdict(hosted=False, sql=sql), sql
+
+
+def test_hosted_falls_back_to_disk_when_db_has_no_model(tmp_path, monkeypatch, capsys):
+    # Hosted, DB configured but EMPTY, yet a disk model exists → guards run off disk (not fail-closed).
+    from store import Store
+
+    url = "sqlite://" + str(tmp_path / "empty.db")
+    Store.connect(url).run_migrations()  # migrated, no model
+    _write_disk(tmp_path / "art" / "acme")
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "art"))
+
+    _, code = execute_sql._model_safety("SELECT id FROM sqlite_master", "acme", None)
+    assert code == 1  # refused by the disk-sourced model, NOT model_unavailable
+    assert json.loads(capsys.readouterr().err.strip())["error"]["kind"] == "table_out_of_scope"
+
+
+def test_hosted_db_load_error_falls_back_to_disk(tmp_path, monkeypatch):
+    # A DB that errors on load must degrade to the disk model, not crash or fail open.
+    _write_disk(tmp_path / "art" / "acme")
+    monkeypatch.setenv("AGAMI_DB_URL", "postgres://user:pw@127.0.0.1:1/nope")  # unreachable
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "art"))
+
+    sql, code = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
+    assert code is None  # disk model resolved + guards passed the declared query
+
+
+def test_hosted_fail_closed_when_model_package_unimportable(tmp_path, monkeypatch, capsys):
+    # Even the model PACKAGE being unavailable must fail closed on hosted — the guards can't run at
+    # all, which is the same "can't guarantee safety" condition as a missing model. Force the very
+    # first `from semantic_model import runtime` to raise, so the except branch is what's exercised.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def boom(name, _globals=None, _locals=None, fromlist=(), level=0):
+        if name == "semantic_model" and fromlist and "runtime" in fromlist:
+            raise ImportError("forced: semantic_model.runtime unavailable")
+        return real_import(name, _globals, _locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", boom)
+    monkeypatch.setenv("AGAMI_DB_URL", "sqlite://" + str(tmp_path / "x.db"))
+
+    _, code = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
+    assert code == 1  # fail closed — no DB load is even attempted (we never resolve a model)
+    assert json.loads(capsys.readouterr().err.strip())["error"]["kind"] == "model_unavailable"

--- a/tests/test_ace051_fail_closed.py
+++ b/tests/test_ace051_fail_closed.py
@@ -1,0 +1,126 @@
+"""ACE-051 — the hosted safety guard resolves the model from the DB and FAILS CLOSED when no model
+can be found: a served query never runs with the fan/chasm/scope/PII guards silently off. Locally
+(no DB configured) a not-yet-built model is still a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import execute_sql  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+
+
+def _org() -> m.Organization:
+    """A model declaring exactly two tables: orders, customers."""
+    def _t(name):
+        return m.Table(name=name, schema="public", storage_connection="c", grain=["id"],
+                       description=name, columns=[m.Column(name="id", type="integer")])
+    return m.Organization(
+        organization="Shop",
+        subject_areas=[m.SubjectArea(name="sales", tables_defined=[_t("orders"), _t("customers")])],
+    )
+
+
+def _seed_db(url: str, ds: str = "acme") -> None:
+    import model_store
+    from store import Store
+
+    s = Store.connect(url)
+    s.run_migrations()
+    model_store.write_organization(s, ds, _org())
+    s.close()
+
+
+def _write_disk(root: Path) -> None:
+    import yaml
+
+    (root / "subject_areas" / "sales" / "tables").mkdir(parents=True)
+    (root / "org.yaml").write_text(
+        yaml.safe_dump({"organization": "Shop", "version": 1, "subject_areas": ["subject_areas/sales"]})
+    )
+    (root / "subject_areas" / "sales" / "subject_area.yaml").write_text(
+        yaml.safe_dump({"name": "sales", "tables": [
+            {"storage_connection": "c", "schema": "public", "table": "orders"},
+            {"storage_connection": "c", "schema": "public", "table": "customers"}]})
+    )
+    for t in ("orders", "customers"):
+        (root / "subject_areas" / "sales" / "tables" / f"{t}.yaml").write_text(
+            yaml.safe_dump({"name": t, "schema": "public", "storage_connection": "c", "grain": ["id"],
+                            "description": t,
+                            "columns": [{"name": "id", "type": "integer", "primary_key": True}]})
+        )
+
+
+def test_hosted_fail_closed_refuses_when_no_model(tmp_path, monkeypatch, capsys):
+    # Hosted (DB configured) but NO model resolvable (DB migrated-but-empty + no disk) → refuse,
+    # never run the query with the guards silently off.
+    from store import Store
+
+    url = "sqlite://" + str(tmp_path / "empty.db")
+    Store.connect(url).run_migrations()
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_artifacts"))
+
+    _, code = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
+    assert code == 1  # refused, not run
+    assert json.loads(capsys.readouterr().err.strip())["error"]["kind"] == "model_unavailable"
+
+
+def test_local_missing_model_is_noop(tmp_path, monkeypatch):
+    # No DB configured → local path: a not-yet-built model legitimately means "no model" → no-op.
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "empty"))
+
+    sql, code = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
+    assert code is None and sql == "SELECT id FROM orders"  # unchanged, guards inert
+
+
+def test_db_sourced_model_enforces_guards(tmp_path, monkeypatch, capsys):
+    # Model in the DB, NOTHING on disk → the guards run off the DB-sourced model.
+    url = "sqlite://" + str(tmp_path / "model.db")
+    _seed_db(url, "acme")
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_disk"))
+
+    _, code = execute_sql._model_safety("SELECT id FROM sqlite_master", "acme", None)
+    assert code == 1  # undeclared table refused by the table-scope guard, sourced from the DB model
+    assert json.loads(capsys.readouterr().err.strip())["error"]["kind"] == "table_out_of_scope"
+
+    sql, code = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
+    assert code is None  # a declared table with a named projection passes
+
+
+def test_disk_db_verdict_parity(tmp_path, monkeypatch, capsys):
+    # The same model sourced from disk vs the DB must yield identical guard verdicts.
+    _write_disk(tmp_path / "art" / "acme")
+    url = "sqlite://" + str(tmp_path / "model.db")
+    _seed_db(url, "acme")
+
+    def verdict(hosted: bool, sql: str):
+        if hosted:
+            monkeypatch.setenv("AGAMI_DB_URL", url)
+            monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_disk"))  # DB is the only source
+        else:
+            monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+            monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "art"))  # disk is the only source
+        _, code = execute_sql._model_safety(sql, "acme", None)
+        capsys.readouterr()
+        return code
+
+    for sql in ("SELECT id FROM sqlite_master", "SELECT id FROM orders"):
+        assert verdict(hosted=True, sql=sql) == verdict(hosted=False, sql=sql)


### PR DESCRIPTION
**Spec:** ACE-051 (contract F12) · **Req:** REQ-017, REQ-001 · **Lane:** HIGH (safety enforcement) · depends on shipped ACE-045

## Summary
The safety guards (fan/chasm-trap, table/column scope, SELECT* ban, PII projection) need the semantic model. Today `_model_safety` reads it **from disk only** and **silently runs the query unguarded** (`return sql, None`) when it's missing — so a hosted deploy serving from Postgres (or with the `/artifacts` mount absent) would have the guards silently off. This makes the hosted path **fail closed**.

## Changes (packages/agami-core/src/execute_sql.py + mirror)
- **`_resolve_guard_model`** — mirrors `tools._load_org`: the model resolves from the **DB** when `AGAMI_DB_URL`/`APP_DATABASE_URL` is set (hosted; the disk mount may be absent), else on-disk YAML. The DB import is **lazy + env-guarded** because the stdlib-lean local mirror doesn't ship `store`/`model_store`; a DB-load failure degrades to disk.
- **`_model_safety` fails closed on hosted** — when no model can be resolved, it refuses (`{"kind": "model_unavailable"}`, exit 1) instead of running unguarded. Extended (per security review) so a missing model **package** on hosted also fails closed. Local (no DB) keeps its no-op-on-missing.

## Scope note (open-core)
Standalone build: ACE-035's formal refusal Envelope isn't merged yet, so this uses the **existing** refusal style (foldable into ACE-035 later). The DB source reuses the same seam the query path already uses — no fork, no new egress.

## Security review (mandatory, high-lane)
The fail-closed for a missing/unresolvable model is **airtight** — DB→disk resolution, correct caller consumption, and a **lossless** DB round-trip (verified: the DB model yields identical guard verdicts to disk). Dispositioned: the missing-**package** fail-open is now closed here. **Known follow-up (belongs to ACE-037):** a missing/unparseable-by-`sqlglot` still degrades the guards to *allow* on hosted — that's ACE-037's `unscopable_sql` fail-closed, flagged in the code comment, not scoped into this PR.

## Tests
`tests/test_ace051_fail_closed.py`: DB-sourced model enforces the guards; no model on hosted → refuses; local missing → no-op; **disk↔DB verdict parity** (queries both declared tables + a bad column, so a lossy round-trip can't hide); hosted DB-empty → falls back to disk; DB-load-error → falls back to disk; and a missing model package on hosted → fails closed.

## Checklist
- [x] `uv run dev.py check` green (ruff + full suite + gitleaks + lib-mirror drift)
- [x] Spec-linked (`Spec: ACE-051` on every commit)
- [x] High-lane: security-reviewed; fail-closed verified airtight for the model-resolution scope
- [x] No new egress; local path unchanged