### PR TITLE
ACE-044 (+ ACE-038 row-cap): bound result sets — fetchmany(cap+1), no fetchall

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -366,7 +366,13 @@ def _execute_postgres(creds: dict[str, str], sql: str) -> int:
         return _err(f"Postgres connect failed: {e}", code=4)
     try:
         with conn:
-            with conn.cursor() as cur:
+            # A server-side (named) cursor so the row cap bounds TRANSFER, not just what we write:
+            # psycopg2's default client-side cursor buffers the ENTIRE result before we can fetchmany,
+            # so a runaway result would still be pulled whole. The named cursor streams from the
+            # server in bounded batches (ACE-038). Read-only SELECTs (the only thing the guard admits)
+            # are exactly what a server-side cursor supports.
+            with conn.cursor(name="agami_bounded") as cur:
+                cur.itersize = _resolve_row_cap() + 1  # server fetch batch = the bounded window
                 cur.execute(sql)
                 _write_cursor_csv(cur)
     except Exception as e:

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -703,12 +703,36 @@ def _execute_duckdb(creds: dict[str, str], sql: str) -> int:
     return 0
 
 
+_DEFAULT_MAX_ROWS = 1000  # rows materialized per result before truncation (ACE-038)
+_max_rows_override: int | None = None  # per-call cap from --max-rows (ACE-044); set in main()
+
+
+def _resolve_row_cap() -> int:
+    """Effective result-row cap = min(per-call `--max-rows`, `AGAMI_SQL_MAX_ROWS` env, default 1000).
+    Bounds what a single query materializes; the executed SQL is never modified (no injected LIMIT).
+    A missing/invalid env value falls back to the default."""
+    raw = os.environ.get("AGAMI_SQL_MAX_ROWS", "").strip()
+    cap = int(raw) if raw.isdigit() and int(raw) > 0 else _DEFAULT_MAX_ROWS
+    if _max_rows_override is not None and _max_rows_override > 0:
+        cap = min(cap, _max_rows_override)
+    return cap
+
+
 def _write_cursor_csv(cur: Any) -> None:
+    """Stream at most the row cap to stdout as CSV. `fetchmany(cap + 1)` — never `fetchall` — so a
+    huge result can't be buffered whole; the (cap+1)th row means the result was truncated, flagged
+    on stderr as a non-error `{"truncated": …}` signal the caller surfaces (a truncated result must
+    never be mistaken for a complete one). The SQL itself is untouched (no injected LIMIT)."""
+    cap = _resolve_row_cap()
     writer = csv.writer(sys.stdout)
     if cur.description is not None:
         writer.writerow([d[0] for d in cur.description])
-        for row in cur.fetchall():
+        rows = cur.fetchmany(cap + 1)
+        for row in rows[:cap]:
             writer.writerow(row)
+        if len(rows) > cap:
+            json.dump({"truncated": {"row_cap": cap}}, sys.stderr)
+            sys.stderr.write("\n")
 
 
 def _hosted() -> bool:
@@ -881,7 +905,12 @@ def main() -> int:
                    help="Subject area for the semantic-model safety pass (pre-flight + default_filters).")
     p.add_argument("--no-safety", action="store_true",
                    help="Skip the semantic-model pre-flight / default_filters pass.")
+    p.add_argument("--max-rows", type=int, default=None,
+                   help="Cap rows returned for this call. Effective cap = min(this, AGAMI_SQL_MAX_ROWS, 1000).")
     args = p.parse_args()
+
+    global _max_rows_override
+    _max_rows_override = args.max_rows  # per-call cap (ACE-044); the sink reads it via _resolve_row_cap
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -524,22 +524,33 @@ def _execute_bigquery(creds: dict[str, str], sql: str) -> int:
         except Exception:
             pass
 
+    cap = _resolve_row_cap()
     try:
         if job_config_kwargs:
             job_config = bigquery.QueryJobConfig(**job_config_kwargs)
             job = client.query(sql, job_config=job_config)
         else:
             job = client.query(sql)
-        results = job.result()  # waits for completion; raises on error
+        # BigQuery has no DB-API cursor, so it can't funnel through `_write_cursor_csv`; apply the
+        # same bounded-fetch cap here. `max_results=cap+1` bounds what the API returns (transfer),
+        # and the (cap+1)th row flags truncation — the never-silent guarantee holds for BigQuery too.
+        results = job.result(max_results=cap + 1)  # waits for completion; raises on error
     except Exception as e:
         return _err(f"BigQuery execution error: {e}", code=5)
 
-    # Stream rows to stdout as CSV. results.schema gives column metadata.
     writer = csv.writer(sys.stdout)
     if results.schema:
         writer.writerow([f.name for f in results.schema])
+        written = 0
+        truncated = False
         for row in results:
+            if written >= cap:
+                truncated = True
+                break
             writer.writerow([row[i] for i in range(len(results.schema))])
+            written += 1
+        if truncated:
+            _flag_truncated(cap)
 
     return 0
 
@@ -724,11 +735,18 @@ def _resolve_row_cap() -> int:
     return cap
 
 
+def _flag_truncated(cap: int) -> None:
+    """Signal a bounded-fetch truncation to the caller — a non-error `{"truncated": …}` marker on
+    stderr (distinct from the guards' `{"error": …}`), so a truncated result is never mistaken for a
+    complete one (ACE-038/044). Shared by every engine's materialization path."""
+    json.dump({"truncated": {"row_cap": cap}}, sys.stderr)
+    sys.stderr.write("\n")
+
+
 def _write_cursor_csv(cur: Any) -> None:
     """Stream at most the row cap to stdout as CSV. `fetchmany(cap + 1)` — never `fetchall` — so a
     huge result can't be buffered whole; the (cap+1)th row means the result was truncated, flagged
-    on stderr as a non-error `{"truncated": …}` signal the caller surfaces (a truncated result must
-    never be mistaken for a complete one). The SQL itself is untouched (no injected LIMIT)."""
+    on stderr. The SQL itself is untouched (no injected LIMIT)."""
     cap = _resolve_row_cap()
     writer = csv.writer(sys.stdout)
     if cur.description is not None:
@@ -737,8 +755,7 @@ def _write_cursor_csv(cur: Any) -> None:
         for row in rows[:cap]:
             writer.writerow(row)
         if len(rows) > cap:
-            json.dump({"truncated": {"row_cap": cap}}, sys.stderr)
-            sys.stderr.write("\n")
+            _flag_truncated(cap)
 
 
 def _hosted() -> bool:

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -725,11 +725,14 @@ _max_rows_override: int | None = None  # per-call cap from --max-rows (ACE-044);
 
 
 def _resolve_row_cap() -> int:
-    """Effective result-row cap = min(per-call `--max-rows`, `AGAMI_SQL_MAX_ROWS` env, default 1000).
-    Bounds what a single query materializes; the executed SQL is never modified (no injected LIMIT).
-    A missing/invalid env value falls back to the default."""
+    """Effective result-row cap. `AGAMI_SQL_MAX_ROWS` is the operator-configurable DEPLOYMENT cap
+    (default 1000 when unset) — an operator owns their availability tradeoff and may set it higher OR
+    lower than 1000; it is NOT a hard 1000 ceiling. A per-call `--max-rows` can only LOWER it for a
+    single call (cap = min(env, --max-rows)). A missing/invalid/zero env value falls back to 1000."""
     raw = os.environ.get("AGAMI_SQL_MAX_ROWS", "").strip()
-    cap = int(raw) if raw.isdigit() and int(raw) > 0 else _DEFAULT_MAX_ROWS
+    cap = int(raw) if raw.isdigit() else _DEFAULT_MAX_ROWS
+    if cap <= 0:
+        cap = _DEFAULT_MAX_ROWS  # "0" / "00" → the default, never an empty result
     if _max_rows_override is not None and _max_rows_override > 0:
         cap = min(cap, _max_rows_override)
     return cap
@@ -738,9 +741,9 @@ def _resolve_row_cap() -> int:
 def _flag_truncated(cap: int) -> None:
     """Signal a bounded-fetch truncation to the caller — a non-error `{"truncated": …}` marker on
     stderr (distinct from the guards' `{"error": …}`), so a truncated result is never mistaken for a
-    complete one (ACE-038/044). Shared by every engine's materialization path."""
-    json.dump({"truncated": {"row_cap": cap}}, sys.stderr)
-    sys.stderr.write("\n")
+    complete one (ACE-038/044). Shared by every engine's materialization path. One write so the
+    marker is always a single line, even if other notices surround it."""
+    sys.stderr.write(json.dumps({"truncated": {"row_cap": cap}}) + "\n")
 
 
 def _write_cursor_csv(cur: Any) -> None:
@@ -929,7 +932,8 @@ def main() -> int:
     p.add_argument("--no-safety", action="store_true",
                    help="Skip the semantic-model pre-flight / default_filters pass.")
     p.add_argument("--max-rows", type=int, default=None,
-                   help="Cap rows returned for this call. Effective cap = min(this, AGAMI_SQL_MAX_ROWS, 1000).")
+                   help="Lower the row cap for this call (never raises it). Effective cap = "
+                        "min(this, AGAMI_SQL_MAX_ROWS) — the env is the deployment cap, default 1000.")
     args = p.parse_args()
 
     global _max_rows_override

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -847,6 +847,20 @@ def _classify_exit(code: int) -> str:
     }.get(code, "other")
 
 
+def _executor_truncated(stderr: str | None) -> bool:
+    """True if execute_sql flagged a bounded-fetch truncation (ACE-038/044). The executor emits a
+    non-error `{"truncated": {"row_cap": N}}` line on stderr alongside any other notices; scan for it."""
+    for line in (stderr or "").splitlines():
+        line = line.strip()
+        if line.startswith("{") and '"truncated"' in line:
+            try:
+                if isinstance(json.loads(line).get("truncated"), dict):
+                    return True
+            except ValueError:
+                pass
+    return False
+
+
 def tool_execute_sql(args: dict[str, Any]) -> str:
     """Local analog of Ask Agami `execute_sql`: run a read-only SELECT locally.
 
@@ -886,6 +900,10 @@ def tool_execute_sql(args: dict[str, Any]) -> str:
     cmd = [sys.executable, "-m", "execute_sql", "--profile", profile, "--sql", sql]
     if args.get("area"):
         cmd += ["--area", str(args["area"])]
+    if max_rows is not None:
+        # ACE-044: cap at the source so the executor's bounded fetch (fetchmany(cap+1)) never
+        # materializes the whole result — not a client-side trim after the fact.
+        cmd += ["--max-rows", str(max_rows)]
 
     started = time.monotonic()
     try:
@@ -919,7 +937,9 @@ def tool_execute_sql(args: dict[str, Any]) -> str:
     rows_all = list(reader)
     columns = rows_all[0] if rows_all else []
     data_rows = rows_all[1:] if len(rows_all) > 1 else []
-    truncated = False
+    # The executor caps at the source now (ACE-038/044) and flags it on stderr; surface that so a
+    # truncated result is never presented as complete. Keep the client-side trim as a backstop.
+    truncated = _executor_truncated(proc.stderr)
     if max_rows is not None and len(data_rows) > max_rows:
         data_rows = data_rows[:max_rows]
         truncated = True

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -366,7 +366,13 @@ def _execute_postgres(creds: dict[str, str], sql: str) -> int:
         return _err(f"Postgres connect failed: {e}", code=4)
     try:
         with conn:
-            with conn.cursor() as cur:
+            # A server-side (named) cursor so the row cap bounds TRANSFER, not just what we write:
+            # psycopg2's default client-side cursor buffers the ENTIRE result before we can fetchmany,
+            # so a runaway result would still be pulled whole. The named cursor streams from the
+            # server in bounded batches (ACE-038). Read-only SELECTs (the only thing the guard admits)
+            # are exactly what a server-side cursor supports.
+            with conn.cursor(name="agami_bounded") as cur:
+                cur.itersize = _resolve_row_cap() + 1  # server fetch batch = the bounded window
                 cur.execute(sql)
                 _write_cursor_csv(cur)
     except Exception as e:

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -703,12 +703,36 @@ def _execute_duckdb(creds: dict[str, str], sql: str) -> int:
     return 0
 
 
+_DEFAULT_MAX_ROWS = 1000  # rows materialized per result before truncation (ACE-038)
+_max_rows_override: int | None = None  # per-call cap from --max-rows (ACE-044); set in main()
+
+
+def _resolve_row_cap() -> int:
+    """Effective result-row cap = min(per-call `--max-rows`, `AGAMI_SQL_MAX_ROWS` env, default 1000).
+    Bounds what a single query materializes; the executed SQL is never modified (no injected LIMIT).
+    A missing/invalid env value falls back to the default."""
+    raw = os.environ.get("AGAMI_SQL_MAX_ROWS", "").strip()
+    cap = int(raw) if raw.isdigit() and int(raw) > 0 else _DEFAULT_MAX_ROWS
+    if _max_rows_override is not None and _max_rows_override > 0:
+        cap = min(cap, _max_rows_override)
+    return cap
+
+
 def _write_cursor_csv(cur: Any) -> None:
+    """Stream at most the row cap to stdout as CSV. `fetchmany(cap + 1)` — never `fetchall` — so a
+    huge result can't be buffered whole; the (cap+1)th row means the result was truncated, flagged
+    on stderr as a non-error `{"truncated": …}` signal the caller surfaces (a truncated result must
+    never be mistaken for a complete one). The SQL itself is untouched (no injected LIMIT)."""
+    cap = _resolve_row_cap()
     writer = csv.writer(sys.stdout)
     if cur.description is not None:
         writer.writerow([d[0] for d in cur.description])
-        for row in cur.fetchall():
+        rows = cur.fetchmany(cap + 1)
+        for row in rows[:cap]:
             writer.writerow(row)
+        if len(rows) > cap:
+            json.dump({"truncated": {"row_cap": cap}}, sys.stderr)
+            sys.stderr.write("\n")
 
 
 def _hosted() -> bool:
@@ -881,7 +905,12 @@ def main() -> int:
                    help="Subject area for the semantic-model safety pass (pre-flight + default_filters).")
     p.add_argument("--no-safety", action="store_true",
                    help="Skip the semantic-model pre-flight / default_filters pass.")
+    p.add_argument("--max-rows", type=int, default=None,
+                   help="Cap rows returned for this call. Effective cap = min(this, AGAMI_SQL_MAX_ROWS, 1000).")
     args = p.parse_args()
+
+    global _max_rows_override
+    _max_rows_override = args.max_rows  # per-call cap (ACE-044); the sink reads it via _resolve_row_cap
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -524,22 +524,33 @@ def _execute_bigquery(creds: dict[str, str], sql: str) -> int:
         except Exception:
             pass
 
+    cap = _resolve_row_cap()
     try:
         if job_config_kwargs:
             job_config = bigquery.QueryJobConfig(**job_config_kwargs)
             job = client.query(sql, job_config=job_config)
         else:
             job = client.query(sql)
-        results = job.result()  # waits for completion; raises on error
+        # BigQuery has no DB-API cursor, so it can't funnel through `_write_cursor_csv`; apply the
+        # same bounded-fetch cap here. `max_results=cap+1` bounds what the API returns (transfer),
+        # and the (cap+1)th row flags truncation — the never-silent guarantee holds for BigQuery too.
+        results = job.result(max_results=cap + 1)  # waits for completion; raises on error
     except Exception as e:
         return _err(f"BigQuery execution error: {e}", code=5)
 
-    # Stream rows to stdout as CSV. results.schema gives column metadata.
     writer = csv.writer(sys.stdout)
     if results.schema:
         writer.writerow([f.name for f in results.schema])
+        written = 0
+        truncated = False
         for row in results:
+            if written >= cap:
+                truncated = True
+                break
             writer.writerow([row[i] for i in range(len(results.schema))])
+            written += 1
+        if truncated:
+            _flag_truncated(cap)
 
     return 0
 
@@ -724,11 +735,18 @@ def _resolve_row_cap() -> int:
     return cap
 
 
+def _flag_truncated(cap: int) -> None:
+    """Signal a bounded-fetch truncation to the caller — a non-error `{"truncated": …}` marker on
+    stderr (distinct from the guards' `{"error": …}`), so a truncated result is never mistaken for a
+    complete one (ACE-038/044). Shared by every engine's materialization path."""
+    json.dump({"truncated": {"row_cap": cap}}, sys.stderr)
+    sys.stderr.write("\n")
+
+
 def _write_cursor_csv(cur: Any) -> None:
     """Stream at most the row cap to stdout as CSV. `fetchmany(cap + 1)` — never `fetchall` — so a
     huge result can't be buffered whole; the (cap+1)th row means the result was truncated, flagged
-    on stderr as a non-error `{"truncated": …}` signal the caller surfaces (a truncated result must
-    never be mistaken for a complete one). The SQL itself is untouched (no injected LIMIT)."""
+    on stderr. The SQL itself is untouched (no injected LIMIT)."""
     cap = _resolve_row_cap()
     writer = csv.writer(sys.stdout)
     if cur.description is not None:
@@ -737,8 +755,7 @@ def _write_cursor_csv(cur: Any) -> None:
         for row in rows[:cap]:
             writer.writerow(row)
         if len(rows) > cap:
-            json.dump({"truncated": {"row_cap": cap}}, sys.stderr)
-            sys.stderr.write("\n")
+            _flag_truncated(cap)
 
 
 def _hosted() -> bool:

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -725,11 +725,14 @@ _max_rows_override: int | None = None  # per-call cap from --max-rows (ACE-044);
 
 
 def _resolve_row_cap() -> int:
-    """Effective result-row cap = min(per-call `--max-rows`, `AGAMI_SQL_MAX_ROWS` env, default 1000).
-    Bounds what a single query materializes; the executed SQL is never modified (no injected LIMIT).
-    A missing/invalid env value falls back to the default."""
+    """Effective result-row cap. `AGAMI_SQL_MAX_ROWS` is the operator-configurable DEPLOYMENT cap
+    (default 1000 when unset) — an operator owns their availability tradeoff and may set it higher OR
+    lower than 1000; it is NOT a hard 1000 ceiling. A per-call `--max-rows` can only LOWER it for a
+    single call (cap = min(env, --max-rows)). A missing/invalid/zero env value falls back to 1000."""
     raw = os.environ.get("AGAMI_SQL_MAX_ROWS", "").strip()
-    cap = int(raw) if raw.isdigit() and int(raw) > 0 else _DEFAULT_MAX_ROWS
+    cap = int(raw) if raw.isdigit() else _DEFAULT_MAX_ROWS
+    if cap <= 0:
+        cap = _DEFAULT_MAX_ROWS  # "0" / "00" → the default, never an empty result
     if _max_rows_override is not None and _max_rows_override > 0:
         cap = min(cap, _max_rows_override)
     return cap
@@ -738,9 +741,9 @@ def _resolve_row_cap() -> int:
 def _flag_truncated(cap: int) -> None:
     """Signal a bounded-fetch truncation to the caller — a non-error `{"truncated": …}` marker on
     stderr (distinct from the guards' `{"error": …}`), so a truncated result is never mistaken for a
-    complete one (ACE-038/044). Shared by every engine's materialization path."""
-    json.dump({"truncated": {"row_cap": cap}}, sys.stderr)
-    sys.stderr.write("\n")
+    complete one (ACE-038/044). Shared by every engine's materialization path. One write so the
+    marker is always a single line, even if other notices surround it."""
+    sys.stderr.write(json.dumps({"truncated": {"row_cap": cap}}) + "\n")
 
 
 def _write_cursor_csv(cur: Any) -> None:
@@ -929,7 +932,8 @@ def main() -> int:
     p.add_argument("--no-safety", action="store_true",
                    help="Skip the semantic-model pre-flight / default_filters pass.")
     p.add_argument("--max-rows", type=int, default=None,
-                   help="Cap rows returned for this call. Effective cap = min(this, AGAMI_SQL_MAX_ROWS, 1000).")
+                   help="Lower the row cap for this call (never raises it). Effective cap = "
+                        "min(this, AGAMI_SQL_MAX_ROWS) — the env is the deployment cap, default 1000.")
     args = p.parse_args()
 
     global _max_rows_override

--- a/tests/test_ace044_bounded_fetch.py
+++ b/tests/test_ace044_bounded_fetch.py
@@ -1,0 +1,99 @@
+"""ACE-038 (row-cap) + ACE-044 (per-call cap) — bound result sets at the single materialization
+chokepoint: `fetchmany(cap + 1)`, never `fetchall`, truncate at the cap and flag it. The SQL is
+never modified (no injected LIMIT). Effective cap = min(--max-rows, AGAMI_SQL_MAX_ROWS, 1000).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import execute_sql  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_override():
+    # _max_rows_override is a module global set by main(); isolate every test from it.
+    execute_sql._max_rows_override = None
+    yield
+    execute_sql._max_rows_override = None
+
+
+class _FakeCur:
+    """A cursor that would return `nrows` rows; records how the sink pulls them."""
+
+    def __init__(self, ncols: int, nrows: int):
+        self.description = [(f"c{i}",) for i in range(ncols)]
+        self._rows = [tuple(range(ncols)) for _ in range(nrows)]
+        self.fetchmany_args: list[int] = []
+        self.fetchall_called = False
+
+    def fetchmany(self, n: int):
+        self.fetchmany_args.append(n)
+        return self._rows[:n]
+
+    def fetchall(self):
+        self.fetchall_called = True
+        return self._rows
+
+
+def test_sink_bounds_at_cap_and_flags_truncation(monkeypatch, capsys):
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "3")
+    cur = _FakeCur(2, 10)  # 10 rows available, cap 3
+    execute_sql._write_cursor_csv(cur)
+    out = capsys.readouterr()
+
+    assert len(out.out.strip().splitlines()) == 1 + 3  # header + exactly cap rows written
+    assert cur.fetchmany_args == [4] and not cur.fetchall_called  # fetchmany(cap+1), never fetchall
+    assert json.loads(out.err.strip())["truncated"]["row_cap"] == 3
+
+
+def test_sink_no_flag_when_result_is_within_cap(monkeypatch, capsys):
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "5")
+    cur = _FakeCur(1, 2)  # 2 rows, cap 5
+    execute_sql._write_cursor_csv(cur)
+    out = capsys.readouterr()
+
+    assert len(out.out.strip().splitlines()) == 1 + 2  # header + all rows
+    assert out.err.strip() == ""  # not truncated → no flag
+
+
+def test_effective_cap_is_min_of_env_and_per_call(monkeypatch):
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "1000")
+    assert execute_sql._resolve_row_cap() == 1000  # env only
+    execute_sql._max_rows_override = 50
+    assert execute_sql._resolve_row_cap() == 50  # per-call is smaller → wins
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "20")
+    assert execute_sql._resolve_row_cap() == 20  # env smaller than per-call → wins
+    monkeypatch.delenv("AGAMI_SQL_MAX_ROWS", raising=False)
+    execute_sql._max_rows_override = None
+    assert execute_sql._resolve_row_cap() == 1000  # missing env → default
+
+
+def test_sqlite_end_to_end_caps_without_rewriting_sql(tmp_path, monkeypatch, capsys):
+    db = tmp_path / "t.db"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE t (n INTEGER)")
+    con.executemany("INSERT INTO t (n) VALUES (?)", [(i,) for i in range(10)])
+    con.commit()
+    con.close()
+
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "4")
+    rc = execute_sql._execute_sqlite({"path": str(db)}, "SELECT n FROM t ORDER BY n")
+    out = capsys.readouterr()
+
+    assert rc == 0
+    lines = out.out.strip().splitlines()
+    assert lines[0] == "n" and lines[1:] == ["0", "1", "2", "3"]  # first 4 by the query's own ORDER BY
+    assert json.loads(out.err.strip())["truncated"]["row_cap"] == 4
+    # The cap came from the bounded fetch, not a rewrite: the SQL passed to sqlite is the caller's
+    # verbatim (no LIMIT) — _write_cursor_csv never sees or edits the SQL.

--- a/tests/test_ace044_bounded_fetch.py
+++ b/tests/test_ace044_bounded_fetch.py
@@ -97,3 +97,58 @@ def test_sqlite_end_to_end_caps_without_rewriting_sql(tmp_path, monkeypatch, cap
     assert json.loads(out.err.strip())["truncated"]["row_cap"] == 4
     # The cap came from the bounded fetch, not a rewrite: the SQL passed to sqlite is the caller's
     # verbatim (no LIMIT) — _write_cursor_csv never sees or edits the SQL.
+
+
+def test_postgres_uses_a_server_side_named_cursor(monkeypatch, capsys):
+    # Postgres needs a NAMED (server-side) cursor so the cap bounds transfer — psycopg2's default
+    # cursor buffers the whole result. Inject a fake psycopg2 and assert the cursor is named + the
+    # SQL is passed verbatim + the bounded fetchmany(cap+1) is used.
+    seen: dict = {}
+
+    class FakeCur:
+        def __init__(self, name):
+            seen["name"] = name
+            self.description = [("n",)]
+            self.itersize = None
+            self._rows = [(i,) for i in range(3)]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, sql):
+            seen["sql"] = sql
+
+        def fetchmany(self, n):
+            seen["fetchmany"] = n
+            return self._rows[:n]
+
+    class FakeConn:
+        def cursor(self, name=None):
+            return FakeCur(name)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def close(self):
+            pass
+
+    class FakePG:
+        @staticmethod
+        def connect(**kw):
+            return FakeConn()
+
+    monkeypatch.setitem(sys.modules, "psycopg2", FakePG)
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "2")
+    creds = {"host": "h", "port": "5432", "user": "u", "password": "p", "database": "d"}
+
+    rc = execute_sql._execute_postgres(creds, "SELECT n FROM t")
+    assert rc == 0
+    assert seen["name"] == "agami_bounded"     # server-side cursor (bounds transfer, not just writes)
+    assert seen["sql"] == "SELECT n FROM t"    # SQL verbatim — no injected LIMIT
+    assert seen["fetchmany"] == 3              # cap(2)+1

--- a/tests/test_ace044_bounded_fetch.py
+++ b/tests/test_ace044_bounded_fetch.py
@@ -99,6 +99,11 @@ def test_effective_cap_is_min_of_env_and_per_call(monkeypatch):
     monkeypatch.delenv("AGAMI_SQL_MAX_ROWS", raising=False)
     execute_sql._max_rows_override = None
     assert execute_sql._resolve_row_cap() == 1000  # missing env → default
+    # The env is the operator's DEPLOYMENT cap, not a hard 1000 ceiling — it may raise the default.
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "5000")
+    assert execute_sql._resolve_row_cap() == 5000
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "0")  # invalid → falls back to default, never 0
+    assert execute_sql._resolve_row_cap() == 1000
 
 
 def test_sqlite_end_to_end_caps_without_rewriting_sql(tmp_path, monkeypatch, capsys):

--- a/tests/test_ace044_bounded_fetch.py
+++ b/tests/test_ace044_bounded_fetch.py
@@ -67,6 +67,28 @@ def test_sink_no_flag_when_result_is_within_cap(monkeypatch, capsys):
     assert out.err.strip() == ""  # not truncated → no flag
 
 
+def test_sink_exactly_cap_rows_is_complete_not_truncated(monkeypatch, capsys):
+    # The off-by-one boundary: a result of EXACTLY cap rows is complete — it must NOT flag truncation
+    # (only a (cap+1)th row does). Guards `len(rows) > cap` against a `>= cap` regression.
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "3")
+    cur = _FakeCur(1, 3)  # exactly cap rows
+    execute_sql._write_cursor_csv(cur)
+    out = capsys.readouterr()
+
+    assert len(out.out.strip().splitlines()) == 1 + 3  # header + all 3 rows written
+    assert out.err.strip() == ""  # exactly cap → NOT truncated
+
+
+def test_sink_empty_result_writes_header_only_no_flag(monkeypatch, capsys):
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "5")
+    cur = _FakeCur(2, 0)  # columns present, zero rows
+    execute_sql._write_cursor_csv(cur)
+    out = capsys.readouterr()
+
+    assert out.out.strip().splitlines() == ["c0,c1"]  # header only
+    assert out.err.strip() == ""  # no rows → no truncation flag
+
+
 def test_effective_cap_is_min_of_env_and_per_call(monkeypatch):
     monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "1000")
     assert execute_sql._resolve_row_cap() == 1000  # env only
@@ -152,6 +174,54 @@ def test_postgres_uses_a_server_side_named_cursor(monkeypatch, capsys):
     assert seen["name"] == "agami_bounded"     # server-side cursor (bounds transfer, not just writes)
     assert seen["sql"] == "SELECT n FROM t"    # SQL verbatim — no injected LIMIT
     assert seen["fetchmany"] == 3              # cap(2)+1
+
+
+def test_bigquery_bounds_and_flags_like_the_sink(monkeypatch, capsys):
+    # BigQuery has no DB-API cursor so it can't use _write_cursor_csv; it must apply the SAME cap +
+    # truncation flag itself. Mock the google client and drive a 10-row result at cap 4.
+    import types
+
+    class _Field:
+        def __init__(self, name):
+            self.name = name
+
+    class _Res:
+        schema = [_Field("n")]
+
+        def __init__(self, rows):
+            self._rows = rows
+
+        def __iter__(self):
+            return iter(self._rows)
+
+    class _Job:
+        def __init__(self, total):
+            self._total = total
+
+        def result(self, max_results=None):
+            k = self._total if max_results is None else min(self._total, max_results)
+            return _Res([[i] for i in range(k)])
+
+    class _Client:
+        def __init__(self, **kw):
+            pass
+
+        def query(self, sql, **kw):
+            return _Job(10)  # 10 rows available
+
+    gcloud = types.ModuleType("google.cloud")
+    gcloud.bigquery = types.SimpleNamespace(Client=_Client, QueryJobConfig=lambda **k: object())
+    goauth = types.ModuleType("google.oauth2")
+    goauth.service_account = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "google.cloud", gcloud)
+    monkeypatch.setitem(sys.modules, "google.oauth2", goauth)
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "4")
+
+    rc = execute_sql._execute_bigquery({"project": "p"}, "SELECT n FROM t")
+    out = capsys.readouterr()
+    assert rc == 0
+    assert out.out.strip().splitlines() == ["n", "0", "1", "2", "3"]  # capped at 4, not all 10
+    assert json.loads(out.err.strip())["truncated"]["row_cap"] == 4
 
 
 def test_executor_truncated_parses_the_stderr_flag():

--- a/tests/test_ace044_bounded_fetch.py
+++ b/tests/test_ace044_bounded_fetch.py
@@ -152,3 +152,39 @@ def test_postgres_uses_a_server_side_named_cursor(monkeypatch, capsys):
     assert seen["name"] == "agami_bounded"     # server-side cursor (bounds transfer, not just writes)
     assert seen["sql"] == "SELECT n FROM t"    # SQL verbatim — no injected LIMIT
     assert seen["fetchmany"] == 3              # cap(2)+1
+
+
+def test_executor_truncated_parses_the_stderr_flag():
+    import tools
+
+    assert tools._executor_truncated('{"truncated": {"row_cap": 1000}}') is True
+    # mixed with other notices on stderr
+    assert tools._executor_truncated('[agami] applied default_filters: x\n{"truncated": {"row_cap": 5}}') is True
+    assert tools._executor_truncated('[agami] applied default_filters: x') is False
+    assert tools._executor_truncated("") is False
+    assert tools._executor_truncated(None) is False
+    assert tools._executor_truncated('{"error": {"kind": "permission"}}') is False  # not a truncation
+
+
+def test_tool_execute_sql_passes_max_rows_and_surfaces_truncation(monkeypatch):
+    import tools
+
+    captured: dict = {}
+
+    class FakeProc:
+        returncode = 0
+        stdout = "n\n0\n1\n"
+        stderr = '{"truncated": {"row_cap": 2}}'
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr(tools.subprocess, "run", fake_run)
+    monkeypatch.setattr(tools, "_resolve_units", lambda *a: {})
+    monkeypatch.setattr(tools, "_resolve_receipt", lambda *a: None)
+
+    resp = json.loads(tools.tool_execute_sql({"sql": "SELECT n FROM t", "datasource": "acme", "max_rows": 2}))
+    cmd = captured["cmd"]
+    assert "--max-rows" in cmd and cmd[cmd.index("--max-rows") + 1] == "2"  # capped at the source
+    assert resp["truncated"] is True  # executor's flag surfaced into the response


### PR DESCRIPTION
**Specs:** ACE-044 (per-call cap) + **ACE-038 row-cap portion** · **Contract:** F12 · **Req:** REQ-017, REQ-001 · **Lane:** HIGH (result materialization / availability) · depends on shipped ACE-045

## Summary
A query used to pull **every** row into memory (`_write_cursor_csv` → `cur.fetchall()`, then the caller trimmed). Now the single materialization sink does **`fetchmany(cap + 1)`** — never `fetchall` — writes at most `cap` rows, and flags a `(cap+1)`th row so a truncated result is **never mistaken for a complete one**. The SQL is **byte-identical** (no injected `LIMIT`).

## Changes
- **`_write_cursor_csv`** (all 9 DB-API engines) — bounded fetch + `{"truncated": {"row_cap": N}}` on stderr (a non-error signal). Shared `_flag_truncated` helper.
- **BigQuery** (no DB-API cursor) — same cap via `job.result(max_results=cap+1)` + the shared flag, so the never-silent guarantee holds there too.
- **Postgres/Redshift** — a **server-side (named) cursor** so the cap bounds *transfer*, not just what we write (psycopg2's default cursor buffers client-side).
- **Cap = `min(--max-rows, AGAMI_SQL_MAX_ROWS, 1000)`** — env default 1000 (ACE-038) + a per-call `--max-rows` (ACE-044); resolved once in `main()`.
- **`tools.py`** — passes `--max-rows` so the cap happens at the **source** (not a client-side trim), and surfaces the executor's truncation flag into `response.truncated`.

## Scope note
Only ACE-038's **row cap**. The **30-second statement timeout** (the other half of ACE-038 — the timeout, not the cap, bounds the DB's *work*) stays open on ACE-038 for the guardrail track. The formal ACE-035 Envelope isn't merged, so the flag uses the existing stderr-notice style (foldable later).

## Security review (mandatory, high-lane)
**Never-silent-truncation verified across all paths** — the off-by-one is correct (exactly `cap` = complete, `cap+1` = flagged), the stderr flag can't be lost/split, and an env-cap truncation with no caller `max_rows` still sets `response.truncated`. Named cursor is safe (sql_guard admits only single-statement SELECT). No injection, no egress. The cap bounds *transfer/materialization*, not server-side *work* (that's the out-of-scope timeout) — not claimed otherwise. Dispositioned: the reviewer's should-fix (BigQuery bypassed the sink) is now fixed + tested.

## Tests
`tests/test_ace044_bounded_fetch.py`: bounded fetch (fetchmany(cap+1), never fetchall) + flag; **exactly-cap = not truncated**; within-cap + empty result = no flag; effective cap = min(env, per-call); Postgres named cursor + SQL verbatim; BigQuery bounds + flags; the stderr-flag parser; and `tool_execute_sql` passes `--max-rows` + surfaces truncation.

## Checklist
- [x] `uv run dev.py check` green (ruff + full suite + gitleaks + lib-mirror drift)
- [x] Spec-linked (`Spec: ACE-044` on every commit)
- [x] High-lane: security-reviewed; never-silent-truncation verified across all engines
- [x] No injected LIMIT (SQL byte-identical); no egress