### PR TITLE
Release v0.4.0: bump package + plugin to 0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.3.9",
+    "version": "0.4.0",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.3.9",
+      "version": "0.4.0",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,24 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
-## [Unreleased]
+## [0.4.0] — 2026-07-12
+
+Runtime scalability & safety hardening: the server stays responsive and bounded as model size,
+result size, and concurrent load grow. Behaviour-preserving unless a note says otherwise.
+
+### Added
+
+- **Bounded result sets.** A query now materialises at most a row cap instead of the whole result:
+  `AGAMI_SQL_MAX_ROWS` (default 1000) is the deployment cap; a per-call cap is available via the
+  executor's `--max-rows` (which can only lower it). Truncation is flagged (`result.truncated`) so a
+  cut-off result is never presented as complete. The SQL is never rewritten (no injected `LIMIT`);
+  Postgres uses a server-side cursor so the cap bounds transfer, not just what's written.
+- **Multi-worker HTTP server.** The server can run with `--workers=N` (uvicorn import-string
+  factory). MCP session state is already stateless (JWT + Postgres), so it scales horizontally.
 
 ### Changed
 
-- **OAuth refresh-token storage is now configurable — default `overwrite` (ACE-050).**
+- **OAuth refresh-token storage is now configurable — default `overwrite`.**
   `AGAMI_REFRESH_TOKEN_MODE` selects `overwrite` (default: each refresh UPDATEs the session's single
   token row in place — one row per session, no growing heap of dead tokens) or `rotate` (the prior
   behaviour: insert-new + revoke-old, keeping OAuth 2.1 **stolen-token reuse detection**, plus a
@@ -25,6 +38,24 @@ below corresponds to one such version.
   cleared at authorize, and the query/activity logs (`query_executions` / `tool_calls`) are
   explicitly **retained** — never deleted by any default path — with a new `idx_query_executions_ts`
   index to keep newest-first reads fast as history grows.
+- **Hosted safety guard is now fail-closed and DB-backed.** On the hosted server the fan/chasm-trap,
+  table/column-scope, SELECT-\* and PII guards resolve the semantic model from the database (not only
+  the `/artifacts` disk mount) and **refuse** a query when no model can be resolved — instead of
+  silently running it unguarded. The local single-player path is unchanged (a not-yet-built model is
+  still fine, not an error).
+
+### Performance (behaviour-preserving)
+
+- **Per-process semantic-model cache + single SQL parse.** The model loads once per process and the
+  SQL is parsed once per query, with the safety-guard indices built once and shared — down from a
+  reload/re-parse per query on a long-lived server. Biggest latency win.
+- **Blocking work runs off the event loop.** Password hashing (argon2), OIDC HTTP calls, and the
+  per-call audit write no longer stall the async server — one slow login can't freeze all traffic.
+- **Incremental model-authoring validation.** Curation/enrichment re-validates only the edited area,
+  and snapshots read each file once, so authoring a large (many-area) model no longer grows
+  super-linearly. Same verdicts and snapshots.
+- **Faster schema discovery.** `get_datasource_schema` resolves tables via an O(1) index instead of
+  re-scanning the model per table — byte-identical output, faster on wide models.
 
 ## [0.3.9] — 2026-07-10
 

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.3.9"
+version = "0.4.0"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary
Cuts **v0.4.0** — bumps `packages/agami-core/pyproject.toml`, `plugins/agami/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` from 0.3.9 → 0.4.0, and finalises the CHANGELOG.

This releases the **runtime-scalability & safety-hardening** batch already on `main` (F12): bounded result sets, per-process model cache + single SQL parse, off-loop blocking work + multi-worker, incremental curation validation, O(1) schema lookups, hosted-guard fail-closed + DB-backed model source, and configurable refresh-token storage.

## ⚠ Upgrade note
The refresh-token default is now `overwrite`, which **turns off stolen-token reuse detection**. A deployment that wants OAuth 2.1 family-revocation must set `AGAMI_REFRESH_TOKEN_MODE=rotate`. (Full note in the CHANGELOG.)

## Release mechanics
Merging this only lands the version bump. **Publishing to PyPI is triggered separately** by creating the GitHub Release `v0.4.0` (trusted-publishing OIDC; `release-pypi.yml` verifies the tag matches the package version).

## Changes
- version 0.3.9 → 0.4.0 (3 source-of-truth files)
- CHANGELOG `[Unreleased]` → `[0.4.0] — 2026-07-12`, expanded to cover the F12 batch

## Checklist
- [x] `uv run dev.py check` green
- [x] Version consistent across pyproject / plugin.json / marketplace.json
- [x] CHANGELOG finalised with the upgrade note