### PR TITLE
perf(mcp_http): run the tool handler off the event loop (completes ACE-048)

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -309,7 +309,13 @@ def build_server(registry: dict | None = None):
         result_text = None
         raised = False
         try:
-            result_text = meta["handler"](arguments or {})
+            # Run the tool handler OFF the event loop. The heavy handlers block for the whole query —
+            # execute_sql shells out to a subprocess (up to 240 s) and hits the warehouse — so on the
+            # loop a single slow query would freeze every other in-flight request. This completes
+            # ACE-048 (which off-loaded the KDF/OIDC/audit calls but left the handler on the loop).
+            # `run_blocking` (anyio.to_thread) copies the request context into the worker thread, so
+            # the org-scoped model cache (ACE-045, read via `_current_org_ctx`) stays tenant-correct.
+            result_text = await run_blocking(meta["handler"], arguments or {})
             return [mt.TextContent(type="text", text=result_text)]
         except Exception:
             raised = True

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -27,6 +27,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 import time
 from collections.abc import Callable
 from contextvars import ContextVar
@@ -290,6 +291,11 @@ def _current_org_id() -> str:
 # model to another, and invalidated when the model version bumps. The execute_sql subprocess is a fresh process
 # per query and does NOT share this (its win is the Slice-1 GuardContext, not a cross-query cache).
 _ORG_CACHE: dict[tuple[str, str, "str | None"], Any] = {}
+# Tool handlers now run in parallel worker threads (mcp_http off-loads them), so this process-global
+# cache is genuinely concurrent. The lock keeps a miss provably race-free: the fast path (a hit) stays
+# lock-free, and only concurrent misses serialize — one loads, the rest double-check and reuse it,
+# which also avoids the eviction loop mutating the dict while another thread iterates it.
+_ORG_CACHE_LOCK = threading.Lock()
 
 
 def get_cached_org(profile: str):
@@ -303,15 +309,19 @@ def get_cached_org(profile: str):
         return _load_org(profile)
     org_id = _current_org_id()
     key = (org_id, profile, version)
-    cached = _ORG_CACHE.get(key)
+    cached = _ORG_CACHE.get(key)  # fast path: a hit is a single atomic dict.get, no lock
     if cached is not None:
         return cached
-    org = _load_org(profile)
-    # Drop any stale (org, datasource) entry at a previous version so the cache stays bounded.
-    for stale in [k for k in _ORG_CACHE if k[0] == org_id and k[1] == profile and k != key]:
-        del _ORG_CACHE[stale]
-    _ORG_CACHE[key] = org
-    return org
+    with _ORG_CACHE_LOCK:
+        cached = _ORG_CACHE.get(key)  # double-check: another thread may have loaded it meanwhile
+        if cached is not None:
+            return cached
+        org = _load_org(profile)
+        # Drop any stale (org, datasource) entry at a previous version so the cache stays bounded.
+        for stale in [k for k in _ORG_CACHE if k[0] == org_id and k[1] == profile and k != key]:
+            del _ORG_CACHE[stale]
+        _ORG_CACHE[key] = org
+        return org
 
 
 def _domain_memory(profile: str) -> tuple[str, str | None]:

--- a/tests/test_async_offload.py
+++ b/tests/test_async_offload.py
@@ -49,6 +49,35 @@ def test_run_blocking_propagates_the_callables_exception():
         anyio.run(_call)
 
 
+def test_offloaded_handler_keeps_org_context_in_the_worker_thread():
+    """The tool handler is now run via `run_blocking` (mcp_http `_call_tool`). That must preserve the
+    per-request org context so the org-scoped model cache (ACE-045) stays tenant-correct off-loop —
+    otherwise an offloaded handler would read the DEFAULT org and could serve one tenant another's
+    cached model. Proves run_blocking copies `_current_org_ctx` into the worker thread."""
+    import tools
+
+    main_thread = threading.get_ident()
+    seen: dict[str, object] = {}
+
+    def fake_handler(_args):
+        seen["thread"] = threading.get_ident()
+        seen["org"] = tools._current_org_id()  # reads _current_org_ctx
+        return "ok"
+
+    async def _call():
+        tools._current_org_ctx.set("tenant-A")
+        return await run_blocking(fake_handler, {})
+
+    try:
+        result = anyio.run(_call)
+    finally:
+        tools._current_org_ctx.set(None)
+
+    assert result == "ok"
+    assert seen["thread"] != main_thread  # ran off the event-loop thread
+    assert seen["org"] == "tenant-A"  # request org context propagated → tenant-correct cache
+
+
 def test_uvicorn_factory_import_string_resolves(monkeypatch):
     """`main()` binds uvicorn to the import string 'mcp_http:build_app' with factory=True — the callable
     must resolve and produce a Starlette app so multi-worker forking works."""


### PR DESCRIPTION
## Summary
Follow-up to **ACE-048**. That spec off-loaded the KDF / OIDC / audit-write calls, but the **tool handler itself was left on the event loop** ([mcp_http.py:312](../blob/main/packages/agami-core/src/mcp_http.py)). The heavy handlers block for the whole query — `execute_sql` shells out to a subprocess (up to 240 s) and hits the warehouse — so on the loop **one slow query froze every other in-flight request** on that worker. This wraps the handler in `run_blocking` so the loop stays responsive.

## Tenant-safety (the reason this needed care, not a one-liner)
Offloading to a thread would break the org-scoped model cache (ACE-045, read via `_current_org_ctx`) **if the request context didn't survive the thread hop** — a hosted server could then serve one tenant another's cached model. Verified empirically that `anyio.to_thread` (what `run_blocking` uses) **copies the context into the worker thread**, so the org stays tenant-correct. The added test asserts exactly this: an offloaded handler runs off the loop thread **and** sees the request's org.

## Tradeoff (called out honestly)
This raises concurrent query execution from **serialized (1/worker)** to anyio's default cap (**~40**), which also raises **peak concurrent warehouse connections**. For agami-core's single / small-team users that ceiling is academic and the loop-unblock is pure win; at real scale it's a knob to tune (anyio limiter / PG `max_connections`). The full fix for per-call connection cost is the parked **ACE-028** (in-process executor + connection reuse), which ACE-051 just unblocked.

## Checklist
- [x] `uv run dev.py check` green
- [x] Behaviour-preserving (same results, off-loop); tenant-context preservation tested
- [x] No egress; no new deps (`run_blocking` already exists from ACE-048)