### PR TITLE
feat: default the HTTP server to in-process execution (ACE-028)

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1170,7 +1170,10 @@ def main() -> int:
                         "min(this, AGAMI_SQL_MAX_ROWS) — the env is the deployment cap, default 1000.")
     args = p.parse_args()
 
-    _max_rows_override.set(args.max_rows)  # per-call cap (ACE-044); the sink reads it via _resolve_row_cap
+    # Per-call cap (ACE-044); the sink reads it via _resolve_row_cap. No token/reset kept: main() is
+    # the one-shot subprocess/CLI entry (one process, one thread), so there's no sibling request to
+    # isolate from — unlike the in-process server path, which resets the token in tools._run_in_process.
+    _max_rows_override.set(args.max_rows)
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -47,6 +47,7 @@ import stat
 import sys
 import urllib.parse
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -769,7 +770,12 @@ def _run_duckdb(creds: dict[str, str], sql: str) -> ExecResult:
 
 
 _DEFAULT_MAX_ROWS = 1000  # rows materialized per result before truncation (ACE-038)
-_max_rows_override: int | None = None  # per-call cap from --max-rows (ACE-044); set in main()
+# Per-call cap from --max-rows (ACE-044). A ContextVar, not a plain global, so it is REQUEST-SCOPED
+# once the HTTP server runs execution in-process (ACE-028): concurrent handlers run in worker threads
+# (`run_blocking` copies the context per call, like `_current_org_ctx`), so each request's cap is
+# isolated and can't stomp another's. In the subprocess/CLI (one process, one thread) it behaves
+# exactly as the old module global did.
+_max_rows_override: ContextVar[int | None] = ContextVar("_max_rows_override", default=None)
 
 
 def _resolve_row_cap() -> int:
@@ -781,8 +787,9 @@ def _resolve_row_cap() -> int:
     cap = int(raw) if raw.isdigit() else _DEFAULT_MAX_ROWS
     if cap <= 0:
         cap = _DEFAULT_MAX_ROWS  # "0" / "00" → the default, never an empty result
-    if _max_rows_override is not None and _max_rows_override > 0:
-        cap = min(cap, _max_rows_override)
+    override = _max_rows_override.get()
+    if override is not None and override > 0:
+        cap = min(cap, override)
     return cap
 
 
@@ -1122,7 +1129,7 @@ def execute_guarded(
     its JSON envelope for the caller to emit; a model-safety refusal already wrote its JSON to stderr
     and carries only the exit code) and ``ExecutorError`` on a connect/run failure — so the
     subprocess ``main`` and the in-process MCP handler apply the same guard and surface errors
-    identically. The row cap rides the ``_max_rows_override`` module global the caller sets."""
+    identically. The row cap rides the request-scoped ``_max_rows_override`` ContextVar the caller sets."""
     import sql_guard
 
     reason = sql_guard.check_read_only(sql)
@@ -1163,8 +1170,7 @@ def main() -> int:
                         "min(this, AGAMI_SQL_MAX_ROWS) — the env is the deployment cap, default 1000.")
     args = p.parse_args()
 
-    global _max_rows_override
-    _max_rows_override = args.max_rows  # per-call cap (ACE-044); the sink reads it via _resolve_row_cap
+    _max_rows_override.set(args.max_rows)  # per-call cap (ACE-044); the sink reads it via _resolve_row_cap
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -28,6 +28,7 @@ import admin
 import onboarding
 import user_store
 from async_offload import run_blocking
+from execute_sql import BUILTIN_EXECUTOR
 from oss_adapters import (
     FileActivitySink,
     PresenceAuthProvider,
@@ -111,15 +112,21 @@ def _build_org_resolver() -> SingleTenantOrgResolver:
 
 
 def default_adapters() -> Adapters:
-    """The OSS default adapters bundled for the composition root (env-driven auth + org, exactly as
-    today). `create_app(adapters=None)` uses these — so a plain deploy is unchanged. `create_app`
-    wires `auth_provider` + `org_resolver` into the request path; `activity_sink` + `governance` are
-    carried on the container for consumers and not yet referenced by a core call site."""
+    """The OSS default adapters bundled for the composition root (env-driven auth + org). Used only by
+    `create_app(adapters=None)` — the HTTP server's defaults. `create_app` wires `auth_provider` +
+    `org_resolver` into the request path and registers `executor`; `activity_sink` + `governance` are
+    carried on the container for consumers.
+
+    `executor=BUILTIN_EXECUTOR` (ACE-028) makes the HTTP server run execution **in-process** by default
+    — no per-query subprocess fork, no CSV round-trip — behind the same guard (AH-012). The forking
+    subprocess is the wrong shape for a long-running server; the local stdio path (`mcp_harness`) and
+    the `python -m execute_sql` CLI never build these adapters, so they keep the subprocess isolation."""
     return Adapters(
         activity_sink=FileActivitySink(),
         org_resolver=_build_org_resolver(),
         auth_provider=_build_auth_provider(),
         governance=WarnOnlyGovernancePolicy(),
+        executor=BUILTIN_EXECUTOR,
     )
 
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -961,11 +961,11 @@ def _run_in_process(
     (see the AH-012 spec); flipping this one coercion is the follow-up once that's settled."""
     import execute_sql
 
-    # The per-call cap rides execute_sql's module global (ACE-044). ACE-028, which makes in-process
-    # the real serving path, must thread the cap per-call instead — this global is not safe under
-    # concurrent in-process queries with different caps. Save/restore keeps it inert by default.
-    prev_cap = execute_sql._max_rows_override
-    execute_sql._max_rows_override = max_rows
+    # The per-call cap rides execute_sql's `_max_rows_override` ContextVar (ACE-028) — request-scoped,
+    # so concurrent in-process queries with different caps don't stomp each other. Set/reset via the
+    # token (the `_current_org_ctx` pattern); `run_blocking` copied this request's context into the
+    # worker thread, so the set is isolated to this call.
+    cap_token = execute_sql._max_rows_override.set(max_rows)
     try:
         result = execute_sql.execute_guarded(sql, profile, area, executor=executor)
     except execute_sql.GuardRefused as refusal:
@@ -991,7 +991,7 @@ def _run_in_process(
         return {"error": {"kind": _classify_exit(code),
                           "remediation": "Datasource configuration error."}}
     finally:
-        execute_sql._max_rows_override = prev_cap
+        execute_sql._max_rows_override.reset(cap_token)
 
     columns = list(result.columns)
     data_rows = [["" if v is None else str(v) for v in row] for row in result.rows]

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1170,7 +1170,10 @@ def main() -> int:
                         "min(this, AGAMI_SQL_MAX_ROWS) — the env is the deployment cap, default 1000.")
     args = p.parse_args()
 
-    _max_rows_override.set(args.max_rows)  # per-call cap (ACE-044); the sink reads it via _resolve_row_cap
+    # Per-call cap (ACE-044); the sink reads it via _resolve_row_cap. No token/reset kept: main() is
+    # the one-shot subprocess/CLI entry (one process, one thread), so there's no sibling request to
+    # isolate from — unlike the in-process server path, which resets the token in tools._run_in_process.
+    _max_rows_override.set(args.max_rows)
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -47,6 +47,7 @@ import stat
 import sys
 import urllib.parse
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -769,7 +770,12 @@ def _run_duckdb(creds: dict[str, str], sql: str) -> ExecResult:
 
 
 _DEFAULT_MAX_ROWS = 1000  # rows materialized per result before truncation (ACE-038)
-_max_rows_override: int | None = None  # per-call cap from --max-rows (ACE-044); set in main()
+# Per-call cap from --max-rows (ACE-044). A ContextVar, not a plain global, so it is REQUEST-SCOPED
+# once the HTTP server runs execution in-process (ACE-028): concurrent handlers run in worker threads
+# (`run_blocking` copies the context per call, like `_current_org_ctx`), so each request's cap is
+# isolated and can't stomp another's. In the subprocess/CLI (one process, one thread) it behaves
+# exactly as the old module global did.
+_max_rows_override: ContextVar[int | None] = ContextVar("_max_rows_override", default=None)
 
 
 def _resolve_row_cap() -> int:
@@ -781,8 +787,9 @@ def _resolve_row_cap() -> int:
     cap = int(raw) if raw.isdigit() else _DEFAULT_MAX_ROWS
     if cap <= 0:
         cap = _DEFAULT_MAX_ROWS  # "0" / "00" → the default, never an empty result
-    if _max_rows_override is not None and _max_rows_override > 0:
-        cap = min(cap, _max_rows_override)
+    override = _max_rows_override.get()
+    if override is not None and override > 0:
+        cap = min(cap, override)
     return cap
 
 
@@ -1122,7 +1129,7 @@ def execute_guarded(
     its JSON envelope for the caller to emit; a model-safety refusal already wrote its JSON to stderr
     and carries only the exit code) and ``ExecutorError`` on a connect/run failure — so the
     subprocess ``main`` and the in-process MCP handler apply the same guard and surface errors
-    identically. The row cap rides the ``_max_rows_override`` module global the caller sets."""
+    identically. The row cap rides the request-scoped ``_max_rows_override`` ContextVar the caller sets."""
     import sql_guard
 
     reason = sql_guard.check_read_only(sql)
@@ -1163,8 +1170,7 @@ def main() -> int:
                         "min(this, AGAMI_SQL_MAX_ROWS) — the env is the deployment cap, default 1000.")
     args = p.parse_args()
 
-    global _max_rows_override
-    _max_rows_override = args.max_rows  # per-call cap (ACE-044); the sink reads it via _resolve_row_cap
+    _max_rows_override.set(args.max_rows)  # per-call cap (ACE-044); the sink reads it via _resolve_row_cap
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/tests/test_ace028_in_process_default.py
+++ b/tests/test_ace028_in_process_default.py
@@ -75,8 +75,8 @@ def test_run_blocking_isolates_the_cap_across_worker_threads(monkeypatch):
 
     async def _call():
         async with anyio.create_task_group() as tg:
-            tg.start_soon(lambda: run_blocking(_work, "a", 10))
-            tg.start_soon(lambda: run_blocking(_work, "b", 500))
+            tg.start_soon(run_blocking, _work, "a", 10)
+            tg.start_soon(run_blocking, _work, "b", 500)
 
     anyio.run(_call)
     assert seen == {"a": 10, "b": 500}  # no cross-request stomp

--- a/tests/test_ace028_in_process_default.py
+++ b/tests/test_ace028_in_process_default.py
@@ -57,12 +57,13 @@ def test_row_cap_is_isolated_per_context(monkeypatch):
     assert execute_sql._max_rows_override.get() is None  # the outer context is untouched by either
 
 
-def test_run_blocking_isolates_the_cap_across_worker_threads():
+def test_run_blocking_isolates_the_cap_across_worker_threads(monkeypatch):
     # The real offload path: two `run_blocking` calls (worker threads, each a copied context) set
     # different caps concurrently and must not see each other's. Guards the ACE-028 concurrency claim.
     anyio = pytest.importorskip("anyio")
     from async_offload import run_blocking
 
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "1000")
     seen: dict[str, int] = {}
 
     def _work(key: str, cap: int):
@@ -73,20 +74,11 @@ def test_run_blocking_isolates_the_cap_across_worker_threads():
         seen[key] = execute_sql._resolve_row_cap()
 
     async def _call():
-        import os
-
-        os.environ["AGAMI_SQL_MAX_ROWS"] = "1000"
         async with anyio.create_task_group() as tg:
             tg.start_soon(lambda: run_blocking(_work, "a", 10))
             tg.start_soon(lambda: run_blocking(_work, "b", 500))
 
-    try:
-        anyio.run(_call)
-    finally:
-        import os
-
-        os.environ.pop("AGAMI_SQL_MAX_ROWS", None)
-
+    anyio.run(_call)
     assert seen == {"a": 10, "b": 500}  # no cross-request stomp
 
 

--- a/tests/test_ace028_in_process_default.py
+++ b/tests/test_ace028_in_process_default.py
@@ -1,0 +1,185 @@
+"""ACE-028 — in-process execution is the HTTP server's default (no fork), and the per-call row cap is
+request-scoped so concurrent in-process queries can't stomp each other's cap.
+
+Two things this pins:
+  1. `default_adapters()` carries `BUILTIN_EXECUTOR`, so `create_app()` runs execution in-process; the
+     stdio/CLI path (no injected executor) still forks.
+  2. `_max_rows_override` is a `ContextVar` — set in one context does not leak into another, which is
+     what makes it safe once concurrent requests share the server process.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import execute_sql  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    import tools
+
+    execute_sql._max_rows_override.set(None)
+    tools.set_injected_executor(None)
+    yield
+    execute_sql._max_rows_override.set(None)
+    tools.set_injected_executor(None)
+
+
+# --- the row cap is request-scoped (ContextVar), not a shared global -----------------------------
+
+
+def test_row_cap_is_isolated_per_context(monkeypatch):
+    # Two independent contexts set different caps; neither sees the other's. This is the property that
+    # makes in-process serving safe under concurrent requests (each runs in its own copied context).
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "1000")
+
+    def _cap_with_override(n: int | None) -> int:
+        execute_sql._max_rows_override.set(n)
+        return execute_sql._resolve_row_cap()
+
+    ctx_a = contextvars.copy_context()
+    ctx_b = contextvars.copy_context()
+    cap_a = ctx_a.run(_cap_with_override, 10)
+    cap_b = ctx_b.run(_cap_with_override, 500)
+
+    assert cap_a == 10 and cap_b == 500  # each context kept its own cap
+    assert execute_sql._max_rows_override.get() is None  # the outer context is untouched by either
+
+
+def test_run_blocking_isolates_the_cap_across_worker_threads():
+    # The real offload path: two `run_blocking` calls (worker threads, each a copied context) set
+    # different caps concurrently and must not see each other's. Guards the ACE-028 concurrency claim.
+    anyio = pytest.importorskip("anyio")
+    from async_offload import run_blocking
+
+    seen: dict[str, int] = {}
+
+    def _work(key: str, cap: int):
+        execute_sql._max_rows_override.set(cap)
+        # a tiny bit of work so the two overlap; the ContextVar must stay this call's value throughout
+        for _ in range(1000):
+            pass
+        seen[key] = execute_sql._resolve_row_cap()
+
+    async def _call():
+        import os
+
+        os.environ["AGAMI_SQL_MAX_ROWS"] = "1000"
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(lambda: run_blocking(_work, "a", 10))
+            tg.start_soon(lambda: run_blocking(_work, "b", 500))
+
+    try:
+        anyio.run(_call)
+    finally:
+        import os
+
+        os.environ.pop("AGAMI_SQL_MAX_ROWS", None)
+
+    assert seen == {"a": 10, "b": 500}  # no cross-request stomp
+
+
+# --- the HTTP server defaults to in-process; stdio/CLI still forks --------------------------------
+
+
+def test_default_adapters_carry_the_builtin_executor():
+    import mcp_http
+
+    assert mcp_http.default_adapters().executor is execute_sql.BUILTIN_EXECUTOR
+
+
+def test_http_server_runs_in_process_by_default_no_fork(monkeypatch):
+    # A default create_app() registers the built-in executor, so tool_execute_sql runs in-process —
+    # NO subprocess fork.
+    pytest.importorskip("starlette")
+    pytest.importorskip("mcp")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://agami.example.test")
+    import mcp_http
+    import tools
+
+    mcp_http.create_app()  # default adapters
+    assert tools._INJECTED_EXECUTOR is execute_sql.BUILTIN_EXECUTOR
+
+    monkeypatch.setattr(tools, "resolve_profile", lambda ds: "acme")
+    monkeypatch.setattr(execute_sql, "_load_credentials", lambda p: {"type": "sqlite", "path": ":memory:"})
+    monkeypatch.setattr(execute_sql, "_model_safety", lambda s, p, a: (s, None))
+    monkeypatch.setattr(tools.subprocess, "run", lambda *a, **k: pytest.fail("HTTP default must not fork"))
+
+    out = json.loads(tools.tool_execute_sql({"sql": "SELECT 1 AS n", "datasource": "acme"}))
+    assert out["columns"] == ["n"]  # ran in-process, no subprocess
+
+
+def test_stdio_cli_path_still_forks_when_no_executor_injected(monkeypatch):
+    # With no injected executor (the stdio/CLI default), tool_execute_sql shells the subprocess.
+    import tools
+
+    tools.set_injected_executor(None)
+    monkeypatch.setattr(tools, "resolve_profile", lambda ds: "acme")
+    captured: dict = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = "n\r\n1\r\n"
+        stderr = ""
+
+    def _fake_run(cmd, **k):
+        captured["cmd"] = cmd
+        return _Proc()
+
+    monkeypatch.setattr(tools.subprocess, "run", _fake_run)
+
+    out = json.loads(tools.tool_execute_sql({"sql": "SELECT n FROM t", "datasource": "acme"}))
+    assert "-m" in captured["cmd"] and "execute_sql" in captured["cmd"]  # forked
+    assert out["rows"] == [["1"]]
+
+
+def test_in_process_default_matches_subprocess_result_envelope(monkeypatch, tmp_path):
+    # Parity: the in-process default and the REAL subprocess fork return the same successful envelope
+    # for the same query. Both resolve creds from the SAME file (the subprocess is a separate process,
+    # so a `_load_credentials` monkeypatch wouldn't reach it) — the sqlite profile has no model, so the
+    # safety pass is inert locally on both.
+    import sqlite3
+
+    import agami_paths
+    import tools
+
+    db = tmp_path / "t.db"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE t (n INTEGER, s TEXT)")
+    con.executemany("INSERT INTO t (n, s) VALUES (?, ?)", [(1, "a"), (2, "b")])
+    con.commit()
+    con.close()
+
+    # A real credentials file both paths read: the subprocess via AGAMI_ARTIFACTS_DIR, the in-process
+    # module via its CREDENTIALS_PATH global (both point at the same file).
+    art = tmp_path / "art"
+    (art / "local").mkdir(parents=True)
+    creds = art / "local" / "credentials"
+    creds.write_text(f"[acme]\ntype = sqlite\npath = {db}\n")
+    creds.chmod(0o600)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+    monkeypatch.setattr(execute_sql, "CREDENTIALS_PATH", creds)
+    monkeypatch.setattr(tools, "resolve_profile", lambda ds: "acme")
+    monkeypatch.setattr(agami_paths, "credentials_path", lambda: creds)
+    args = {"sql": "SELECT n, s FROM t ORDER BY n", "datasource": "acme"}
+
+    tools.set_injected_executor(None)  # subprocess fork through `python -m execute_sql`
+    sub = json.loads(tools.tool_execute_sql(args))
+
+    tools.set_injected_executor(execute_sql.BUILTIN_EXECUTOR)  # in-process, as the HTTP default does
+    inproc = json.loads(tools.tool_execute_sql(args))
+
+    assert "columns" in sub, sub  # subprocess actually produced a result (not a creds error)
+    for key in ("columns", "rows", "row_count", "truncated"):
+        assert sub[key] == inproc[key]  # identical successful envelope whichever ran it

--- a/tests/test_ace044_bounded_fetch.py
+++ b/tests/test_ace044_bounded_fetch.py
@@ -22,10 +22,10 @@ import execute_sql  # noqa: E402
 
 @pytest.fixture(autouse=True)
 def _reset_override():
-    # _max_rows_override is a module global set by main(); isolate every test from it.
-    execute_sql._max_rows_override = None
+    # _max_rows_override is a request-scoped ContextVar (ACE-028); isolate every test from it.
+    execute_sql._max_rows_override.set(None)
     yield
-    execute_sql._max_rows_override = None
+    execute_sql._max_rows_override.set(None)
 
 
 class _FakeCur:
@@ -92,12 +92,12 @@ def test_sink_empty_result_writes_header_only_no_flag(monkeypatch, capsys):
 def test_effective_cap_is_min_of_env_and_per_call(monkeypatch):
     monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "1000")
     assert execute_sql._resolve_row_cap() == 1000  # env only
-    execute_sql._max_rows_override = 50
+    execute_sql._max_rows_override.set(50)
     assert execute_sql._resolve_row_cap() == 50  # per-call is smaller → wins
     monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "20")
     assert execute_sql._resolve_row_cap() == 20  # env smaller than per-call → wins
     monkeypatch.delenv("AGAMI_SQL_MAX_ROWS", raising=False)
-    execute_sql._max_rows_override = None
+    execute_sql._max_rows_override.set(None)
     assert execute_sql._resolve_row_cap() == 1000  # missing env → default
     # The env is the operator's DEPLOYMENT cap, not a hard 1000 ceiling — it may raise the default.
     monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "5000")

--- a/tests/test_ah012_executor_seam.py
+++ b/tests/test_ah012_executor_seam.py
@@ -30,10 +30,10 @@ import execute_sql  # noqa: E402
 
 @pytest.fixture(autouse=True)
 def _reset_override():
-    # _max_rows_override is a module global (ACE-044); isolate every test from it.
-    execute_sql._max_rows_override = None
+    # _max_rows_override is a request-scoped ContextVar (ACE-028); isolate every test from it.
+    execute_sql._max_rows_override.set(None)
     yield
-    execute_sql._max_rows_override = None
+    execute_sql._max_rows_override.set(None)
 
 
 class _SpyExecutor:
@@ -196,10 +196,12 @@ def test_create_app_registers_and_clears_the_injected_executor(monkeypatch):
         auth_provider=base.auth_provider, governance=base.governance, executor=fake,
     )
     mcp_http.create_app(adapters=adapters)
-    assert tools._INJECTED_EXECUTOR is fake  # wired from adapters.executor
+    assert tools._INJECTED_EXECUTOR is fake  # a consumer's explicit executor is wired from adapters
 
-    mcp_http.create_app()  # default adapters carry no executor
-    assert tools._INJECTED_EXECUTOR is None  # default path stays the subprocess fork
+    # ACE-028: the default adapters now carry the built-in executor, so a plain HTTP server runs
+    # in-process (the None-means-fork behaviour is still exercised via set_injected_executor(None)).
+    mcp_http.create_app()
+    assert tools._INJECTED_EXECUTOR is execute_sql.BUILTIN_EXECUTOR
 
 
 def test_injected_executor_runs_in_process_with_vetted_sql_and_no_fork(monkeypatch):

--- a/tests/test_ah012_executor_seam.py
+++ b/tests/test_ah012_executor_seam.py
@@ -181,7 +181,7 @@ def _reset_injected_executor():
     tools.set_injected_executor(None)
 
 
-def test_create_app_registers_and_clears_the_injected_executor(monkeypatch):
+def test_create_app_wires_injected_executor_and_defaults_to_builtin(monkeypatch):
     pytest.importorskip("starlette")
     pytest.importorskip("mcp")
     monkeypatch.setenv("PUBLIC_BASE_URL", "https://agami.example.test")


### PR DESCRIPTION
**Spec: ACE-028** — In-process execution, default for the HTTP server (contract: F1-hosted-mcp-server · REQ-002 · depends_on AH-012).

## Summary
The self-hosted **HTTP server** forked `python -m execute_sql` per query — the wrong shape for a long-running server (fork + interpreter start + a CSV serialize/re-parse round-trip every request). AH-012 shipped the seam; this **turns it on by default for the HTTP server**: no fork, no CSV round-trip, native rows, all behind the same guard. The **local stdio server (`mcp_harness`) and the `python -m execute_sql` CLI keep forking** — they never build these adapters, and the throwaway-process isolation is worth keeping for a single-user tool.

## Changes
- **`mcp_http.default_adapters()`** now carries `executor=BUILTIN_EXECUTOR`. `create_app()` already calls `set_injected_executor(adapters.executor)` (AH-012), so a plain HTTP server runs `tool_execute_sql` in-process via `execute_guarded`. Consumers passing their own `Adapters` (or `executor=None`) are unaffected.
- **`execute_sql._max_rows_override` → `ContextVar`.** The per-call `--max-rows` cap was a module global that would race once in-process is the default under concurrent worker-thread requests. It's now request-scoped: `run_blocking` copies the context per call, so each request's cap is isolated. Set/reset via token in `tools._run_in_process`; `main()` sets it once (one-shot process, no reset).

## Owner decisions (recorded in the spec)
- **Connect-per-query, no connection reuse** — reuse/pooling stays a trigger-gated follow-up (revisit on measured Snowflake connect-latency).
- **Default, not opt-in** — the fork is bad design for a server, so the server shouldn't ship it as the default.

## Isolation trade-off (accepted)
In-process, the warehouse connection + resolved credential live in the server process for the query's duration (a per-query subprocess held them before). Connect-per-query, no pooling — nothing is held across requests; no cross-request state. A server already holds the model + auth in-process.

## Out of scope / tracked follow-ups
- Connection reuse/pooling (trigger-gated).
- Native-typed rows at the MCP JSON edge (AH-012 deferred — rows stay textualized).
- Structured-refusal parity: making in-process the default surfaces AH-012's known refusal-envelope difference (in-process model-safety refusals return a clean generic remediation with detail in the server log, vs the subprocess's stderr JSON). Its own follow-up (`_model_safety` returning its envelope).

## Test plan / checklist
- [x] HTTP server runs in-process **by default** (no `subprocess.run`); **stdio/CLI still forks**; the built-in executor is on `default_adapters`.
- [x] **Parity**: in-process default vs a **real subprocess fork** return the same successful envelope (columns/rows/row_count/truncated) — both reading the same credentials file.
- [x] **Row cap concurrency-safe**: per-context isolation + a real `run_blocking` two-worker overlap test (`{"a":10,"b":500}`, no stomp).
- [x] Guard un-bypassable on every in-process query (via `execute_guarded`, AH-012 tests + the default-path test).
- [x] `uv run dev.py check` green (ruff + full suite + gitleaks); **100% patch coverage**; mirror synced.
- [x] Review panel (security/concurrency + correctness/test-quality): **0 must-fix** — `run_blocking` context-copy isolation verified empirically; guard remains the single chokepoint.
