### PR TITLE
fix: Postgres/Redshift returned 0 rows (read cursor description after fetch)

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -806,16 +806,19 @@ def _collect_cursor(cur: Any) -> ExecResult:
     `fetchmany(cap + 1)` — never `fetchall` — so a huge result can't be buffered whole; a (cap+1)th
     row means the result was truncated. The SQL itself is untouched (no injected LIMIT). This is the
     single bounded-fetch implementation both the CSV wire (`_write_cursor_csv`) and the in-process
-    executor path share, so the row cap is enforced once, identically, for every caller."""
+    executor path share, so the row cap is enforced once, identically, for every caller.
+
+    Fetch FIRST, then read ``cur.description``: a psycopg2 **server-side (named) cursor** — which the
+    Postgres/Redshift path uses to bound transfer (ACE-038) — reports ``description is None`` until the
+    first fetch, so reading it beforehand would drop EVERY row of a real Postgres result. Client-side
+    cursors (sqlite/mysql/…) set ``description`` at execute, so fetch-first is equally correct there."""
     cap = _resolve_row_cap()
+    fetched = cur.fetchmany(cap + 1)
     if cur.description is None:
-        # No result set (a non-row statement). `_emit_result_csv` writes nothing for empty columns,
-        # matching the old sink. A description that is an *empty list* (a zero-column result set)
-        # would diverge from the old bare-header line, but the read-only guard admits only
-        # SELECT/WITH…SELECT, which always project >= 1 column — so that case can't reach here.
+        # A statement with no result set. The read-only guard admits only SELECT/WITH…SELECT (which
+        # always have a result set), so this is defensive; emit nothing, matching the old sink.
         return ExecResult(columns=[], rows=[], truncated=False)
     columns = [d[0] for d in cur.description]
-    fetched = cur.fetchmany(cap + 1)
     truncated = len(fetched) > cap
     return ExecResult(columns=columns, rows=[tuple(r) for r in fetched[:cap]], truncated=truncated)
 

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -806,16 +806,19 @@ def _collect_cursor(cur: Any) -> ExecResult:
     `fetchmany(cap + 1)` — never `fetchall` — so a huge result can't be buffered whole; a (cap+1)th
     row means the result was truncated. The SQL itself is untouched (no injected LIMIT). This is the
     single bounded-fetch implementation both the CSV wire (`_write_cursor_csv`) and the in-process
-    executor path share, so the row cap is enforced once, identically, for every caller."""
+    executor path share, so the row cap is enforced once, identically, for every caller.
+
+    Fetch FIRST, then read ``cur.description``: a psycopg2 **server-side (named) cursor** — which the
+    Postgres/Redshift path uses to bound transfer (ACE-038) — reports ``description is None`` until the
+    first fetch, so reading it beforehand would drop EVERY row of a real Postgres result. Client-side
+    cursors (sqlite/mysql/…) set ``description`` at execute, so fetch-first is equally correct there."""
     cap = _resolve_row_cap()
+    fetched = cur.fetchmany(cap + 1)
     if cur.description is None:
-        # No result set (a non-row statement). `_emit_result_csv` writes nothing for empty columns,
-        # matching the old sink. A description that is an *empty list* (a zero-column result set)
-        # would diverge from the old bare-header line, but the read-only guard admits only
-        # SELECT/WITH…SELECT, which always project >= 1 column — so that case can't reach here.
+        # A statement with no result set. The read-only guard admits only SELECT/WITH…SELECT (which
+        # always have a result set), so this is defensive; emit nothing, matching the old sink.
         return ExecResult(columns=[], rows=[], truncated=False)
     columns = [d[0] for d in cur.description]
-    fetched = cur.fetchmany(cap + 1)
     truncated = len(fetched) > cap
     return ExecResult(columns=columns, rows=[tuple(r) for r in fetched[:cap]], truncated=truncated)
 

--- a/tests/test_ace044_bounded_fetch.py
+++ b/tests/test_ace044_bounded_fetch.py
@@ -46,6 +46,36 @@ class _FakeCur:
         return self._rows
 
 
+class _NamedCur:
+    """Mimics a psycopg2 **server-side (named) cursor**: `description` is None until the first fetch,
+    then reports the columns. The Postgres/Redshift path (`cursor(name="agami_bounded")`, ACE-038)
+    behaves exactly this way — the previous `_FakeCur` set `description` at construction and so never
+    reproduced it, masking a bug where every real Postgres row was dropped."""
+
+    def __init__(self, columns: list[str], rows: list[tuple]):
+        self._columns = columns
+        self._rows = rows
+        self.description = None  # None until the first fetch, like a real named cursor
+
+    def fetchmany(self, n: int):
+        self.description = [(c,) for c in self._columns]  # populated only after the first fetch
+        return self._rows[:n]
+
+
+def test_collect_cursor_reads_description_after_fetch_for_named_cursors(monkeypatch):
+    # Regression: a server-side named cursor reports description=None until the first fetch, so
+    # `_collect_cursor` must fetch FIRST. Under the pre-fix (read-before-fetch) this returned empty
+    # columns/rows — i.e. every Postgres/Redshift query silently returned 0 rows.
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "1000")
+    cur = _NamedCur(["name", "region"], [("Alice", "NA"), ("Bob", "EU")])
+
+    result = execute_sql._collect_cursor(cur)
+
+    assert result.columns == ["name", "region"]  # would be [] before the fix
+    assert result.rows == [("Alice", "NA"), ("Bob", "EU")]
+    assert result.truncated is False
+
+
 def test_sink_bounds_at_cap_and_flags_truncation(monkeypatch, capsys):
     monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "3")
     cur = _FakeCur(2, 10)  # 10 rows available, cap 3

--- a/tests/test_postgres_named_cursor_integration.py
+++ b/tests/test_postgres_named_cursor_integration.py
@@ -1,0 +1,87 @@
+"""Integration guard: run the REAL Postgres path (a psycopg2 server-side *named* cursor) against a
+live Postgres and assert it returns the actual rows. This is the coverage the fake-cursor unit tests
+can't give — a named cursor reports `description is None` until the first fetch, and only a real
+driver reproduces that.
+
+Opt-in: it **skips unless `AGAMI_IT_PG_PASSWORD` is set** (so normal CI, which has no Postgres, is
+unaffected, and no test password lives in the source). To run it against the integration fixture:
+
+    docker compose -f tests/integration/docker-compose.yml up -d postgres
+    AGAMI_IT_PG_PASSWORD=<the fixture's POSTGRES_PASSWORD> \
+        uv run pytest tests/test_postgres_named_cursor_integration.py
+
+Host/port/user/db default to the fixture's values and can be overridden via the other AGAMI_IT_PG_*
+vars. Regression target: before the fetch-first fix, every Postgres/Redshift query returned 0 rows.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import execute_sql  # noqa: E402
+
+
+def _pg_creds() -> dict[str, str]:
+    # The password is env-only (no source-embedded test secret); host/port/user/db default to the
+    # fixture's values. Override any of them via AGAMI_IT_PG_* to point at another Postgres.
+    return {
+        "type": "postgres",
+        "host": os.environ.get("AGAMI_IT_PG_HOST", "127.0.0.1"),
+        "port": os.environ.get("AGAMI_IT_PG_PORT", "55432"),
+        "user": os.environ.get("AGAMI_IT_PG_USER", "agami_test"),
+        "password": os.environ["AGAMI_IT_PG_PASSWORD"],
+        "database": os.environ.get("AGAMI_IT_PG_DB", "shop"),
+    }
+
+
+@pytest.fixture
+def pg_conn():
+    psycopg2 = pytest.importorskip("psycopg2")
+    if not os.environ.get("AGAMI_IT_PG_PASSWORD"):
+        pytest.skip("set AGAMI_IT_PG_PASSWORD to run the live-Postgres integration test")
+    creds = _pg_creds()
+    try:
+        conn = psycopg2.connect(
+            host=creds["host"], port=int(creds["port"]), user=creds["user"],
+            password=creds["password"], dbname=creds["database"], connect_timeout=3,
+        )
+    except Exception as exc:  # no DB in this environment → skip, don't fail
+        pytest.skip(f"no reachable Postgres for the integration test ({exc})")
+    try:
+        yield conn, creds
+    finally:
+        conn.close()
+
+
+def test_run_postgres_returns_real_rows_through_the_named_cursor(pg_conn, monkeypatch):
+    conn, creds = pg_conn
+    # Self-contained: create our own table so the test doesn't depend on any fixture schema.
+    with conn.cursor() as c:
+        c.execute("DROP TABLE IF EXISTS agami_it_named_cursor")
+        c.execute("CREATE TABLE agami_it_named_cursor (id int, label text)")
+        c.execute("INSERT INTO agami_it_named_cursor VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+        conn.commit()
+
+    monkeypatch.setenv("AGAMI_SQL_MAX_ROWS", "1000")
+    try:
+        # _run_postgres opens its own connection and uses cursor(name="agami_bounded") — the REAL
+        # server-side named cursor whose description is None until the first fetch.
+        result = execute_sql._run_postgres(
+            creds, "SELECT id, label FROM agami_it_named_cursor ORDER BY id"
+        )
+        assert result.columns == ["id", "label"]
+        assert result.rows == [(1, "a"), (2, "b"), (3, "c")]  # 0 rows before the fetch-first fix
+        assert result.truncated is False
+    finally:
+        with conn.cursor() as c:
+            c.execute("DROP TABLE IF EXISTS agami_it_named_cursor")
+            conn.commit()


### PR DESCRIPTION
## Summary
**Postgres and Redshift queries silently returned 0 rows** through the Python (tier-3) executor. `_collect_cursor` read `cur.description` **before** fetching — but the Postgres/Redshift path uses a psycopg2 **server-side (named) cursor** (`cursor(name="agami_bounded")`, added in ACE-038 for bounded transfer), and a named cursor reports `description is None` **until the first fetch**. So the guard-before-fetch check concluded "no result set" and returned empty columns/rows — for every Postgres query. Client-side cursors (SQLite/MySQL/etc., `description` set at execute) were unaffected.

**Pre-existing since ACE-038** — the old `_write_cursor_csv` had the same read-before-fetch order. It was exposed while validating the new in-process HTTP default (ACE-028) with a **real end-to-end smoke test**: booting the actual `create_app()` composition root against a live Postgres returned **0 rows before, 5 real rows after**.

## Fix
One reorder in `_collect_cursor`: **fetch first, then read `description`** (populated by then on a named cursor; already set at execute for client-side cursors). Empty-result and truncation edges verified against a live Postgres.

## Why it slipped through
- The unit test `test_postgres_uses_a_server_side_named_cursor` used a **fake** cursor that set `description` at construction — so it never reproduced the real named-cursor contract. Green unit tests, broken reality.
- The `tests/integration/*.sh` scripts exercise the native `psql` (tier-1) path, not the Python executor.

## Tests
- **`test_collect_cursor_reads_description_after_fetch_for_named_cursors`** (test_ace044) — a `_NamedCur` fake whose `description` is `None` until the first `fetchmany`. **Fails pre-fix**, passes post-fix — the CI-level regression guard the old fake couldn't provide.
- **`test_postgres_named_cursor_integration.py`** — the REAL psycopg2 named cursor against a live Postgres (the `tests/integration` docker fixture, or any PG via `AGAMI_IT_PG_*`). **Auto-skips** when no DB is reachable, so normal CI is unaffected; runs locally/in an integration job.

## Checklist
- [x] `uv run dev.py check` green (ruff + full suite + gitleaks); **100% patch coverage**; mirror synced.
- [x] Verified end-to-end against a live Postgres (real rows, no subprocess fork, guard intact) + empty-result/truncation edges.
- [x] Affects Postgres + Redshift (named cursor); SQLite/MySQL/etc. unchanged. No egress, no customer data.
