### PR TITLE
release: 0.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.4.1] — 2026-07-12
+
+The self-hosted HTTP server now runs SQL **in-process** by default — no per-query subprocess fork,
+no CSV round-trip — behind a swappable execution seam. Plus a correctness fix for Postgres/Redshift.
+
+### Added
+
+- **Executor seam (`ports.Executor`).** `execute_sql` is split into a shared, un-bypassable *guarded
+  envelope* (read-only guard → semantic-model safety → resolve datasource → execute) and a swappable
+  **`Executor` port**. The built-in executor is the default and behaviour is unchanged; a consumer can
+  inject a custom executor (e.g. pooled / per-user-RBAC) via `create_app(adapters=…)` **behind the same
+  guard** — one execution implementation, never forked.
+
+### Changed
+
+- **The HTTP server executes queries in-process by default.** Previously every query forked
+  `python -m execute_sql`; now the served path runs through the executor seam in-process — no fork, no
+  CSV serialize/re-parse round-trip, native rows. The local stdio path and the `python -m execute_sql`
+  CLI still fork (the throwaway-process isolation is kept for the single-user tool). Successful query
+  results are identical to before.
+- **The per-call row cap is request-scoped.** `--max-rows` now rides a `ContextVar` (was a module
+  global), so concurrent in-process queries with different caps can't affect each other.
+
+### Fixed
+
+- **Postgres/Redshift queries returned 0 rows through the Python executor.** A psycopg2 server-side
+  (named) cursor reports `description = None` until the first fetch, and the result collector read it
+  *before* fetching — so it concluded "no result set" and returned empty. It now fetches first, then
+  reads the description. SQLite/MySQL/etc. (client-side cursors) were unaffected. (Present since the
+  server-side cursor was introduced for bounded transfer.)
+
+### Performance
+
+- **Tool handler runs off the event loop.** The heavy query handler is offloaded via `run_blocking`
+  (completing the async-offload work), so one slow query no longer stalls the server's event loop.
+
 ## [0.4.0] — 2026-07-12
 
 Runtime scalability & safety hardening: the server stays responsive and bounded as model size,

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Version bump 0.4.0 → 0.4.1 + CHANGELOG.

Ships since v0.4.0:
- **AH-012** executor seam (`ports.Executor` + guarded envelope) — #116
- **ACE-028** HTTP server runs in-process by default; request-scoped row cap — #117
- **fix** Postgres/Redshift returned 0 rows (named-cursor description-before-fetch) — #118 — *validated end-to-end against a live Postgres*
- **perf** tool handler off the event loop (ACE-048) — #114

Patch bump (0.4.1) per owner call. After merge: create GitHub Release `v0.4.1` → trusted-publish to PyPI (the workflow verifies the tag matches pyproject `0.4.1`).

- [x] version bumped in all 3 files (4 fields); CHANGELOG updated
- [x] `uv run dev.py check` green