### PR TITLE
fix(onboarding): star-free seed probe, sm approve-queue + at-stamp, pytz-aware duckdb resolver (ACE-062)

### DIFF
--- a/packages/agami-core/src/semantic_model/cli.py
+++ b/packages/agami-core/src/semantic_model/cli.py
@@ -27,6 +27,7 @@ import json
 import os
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -38,6 +39,23 @@ from . import validator as V
 def _print_json(obj) -> None:
     json.dump(obj, sys.stdout, indent=2, default=str)
     sys.stdout.write("\n")
+
+
+def _utc_now_iso() -> str:
+    """ISO-8601 UTC (`...Z`) — the sign-off timestamp format the validator expects."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _stamp_approve_ops(ops: list) -> list:
+    """Stamp `at` on any `approve` op that lacks one. curate.apply deliberately can't read
+    the clock itself (`op.get("at")` — "caller stamps"); an approve op without `at` records
+    `signed_off_at: null` and the validator then rejects the whole batch. The CLI process
+    *can* read the clock, so it stamps here — one place, for every CLI caller."""
+    now = _utc_now_iso()
+    for op in ops:
+        if isinstance(op, dict) and op.get("op") == "approve" and not op.get("at"):
+            op["at"] = now
+    return ops
 
 
 def cmd_validate(args) -> int:
@@ -280,8 +298,31 @@ def cmd_curate(args) -> int:
         ops = json.load(fh)
     if isinstance(ops, dict):
         ops = ops.get("ops", [])
+    _stamp_approve_ops(ops)
     res = curate.apply(args.root, ops, signer=args.signer, role=args.role)
     _print_json(res.as_dict())
+    return 0 if res.validated else 1
+
+
+def cmd_approve_queue(args) -> int:
+    """Sign off the whole pending review queue in one call — the first-class no-browser
+    path (the HTML explorer's CLI equivalent). Reads the same queue `review-queue` builds
+    (Rule 1 metrics/named-filters + Rule 2 joins/entities), turns each item into a
+    self-stamped `approve` op, and applies via curate.apply. `--kind` narrows to one item
+    type; `--dry-run` prints the ops without touching the model."""
+    from . import curate
+    org = L.load_organization(args.root)
+    queue = curate.review_queue(org)
+    kinds = set(args.kind) if args.kind else None
+    ops = [{"op": "approve", "kind": it["kind"], "area": it["area"],
+            "name": it["name"], "at": _utc_now_iso()}
+           for bucket in ("rule_1", "rule_2") for it in queue.get(bucket, [])
+           if kinds is None or it["kind"] in kinds]
+    if args.dry_run:
+        _print_json({"dry_run": True, "count": len(ops), "ops": ops})
+        return 0
+    res = curate.apply(args.root, ops, signer=args.signer, role=args.role)
+    _print_json({"approved": len(ops), **res.as_dict()})
     return 0 if res.validated else 1
 
 
@@ -1110,6 +1151,17 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--signer", default=None, help="sign-off email for approve ops")
     sp.add_argument("--role", default=None, help="sign-off role for approve ops")
     sp.set_defaults(func=cmd_curate)
+
+    sp = sub.add_parser("approve-queue",
+                        help="sign off the whole pending review queue in one call (no-browser path)")
+    sp.add_argument("root")
+    sp.add_argument("--signer", default=None, help="sign-off email recorded on each item")
+    sp.add_argument("--role", default=None, help="sign-off role recorded on each item")
+    sp.add_argument("--kind", action="append", choices=["metric", "entity", "relationship"],
+                    help="restrict to one item kind (repeatable); default approves all")
+    sp.add_argument("--dry-run", action="store_true", dest="dry_run",
+                    help="print the approve ops that would be applied, without applying them")
+    sp.set_defaults(func=cmd_approve_queue)
 
     sp = sub.add_parser("add", help="create metric/entity YAMLs from a JSON file (validated, revertable)")
     sp.add_argument("root")

--- a/packages/agami-core/src/semantic_model/cli.py
+++ b/packages/agami-core/src/semantic_model/cli.py
@@ -1155,8 +1155,11 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("approve-queue",
                         help="sign off the whole pending review queue in one call (no-browser path)")
     sp.add_argument("root")
-    sp.add_argument("--signer", default=None, help="sign-off email recorded on each item")
-    sp.add_argument("--role", default=None, help="sign-off role recorded on each item")
+    # required: curate._set_trust only stamps signed_off_* when a signer is present, so an
+    # approve with no signer records an incomplete trust block and the validator reverts the
+    # whole batch. A sign-off must record who — mirror that at the CLI surface.
+    sp.add_argument("--signer", required=True, help="sign-off email recorded on each item")
+    sp.add_argument("--role", required=True, help="sign-off role recorded on each item")
     sp.add_argument("--kind", action="append", choices=["metric", "entity", "relationship"],
                     help="restrict to one item kind (repeatable); default approves all")
     sp.add_argument("--dry-run", action="store_true", dest="dry_run",

--- a/packages/agami-core/src/semantic_model/curate.py
+++ b/packages/agami-core/src/semantic_model/curate.py
@@ -945,7 +945,7 @@ def remove_examples(root: str | Path, area: str, questions: list[str],
 def validate_seeds(candidates: list[dict], runner) -> tuple[list[dict], list[dict]]:
     """Split candidate examples into (passing, rejected) by validating each SQL against
     the live DB — dialect-agnostically and scanning no data. Each SQL is wrapped to
-    return zero rows (`SELECT * FROM (<sql>) WHERE 1=0`) and run via `runner` (which
+    return zero rows (`SELECT 1 FROM (<sql>) WHERE 1=0`) and run via `runner` (which
     raises on a bad query). This is the packaged Phase-5 validation loop, so the skill
     never writes a throwaway script to EXPLAIN seeds one by one. Passing examples get
     `source: seed` / `status: confirmed` defaults; rejected carry the DB error."""
@@ -957,7 +957,11 @@ def validate_seeds(candidates: list[dict], runner) -> tuple[list[dict], list[dic
         if not sql or not q:
             rejected.append({"question": q or "?", "error": "question and sql are required"})
             continue
-        probe = "SELECT * FROM (\n" + str(sql).strip().rstrip(";") + "\n) AS _agami_seed_validate WHERE 1=0"
+        # `SELECT 1` (not `SELECT *`): the star-free wrapper still forces the DB to parse +
+        # plan the inner query and return zero rows, but the executor's SELECT-* ban
+        # (runtime.check_no_select_star) walks every SELECT in the tree — a `SELECT *` wrapper
+        # would trip the ban on itself and reject every seed regardless of its own SQL.
+        probe = "SELECT 1 FROM (\n" + str(sql).strip().rstrip(";") + "\n) AS _agami_seed_validate WHERE 1=0"
         try:
             runner(probe)
         except Exception as e:

--- a/plugins/agami/scripts/connect_resolve.py
+++ b/plugins/agami/scripts/connect_resolve.py
@@ -63,6 +63,10 @@ _DRIVER_MOD = {
     "sqlserver": "pymssql", "oracle": "oracledb", "databricks": "databricks.sql",
     "trino": "trino", "duckdb": "duckdb", "sqlite": "",
 }
+# Extra runtime modules a driver needs but doesn't pull in itself, folded into has_driver so
+# the "driver missing" branch installs them up front. duckdb needs pytz to materialize
+# TIMESTAMP WITH TIME ZONE values into Python — without it a timestamptz query fails at runtime.
+_DRIVER_EXTRA = {"duckdb": ["pytz"]}
 _MODEL_DEPS = ("pydantic", "sqlglot", "yaml")
 _NATIVE_TOOLS = ("psql", "mysql", "snowsql", "sqlite3", "duckdb", "bq")
 
@@ -110,8 +114,10 @@ def _resolve_interpreter(db_type: str | None, configured: str | None) -> dict:
     """Score candidates on (driver + model deps); pick the best. A configured
     interpreter that still satisfies everything wins (no churn). Mirrors 0a.5 — but
     deterministically, so we never record a Python that's missing a dep."""
-    driver = _DRIVER_MOD.get((db_type or "").lower(), None)
+    db_key = (db_type or "").lower()
+    driver = _DRIVER_MOD.get(db_key, None)
     want_driver = bool(driver)
+    driver_mods = [driver, *_DRIVER_EXTRA.get(db_key, [])] if want_driver else []
     candidates = []
     if configured and os.access(configured, os.X_OK):
         candidates.append(configured)
@@ -121,7 +127,7 @@ def _resolve_interpreter(db_type: str | None, configured: str | None) -> dict:
     best = None
     for py in candidates:
         has_deps = _probe(py, list(_MODEL_DEPS))
-        has_driver = _probe(py, [driver]) if want_driver else None
+        has_driver = _probe(py, driver_mods) if want_driver else None
         score = (1 if has_deps else 0) + (1 if (has_driver or not want_driver) else 0)
         # canonical path
         try:

--- a/tests/test_connect_resolve.py
+++ b/tests/test_connect_resolve.py
@@ -155,3 +155,23 @@ def test_interpreter_falls_back_to_base_when_none_equipped(monkeypatch):
     res = CR._resolve_interpreter("postgres", configured=None)
     assert res["python3"] == base
     assert res["has_model_deps"] is False
+
+
+def test_duckdb_driver_requires_pytz(monkeypatch):
+    """ACE-062 A3: the duckdb driver probe must require pytz as well — duckdb needs it to
+    materialize TIMESTAMP WITH TIME ZONE values. An interpreter with duckdb but not pytz
+    must score has_driver=False so the skill installs pytz before the first timestamptz
+    query (rather than the query failing at runtime with 'pytz failed to import')."""
+    no_pytz, full = "/fake/duckdb-no-pytz/python3", "/fake/duckdb-pytz/python3"
+    have = {no_pytz: {"pydantic", "sqlglot", "yaml", "duckdb"},
+            full: {"pydantic", "sqlglot", "yaml", "duckdb", "pytz"}}
+    monkeypatch.setattr(CR, "_candidate_interpreters", lambda: [no_pytz, full])
+    # content-aware probe: an interpreter passes only if it has EVERY requested module
+    monkeypatch.setattr(CR, "_probe",
+                        lambda py, mods: all(m in have.get(py, set()) for m in mods if m))
+
+    res = CR._resolve_interpreter("duckdb", configured=None)
+    scored = {c["python3"]: c for c in res["candidates_scored"]}
+    assert scored[no_pytz]["has_driver"] is False   # duckdb present, pytz missing → not ready
+    assert scored[full]["has_driver"] is True
+    assert res["python3"] == full                    # the pytz-equipped interpreter is chosen

--- a/tests/test_semantic_model_cli.py
+++ b/tests/test_semantic_model_cli.py
@@ -728,10 +728,20 @@ def test_approve_queue_signs_off_all_pending(tmp_path):
     assert mm["signed_off_at"] and mm["signed_off_by"] == "you@example.com" and mm["signed_off_role"] == "owner"
 
 
+def test_approve_queue_requires_a_signer(tmp_path):
+    """`--signer`/`--role` are required: curate only stamps signed_off_* when a signer is
+    present, so a signer-less approve would record an incomplete trust block and the whole
+    batch would revert at validation. argparse must reject the call up front instead."""
+    _model_with_pending(tmp_path)
+    with pytest.raises(SystemExit):  # argparse errors out on the missing required flags
+        _run(["approve-queue", str(tmp_path)])
+
+
 def test_approve_queue_kind_filter_and_dry_run(tmp_path):
     """`--kind` narrows to one item type; `--dry-run` prints ops without mutating the model."""
     _model_with_pending(tmp_path)
-    rc, out = _run(["approve-queue", str(tmp_path), "--kind", "metric", "--dry-run"])
+    rc, out = _run(["approve-queue", str(tmp_path), "--signer", "you@example.com",
+                    "--role", "owner", "--kind", "metric", "--dry-run"])
     assert rc == 0
     payload = json.loads(out)
     assert payload["dry_run"] is True

--- a/tests/test_semantic_model_cli.py
+++ b/tests/test_semantic_model_cli.py
@@ -694,3 +694,63 @@ def test_suggest_units_finds_money_columns(tmp_path):
     assert ("orders", "total") in names            # numeric + money-named
     assert ("order_items", "qty") not in names      # a count, not money
     assert all(c["column"] != "id" for c in cols)   # ids excluded
+
+
+def _model_with_pending(root: Path) -> None:
+    """Like `_model`, but the relationship is unreviewed and a proposed metric is added — so
+    the review queue is non-empty (a Rule-1 metric + a Rule-2 join) for approve-queue tests."""
+    _model(root)
+    (root / "subject_areas" / "s" / "metrics").mkdir(parents=True, exist_ok=True)
+    (root / "subject_areas" / "s" / "metrics" / "order_count.yaml").write_text(yaml.safe_dump({
+        "name": "order_count", "calculation": "count of orders",
+        "bindings": {"PostgreSQL": "COUNT(*)"}, "source_tables": ["orders"],
+        "confidence": "proposed", "review_state": "unreviewed"}))
+    (root / "subject_areas" / "s" / "relationships.yaml").write_text(yaml.safe_dump({
+        "relationships": [{"from_table": "order_items", "from_column": "order_id",
+                           "to_table": "orders", "to_column": "id", "relationship": "many_to_one",
+                           "confidence": "inferred", "review_state": "unreviewed"}]}))
+
+
+def test_approve_queue_signs_off_all_pending(tmp_path):
+    """`sm approve-queue` turns the whole pending queue into self-stamped approve ops and applies
+    them — the no-browser sign-off path. Queue → 0, gate's preseed_count → 0, sign-off recorded."""
+    _model_with_pending(tmp_path)
+    rc, out = _run(["approve-queue", str(tmp_path),
+                    "--signer", "you@example.com", "--role", "owner"])
+    assert rc == 0, out
+    assert json.loads(out)["validated"] is True
+
+    assert json.loads(_run(["review-queue", str(tmp_path)])[1])["counts"]["total"] == 0
+    assert json.loads(_run(["curate-gate", str(tmp_path)])[1])["preseed_count"] == 0
+
+    mm = yaml.safe_load((tmp_path / "subject_areas" / "s" / "metrics" / "order_count.yaml").read_text())
+    assert mm["review_state"] == "approved"
+    assert mm["signed_off_at"] and mm["signed_off_by"] == "you@example.com" and mm["signed_off_role"] == "owner"
+
+
+def test_approve_queue_kind_filter_and_dry_run(tmp_path):
+    """`--kind` narrows to one item type; `--dry-run` prints ops without mutating the model."""
+    _model_with_pending(tmp_path)
+    rc, out = _run(["approve-queue", str(tmp_path), "--kind", "metric", "--dry-run"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["dry_run"] is True
+    assert [op["kind"] for op in payload["ops"]] == ["metric"]  # relationship excluded
+    assert all(op["at"] for op in payload["ops"])               # self-stamped
+    # nothing applied: the queue is still full
+    assert json.loads(_run(["review-queue", str(tmp_path)])[1])["counts"]["total"] == 2
+
+
+def test_curate_auto_stamps_missing_at(tmp_path):
+    """Regression (ACE-062 A2a): an approve op that omits `at` used to record signed_off_at:null
+    and the validator rejected the whole batch. `sm curate` now stamps `at` at the CLI boundary."""
+    _model_with_pending(tmp_path)
+    ops = tmp_path / "ops.json"
+    ops.write_text(json.dumps([{"op": "approve", "kind": "metric", "area": "s",
+                                "name": "order_count"}]))  # note: no "at"
+    rc, out = _run(["curate", str(tmp_path), "--ops-file", str(ops),
+                    "--signer", "you@example.com", "--role", "owner"])
+    assert rc == 0, out
+    assert json.loads(out)["validated"] is True
+    mm = yaml.safe_load((tmp_path / "subject_areas" / "s" / "metrics" / "order_count.yaml").read_text())
+    assert mm["review_state"] == "approved" and mm["signed_off_at"]  # non-null, auto-stamped

--- a/tests/test_semantic_model_curate.py
+++ b/tests/test_semantic_model_curate.py
@@ -257,3 +257,24 @@ def test_approve_cross_area_relationship_writes_org_yaml(tmp_path):
     assert res2.validated and res2.applied and not res2.skipped, res2.skipped
     cr2 = yaml.safe_load((root / "org.yaml").read_text())["cross_subject_area_relationships"][0]
     assert cr2["description"] == "invoice to its CRM account"
+
+
+def test_validate_seeds_probe_is_star_free(tmp_path):
+    """Regression (ACE-062 A1): the zero-row validation wrapper must not project `SELECT *`.
+    The executor's SELECT-* ban walks every SELECT in the tree, so a `SELECT *` wrapper would
+    trip the ban on itself and reject every seed. We simulate that ban with a runner that
+    raises on any star in the probe, and assert a legit named-column seed still passes."""
+    seen_probes: list[str] = []
+
+    def runner(sql: str) -> None:
+        seen_probes.append(sql)
+        # mimic runtime.check_no_select_star: a projected star anywhere is refused
+        if "SELECT *" in sql or "select *" in sql:
+            raise RuntimeError('{"kind": "select_star"}')
+
+    seed = {"question": "how many orders?", "sql": "SELECT COUNT(id) AS n FROM orders"}
+    passing, rejected = curate.validate_seeds([seed], runner)
+
+    assert not rejected, rejected
+    assert len(passing) == 1 and passing[0]["source"] == "seed"
+    assert seen_probes and "SELECT *" not in seen_probes[0]  # wrapper is star-free

--- a/tests/test_semantic_model_curate.py
+++ b/tests/test_semantic_model_curate.py
@@ -3,11 +3,16 @@ apply (exclude/include/approve/reject) write path with validation gating."""
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+# case/whitespace-insensitive star projection — mirrors runtime.check_no_select_star (AST-based),
+# so the test isn't fooled by `SELECT  *` / `select *` the way a plain substring check would be.
+_STAR_PROJECTION = re.compile(r"(?i)\bselect\s*\*")
 
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlglot")
@@ -269,7 +274,7 @@ def test_validate_seeds_probe_is_star_free(tmp_path):
     def runner(sql: str) -> None:
         seen_probes.append(sql)
         # mimic runtime.check_no_select_star: a projected star anywhere is refused
-        if "SELECT *" in sql or "select *" in sql:
+        if _STAR_PROJECTION.search(sql):
             raise RuntimeError('{"kind": "select_star"}')
 
     seed = {"question": "how many orders?", "sql": "SELECT COUNT(id) AS n FROM orders"}
@@ -277,4 +282,4 @@ def test_validate_seeds_probe_is_star_free(tmp_path):
 
     assert not rejected, rejected
     assert len(passing) == 1 and passing[0]["source"] == "seed"
-    assert seen_probes and "SELECT *" not in seen_probes[0]  # wrapper is star-free
+    assert seen_probes and not _STAR_PROJECTION.search(seen_probes[0])  # wrapper is star-free


### PR DESCRIPTION
**Spec: ACE-062**

## Summary
Three reproducible defects surfaced by an external tester onboarding an OMOP CDM (Common Data Model) healthcare dataset — a schema where every clinical table carries `TIMESTAMP WITH TIME ZONE` columns — on the connect → curate → seed path. This is the **code** half; the docs/packaging half is **ACE-063** (depends on this PR).

## Changes
- **A1 — star-free seed probe** (`semantic_model/curate.py`). `validate_seeds()` wrapped each seed as `SELECT * FROM (<sql>) WHERE 1=0`; the wrapper's own `SELECT *` tripped `runtime.check_no_select_star` (which walks *every* SELECT in the tree), so **every** seed was rejected as `select_star` regardless of its SQL. Switched the wrapper to `SELECT 1` — still parses + plans the inner query and returns zero rows, but projects no star.
- **A2 — `sm approve-queue` + `at` auto-stamp** (`semantic_model/cli.py`). New `sm approve-queue <root> --signer --role [--kind ...] [--dry-run]`: reads the pending review queue (Rule 1 metrics/filters + Rule 2 joins/entities), builds a self-stamped `approve` op per item, and applies via `curate.apply` — a first-class **no-browser** sign-off path. Also fixes a silent trap: `curate.apply` reads `signed_off_at` from `op.get("at")` (the engine deliberately can't call the clock), so an approve op missing `at` recorded `signed_off_at: null` and the validator rejected the whole batch. `cmd_curate` (and `approve-queue`) now stamp `at` at the CLI boundary, where the clock is available. `--signer`/`--role` still required, so who-signed-off is unchanged.
- **A3 — pytz-aware duckdb probe** (`plugins/agami/scripts/connect_resolve.py`). duckdb needs `pytz` to materialize `TIMESTAMP WITH TIME ZONE` into Python; the probe only checked `import duckdb`, so an interpreter without pytz scored as ready and then failed at query time on any timestamptz column. Folded pytz into the duckdb `has_driver` probe via `_DRIVER_EXTRA` so the skill's driver-missing branch installs it up front.

## Test plan
- `test_validate_seeds_probe_is_star_free` — a legit named-column seed passes; the probe handed to the runner is star-free.
- `test_approve_queue_signs_off_all_pending` — queue → `total: 0`, `curate-gate` `preseed_count` → 0, sign-off fields recorded; `test_approve_queue_kind_filter_and_dry_run` — `--kind` narrows, `--dry-run` mutates nothing; `test_curate_auto_stamps_missing_at` — an approve op with no `at` now applies cleanly.
- `test_duckdb_driver_requires_pytz` — duckdb-without-pytz scores `has_driver: false`; with pytz, `true` and chosen.

## Checklist
- [x] `uv run dev.py check` green — full suite **1503 passed**, ruff clean, gitleaks clean
- [x] `uv run dev.py cover` — **100%** patch coverage on changed lines
- [x] Regression test per fix; no tests weakened or deleted
- [x] Customer-safety: neutral placeholders only (`you@example.com`), no customer/personal identifiers in code, tests, or comments
- [x] `/agami-sdlc:review` run — 0 must-fix, 0 nits
- [ ] Human PR approval

## Out of scope
- Docs/packaging half (`pip install duckdb pytz`, render-flag fix, sample-6B auto-approve, headless-sign-off docs) → **ACE-063**.
- No change to the `SELECT *` ban or the preseed gate's strictness for real databases.
