### PR TITLE
docs: lead free-vs-paid copy with value, not the external-use restriction (ACE-065)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,11 @@ connect with your permission). Details: [docs/privacy.md](docs/privacy.md).
 
 ## Fair-code vs hosted
 
-agami is **fair-code** (source-available). Running it on your own machine —
-introspection, the portable semantic model, NL→SQL + local execution, the trust layer,
-corrections, and the local MCP server — is **free to self-host for your own team**.
-Exposing data or the MCP to people outside your organization is the paid line — the team
-cloud (a multi-tenant model registry over a remote MCP endpoint, shared governed context,
-always-on evals). The boundary, stated plainly:
+agami is **fair-code** (source-available). Everything here — introspection, the portable
+semantic model, NL→SQL + local execution, the trust layer, corrections, and self-hosting for
+your own team — is **free**. The hosted cloud adds the org-scale layer on top: advanced
+governance and access controls (**RBAC**, audit, enterprise **SSO** with SAML/SCIM), a shared
+multi-tenant model registry, and continuous evals. What's free vs paid, in full:
 [docs/open-vs-hosted.md](docs/open-vs-hosted.md).
 
 ## Self-hosted team server — Early access (in testing)

--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ connect with your permission). Details: [docs/privacy.md](docs/privacy.md).
 
 agami is **fair-code** (source-available). Everything here — introspection, the portable
 semantic model, NL→SQL + local execution, the trust layer, corrections, and self-hosting for
-your own team — is **free**. The hosted cloud adds the org-scale layer on top: advanced
-governance and access controls (**RBAC**, audit, enterprise **SSO** with SAML/SCIM), a shared
-multi-tenant model registry, and continuous evals. What's free vs paid, in full:
+your own organization — is **free** (serving people outside your organization needs a commercial
+license). The hosted cloud adds the org-scale layer on top: advanced governance and access
+controls (**RBAC**, audit, enterprise **SSO** with SAML/SCIM), a shared multi-tenant model
+registry, and continuous evals. What's free vs paid, in full:
 [docs/open-vs-hosted.md](docs/open-vs-hosted.md).
 
 ## Self-hosted team server — Early access (in testing)

--- a/docs/open-vs-hosted.md
+++ b/docs/open-vs-hosted.md
@@ -1,9 +1,10 @@
 # What's free, what's hosted
 
 agami is **fair-code** (source-available): **self-hosting for your own organization is
-free**, and the hosted cloud adds an org-scale governance layer on top (it's also the
-licensed path for serving people **outside** your organization). The short version of the
-license is in [LICENSING.md](../LICENSING.md); the binding terms are in [LICENSE](../LICENSE).
+free**, and the hosted cloud adds an org-scale governance layer on top. Serving people
+**outside** your organization needs a commercial license — that's what the hosted/enterprise
+product is for. The short version of the license is in [LICENSING.md](../LICENSING.md); the
+binding terms are in [LICENSE](../LICENSE).
 
 ## Free — self-host for your own team
 
@@ -26,7 +27,8 @@ Run agami on your own machines, for your own people (multi-user included):
 ## Paid — the hosted cloud
 
 The org-scale layer — advanced governance, shared context, and continuous evals — for teams
-that want it served (and the licensed path for serving people **outside** your organization):
+that want it served. (Serving people **outside** your organization needs a commercial license;
+this is what it's for.)
 
 - A **multi-tenant model registry** over a remote MCP endpoint.
 - **Shared, governed** examples + context across a team.

--- a/docs/open-vs-hosted.md
+++ b/docs/open-vs-hosted.md
@@ -1,9 +1,9 @@
 # What's free, what's hosted
 
-agami is **fair-code** (source-available): **free to self-host for your own
-organization**, paid when you expose it to people **outside** it. The short version
-of the license is in [LICENSING.md](../LICENSING.md); the binding terms are in
-[LICENSE](../LICENSE).
+agami is **fair-code** (source-available): **self-hosting for your own organization is
+free**, and the hosted cloud adds an org-scale governance layer on top (it's also the
+licensed path for serving people **outside** your organization). The short version of the
+license is in [LICENSING.md](../LICENSING.md); the binding terms are in [LICENSE](../LICENSE).
 
 ## Free — self-host for your own team
 
@@ -25,7 +25,8 @@ Run agami on your own machines, for your own people (multi-user included):
 
 ## Paid — the hosted cloud
 
-For teams that need it served, and for serving people **outside** your organization:
+The org-scale layer — advanced governance, shared context, and continuous evals — for teams
+that want it served (and the licensed path for serving people **outside** your organization):
 
 - A **multi-tenant model registry** over a remote MCP endpoint.
 - **Shared, governed** examples + context across a team.


### PR DESCRIPTION
**Spec: ACE-065** · docs/copy only — no code change. Fast-follow to #126 (ACE-064).

## Summary
The free-vs-paid copy led with what the paid tier **restricts** ("exposing data to people outside your organization is the paid line"), which read defensive and buried the product. Reframe to lead with what the hosted cloud **delivers** — the org-scale governance layer (RBAC, audit, enterprise SSO with SAML/SCIM, a shared multi-tenant model registry, continuous evals) — while keeping the fair-code external-serving boundary present as a factual clause. **Raising for wording review.**

## Changes
- **README.md "Fair-code vs hosted"** — now: "Everything here … is **free**. The hosted cloud adds the org-scale layer on top: advanced governance and access controls (RBAC, audit, enterprise SSO with SAML/SCIM), a shared multi-tenant model registry, and continuous evals." Keeps a neutral "what's free vs paid, in full" link. No longer opens with the external-use restriction.
- **docs/open-vs-hosted.md** — intro + "## Paid — the hosted cloud" lead reframed to lead with the capability layer; the external-serving boundary stays as a trailing factual clause; LICENSING.md/LICENSE links and the feature list unchanged.

## Accuracy guardrail
The fair-code license genuinely gates external serving, so I did **not** claim external use is free — the boundary is preserved in open-vs-hosted.md (as a "licensed path for serving people outside your organization" clause) and LICENSING.md/LICENSE are untouched. Only the framing changed: value first, restriction as a factual note.

## Verification
- `git diff` touches only `README.md` + `docs/open-vs-hosted.md`; LICENSING.md/LICENSE unchanged.
- README paid line names the value (RBAC/audit/SSO/governance) and no longer opens with "outside your organization".
- `uv run dev.py check` green (ruff + full suite + gitleaks).

## Checklist
- [x] `uv run dev.py check` green
- [x] Licensing boundary preserved; no claim external serving is free
- [x] Scope: only the two copy surfaces; no code, no LICENSE change
- [ ] **Human wording review + approval** ← this PR is up for that
