### PR TITLE
release: 0.4.2 — onboarding hardening + launch docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.4.2] — 2026-07-14
+
+Onboarding hardening for the public launch — fixes to the first-run `/agami-connect` path — plus a
+documentation pass. No breaking changes; the executor internals from 0.4.1 are unchanged.
+
+### Fixed
+
+- **Seed validation no longer rejects every seed example.** The zero-row validation probe wrapped each
+  seed as `SELECT * FROM (<sql>) WHERE 1=0`; its own `SELECT *` tripped the `SELECT *` ban and every seed
+  was rejected regardless of its SQL. The probe now projects `SELECT 1` — it still parses and plans the
+  inner query, but no longer trips the ban.
+- **DuckDB readiness now requires `pytz`.** DuckDB needs `pytz` to materialize `TIMESTAMP WITH TIME ZONE`
+  values; the driver probe only checked `import duckdb`, so an interpreter missing `pytz` scored as ready
+  and then failed at query time on any `timestamptz` column. `pytz` is now part of the DuckDB probe.
+- **Approve operations auto-stamp their timestamp.** An approve op without a `signed_off_at` recorded
+  `null` and the validator rejected the whole batch. The timestamp is now stamped at the CLI boundary
+  (where the clock is available), so sign-off batches apply cleanly.
+
+### Added
+
+- **Headless sign-off (`sm approve-queue`).** A no-browser path that reads the pending review queue
+  (Rule 1 + Rule 2), builds a self-stamped approve op per item, and applies it (`--kind` to narrow,
+  `--dry-run` to preview) — so onboarding can complete without opening the review dashboard.
+- **The no-DB sample clears its own pre-seed gate.** The sample's silent build auto-approves its pre-seed
+  queue as `signer=system` before seeding; real databases keep the human sign-off gate.
+
+### Docs
+
+- **Launch positioning.** The self-hosted team server (`/agami-deploy`) is labeled **Early access (in
+  testing)** throughout; the free-vs-paid copy leads with the value the hosted cloud adds.
+- **README.** A **Databases supported** section (all engines + how each executes), VS Code/Cursor install
+  clarified as Manage-Plugins-UI (not the CLI slash-command form), and the sample-query copy made generic.
+- **Guides.** Onboarding docs (`duckdb pytz` install, explicit render flags, the headless sign-off path),
+  a plain-English trust-layer intro, an `/agami-serve` (Claude Desktop) usage section, and an accurate
+  `migrations/core` README (the self-hosted server schema).
+
 ## [0.4.1] — 2026-07-12
 
 The self-hosted HTTP server now runs SQL **in-process** by default — no per-query subprocess fork,

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.4.1"
+version = "0.4.2"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Release 0.4.2 — onboarding hardening + launch docs

Cut for the public launch (HN / Reddit). Ships the onboarding fixes that have accumulated on `main` since 0.4.1 — the first-run `/agami-connect` path a wave of new users will hit — plus the launch documentation pass. **No breaking changes;** the 0.4.1 executor internals are unchanged.

### Version bump
- `.claude-plugin/marketplace.json` (both fields), `plugins/agami/.claude-plugin/plugin.json`, `packages/agami-core/pyproject.toml`: `0.4.1 → 0.4.2`
- `CHANGELOG.md`: new `[0.4.2]` section

### What's included (already merged since 0.4.1)
- **ACE-062 (#123)** — `fix(onboarding)`: star-free seed probe (`SELECT 1` instead of `SELECT *`, which was rejecting every seed), pytz-aware DuckDB readiness probe, `at`-stamp on approve ops, `sm approve-queue` headless sign-off.
- **ACE-063 (#125)** — onboarding docs + sample pre-seed auto-approve.
- **ACE-064 (#126) / ACE-065 (#127)** — launch positioning (self-hosted = Early access; value-forward free-vs-paid copy).
- **#130** — docs cleanup (DB-support section, install clarity, trust-layer, agami-serve, migrations README, generic governance copy).

### Verification
- `uv run dev.py check` — **green** (ruff clean, ruff format clean, 1504 passed / 1 skipped, gitleaks clean).
- Post-merge: tag `v0.4.2` → GitHub Release → trusted-publish workflow pushes to PyPI (same flow as 0.4.1).

### Customer-safety
Version + changelog + docs only. No real names/data/credentials.
