### PR TITLE
docs(pypi): reframe agami-core README as a readable landing page + add project.urls

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.4.3] — 2026-07-14
+
+Documentation-only release. No behavior changes; the executor and skills from 0.4.2 are unchanged.
+
+### Changed
+
+- **`agami-core` PyPI page is now a readable landing page.** Reframed
+  `packages/agami-core/README.md` (the PyPI `long_description`) to lead with the value proposition
+  and clarify the plugin-vs-`pip` audiences, and trimmed the deep HTTP-server internals down to a
+  summary plus links to `deploy/README.md` and `docs/`. Added `[project.urls]`
+  (Homepage/Repository/Documentation/Issues) so PyPI shows sidebar navigation. Publishing this
+  version is what refreshes the live PyPI page.
+
 ## [0.4.2] — 2026-07-14
 
 Onboarding hardening for the public launch — fixes to the first-run `/agami-connect` path — plus a

--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -1,11 +1,32 @@
-# agami-core (library)
+# agami-core
 
-The importable core behind agami: the governed **semantic model**, the shared **MCP `TOOLS`
-harness** (stdio entrypoint), and the **unified local query executor** (`execute_sql` + the
-read-only safety pass + unit formatting).
+**The governed trust layer between an AI agent and your database.** The importable core behind the
+[agami](https://agami.ai) Claude Code skill and MCP server — the semantic model, the shared MCP
+`TOOLS` harness, and the local query executor.
 
-One package serves every consumer — the local Claude Code skill, the MCP server, and any
-downstream that imports the same flat module names.
+## What it does
+
+Point an AI agent at a database and it answers by **guessing** — at the join, at what *"revenue"*
+means, at which rows it's allowed to read. agami-core turns your schema into a **governed semantic
+model** where every join is FK-derived or human-approved and every metric is signed off before the
+runtime trusts it. Every answer then ships a **receipt** — the exact SQL it ran and the model
+version it pinned — so a silent join mistake never reaches you as a confident wrong number.
+
+It runs **locally**: credentials, schema, and query results never leave your machine.
+
+## Most people don't `pip install` this
+
+If you just want to *use* agami, install the **Claude Code plugin** — you don't touch this package
+directly:
+
+```
+/plugin marketplace add AgamiAI/agami-core
+/plugin install agami-core@agami
+```
+
+`pip install agami-core` is for the other two audiences: **importing the library** into your own
+code, or **self-hosting the MCP server**. Full product docs and the plugin walkthrough live in the
+[repository](https://github.com/AgamiAI/agami-core#readme).
 
 ## Install
 
@@ -17,10 +38,11 @@ pip install 'agami-core[server]'  # + the networked HTTP MCP server (see below)
 
 From a checkout, swap in the editable path — `pip install -e 'packages/agami-core[model]'`.
 
-## Flat module names (an invariant)
+## Importing the library
 
-`semantic_model`, `mcp_harness`, `execute_sql`, `agami_paths` are top-level importable names —
-no `sys.path` manipulation, no parent package — so a consumer's imports resolve unchanged:
+The top-level names — `semantic_model`, `mcp_harness`, `execute_sql`, `agami_paths` — are a
+deliberate flat invariant (no parent package, no `sys.path` juggling), so a consumer's imports
+resolve unchanged:
 
 ```python
 from mcp_harness import TOOLS
@@ -28,140 +50,47 @@ import semantic_model
 import execute_sql
 ```
 
-## Entry points
+Module entry points:
 
 ```bash
-python -m mcp_harness          # the stdio MCP server (Claude Desktop)
-python -m execute_sql --sql …  # the local query executor
-python -m semantic_model.cli   # the semantic-model CLI (driven by the `sm` launcher)
-python -m mcp_http             # the networked HTTP MCP server (see below)
+python -m mcp_harness           # the stdio MCP server (Claude Desktop)
+python -m execute_sql --sql …   # the local query executor
+python -m semantic_model.cli    # the semantic-model CLI (driven by the `sm` launcher)
+python -m mcp_http              # the networked HTTP MCP server (see below)
 ```
 
-## HTTP server — networked, with auth (`python -m mcp_http`)
+## HTTP MCP server (`[server]`) — early access, in testing
 
-The `[server]` extra (`pip install 'agami-core[server]'`) adds a networked MCP
-transport: the same `TOOLS` surface as the stdio server, but over HTTP with OAuth + a small admin
-console. It's the self-host shape of the hosted product.
+The `[server]` extra adds a networked MCP transport: the **same `TOOLS` surface** as the stdio
+server, but over HTTP with OAuth and a small admin console. It's the self-host shape of the hosted
+product — deploy it to your own host and a whole team connects their own Claude to one URL, still
+zero-egress.
+
+> 🧪 **Early access.** This team/server layer is usable today but newer than the local single-player
+> path — expect the occasional rough edge, and please report anything broken via a
+> [GitHub issue](https://github.com/AgamiAI/agami-core/issues). The local library and stdio server
+> are the stable path.
+
+A minimal local launch (SQLite store, password admin):
 
 ```bash
 PUBLIC_BASE_URL=https://your-host \
 AGAMI_SIGNING_SECRET=$(openssl rand -hex 32) \
-AGAMI_DB_URL=postgresql://… \
-AGAMI_ADMIN_USERNAME=you@example.com \
-AGAMI_ADMIN_FIRST_NAME=Alex AGAMI_ADMIN_LAST_NAME=Kim \
-AGAMI_ADMIN_PASSWORD=… \
-AGAMI_ADMIN_PROVIDER=google \
-AGAMI_OIDC_GOOGLE_CLIENT_ID=… AGAMI_OIDC_GOOGLE_CLIENT_SECRET=… \
-python -m mcp_http
-```
-
-The admin is identified by **email** (`AGAMI_ADMIN_USERNAME`). Their sign-in method is whatever you
-configure — **a password and/or a pinned social provider, at least one**: set `AGAMI_ADMIN_PASSWORD`,
-and/or `AGAMI_ADMIN_PROVIDER` (`google` | `microsoft`, which must also have its
-`AGAMI_OIDC_<PROVIDER>_CLIENT_ID/SECRET` set). The admin login then offers the same Google/Microsoft
-option as the MCP login. Register **one** OAuth redirect URI with the provider —
-`{base}/oauth/oidc/callback` — it serves both the connector and the admin flows.
-
-### One host, two entry points
-
-A deployment is one host (`PUBLIC_BASE_URL`). Everything lives under it:
-
-| URL | Who | What |
-|---|---|---|
-| `{base}/mcp` | a teammate, in Claude | the **only** URL to add as a custom connector — Claude auto-discovers the OAuth endpoints from it |
-| `{base}/admin` | the admin, in a browser | the console to add/enable/disable users |
-
-### Access model — two separate credentials
-
-- **Query surface (`/mcp`)** — gated by a **Bearer JWT** from the OAuth flow. **Any** onboarded user
-  who signs in can query (that's the product). No token → `401` + `WWW-Authenticate`, which starts
-  Claude's OAuth. Admin-ness does **not** gate `/mcp`.
-- **Admin surface (`/admin`)** — gated by a **session cookie** *and* the admin-gate
-  (`AGAMI_ADMIN_USERNAME`). The admin signs in with their **pinned** social provider or a password; a
-  valid non-admin is refused (and a social identity for the admin email via a *different* provider is
-  refused — the pin closes IdP-confusion). An `/mcp` bearer token is useless here (different
-  credential). Unset `AGAMI_ADMIN_USERNAME` ⇒ the admin console is disabled entirely.
-
-### Onboarding a teammate
-
-The admin adds a teammate by **email + name** (a *pending* user). How they finish setting up follows
-the deployment's **single auth method** — uniform for everyone, set by what you configured:
-
-- **OIDC deployment** (a Google/Microsoft client is configured): the teammate just adds `{base}/mcp` to
-  Claude and signs in with that provider — the IdP verifies their email and binds the account on first
-  login. No link to share.
-- **Password deployment** (no OIDC configured): the admin **copies the teammate's setup link** from the
-  Users tab and shares it out-of-band; the teammate opens it and sets their own password. The link is a
-  signed, time-boxed token and is single-use (it stops working once the account is set up).
-
-The login surfaces show only the configured method (the admin keeps a password **break-glass** fallback
-on `/admin/login`).
-
-> **Trust note.** OIDC onboarding binds the account to whoever first proves the teammate's email at the
-> configured IdP — so add a teammate by an email the *right* person controls there. The setup link and
-> the other pre-auth endpoints aren't rate-limited in-process; put them behind your proxy/LB if exposed.
-
-### Activity view
-
-The admin console has one read-only **Activity** tab: every MCP tool call, folded into the conversation
-it belongs to — **thread (conversation) ▸ turn (one user question) ▸ call**. Open a conversation and you
-see its whole arc, *not just the queries*: the `list_datasources` / `get_datasource_schema` calls that
-scoped the work sit alongside the `execute_sql`s that answered it (*"User asked what datasources →
-`list_datasources`; user asked revenue by region → `get_datasource_schema`, then `execute_sql` ×2"*). A
-query call shows its SQL, row count, latency, and status; a non-query call shows its tool name. Every
-call carries its **own** datasource, because a conversation — or even a single turn — can span several:
-the user switches datasource mid-session, or asks something that runs one query per datasource. The
-conversation row lists the full set it touched.
-
-The split is deliberate: it is **audit-grade for *what* ran** — the server observes every call directly,
-so nothing is dropped — and **best-effort for *how* it's grouped**. The MCP protocol carries neither the
-user's question, a conversation id, nor a turn boundary, so Claude self-reports them on every call: a
-`user_question` (kept verbatim), a `thread_id` (per conversation), and a `correlation_id` (per turn). The
-turn's question is taken from the **first** call in the turn (the model sometimes drifts it on later
-refinements). When Claude doesn't supply the ids, a call simply shows as its own singleton conversation —
-the view degrades, never drops a call. Treat the self-reported grouping as a hint, not a record.
-
-> **Free-tier limit.** A turn that produces **no** tool call — Claude answering "let's continue" from
-> context — never reaches the server and so can't appear here; this is an audit of what ran against your
-> data, not a chat transcript.
-
-The `tool_calls` log grows one row per call and has **no automatic retention** — it's your local store,
-so prune it on your own schedule if it gets large.
-
-### Model view
-
-The **Model** tab (`{base}/admin/model`) is a **read-only** explorer of the semantic model you've
-deployed — the same tree the MCP tools serve, so it can't drift from what Claude actually reads. It's a
-catalog: a browse rail (datasource → subject area → table) and one page at a time —
-
-- a **datasource overview** (description, glossary, storage-connection names/types, the subject areas),
-- a **subject-area landing** (its tables, metrics, entities),
-- a **table page** — the schema, with each column's type and description, and flags only where they
-  carry signal (**PK / FK / sensitive / unit / enum / caveat**). Trust is shown as a single table-level
-  **confidence** badge; **caveats** (the domain gotchas) are elevated to a callout; wide tables collapse
-  behind "show all N", and tables that author `column_groups` render those as collapsible sections,
-- a **Relationships** page (when the model has cross-area joins) — the org-level relationships that
-  span subject areas, **grouped by area-pair**, so the cross-area topology is readable in one place,
-- a **domain-context** page (your `ORGANIZATION.md`, rendered as safe markdown).
-
-It is **read-only by construction** — a single GET endpoint, no write path. Editing the model stays
-conversational in Claude (the in-app editor is a Hosted feature); connection **credentials are never
-rendered** (names and types only). Deploy a change in Claude and it shows up here on the next deploy.
-
-### Local end-to-end test (HTTPS via a tunnel)
-
-OAuth and the `Secure` admin cookie need HTTPS, so expose the local server through a tunnel:
-
-```bash
-# terminal 1 — the server
-PUBLIC_BASE_URL=https://<your-subdomain>.trycloudflare.com \
-AGAMI_SIGNING_SECRET=$(openssl rand -hex 32) \
 AGAMI_DB_URL=sqlite:///$PWD/agami.db \
 AGAMI_ADMIN_USERNAME=you@example.com AGAMI_ADMIN_PASSWORD=choose-a-strong-one \
 python -m mcp_http
-
-# terminal 2 — the HTTPS tunnel (prints the https URL to use as PUBLIC_BASE_URL)
-cloudflared tunnel --url http://127.0.0.1:8000
 ```
 
-Open `{base}/admin`, sign in, add a user — then add `{base}/mcp` as a connector in Claude.
+The full detail — the auth/access model, OIDC onboarding, the admin console (Activity + Model
+views), and every environment variable — lives in the docs rather than here:
+
+- **Deploy the Docker bundle** → [deploy/README.md](https://github.com/AgamiAI/agami-core/blob/main/deploy/README.md)
+- **Manual install + full env-var reference** → [docs/self-hosting.md](https://github.com/AgamiAI/agami-core/blob/main/docs/self-hosting.md)
+- **Use agami from Claude Desktop (stdio)** → [docs/mcp-server.md](https://github.com/AgamiAI/agami-core/blob/main/docs/mcp-server.md)
+
+## Links
+
+- **Repository & full docs** — [github.com/AgamiAI/agami-core](https://github.com/AgamiAI/agami-core#readme)
+- **Homepage** — [agami.ai](https://agami.ai)
+- **License** — fair-code (source-available), the Agami Functional Use License. Self-hosting for your
+  own organization is free; serving people outside it needs a commercial license.

--- a/packages/agami-core/README.md
+++ b/packages/agami-core/README.md
@@ -53,18 +53,18 @@ import execute_sql
 Module entry points:
 
 ```bash
-python -m mcp_harness           # the stdio MCP server (Claude Desktop)
-python -m execute_sql --sql …   # the local query executor
-python -m semantic_model.cli    # the semantic-model CLI (driven by the `sm` launcher)
-python -m mcp_http              # the networked HTTP MCP server (see below)
+python -m mcp_harness                        # the stdio MCP server (Claude Desktop)
+python -m execute_sql --sql-file query.sql   # the local query executor
+python -m semantic_model.cli                 # the semantic-model CLI (driven by the `sm` launcher)
+python -m mcp_http                           # the networked HTTP MCP server (see below)
 ```
 
 ## HTTP MCP server (`[server]`) — early access, in testing
 
 The `[server]` extra adds a networked MCP transport: the **same `TOOLS` surface** as the stdio
 server, but over HTTP with OAuth and a small admin console. It's the self-host shape of the hosted
-product — deploy it to your own host and a whole team connects their own Claude to one URL, still
-zero-egress.
+product — deploy it to your own host and a whole team connects their own Claude to one URL,
+zero-egress by default (enabling OIDC/SSO adds one outbound call to your identity provider).
 
 > 🧪 **Early access.** This team/server layer is usable today but newer than the local single-player
 > path — expect the occasional rough edge, and please report anything broken via a

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.4.2"
+version = "0.4.3"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -22,6 +22,12 @@ authors = [{ name = "Agami AI", email = "skills@agami.ai" }]
 # Python-driver tier stays lean; `sm` / the server install [model].
 dependencies = []
 
+[project.urls]
+Homepage = "https://agami.ai"
+Repository = "https://github.com/AgamiAI/agami-core"
+Documentation = "https://github.com/AgamiAI/agami-core#readme"
+Issues = "https://github.com/AgamiAI/agami-core/issues"
+
 [project.optional-dependencies]
 model = [
   "pydantic>=2,<3",

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## What

Makes the [agami-core PyPI page](https://pypi.org/project/agami-core/) readable, and cuts the docs-only **0.4.3** release that will republish it.

**`packages/agami-core/README.md` — full reframe** (167 → ~95 lines):
- Leads with a plain-English value prop instead of jargon.
- New "Most people don't `pip install` this" callout — end users get agami via the Claude Code **plugin**; pip is for **importing the library** or **self-hosting the server**.
- Keeps the accurate install / flat-module import / entry-point reference, condensed.
- Trims the ~130-line HTTP-server deep-dive to a summary + minimal launch example + links to `deploy/README.md`, `docs/self-hosting.md`, `docs/mcp-server.md`. Preserves the "early access / in testing" caveat; uses absolute GitHub URLs (relative links break on PyPI).

**`packages/agami-core/pyproject.toml`** — adds `[project.urls]` (Homepage / Repository / Documentation / Issues) for PyPI sidebar navigation.

**Version bump `0.4.2 → 0.4.3`** across pyproject, `.claude-plugin/marketplace.json` (×2), `plugins/agami/.claude-plugin/plugin.json`, + CHANGELOG. PyPI only refreshes a page on publish, so a GitHub Release tagged `v0.4.3` (which triggers `release-pypi.yml`) is what makes the new page go live.

## Copilot review — addressed

- `execute_sql` example → `--sql-file query.sql` (the preferred form per its docstring), dropping the copy-paste-hostile Unicode ellipsis.
- "still zero-egress" → "zero-egress by default" (the `[server]` OIDC/SSO path makes one outbound call to the IdP).

## Verification

- `twine check` passes on sdist + wheel at 0.4.3; all four `Project-URL` entries land in the built metadata; `Description-Content-Type: text/markdown`.
- Both plugin JSON files validated; all four version strings confirmed at `0.4.3`.

## After merge

Cut a GitHub Release tagged **`v0.4.3`** to publish to PyPI (the workflow verifies the tag matches pyproject).