### PR TITLE
release: 0.4.4 — fix examples-validation dashboard Edit/Note firing on all cards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.4.4] — 2026-07-14
+
+Onboarding fix for the examples-validation (NL→SQL) dashboard.
+
+### Fixed
+
+- **Examples-validation dashboard: Edit/Add-note no longer fires on every card.** Each example's
+  interaction state was keyed on its display number `n`, which `sm seed-validate` assigns **per
+  subject area** (1..k) — so a dashboard combining multiple areas carried duplicate `n`, and clicking
+  **Edit** (or **Add note**) on one card opened every card that shared that number. It also made the
+  "Generate feedback" block ambiguous (`edit N` could match more than one example). The renderer now
+  assigns a **stable global `1..N`** in render order — the single numbering shared by the interaction
+  key, the `#N` label, the feedback block, and the apply lookup — and normalizes the items file to
+  match, so `edit N` resolves unambiguously.
+
 ## [0.4.3] — 2026-07-14
 
 Documentation-only release. No behavior changes; the executor and skills from 0.4.2 are unchanged.

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.4.3"
+version = "0.4.4"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",

--- a/plugins/agami/scripts/render_examples_validation.py
+++ b/plugins/agami/scripts/render_examples_validation.py
@@ -39,8 +39,7 @@ VALID_STATES = {"unreviewed", "validated", "rejected"}
 def _validate_item(item: dict, idx: int) -> None:
     if not isinstance(item, dict):
         raise ValueError(f"item {idx}: must be an object")
-    if "n" not in item or not isinstance(item["n"], int) or item["n"] < 1:
-        raise ValueError(f"item {idx}: 'n' must be a positive integer")
+    # `n` is assigned by render() (a stable global 1..N), not required from the caller.
     if "question" not in item or not isinstance(item["question"], str):
         raise ValueError(f"item {idx}: 'question' (string) is required")
     state = item.get("state", "unreviewed")
@@ -68,6 +67,16 @@ def render(
 ) -> str:
     if not isinstance(items, list):
         raise ValueError("items must be a list")
+    # `n` is the example's identity end-to-end: the interaction/DOM key, the `#N` label, the
+    # reference emitted in the "Generate feedback" block (`edit N` / `note N`), AND the apply
+    # lookup (the skill maps `N` -> that example's question). So it MUST be unique + stable per
+    # dashboard. `sm seed-validate` numbers seeds 1..k PER AREA, so a dashboard assembled from
+    # several areas collides (two `#1`s) — clicking Edit on one card then opened EVERY card that
+    # shared that `n`, and the feedback block was ambiguous. The renderer is the assembly
+    # chokepoint: renumber to a single global 1..N in render order so every consumer agrees.
+    for i, it in enumerate(items, 1):
+        if isinstance(it, dict):
+            it["n"] = i
     for i, it in enumerate(items):
         _validate_item(it, i)
 
@@ -120,6 +129,14 @@ def main() -> int:
         profile=args.profile,
         items=items,
     ))
+    # render() normalized `n` to a stable global 1..N (in place). Persist it back so a later
+    # apply pass ("edit N" -> the N-th example) resolves against the SAME numbering the dashboard
+    # showed — regardless of the per-area numbers the caller wrote. Best-effort.
+    try:
+        with open(os.path.expanduser(args.items_file), "w") as f:
+            json.dump(items, f)
+    except OSError:
+        pass
     print(f"Wrote {out_path} ({len(items)} example{'s' if len(items) != 1 else ''})")
     return 0
 

--- a/plugins/agami/scripts/render_examples_validation.py
+++ b/plugins/agami/scripts/render_examples_validation.py
@@ -65,6 +65,12 @@ def render(
     profile: str,
     items: list,
 ) -> str:
+    """Render the examples-validation dashboard HTML.
+
+    NOTE: mutates each item's ``n`` in place — assigning a stable global 1..N in render order
+    (see the comment below). A caller that still needs the original per-area numbers should copy
+    the items first.
+    """
     if not isinstance(items, list):
         raise ValueError("items must be a list")
     # `n` is the example's identity end-to-end: the interaction/DOM key, the `#N` label, the
@@ -131,12 +137,17 @@ def main() -> int:
     ))
     # render() normalized `n` to a stable global 1..N (in place). Persist it back so a later
     # apply pass ("edit N" -> the N-th example) resolves against the SAME numbering the dashboard
-    # showed — regardless of the per-area numbers the caller wrote. Best-effort.
+    # showed — regardless of the per-area numbers the caller wrote. Atomic (temp + os.replace) so a
+    # failed write never leaves the items file truncated; non-fatal (the HTML already embeds the
+    # normalized numbering), so a write failure warns rather than aborting the render.
+    items_path = os.path.expanduser(args.items_file)
     try:
-        with open(os.path.expanduser(args.items_file), "w") as f:
+        tmp_path = items_path + ".tmp"
+        with open(tmp_path, "w") as f:
             json.dump(items, f)
-    except OSError:
-        pass
+        os.replace(tmp_path, items_path)
+    except OSError as e:
+        sys.stderr.write(f"warning: could not normalize {items_path}: {e}\n")
     print(f"Wrote {out_path} ({len(items)} example{'s' if len(items) != 1 else ''})")
     return 0
 

--- a/plugins/agami/skills/agami-connect/SKILL.md
+++ b/plugins/agami/skills/agami-connect/SKILL.md
@@ -857,7 +857,7 @@ Open it: green = numbers match, red = mismatch (drill in to see the SQL).
 Reply: approve N · reject N · edit N · done (when you're through).
 ```
 
-**Processing the batch:** the dashboard emits `validate N` / `reject N` / `edit N` / `add example` / `note N` / `note all` — apply each through the **packaged commands**, never by hand-rewriting `examples.yaml`:
+**Processing the batch:** the dashboard emits `validate N` / `reject N` / `edit N` / `add example` / `note N` / `note all` — apply each through the **packaged commands**, never by hand-rewriting `examples.yaml`. **`N` is the dashboard's global example number (1..N across every area, assigned in render order).** `render_examples_validation.py` normalizes the items file to this same numbering, so resolve `N` → its example by reading that file back (the per-area seed numbers no longer collide):
 - **`validate N`** → the example is a trusted anchor; if the user signed in (the `by <email>` clause), stamp it via `sm add-example` (re-write the same example with `--signer`/`--role`).
 - **`reject N`** → **`sm remove-example "$ROOT" --area <area> --question "<that example's exact question>"`** (`--signer`/`--role` to record who). It flags the example `status: rejected` — kept in `examples.yaml` for audit, dropped from the runtime ranker. **Do NOT hand-delete or hand-rewrite the YAML** (there's a command now); map `N` → the example's question from the items you rendered.
 - **`edit N`** that fixes *that example's* SQL → re-write it with `sm add-example` (dedups by question, so it replaces). Re-run the new SQL to capture its number.

--- a/tests/test_render_examples_validation.py
+++ b/tests/test_render_examples_validation.py
@@ -138,11 +138,23 @@ def test_render_rejects_missing_required_question():
         render(title="x", profile="p", items=[bad])
 
 
-def test_render_rejects_n_not_positive():
-    bad = _example_unreviewed()
-    bad["n"] = 0
-    with pytest.raises(ValueError, match="n"):
-        render(title="x", profile="p", items=[bad])
+def test_render_renumbers_duplicate_n_to_unique_sequential():
+    """A1 regression: `sm seed-validate` numbers per-area (1..k), so a combined dashboard can
+    carry duplicate `n`. The renderer must renumber to a stable global 1..N — otherwise the
+    interaction key / `#N` label / feedback reference collide and Edit/Note on one card fires
+    for every same-`n` card. Assert the embedded items JSON has unique sequential `n`."""
+    a = _example_unreviewed()          # n=1 (per-area)
+    b = _example_validated()           # n=2
+    c = _example_errored()             # n=3
+    b["n"] = 1                         # simulate a second area also numbered from 1
+    c["n"] = 1                         # ...and a third
+    items = [a, b, c]
+    html = render(title="x", profile="p", items=items)
+    # The renderer mutates in place AND embeds the normalized numbering.
+    assert [it["n"] for it in items] == [1, 2, 3]
+    assert '"n": 1' in html and '"n": 2' in html and '"n": 3' in html
+    # No duplicate `#` labels would collide now — each card has a unique key.
+    assert len({it["n"] for it in items}) == 3
 
 
 def test_render_rejects_row_preview_not_list_of_lists():


### PR DESCRIPTION
## Release 0.4.4 — fix examples-validation dashboard: Edit/Note fires on all cards

Launch hotfix for a visible bug on the onboarding path. **A1 only** — the H1 fan-trap item was investigated and deliberately deferred (see below).

### The bug (A1)
On the NL→SQL examples-validation dashboard, clicking **Edit** (or **Add note**) on one example opened the editor on **every** example.

**Root cause:** each card's interaction state is keyed on its display number `n`. `sm seed-validate` assigns `n` **per subject area** (`1..k`), so a dashboard combining several areas carries **duplicate `n`** — `pendingActions[n]` becomes a shared bucket and every same-`n` card re-renders into edit/note mode. It also made the "Generate feedback" block's `edit N` / `note N` **ambiguous at apply time** (the skill maps `N` → an example's question, which isn't unique when `n` collides).

### The fix
`render_examples_validation.py` now assigns a **stable global `1..N`** in render order — the single numbering shared by the interaction key, the `#N` label, the feedback block, and the apply lookup — and normalizes the items file to match so `edit N` resolves unambiguously. One-line skill clarification that `N` is the global example number. Regression test covers duplicate-`n` input.

The fix is at the renderer chokepoint, so **no template JS change** was needed — the existing `item.n` keying is correct once `n` is guaranteed unique.

### Why H1 (fan-trap MRR false-positive) is NOT in this release
Investigated fully: the detector flags "SUM a one-side measure across a one-to-many," which is the MRR shape. But the **same SQL is a real fan-trap for one intent and correct MRR for another**, and SQL can't distinguish them — so conservative refusal is correct, fail-safe behavior. Loosening it would risk letting real fan-traps (wrong numbers) through. The right resolution is authoring MRR-shaped aggregations as explicit CTE / metric bindings (which pass cleanly). A grain-aware detector enhancement is deferred to its own spec with a full "real traps still caught" test matrix.

### Verification
- `uv run dev.py check` — green (ruff, ruff-format, **1504 passed / 1 skipped**, gitleaks). New test: `test_render_renumbers_duplicate_n_to_unique_sequential`.

### Version
`0.4.3 → 0.4.4` (marketplace.json ×2, plugin.json, pyproject.toml).
