### PR TITLE
docs(readme): restore the agami logo at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="plugins/agami/shared/agami-logo-light.svg">
+    <img src="plugins/agami/shared/agami-logo-dark.svg" alt="agami" width="240">
+  </picture>
+</p>
 
 **The trust layer between AI and your data. Local. Private. Yours.**
 


### PR DESCRIPTION
Quick fix: the hero revamp in #134 replaced the centered HTML block with plain markdown, which dropped the **logo** along with it. This restores just the centered `<picture>` logo (dark/light variants) above the tagline.

Docs-only, **no version bump**. The badges (license / version / try-the-sample) were also removed in #134 — left out here since only the logo was flagged; say the word if you want those back too.