### PR TITLE
docs(readme): restore license/version/sample badges + logo alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="plugins/agami/shared/agami-logo-light.svg">
-    <img src="plugins/agami/shared/agami-logo-dark.svg" alt="agami" width="240">
+    <img src="plugins/agami/shared/agami-logo-dark.svg" alt="Agami logo" width="240">
   </picture>
 </p>
 
 **The trust layer between AI and your data. Local. Private. Yours.**
 
 **agami-core** — the fair-code core of [Agami](https://agami.ai).
+
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-fair--code-blue.svg" alt="License: fair-code"></a>
+  <a href="https://github.com/AgamiAI/agami-core/releases"><img src="https://img.shields.io/github/v/tag/AgamiAI/agami-core?label=version&sort=semver&color=blue" alt="Version"></a>
+  <a href="#get-started-in-2-minutes"><img src="https://img.shields.io/badge/try%20the%20sample-no%20database%20needed-brightgreen" alt="Try the sample"></a>
+</p>
 
 
 


### PR DESCRIPTION
Follow-up to the logo restore (#135): the #134 hero revamp also dropped the three **badges** (license · version · try-the-sample) — this puts the centered badge row back below the fair-code line.

Also folds in **Copilot's #135 accessibility note**: logo `alt="agami"` → `alt="Agami logo"` for screen readers.

Docs-only, **no version bump**. Verified: the try-the-sample badge's `#get-started-in-2-minutes` anchor still exists; all three badge image/link targets are the same ones that rendered before #134.