### PR TITLE
docs(readme): center the tagline, drop the redundant fair-code subline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
   </picture>
 </p>
 
-**The trust layer between AI and your data. Local. Private. Yours.**
-
-**agami-core** — the fair-code core of [Agami](https://agami.ai).
+<p align="center"><strong>The trust layer between AI and your data. Local. Private. Yours.</strong></p>
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-fair--code-blue.svg" alt="License: fair-code"></a>


### PR DESCRIPTION
Two hero tweaks:
1. **Center** the tagline (`The trust layer between AI and your data. Local. Private. Yours.`) so it matches the centered logo + badges.
2. **Remove** the `agami-core — the fair-code core of Agami` line — redundant with the license badge and the intro paragraph right below.

Docs-only, no version bump.