### PR TITLE
release: 0.4.5 — wheel packaging fix, multi-tenancy org-scoping, extra_instructions seam

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [0.4.5] — 2026-07-15
+
+Hosted/self-hosted server hardening: a real-wheel packaging fix, a multi-tenancy seam, and an
+append-only instructions hook. **The local plugin path is behaviour-preserving** — everything
+resolves to a single `local` org and existing deploys are byte-identical by default.
+
+### Fixed
+
+- **Migrations and static assets now ship inside the wheel.** In a real (non-editable) `pip install`,
+  `store.MIGRATIONS_DIR` resolved outside the package, so the server could boot on an **empty schema**
+  with no error, and the missing `static/` dir made app construction fail. Migrations moved into the
+  package (`agami-core/src/migrations/core`), both are packaged as package-data, and `run_migrations`
+  now **raises** on a missing core-migration root instead of silently applying nothing. (Editable
+  checkouts and the `pip install -e` Docker deploy were unaffected — which is why CI stayed green.)
+
+### Added
+
+- **Multi-tenancy: `org_id` scoping across serving, runtime logs, and credentials.** One deployment
+  can host many tenants whose datasources collide on name (e.g. `prod`). `org_id` (default `local`) is
+  threaded through every serving/runtime read+write; a redeploy DELETE is org-scoped (one tenant's
+  reseed can't wipe another's same-named datasource); per-tenant credential env vars
+  (`<ORG>_DATASOURCE_URL[__<PROFILE>]`) with a **fail-closed** rule (a named tenant never falls back to
+  the org-less DSN); and a resolver may raise `PermissionError` to refuse a caller (clean 403, not 500).
+  A plain OSS/self-host deploy is unchanged — everything resolves to `local`.
+- **Append-only `extra_instructions` seam on the HTTP composition root.** `build_server(...)` /
+  `create_app(...)` accept `extra_instructions` so a consumer can add to the model-facing MCP
+  instructions without forking core. **Append-only, never replace** — so a consumer can't silently drop
+  a safety directive (e.g. the sensitive-column output rule); no-op and byte-identical by default.
+
 ## [0.4.4] — 2026-07-14
 
 Onboarding fix for the examples-validation (NL→SQL) dashboard.

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.4.4"
+version = "0.4.5"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Release 0.4.5

Version bump + changelog for the functional work merged to `main` since 0.4.4. **All hosted/server-side; the local plugin path is behaviour-preserving** (everything resolves to a single `local` org; existing deploys byte-identical by default).

### What's included (already merged)
- **#124 — packaging fix:** ship migrations + static assets *inside the wheel*. In a real (non-editable) `pip install`, `MIGRATIONS_DIR` resolved outside the package so the server could boot on an **empty schema** silently, and the missing `static/` broke app construction. Migrations moved into the package; both packaged as package-data; `run_migrations` now raises on a missing core root. (Editable/`-e` Docker deploys were unaffected — why CI stayed green.)
- **#138 — multi-tenancy:** `org_id` (default `local`) threaded through serving/runtime reads+writes; org-scoped redeploy DELETE; per-tenant credential env vars with a fail-closed rule; resolver may raise `PermissionError` → clean 403.
- **#129 — `extra_instructions` seam:** append-only hook on the HTTP composition root so a consumer can add to the model-facing MCP instructions without forking core; can't drop a safety directive; no-op by default.

### Version bump
`0.4.4 → 0.4.5` — `.claude-plugin/marketplace.json` (×2), `plugins/agami/.claude-plugin/plugin.json`, `packages/agami-core/pyproject.toml` + `CHANGELOG.md`.

### Verification
- `uv run dev.py check` — green (ruff, ruff-format, full test suite, gitleaks).
- Post-merge: tag `v0.4.5` → GitHub Release → trusted-publish to PyPI.

### Customer-safety
Version + changelog only. No real names/data/credentials.
