### PR TITLE
security: close a read-only-guard bypass via a welded quoted identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,23 @@ below corresponds to one such version.
 ### Security
 
 - **Closed a read-only-guard bypass via a welded quoted identifier.** A double-quoted
-  identifier is self-delimiting in SQL, so `SELECT*FROM"pg_read_file"('/etc/passwd')` is a
-  valid statement with no whitespace before the quote. The guard's lexer dropped the quote
-  characters without re-supplying that boundary, fusing two tokens into one
-  (`FROM"pg_class"` → `FROMpg_class`) and destroying the word-boundary anchor every
-  dangerous-function pattern matches on — so the gate stopped seeing the token rather than
-  allowing it, and returned no rejection. Verified against PostgreSQL 16: the welded form
-  executes and reads a server-side file while the guard passed it. The lexer now re-supplies
-  a separator when, and only when, the previous emitted character is a word character, so a
-  qualified name (`t."current_user"`) is still not split. Prior corpus cases all happened to
-  carry a space before the quote, which is why this stayed invisible; the regression corpus
-  now pins the welded forms and the qualified-name negatives.
+  identifier is self-delimiting in SQL on **both** ends, so `SELECT*FROM"pg_read_file"(…)`
+  and `SELECT "x"INTO evil FROM t` are valid statements with no whitespace either side of
+  the quote. The guard's lexer dropped the quote characters without re-supplying those
+  boundaries, fusing neighbouring tokens into one (`FROM"pg_class"` → `FROMpg_class`,
+  `"x"INTO` → `xINTO`) and destroying the word-boundary anchor every deny-list pattern
+  matches on — so the gate stopped *seeing* the token rather than allowing it, and returned
+  no rejection. Verified against PostgreSQL 16: the leading form reads a server-side file
+  and the trailing form creates a table from `SELECT … INTO`, both while the guard passed
+  them. Row locks (`FOR SHARE`) were reachable the same way. The lexer now re-supplies a
+  separator on either side, when and only when the quote was actually separating two word
+  characters — so a qualified name (`t."current_user"`) still neutralizes to one token,
+  `t.current_user`, rather than being split. This restores an invariant the lexer already
+  documented for comments and literals ("never empty"); the identifier branch was the one
+  place not honouring it. Prior corpus cases all happened to carry a space before the
+  quote, which is why this stayed invisible; the corpus now pins both weld directions and
+  asserts the neutralized token structure directly, so neither a one-sided fix nor a
+  blanket separator can pass.
 
 ## [0.5.0] — 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
+## [Unreleased]
+
+### Security
+
+- **Closed a read-only-guard bypass via a welded quoted identifier.** A double-quoted
+  identifier is self-delimiting in SQL, so `SELECT*FROM"pg_read_file"('/etc/passwd')` is a
+  valid statement with no whitespace before the quote. The guard's lexer dropped the quote
+  characters without re-supplying that boundary, fusing two tokens into one
+  (`FROM"pg_class"` → `FROMpg_class`) and destroying the word-boundary anchor every
+  dangerous-function pattern matches on — so the gate stopped seeing the token rather than
+  allowing it, and returned no rejection. Verified against PostgreSQL 16: the welded form
+  executes and reads a server-side file while the guard passed it. The lexer now re-supplies
+  a separator when, and only when, the previous emitted character is a word character, so a
+  qualified name (`t."current_user"`) is still not split. Prior corpus cases all happened to
+  carry a space before the quote, which is why this stayed invisible; the regression corpus
+  now pins the welded forms and the qualified-name negatives.
+
 ## [0.5.0] — 2026-07-25
 
 ### Changed

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -74,6 +74,18 @@ def _neutralize(sql: str) -> str:
     deliberately NOT an escape here — engines disagree (MySQL yes, standard PG no),
     and not honoring it can only stop a literal *early* (fail safe), never late.
     """
+    def _last_emitted(chunks: list[str]) -> str:
+        """The last character actually emitted, skipping empty chunks.
+
+        Peeking at `chunks[-1]` alone is wrong: a zero-length identifier (`""`) appends an
+        empty string, which would hide the real preceding character and drop a separator
+        that is needed.
+        """
+        for chunk in reversed(chunks):
+            if chunk:
+                return chunk[-1]
+        return ""
+
     out: list[str] = []
     i, n = 0, len(sql)
     while i < n:
@@ -130,20 +142,28 @@ def _neutralize(sql: str) -> str:
             # A pathological identifier like "a;b" reduces to a;b and trips the
             # multi-statement check — a deliberate, safe-direction hardening choice.
             #
-            # The quote is ALSO the token delimiter: a delimited identifier is
-            # self-delimiting in SQL, so `FROM"pg_class"` needs no whitespace and is a
-            # valid statement the engine runs. Dropping the quotes without re-supplying a
-            # separator therefore fuses two tokens into one (`FROM"pg_class"` ->
-            # `FROMpg_class`), destroying the `\b` anchor every deny-list pattern below
-            # relies on — the gate stops seeing the token at all rather than allowing it.
-            # Re-supply the boundary ONLY when the previous emitted char is a word char:
-            # a blanket space would split a qualified name (`t."col"` -> `t. col`) and
-            # break the `(?<!\.)` lookbehind that keeps a qualified column from reading as
-            # a bare dangerous identifier.
-            prev = out[-1][-1:] if out and out[-1] else ""
-            if prev.isalnum() or prev == "_":
+            # The quotes are ALSO the token delimiters, on BOTH ends: a delimited
+            # identifier is self-delimiting, so `FROM"pg_class"` and `"x"INTO` are both
+            # valid SQL the engine runs. Dropping the quotes without re-supplying those
+            # boundaries fuses neighbouring tokens into one — `FROM"pg_class"` ->
+            # `FROMpg_class`, `"x"INTO` -> `xINTO` — which defeats the `\b` anchors every
+            # deny-list pattern below relies on. The gate then stops *seeing* the token
+            # rather than allowing it, so it returns no rejection at all. This is the same
+            # invariant the docstring states for comments and literals ("never empty");
+            # the identifier branch is simply the one place that was not honouring it.
+            #
+            # Re-supply a boundary only where the quote was actually separating two word
+            # chars, so a qualified name stays one token: `t."col"` must neutralize to
+            # `t.col`, not `t. col`. That structural fidelity is the neutralizer's job —
+            # it removes hiding places without re-tokenizing the statement — and it is
+            # pinned by an explicit output test, since no current rule distinguishes the
+            # two spellings on its own.
+            if _last_emitted(out).isalnum() or _last_emitted(out) == "_":
                 out.append(" ")
             out.append("".join(buf))
+            nxt = sql[j] if j < n else ""
+            if nxt.isalnum() or nxt == "_":
+                out.append(" ")
             i = j
         elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)
             # Only a `$tag$` with a MATCHING close delimiter is a literal we can blank.

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -129,6 +129,20 @@ def _neutralize(sql: str) -> str:
                 j += 1
             # A pathological identifier like "a;b" reduces to a;b and trips the
             # multi-statement check — a deliberate, safe-direction hardening choice.
+            #
+            # The quote is ALSO the token delimiter: a delimited identifier is
+            # self-delimiting in SQL, so `FROM"pg_class"` needs no whitespace and is a
+            # valid statement the engine runs. Dropping the quotes without re-supplying a
+            # separator therefore fuses two tokens into one (`FROM"pg_class"` ->
+            # `FROMpg_class`), destroying the `\b` anchor every deny-list pattern below
+            # relies on — the gate stops seeing the token at all rather than allowing it.
+            # Re-supply the boundary ONLY when the previous emitted char is a word char:
+            # a blanket space would split a qualified name (`t."col"` -> `t. col`) and
+            # break the `(?<!\.)` lookbehind that keeps a qualified column from reading as
+            # a bare dangerous identifier.
+            prev = out[-1][-1:] if out and out[-1] else ""
+            if prev.isalnum() or prev == "_":
+                out.append(" ")
             out.append("".join(buf))
             i = j
         elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -74,6 +74,18 @@ def _neutralize(sql: str) -> str:
     deliberately NOT an escape here — engines disagree (MySQL yes, standard PG no),
     and not honoring it can only stop a literal *early* (fail safe), never late.
     """
+    def _last_emitted(chunks: list[str]) -> str:
+        """The last character actually emitted, skipping empty chunks.
+
+        Peeking at `chunks[-1]` alone is wrong: a zero-length identifier (`""`) appends an
+        empty string, which would hide the real preceding character and drop a separator
+        that is needed.
+        """
+        for chunk in reversed(chunks):
+            if chunk:
+                return chunk[-1]
+        return ""
+
     out: list[str] = []
     i, n = 0, len(sql)
     while i < n:
@@ -130,20 +142,28 @@ def _neutralize(sql: str) -> str:
             # A pathological identifier like "a;b" reduces to a;b and trips the
             # multi-statement check — a deliberate, safe-direction hardening choice.
             #
-            # The quote is ALSO the token delimiter: a delimited identifier is
-            # self-delimiting in SQL, so `FROM"pg_class"` needs no whitespace and is a
-            # valid statement the engine runs. Dropping the quotes without re-supplying a
-            # separator therefore fuses two tokens into one (`FROM"pg_class"` ->
-            # `FROMpg_class`), destroying the `\b` anchor every deny-list pattern below
-            # relies on — the gate stops seeing the token at all rather than allowing it.
-            # Re-supply the boundary ONLY when the previous emitted char is a word char:
-            # a blanket space would split a qualified name (`t."col"` -> `t. col`) and
-            # break the `(?<!\.)` lookbehind that keeps a qualified column from reading as
-            # a bare dangerous identifier.
-            prev = out[-1][-1:] if out and out[-1] else ""
-            if prev.isalnum() or prev == "_":
+            # The quotes are ALSO the token delimiters, on BOTH ends: a delimited
+            # identifier is self-delimiting, so `FROM"pg_class"` and `"x"INTO` are both
+            # valid SQL the engine runs. Dropping the quotes without re-supplying those
+            # boundaries fuses neighbouring tokens into one — `FROM"pg_class"` ->
+            # `FROMpg_class`, `"x"INTO` -> `xINTO` — which defeats the `\b` anchors every
+            # deny-list pattern below relies on. The gate then stops *seeing* the token
+            # rather than allowing it, so it returns no rejection at all. This is the same
+            # invariant the docstring states for comments and literals ("never empty");
+            # the identifier branch is simply the one place that was not honouring it.
+            #
+            # Re-supply a boundary only where the quote was actually separating two word
+            # chars, so a qualified name stays one token: `t."col"` must neutralize to
+            # `t.col`, not `t. col`. That structural fidelity is the neutralizer's job —
+            # it removes hiding places without re-tokenizing the statement — and it is
+            # pinned by an explicit output test, since no current rule distinguishes the
+            # two spellings on its own.
+            if _last_emitted(out).isalnum() or _last_emitted(out) == "_":
                 out.append(" ")
             out.append("".join(buf))
+            nxt = sql[j] if j < n else ""
+            if nxt.isalnum() or nxt == "_":
+                out.append(" ")
             i = j
         elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)
             # Only a `$tag$` with a MATCHING close delimiter is a literal we can blank.

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -129,6 +129,20 @@ def _neutralize(sql: str) -> str:
                 j += 1
             # A pathological identifier like "a;b" reduces to a;b and trips the
             # multi-statement check — a deliberate, safe-direction hardening choice.
+            #
+            # The quote is ALSO the token delimiter: a delimited identifier is
+            # self-delimiting in SQL, so `FROM"pg_class"` needs no whitespace and is a
+            # valid statement the engine runs. Dropping the quotes without re-supplying a
+            # separator therefore fuses two tokens into one (`FROM"pg_class"` ->
+            # `FROMpg_class`), destroying the `\b` anchor every deny-list pattern below
+            # relies on — the gate stops seeing the token at all rather than allowing it.
+            # Re-supply the boundary ONLY when the previous emitted char is a word char:
+            # a blanket space would split a qualified name (`t."col"` -> `t. col`) and
+            # break the `(?<!\.)` lookbehind that keeps a qualified column from reading as
+            # a bare dangerous identifier.
+            prev = out[-1][-1:] if out and out[-1] else ""
+            if prev.isalnum() or prev == "_":
+                out.append(" ")
             out.append("".join(buf))
             i = j
         elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -29,7 +29,7 @@ import sys
 from typing import Any
 
 import pytest
-from sql_guard import _MAX_SQL_CHARS, check_read_only
+from sql_guard import _MAX_SQL_CHARS, _neutralize, check_read_only
 
 # ---------------------------------------------------------------------------
 # Accept — valid single read-only statements
@@ -392,6 +392,19 @@ def test_red_team_quoted_dangerous_fn_bypass(sql: str) -> None:
         'SELECT 1 FROM"pg_class"WHERE"pg_sleep"(10) IS NULL',
         # The weld can also appear mid-statement, after a non-keyword word char.
         'SELECT a FROM t WHERE b="pg_sleep"(1)',
+        # The CLOSING quote delimits too, so a keyword can hide on the trailing side.
+        # `SELECT ... INTO <table>` is a write that opens with SELECT, which is exactly
+        # why INTO is in the DML/DDL list; `\bINTO\b` does not match `xINTO`. Verified on
+        # PostgreSQL 16: each of these creates a table holding the source rows.
+        'SELECT "x"INTO evil FROM t',
+        'SELECT"x"INTO evil FROM t',
+        'SELECT t."x"INTO evil FROM t',
+        'SELECT 1 AS"a"INTO evil',
+        'WITH c AS (SELECT 1 AS "x")SELECT "x"INTO evil FROM c',
+        # Row-lock rule, same root cause. FOR UPDATE survives only because bare UPDATE is
+        # independently in the DML list; FOR SHARE has no such backstop.
+        'SELECT * FROM t AS"a"FOR SHARE',
+        'SELECT * FROM t AS"a"FOR KEY SHARE',
     ],
 )
 def test_red_team_welded_quoted_dangerous_fn_bypass(sql: str) -> None:
@@ -420,6 +433,34 @@ def test_red_team_welded_quoted_dangerous_fn_bypass(sql: str) -> None:
 def test_welded_fix_does_not_over_block_legitimate_quoted_identifiers(sql: str) -> None:
     """The weld fix must not turn a qualified quoted column into a false positive."""
     assert check_read_only(sql) is None, f"Legitimate quoted identifier wrongly blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        # A separator is re-supplied ONLY where the quote actually separated two word
+        # chars — so a qualified name survives as ONE token.
+        ('SELECT t."current_user" FROM t', "SELECT t.current_user FROM t"),
+        ('SELECT "schema"."table" FROM "schema"."table"', "SELECT schema.table FROM schema.table"),
+        ('SELECT c."email" FROM customers c', "SELECT c.email FROM customers c"),
+        # ...and IS re-supplied on both sides where it was separating word chars.
+        ('SELECT * FROM"pg_class"', "SELECT * FROM pg_class"),
+        ('SELECT "x"INTO evil FROM t', "SELECT x INTO evil FROM t"),
+        ('SELECT 1 AS"a"INTO evil', "SELECT 1 AS a INTO evil"),
+    ],
+)
+def test_neutralize_preserves_token_structure(sql: str, expected: str) -> None:
+    """Pin the *shape* of the neutralized text, not just the gate's yes/no.
+
+    Every rule here is `\\b`-anchored, so a blanket separator on both sides would block the
+    same attacks and pass the same negatives — the gate-level tests alone cannot tell the
+    two designs apart, and a future refactor could silently swap one for the other. What a
+    blanket space would change is token *structure*: `t."col"` would become `t. col`, two
+    tokens where the statement meant one. Any rule that reasons about qualification (a
+    pattern anchored on a preceding `.`, say) would then read a qualified column as a bare
+    identifier. Asserting the neutralized string keeps that decision checkable.
+    """
+    assert _neutralize(sql) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -376,6 +376,55 @@ def test_red_team_quoted_dangerous_fn_bypass(sql: str) -> None:
 @pytest.mark.parametrize(
     "sql",
     [
+        # WELDED quoted identifier — no whitespace between the preceding keyword and the
+        # opening `"`. A delimited identifier is self-delimiting in SQL (the quote IS the
+        # token boundary), so these are valid statements the engine happily runs; verified
+        # on PostgreSQL 16 (`SELECT"pg_read_file"('/tmp/x')` returns the file contents).
+        # Dropping the quotes without re-supplying a separator fuses two tokens into one
+        # (`FROM"pg_class"` -> `FROMpg_class`), which destroys the `\b` anchor every
+        # deny-list pattern relies on and silently blinds the gate.
+        "SELECT\"pg_read_file\"('/etc/passwd')",
+        "SELECT*FROM\"pg_read_file\"('/etc/passwd')",
+        'SELECT"pg_sleep"(10)',
+        'SELECT"dblink"(\'host=evil\', \'select 1\')',
+        'SELECT"pg_terminate_backend"(123)',
+        'SELECT"set_config"(\'statement_timeout\', \'0\', false)',
+        'SELECT 1 FROM"pg_class"WHERE"pg_sleep"(10) IS NULL',
+        # The weld can also appear mid-statement, after a non-keyword word char.
+        'SELECT a FROM t WHERE b="pg_sleep"(1)',
+    ],
+)
+def test_red_team_welded_quoted_dangerous_fn_bypass(sql: str) -> None:
+    """A quoted identifier welded to the preceding token must not escape the gate.
+
+    Regression for the `_neutralize` weld: every pre-existing case in the corpus above
+    happens to carry a space before the `"`, so the missing separator was invisible.
+    """
+    assert check_read_only(sql) is not None, f"Welded quoted-fn bypass NOT blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # The separator must be re-supplied ONLY where the quote was actually delimiting
+        # two word chars. A blanket space would break qualified names — `t."col"` must stay
+        # `t.col`, not become `t. col` — so these legitimate reads must still pass.
+        'SELECT t."current_user" FROM t',
+        'SELECT "order id" FROM orders',
+        'SELECT "name", "email" FROM customers',
+        'SELECT c."email" FROM customers c',
+        'SELECT "schema"."table" FROM "schema"."table"',
+        'SELECT a."b" FROM x a',
+    ],
+)
+def test_welded_fix_does_not_over_block_legitimate_quoted_identifiers(sql: str) -> None:
+    """The weld fix must not turn a qualified quoted column into a false positive."""
+    assert check_read_only(sql) is None, f"Legitimate quoted identifier wrongly blocked: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
         # Block comments between keywords must not defeat `\b` word boundaries —
         # comments are stripped to SPACE, not empty.
         "SELECT 1 FROM users WHERE id IN (SELECT/**/pg_sleep(10))",


### PR DESCRIPTION
## Summary

A double-quoted identifier is **self-delimiting** in SQL — the quote *is* the token boundary — so `SELECT*FROM"pg_read_file"('/etc/passwd')` needs no whitespace and is a statement the engine runs.

`_neutralize` (the shared lexer the SQL guard runs before matching anything) dropped the quote characters without re-supplying that boundary, fusing two tokens into one:

```
SELECT*FROM"pg_read_file"(...)   ->   SELECT*FROMpg_read_file(...)
```

Every dangerous-function pattern is `\b`-anchored, and there is no word boundary inside `FROMpg_read_file`. So the gate stopped **seeing** the token rather than allowing it, and `check_read_only` returned `None` (pass).

## Verified end-to-end against PostgreSQL 16

Before the fix — the database executes it, the guard passes it:

```
$ echo "verify" > /tmp/probe.txt
psql  -> verify                             # server-side file read succeeded
guard -> PASS                               # check_read_only returned None
```

After the fix, same string:

```
guard -> REFUSE: function `pg_read_file` is not allowed —
         server-file / OS / process-control / sleep / remote-SQL functions are blocked
```

## Scope of the exploitable shape

The weld only bypasses when it lands on a **non-leading** keyword:

| input | neutralized | outcome before fix |
|---|---|---|
| `SELECT*FROM"pg_read_file"(1)` | `SELECT*FROMpg_read_file(1)` | **bypass** |
| `SELECT 1 FROM"pg_class"WHERE"pg_sleep"(10) IS NULL` | `…FROMpg_classWHEREpg_sleep(10)…` | **bypass** |
| `SELECT"pg_sleep"(10)` | `SELECTpg_sleep(10)` | caught incidentally, by the statement-opener check |

## The fix

Re-supply the separator **only** when the previous emitted character is a word char. A blanket space would split a qualified name (`t."current_user"` → `t. current_user`) and defeat the `(?<!\.)` lookbehind that keeps a qualified column from reading as a bare dangerous identifier.

Applied to both the package source and the vendored plugin mirror via `dev.py sync-lib`, so the drift check stays green and both surfaces are protected.

## Why this was invisible

Every pre-existing case in the red-team corpus happens to carry a space before the quote (`SELECT "pg_sleep"(10)`), so the missing separator never showed. The corpus now pins **8 welded forms** and, on the other side, **6 qualified-name negatives** that must keep passing — so a future over-correction (a blanket space) fails just as loudly as the original gap.

## Test plan

- `python3 dev.py check` green — **1571 passed, 1 skipped**, ruff clean, gitleaks clean, vendored-lib drift check clean
- New regression tests fail on `main` and pass here (2 of the 8 welded cases were live bypasses)
- End-to-end verification against a live PostgreSQL 16 instance, shown above