### PR TITLE
Read every statement in the engine's own grammar, and refuse when we cannot

### DIFF
--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -37,7 +37,11 @@ model = [
 # The HTTP MCP transport (mcp_http): the official MCP SDK + an ASGI server. Kept out of the base
 # install so the local executor/skill stay stdlib-lean — only a hosted deployment installs it.
 server = [
-  "mcp>=1.2",
+  # Capped below 2.0: that release removed `Server.list_tools`, which `mcp_http` builds the tool
+  # surface with, so every HTTP request fails at import. With no ceiling here a resolve simply
+  # picks it up and the whole HTTP transport — and the safety corpus that runs over it — breaks
+  # without a code change. Raise the cap deliberately, once mcp_http is ported to the new API.
+  "mcp>=1.2,<2",
   "anyio>=4",           # async_offload.run_blocking offloads blocking work off the loop (ACE-048)
   "uvicorn>=0.30",
   "psycopg2-binary>=2.9",

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1345,7 +1345,19 @@ def _model_safety(
         else:
             return sql, Refusal("sensitive_columns", sens.reason, sens.suggestion or ""), None
 
-    new_sql, applied = RT.apply_default_filters(sql, org, area=area, ctx=ctx)
+    try:
+        new_sql, applied = RT.apply_default_filters(sql, org, area=area, ctx=ctx)
+    except RT.RowScopingUnavailable as exc:
+        # The model declares a row filter for a table this query reads, and it could not be
+        # applied. Running anyway would return rows the row scoping exists to withhold, so
+        # this refuses. The fault is in the model, not the query, so the remediation is the
+        # operator's and the statement is not worth re-emitting.
+        return sql, Refusal(
+            "model_unavailable",
+            str(exc),
+            "Correct the table's default_filters in the model so the row filter can be "
+            "applied for this datasource's engine.",
+        ), None
     if applied:
         # default_filters only add WHERE conditions, never change the projection list, so the mask
         # plan's output indices stay valid against the rewritten SQL's result.

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1229,6 +1229,23 @@ def _model_safety(
     # returns the same verdict as one that builds its own.
     ctx = RT.build_guard_context(sql, org)
 
+    # Ungovernable-engine gate — if the datasource does not determine which engine its SQL
+    # runs on, there is no grammar to read the statement in, so no gate below can reach a
+    # trustworthy verdict and the statement is refused rather than run blind. This is
+    # deliberately ahead of, and not subject to, the unscopable posture switch: the posture
+    # is a staged-rollout hatch for queries that cannot be scoped, whereas a datasource that
+    # cannot be parsed at all is a configuration fault the operator must fix. Refusing here
+    # also keeps the guarantee independent of which gate would otherwise have run.
+    if ctx is not None and ctx.dialect is None and ctx.parse_error:
+        return sql, Refusal(
+            "unscopable_sql",
+            ctx.parse_error,
+            # No rewrite of the query helps, so this must not invite a retry — it names the
+            # one change that makes the datasource governable.
+            "Declare the datasource's engine (storage_connections[].storage_type) so its SQL "
+            "can be parsed for the right engine, then retry.",
+        ), None
+
     # Scopability gate — refuse a query that can't be fully scoped (unparseable, or a non-`Table`
     # FROM/JOIN source the scope walk can't reject) rather than run it blind. Runs
     # BEFORE the object-scope gates so an unscopable query fails closed instead of reaching their

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1236,14 +1236,33 @@ def _model_safety(
     # is a staged-rollout hatch for queries that cannot be scoped, whereas a datasource that
     # cannot be parsed at all is a configuration fault the operator must fix. Refusing here
     # also keeps the guarantee independent of which gate would otherwise have run.
-    if ctx is not None and ctx.dialect is None and ctx.parse_error:
+    if ctx is not None and getattr(ctx, "dialect", None) is None and getattr(ctx, "parse_error", None):
         return sql, Refusal(
             "unscopable_sql",
             ctx.parse_error,
             # No rewrite of the query helps, so this must not invite a retry — it names the
             # one change that makes the datasource governable.
+            # No trailing "then retry": the statement is not the problem, and an unactionable
+            # invitation to try again turns a configuration fault into a retry loop.
             "Declare the datasource's engine (storage_connections[].storage_type) so its SQL "
-            "can be parsed for the right engine, then retry.",
+            "can be parsed for the right engine.",
+        ), None
+
+    # Unreadable-statement gate — a statement that did not parse leaves every gate below with
+    # no tree, and they each degrade to allow on one, so nothing downstream would object. Also
+    # ahead of the posture switch: `warn` exists to let through queries that parse but cannot be
+    # scoped, not statements nobody can read. Leaving this behind the switch would make `warn`
+    # weaker than it was before parse errors were reported, because the old silently-truncated
+    # tree still named enough for the scope gates to catch some of these.
+    if ctx is not None and ctx.tree is None:
+        return sql, Refusal(
+            "unscopable_sql",
+            getattr(ctx, "parse_error", None) or "the statement could not be read as SQL",
+            getattr(
+                RT,
+                "_REEMIT_REMEDIATION",
+                "Re-emit the query using the declared table and column names.",
+            ),
         ), None
 
     # Scopability gate — refuse a query that can't be fully scoped (unparseable, or a non-`Table`
@@ -1346,8 +1365,11 @@ def _model_safety(
             return sql, Refusal("sensitive_columns", sens.reason, sens.suggestion or ""), None
 
     try:
+        # `getattr` because this file is vendored into the plugin while runtime.py resolves from
+        # the separately-versioned installed package: a newer plugin can meet an older runtime
+        # that has no such exception, and naming it directly would raise AttributeError instead.
         new_sql, applied = RT.apply_default_filters(sql, org, area=area, ctx=ctx)
-    except RT.RowScopingUnavailable as exc:
+    except getattr(RT, "RowScopingUnavailable", ()) as exc:
         # The model declares a row filter for a table this query reads, and it could not be
         # applied. Running anyway would return rows the row scoping exists to withhold, so
         # this refuses. The fault is in the model, not the query, so the remediation is the
@@ -1436,6 +1458,40 @@ def _execute_trino(creds: dict[str, str], sql: str) -> int:
 
 def _execute_duckdb(creds: dict[str, str], sql: str) -> int:
     return _emit_or_err(lambda: _run_duckdb(creds, sql))
+
+
+def _refuse_if_engines_disagree(profile: str, creds: dict[str, str]) -> None:
+    """Refuse when the model's declared engine is not the one the credentials connect to.
+
+    Raises GuardRefused. Silent when either side is absent or unmapped: the executor rejects an
+    unusable credential type itself, and a missing declaration is already refused upstream.
+    """
+    # Imported here rather than at module scope, like the rest of the guard path: a bare install
+    # legitimately has no model package. `getattr` throughout because this file is vendored into
+    # the plugin while runtime.py resolves from the separately-versioned installed package, so an
+    # older runtime simply skips the check instead of raising.
+    try:
+        from semantic_model import runtime as RT
+    except Exception:
+        return
+    engines_disagree = getattr(RT, "engines_disagree", None)
+    dialect_of = getattr(RT, "_dialect_of", None)
+    if engines_disagree is None or dialect_of is None:
+        return
+    org = _resolve_guard_model(profile)
+    if org is None:
+        return
+    if engines_disagree(dialect_of(org)[0], creds.get("type", "")):
+        raise GuardRefused(
+            Refusal(
+                "model_unavailable",
+                "the datasource's declared engine is not the engine its credentials connect "
+                "to, so the statement was checked against the wrong SQL grammar",
+                "Make the model's storage_connections[].storage_type match the engine the "
+                "credentials point at.",
+            ),
+            code=1,
+        )
 
 
 def _builtin_execute(vetted_sql: str, creds: dict[str, str], *, profile: str) -> ExecResult:
@@ -1535,6 +1591,13 @@ def execute_guarded(
         if refusal is not None:
             raise GuardRefused(refusal, code=1)
     creds = _load_credentials(profile, org_id or "local")
+    if not no_safety:
+        # The guard chose its grammar from the model's declared engine; the executor chooses its
+        # driver from these credentials. They are separate pieces of operator configuration, so a
+        # mismatch means the statement was vetted — and, where a filter or join rewrite fired,
+        # regenerated — in a grammar this database does not speak. Credentials are resolved after
+        # the gates by design, so this is the first point the two can be compared.
+        _refuse_if_engines_disagree(profile, creds)
     try:
         result = executor.execute(sql, creds, profile=profile)
         if mask_plan is not None:

--- a/packages/agami-core/src/semantic_model/cli.py
+++ b/packages/agami-core/src/semantic_model/cli.py
@@ -215,7 +215,12 @@ def cmd_prepare(args) -> int:
                      "suggestion": pf.suggestion, "sql": sql})
         return 1
     run_sql = pf.rewritten_sql if (pf.action == "auto_rewrite" and pf.rewritten_sql) else sql
-    final_sql, applied = RT.apply_default_filters(run_sql, org, area=args.area)
+    try:
+        final_sql, applied = RT.apply_default_filters(run_sql, org, area=args.area)
+    except RT.RowScopingUnavailable as exc:
+        # Refuse rather than print a statement the model's row scoping was silently left out of.
+        _print_json({"action": "refuse", "risk": "row_scoping", "reason": str(exc), "sql": run_sql})
+        return 1
     _print_json({
         "action": pf.action,
         "risk": pf.risk,

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -1149,15 +1149,25 @@ def check_column_scope(
 # ---------------------------------------------------------------------------
 
 
-def _unscopable(detail: str) -> Verdict:
+def _unscopable(detail: str, remediation: "str | None" = None) -> Verdict:
     return safety_verdict(
         "unscopable_sql",
         "the query can't be scoped to the declared object surface: "
         + detail
         + " — only queries whose FROM/JOIN sources resolve to declared tables may run.",
-        "Query only declared tables (no table-functions, VALUES, UNNEST, or LATERAL "
+        remediation
+        or "Query only declared tables (no table-functions, VALUES, UNNEST, or LATERAL "
         "sources); add a source to the model if it should be queryable.",
     )
+
+
+# A statement that did not parse is regenerable: the caller can re-emit it and try again, so
+# the remediation names that move rather than the declared-source advice above, which would
+# describe a problem this statement does not have.
+_REEMIT_REMEDIATION = (
+    "Re-emit the query using the declared table and column names, unquoted or quoted the way "
+    "this datasource's engine quotes identifiers."
+)
 
 
 def check_scopable(
@@ -1190,7 +1200,7 @@ def check_scopable(
     if tree is None:
         # Prefer the specific reason over the generic one, so the caller can tell the
         # operator-actionable case apart from the one the query itself can fix.
-        return _unscopable(why_not or "the query did not parse")
+        return _unscopable(why_not or "the query did not parse", _REEMIT_REMEDIATION)
     if tree.find(exp.Select) is None:
         return _unscopable("the query has no SELECT to scope")
     # Table-functions and `ROWS FROM` parse to an `exp.Table` with an EMPTY name (the
@@ -1215,6 +1225,16 @@ def check_scopable(
                 return _unscopable(
                     f"a FROM/JOIN source is a {type(src).__name__.upper()}, not a table"
                 )
+    # Dialect-independent backstop. A statement that reads from something, yet parses to no
+    # named table at all, cannot be attributed to the declared surface — and that is exactly
+    # the shape a mis-read produces. Catching it here means a quoting style nobody has mapped
+    # yet fails closed on its own, without the dialect map having to be complete first. A
+    # statement with no FROM (`SELECT 1`) reads nothing and is left alone.
+    if tree.find(exp.From) is not None and tree.find(exp.Table) is None:
+        return _unscopable(
+            "the query reads from a source that resolves to no named table",
+            _REEMIT_REMEDIATION,
+        )
     return None
 
 

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -57,7 +57,7 @@ from .models import (
 from .models import (
     bare_name as _bare,
 )
-from .sql_dialect import DialectUnresolved, resolve_datasource_dialect
+from .sql_dialect import DialectUnresolved, engines_disagree, resolve_datasource_dialect
 
 # A prober resolves a literal/value against the DB. Returns True if the value
 # exists in <table>.<column>. Injected so runtime stays DB-agnostic.
@@ -93,6 +93,42 @@ class GuardContext:
     # tree but opposite verdicts.
     dialect: "str | None" = None
     parse_error: "str | None" = None
+
+
+# Engines whose identifier quote is the backtick, so a double-quoted token is a *string
+# literal* in their default mode — but an *identifier* when the server runs in an
+# ANSI-quoting mode (MySQL's ANSI_QUOTES, and the equivalent on the Spark-family engines).
+# The parse cannot tell which, because sqlglot does not preserve the quote character: `"x"`
+# and `'x'` both arrive as the same string Literal.
+_BACKTICK_QUOTING_DIALECTS = frozenset({"mysql", "bigquery", "databricks", "spark", "hive"})
+
+# A grammar in which a double-quoted token is unambiguously an identifier, used only to ask
+# "would this read as a column somewhere else?".
+_ANSI_QUOTING_DIALECT = "postgres"
+
+
+def _quote_ambiguous(sql: str, dialect: "str | None") -> bool:
+    """True when a double-quoted token would be a column under ANSI quoting but reads as a
+    string literal in this engine's default mode.
+
+    Such a statement means two different things depending on a server setting the guard
+    cannot see. Under the engine's default mode the gates are right that no column is
+    projected; if the server runs in ANSI-quoting mode the same text selects the column and
+    the gates would have scored a real column as a literal. Rather than guess the server's
+    mode, the statement is treated as unreadable — it is trivially re-emitted in the engine's
+    own quoting, which is unambiguous.
+    """
+    if dialect not in _BACKTICK_QUOTING_DIALECTS:
+        return False
+    native = _parse_sql(sql, dialect)
+    if native is None:
+        return False
+    ansi = _parse_sql(sql, _ANSI_QUOTING_DIALECT)
+    if ansi is None:
+        return False
+    native_cols = {c.name.lower() for c in native.find_all(exp.Column)}
+    ansi_cols = {c.name.lower() for c in ansi.find_all(exp.Column)}
+    return bool(ansi_cols - native_cols)
 
 
 class RowScopingUnavailable(Exception):
@@ -1160,11 +1196,15 @@ def check_column_scope(
 
 
 def _unscopable(detail: str, remediation: "str | None" = None) -> Verdict:
+    # The declared-sources tail explains why a *source* was rejected. It misdescribes a
+    # statement that never parsed at all, so it is attached only alongside the default
+    # remediation it belongs with; a caller supplying its own remediation gets the bare reason.
+    reason = "the query can't be scoped to the declared object surface: " + detail
+    if remediation is None:
+        reason += " — only queries whose FROM/JOIN sources resolve to declared tables may run."
     return safety_verdict(
         "unscopable_sql",
-        "the query can't be scoped to the declared object surface: "
-        + detail
-        + " — only queries whose FROM/JOIN sources resolve to declared tables may run.",
+        reason,
         remediation
         or "Query only declared tables (no table-functions, VALUES, UNNEST, or LATERAL "
         "sources); add a source to the model if it should be queryable.",
@@ -1213,6 +1253,17 @@ def check_scopable(
         return _unscopable(why_not or "the query did not parse", _REEMIT_REMEDIATION)
     if tree.find(exp.Select) is None:
         return _unscopable("the query has no SELECT to scope")
+    # A double-quoted token on a backtick-quoting engine means one thing under the engine's
+    # default mode and another under its ANSI-quoting mode, and the guard cannot see which
+    # the server runs. Read as a literal, a projected sensitive column is invisible to the
+    # column and PII gates while the server may still return it, so the ambiguity is refused
+    # rather than resolved by guessing.
+    if _quote_ambiguous(sql, ctx.dialect if ctx is not None else _dialect_of(org)[0]):
+        return _unscopable(
+            "a double-quoted identifier means either a column or a string literal on this "
+            "datasource's engine, depending on server configuration the guard cannot see",
+            _REEMIT_REMEDIATION,
+        )
     # Table-functions and `ROWS FROM` parse to an `exp.Table` with an EMPTY name (the
     # function lives in `.this`); the object-scope gates skip empty-name tables, so a
     # whole-tree sweep catches them here — including inside a set-operation arm.
@@ -2207,6 +2258,8 @@ __all__ = [
     "PreFlightResult",
     "pre_flight_check",
     "apply_default_filters",
+    "RowScopingUnavailable",
+    "engines_disagree",
     "build_receipt",
     "assemble_receipt",
 ]

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -41,6 +41,7 @@ from guardrail import Verdict, safety_verdict
 try:
     import sqlglot
     from sqlglot import expressions as exp
+    from sqlglot.errors import ErrorLevel, ParseError, TokenError
 
     _HAVE_SQLGLOT = True
 except ImportError:  # pragma: no cover
@@ -56,6 +57,7 @@ from .models import (
 from .models import (
     bare_name as _bare,
 )
+from .sql_dialect import DialectUnresolved, resolve_datasource_dialect
 
 # A prober resolves a literal/value against the DB. Returns True if the value
 # exists in <table>.<column>. Injected so runtime stays DB-agnostic.
@@ -83,17 +85,61 @@ class GuardContext:
     cardinality_index: "list[Relationship]"
     sensitive_by_table: "tuple[dict[str, dict[str, str]], set[str]]"
     model_table_index: "dict[str, tuple]"
+    # The sqlglot dialect every parse and every regeneration in this battery uses, or None
+    # when the datasource does not determine one. `parse_error` is a value-free reason the
+    # statement could not be read — an unresolvable engine, or SQL that does not parse in
+    # the resolved one. Both are set together with `tree`, so a caller can tell "read it and
+    # found nothing to object to" apart from "could not read it", which are the same empty
+    # tree but opposite verdicts.
+    dialect: "str | None" = None
+    parse_error: "str | None" = None
 
 
-def _parse_sql(sql: str) -> "exp.Expression | None":
-    """Parse SQL for the guard battery; None if sqlglot is unavailable or the SQL does not
-    parse (guards degrade to allow). Centralized so a GuardContext parses exactly once."""
-    if not _HAVE_SQLGLOT:
-        return None
+def _dialect_of(org: "Datasource | None") -> "tuple[str | None, str | None]":
+    """Resolve the sqlglot dialect for `org` as (dialect, reason-it-could-not-be-resolved)."""
+    if org is None:
+        return None, "the statement was checked without a model, so its engine is unknown"
     try:
-        return sqlglot.parse_one(sql, error_level="ignore")
+        return resolve_datasource_dialect(org), None
+    except DialectUnresolved as exc:
+        return None, str(exc)
+
+
+def _parse_sql(sql: str, dialect: "str | None" = None) -> "exp.Expression | None":
+    """Parse SQL for the guard battery; None if sqlglot is unavailable or the SQL does not
+    parse. Centralized so a GuardContext parses exactly once.
+
+    Callers that need to distinguish "did not parse" from "parsed to nothing" should use
+    `_parse_reporting`; this form is for the standalone callers that only need the tree.
+    """
+    return _parse_reporting(sql, dialect)[0]
+
+
+def _parse_reporting(
+    sql: str, dialect: "str | None" = None
+) -> "tuple[exp.Expression | None, str | None]":
+    """Parse `sql` in `dialect`, returning (tree, reason-it-failed).
+
+    Two deliberate choices, both load-bearing for the guards that read the result:
+
+    * The dialect is passed through. Parsing in a grammar the engine does not use does not
+      merely lose detail — it produces a tree that describes a different statement, and a
+      gate inspecting it finds nothing to object to.
+    * Errors raise rather than being collected and discarded. sqlglot's error level must be
+      the ErrorLevel enum: it compares the level against enum members, so a *string* level
+      matches no branch and every error is dropped, leaving a silently truncated tree. The
+      reason is value-free (never the statement or the parser's echo of it) so a caller may
+      surface it. TokenError is raised for lexical faults such as an unterminated literal
+      regardless of error level, so both are caught.
+    """
+    if not _HAVE_SQLGLOT:
+        return None, None
+    try:
+        return sqlglot.parse_one(sql, dialect=dialect, error_level=ErrorLevel.RAISE), None
+    except (ParseError, TokenError):
+        return None, "the statement could not be parsed as SQL for this datasource's engine"
     except Exception:
-        return None
+        return None, "the statement could not be read"
 
 
 def build_guard_context(sql: str, org: Datasource) -> "GuardContext | None":
@@ -103,13 +149,20 @@ def build_guard_context(sql: str, org: Datasource) -> "GuardContext | None":
     building the indices would be pure wasted work in that fallback path."""
     if not _HAVE_SQLGLOT:
         return None
+    dialect, dialect_error = _dialect_of(org)
+    tree, parse_error = _parse_reporting(sql, dialect)
     return GuardContext(
         sql=sql,
-        tree=_parse_sql(sql),
+        tree=tree,
         column_index=_column_index(org),
         cardinality_index=_cardinality_index(org),
         sensitive_by_table=_sensitive_by_table(org),
         model_table_index=_model_table_index(org),
+        dialect=dialect,
+        # An unresolvable engine is itself a reason the statement could not be read, and it
+        # outranks a parse failure: the parse only happened generically because there was no
+        # engine to read it in.
+        parse_error=dialect_error or parse_error,
     )
 
 
@@ -763,10 +816,7 @@ def check_sensitive_projection(
     if ctx is not None:
         tree = ctx.tree
     else:
-        try:
-            tree = sqlglot.parse_one(sql, error_level="ignore")
-        except Exception:
-            return SensitiveCheckResult("allow")
+        tree = _parse_sql(sql, _dialect_of(org)[0])
     # A set operation (UNION/INTERSECT/EXCEPT) parses to exp.SetOperation, not
     # exp.Select — gate on "contains a SELECT" and scan every OUTPUT-bearing arm, else
     # `… UNION SELECT ssn FROM customers` would project a sensitive column past this gate.
@@ -856,10 +906,7 @@ def check_table_scope(
     if ctx is not None:
         tree = ctx.tree
     else:
-        try:
-            tree = sqlglot.parse_one(sql, error_level="ignore")
-        except Exception:
-            return None
+        tree = _parse_sql(sql, _dialect_of(org)[0])
     # A set operation (UNION/INTERSECT/EXCEPT) parses to exp.Union, not exp.Select,
     # so gate on "contains a SELECT" rather than "is a SELECT" — otherwise every
     # set-operation arm would bypass the guard. A non-SELECT statement has no SELECT
@@ -911,7 +958,9 @@ def check_table_scope(
 # ---------------------------------------------------------------------------
 
 
-def check_no_select_star(sql: str, ctx: "GuardContext | None" = None) -> Verdict | None:
+def check_no_select_star(
+    sql: str, ctx: "GuardContext | None" = None, *, dialect: "str | None" = None
+) -> Verdict | None:
     """Refuse a query whose projection list contains `*` or `t.*`.
 
     A star defeats column-level scoping (an undeclared column hides behind it) and
@@ -929,10 +978,7 @@ def check_no_select_star(sql: str, ctx: "GuardContext | None" = None) -> Verdict
     if ctx is not None:
         tree = ctx.tree
     else:
-        try:
-            tree = sqlglot.parse_one(sql, error_level="ignore")
-        except Exception:
-            return None
+        tree = _parse_sql(sql, dialect)
     if tree is None or tree.find(exp.Select) is None:
         return None
     for select in tree.find_all(exp.Select):
@@ -976,10 +1022,7 @@ def check_column_scope(
     if ctx is not None:
         tree = ctx.tree
     else:
-        try:
-            tree = sqlglot.parse_one(sql, error_level="ignore")
-        except Exception:
-            return None
+        tree = _parse_sql(sql, _dialect_of(org)[0])
     if tree is None or tree.find(exp.Select) is None:
         return None
 
@@ -1140,9 +1183,14 @@ def check_scopable(
         return None
     if not _HAVE_SQLGLOT:
         return _unscopable("the SQL parser is unavailable")
-    tree = ctx.tree if ctx is not None else _parse_sql(sql)
+    if ctx is not None:
+        tree, why_not = ctx.tree, ctx.parse_error
+    else:
+        tree, why_not = _parse_reporting(sql, _dialect_of(org)[0])
     if tree is None:
-        return _unscopable("the query did not parse")
+        # Prefer the specific reason over the generic one, so the caller can tell the
+        # operator-actionable case apart from the one the query itself can fix.
+        return _unscopable(why_not or "the query did not parse")
     if tree.find(exp.Select) is None:
         return _unscopable("the query has no SELECT to scope")
     # Table-functions and `ROWS FROM` parse to an `exp.Table` with an EMPTY name (the
@@ -1217,14 +1265,18 @@ def pre_flight_check(sql: str, org: Datasource,
     # Parse via the same centralized helper the ctx path used (ACE-045), so a ctx and a non-ctx
     # call are byte-identical: _parse_sql swallows an unparseable statement to None exactly as a
     # prebuilt ctx.tree would be None, and both then report the one "no SELECT; skipped" reason.
-    tree = ctx.tree if ctx is not None else _parse_sql(sql)
+    dialect = ctx.dialect if ctx is not None else _dialect_of(org)[0]
+    tree = ctx.tree if ctx is not None else _parse_sql(sql, dialect)
     if tree is None or tree.find(exp.Select) is None:
         return PreFlightResult(None, "allow", sql, reason="no SELECT; skipped")
     if isinstance(tree, exp.Select):
         return _preflight_select(tree, org, sql, allow_rewrite=True, ctx=ctx)
     # Set operation: analyze each arm; a trap in any arm inflates that arm's aggregate.
+    # Each arm is rendered back to text in the datasource's grammar before being re-read —
+    # rendering generically would feed the analysis a statement in a grammar the arm was
+    # never written in, the same mis-read this battery exists to prevent.
     for arm in _output_selects(tree):
-        res = _preflight_select(arm, org, arm.sql(), allow_rewrite=False, ctx=ctx)
+        res = _preflight_select(arm, org, arm.sql(dialect=dialect), allow_rewrite=False, ctx=ctx)
         if res.risk and res.action == "refuse":
             # tie the arm's diagnosis back to the full set-operation query
             return PreFlightResult(
@@ -1303,7 +1355,11 @@ def _preflight_select(tree: "exp.Select", org: Datasource, sql: str, allow_rewri
         many_aliases = {a for a, t in tables_in_scope.items() if t in many_tables}
         referenced_elsewhere = _tables_referenced_outside_from(tree, tables_in_scope) & many_tables
         if allow_rewrite and not has_raw_columns and not referenced_elsewhere:
-            rewritten = _drop_fanout_joins(sql, many_aliases | many_tables)
+            rewritten = _drop_fanout_joins(
+                sql,
+                many_aliases | many_tables,
+                dialect=ctx.dialect if ctx is not None else _dialect_of(org)[0],
+            )
             if rewritten and rewritten.strip() != sql.strip():
                 return PreFlightResult(
                     "fan_trap",
@@ -1391,6 +1447,7 @@ def _semi_additive_columns(org: Datasource) -> dict[tuple[str, str], "Metric"]:
     tables that both have a `balance` don't cross-contaminate. The table is the binding's
     own qualifier when present, else the metric's source_tables. Includes org-level
     cross-subject-area metrics."""
+    dialect, _ = _dialect_of(org)
     all_metrics: list["Metric"] = list(getattr(org, "cross_subject_area_metrics", []) or [])
     for sa in org.subject_areas:
         all_metrics.extend(sa.metrics)
@@ -1400,10 +1457,10 @@ def _semi_additive_columns(org: Datasource) -> dict[tuple[str, str], "Metric"]:
             continue
         srcs = list(mm.source_tables or [])
         for binding in (mm.bindings or {}).values():
-            try:
-                frag = sqlglot.parse_one(binding, error_level="ignore")
-            except Exception:
-                continue
+            # A metric binding is authored with the model, not by the caller, so it is read
+            # in the datasource's engine like everything else; a binding that does not parse
+            # is skipped rather than refusing the caller's statement, which is not at fault.
+            frag = _parse_sql(binding, dialect)
             if frag is None:
                 continue
             for agg in frag.find_all(exp.Sum):
@@ -1611,10 +1668,10 @@ def assemble_receipt(
     }
     if not _HAVE_SQLGLOT:
         return receipt
-    try:
-        tree = sqlglot.parse_one(sql, error_level="ignore")
-    except Exception:
-        tree = None
+    # Read in the datasource's engine: a receipt built from a generically-parsed statement
+    # attributes no tables at all on a backtick- or bracket-quoting engine, under-reporting
+    # what the answer actually read.
+    tree = _parse_sql(sql, _dialect_of(org)[0])
     if tree is None:
         return receipt
 
@@ -1855,13 +1912,17 @@ def _shared_dimension(
     return None
 
 
-def _drop_fanout_joins(sql: str, drop_tables: set[str]) -> Optional[str]:
+def _drop_fanout_joins(
+    sql: str, drop_tables: set[str], *, dialect: "str | None" = None
+) -> Optional[str]:
     """Remove JOINs whose target table/alias is in drop_tables. Used for the
-    safe aggregation-only fan-trap rewrite."""
-    try:
-        tree = sqlglot.parse_one(sql, error_level="ignore")
-    except Exception:
-        return None
+    safe aggregation-only fan-trap rewrite.
+
+    `dialect` is both read and written: the statement returned here is the one the executor
+    runs, so it must be regenerated in the engine's own grammar. Emitting generically would
+    hand the executor a statement the guards never validated.
+    """
+    tree = _parse_sql(sql, dialect)
     if not isinstance(tree, exp.Select):
         return None
     joins = tree.args.get("joins") or []
@@ -1878,7 +1939,7 @@ def _drop_fanout_joins(sql: str, drop_tables: set[str]) -> Optional[str]:
     if not changed:
         return None
     tree.set("joins", kept)
-    return tree.sql()
+    return tree.sql(dialect=dialect)
 
 
 def apply_default_filters(
@@ -1908,11 +1969,10 @@ def apply_default_filters(
         # shared ctx.tree the read-only guards used stays pristine (ACE-045). ctx must be
         # built from this same `sql`, which _model_safety guarantees.
         tree = ctx.tree.copy() if ctx.tree is not None else None
+        dialect = ctx.dialect
     else:
-        try:
-            tree = sqlglot.parse_one(sql, error_level="ignore")
-        except Exception:
-            return sql, []
+        dialect, _ = _dialect_of(org)
+        tree = _parse_sql(sql, dialect)
     if not isinstance(tree, exp.Select):
         return sql, []
 
@@ -1937,14 +1997,22 @@ def apply_default_filters(
         return sql, []
 
     combined = " AND ".join(f"({c})" for c in conditions)
+    # The condition is authored with the model, not by the caller, and is read in the same
+    # engine grammar as the statement it is spliced into. A filter that will not parse is
+    # dropped rather than applied half-formed: returning the original `sql` leaves the row
+    # scoping unapplied, which the caller must treat as a failure to scope, not as a pass.
+    cond_tree = _parse_sql(f"SELECT 1 WHERE {combined}", dialect)
+    if cond_tree is None:
+        return sql, []
     try:
-        cond_expr = sqlglot.parse_one(f"SELECT 1 WHERE {combined}").args["where"].this
+        cond_expr = cond_tree.args["where"].this
         where = tree.args.get("where")
         if where is not None:
             tree.set("where", exp.Where(this=exp.and_(where.this, cond_expr)))
         else:
             tree.set("where", exp.Where(this=cond_expr))
-        return tree.sql(), applied
+        # Regenerate in the datasource's grammar: this statement is what the executor runs.
+        return tree.sql(dialect=dialect), applied
     except Exception:
         return sql, []
 
@@ -1989,7 +2057,6 @@ def resolve_result_units(org: Datasource, sql: str) -> dict[str, str]:
       - COUNT(...) and ratios (any division) get NO currency unit (a count / rate isn't
         money). Returns {} if the model carries no units or sqlglot can't parse.
     """
-    import sqlglot
     from sqlglot import expressions as exp
 
     col_units: dict[str, str] = {}
@@ -2011,10 +2078,7 @@ def resolve_result_units(org: Datasource, sql: str) -> dict[str, str]:
     if not col_units and not metric_units:
         return {}
 
-    try:
-        tree = sqlglot.parse_one(sql, error_level="ignore")
-    except Exception:
-        return {}
+    tree = _parse_sql(sql, _dialect_of(org)[0])
     select = tree.find(exp.Select) if tree is not None else None
     if select is None:
         return {}

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -95,6 +95,16 @@ class GuardContext:
     parse_error: "str | None" = None
 
 
+class RowScopingUnavailable(Exception):
+    """A declared row filter could not be applied, so the query cannot be row-scoped.
+
+    Raised rather than returned because the caller distinguishes "filters applied" from
+    "no filters needed" by an empty list, and silently returning the unfiltered statement
+    would drop the row scoping the model declares. The message is value-free, so a caller
+    may use it as a refusal reason.
+    """
+
+
 def _dialect_of(org: "Datasource | None") -> "tuple[str | None, str | None]":
     """Resolve the sqlglot dialect for `org` as (dialect, reason-it-could-not-be-resolved)."""
     if org is None:
@@ -2018,13 +2028,17 @@ def apply_default_filters(
 
     combined = " AND ".join(f"({c})" for c in conditions)
     # The condition is authored with the model, not by the caller, and is read in the same
-    # engine grammar as the statement it is spliced into. A filter that will not parse is
-    # dropped rather than applied half-formed: returning the original `sql` leaves the row
-    # scoping unapplied, which the caller must treat as a failure to scope, not as a pass.
+    # engine grammar as the statement it is spliced into.
+    #
+    # If it cannot be applied, this must NOT return the statement unchanged. The caller keeps
+    # the rewritten SQL only when `applied` is non-empty, so an empty list is indistinguishable
+    # from "this query needed no filter" — and the query would then run with the row scoping
+    # its model declares silently absent. That is a fail-open in a governance control, so an
+    # unusable filter raises and the caller refuses instead.
     cond_tree = _parse_sql(f"SELECT 1 WHERE {combined}", dialect)
-    if cond_tree is None:
-        return sql, []
     try:
+        if cond_tree is None:
+            raise ValueError("the filter did not parse")
         cond_expr = cond_tree.args["where"].this
         where = tree.args.get("where")
         if where is not None:
@@ -2033,8 +2047,11 @@ def apply_default_filters(
             tree.set("where", exp.Where(this=cond_expr))
         # Regenerate in the datasource's grammar: this statement is what the executor runs.
         return tree.sql(dialect=dialect), applied
-    except Exception:
-        return sql, []
+    except Exception as exc:
+        raise RowScopingUnavailable(
+            "the datasource declares a row filter for a table this query reads, but the "
+            "filter could not be applied, so the query cannot be row-scoped"
+        ) from exc
 
 
 def _similarity(a: str, b: str) -> float:

--- a/packages/agami-core/src/semantic_model/sql_dialect.py
+++ b/packages/agami-core/src/semantic_model/sql_dialect.py
@@ -1,0 +1,122 @@
+"""Resolve a datasource's declared engine to the sqlglot dialect the guard parses with.
+
+The model-scoping guards read a statement by parsing it. If they parse it in the wrong
+grammar the tree does not describe the statement: on a backtick-quoting engine
+``SELECT `ssn` FROM `customers``` parses to *no tables and no columns* under sqlglot's
+generic dialect, so a gate looking for undeclared tables or sensitive columns finds
+nothing to object to and allows the statement. The guard must therefore read every
+statement in the same grammar the executor will run it in.
+
+Two properties this module exists to guarantee:
+
+* **The map is explicit.** ``StorageType.lower()`` is *not* a sqlglot dialect name —
+  ``PostgreSQL`` -> ``postgresql`` and ``SQLServer`` -> ``sqlserver`` both raise, while the
+  other nine happen to work. A derived map would fail on the most common engine and on the
+  one whose quoting diverges most, so every engine is written out by hand.
+* **An unmapped engine is detectable.** Resolution raises rather than falling back to the
+  generic dialect, because falling back is precisely the failure this module prevents. A
+  new ``StorageType`` added without a dialect decision fails the map's test rather than
+  silently reverting the guards to generic parsing for that engine.
+
+Dialect resolution never parses SQL, so it does not disturb the guard battery's
+parse-exactly-once property.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, get_args
+
+from .models import StorageType
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .models import Datasource
+
+
+class DialectUnresolved(Exception):
+    """The engine a statement would run on cannot be determined.
+
+    The message is value-free — it describes the shape of the problem and never carries
+    statement text, data values, schema/column names or driver output — so a caller may
+    use it verbatim as a refusal reason.
+    """
+
+
+# StorageType -> sqlglot dialect name. Written out per engine on purpose: see the module
+# docstring for why lowercasing the StorageType is wrong. Verified against sqlglot 30.10.0.
+_SQLGLOT_DIALECT: dict[str, str] = {
+    "PostgreSQL": "postgres",  # NOT "postgresql" — sqlglot rejects that spelling
+    "MySQL": "mysql",
+    "Snowflake": "snowflake",
+    "BigQuery": "bigquery",
+    "Redshift": "redshift",
+    "SQLite": "sqlite",
+    "DuckDB": "duckdb",
+    "SQLServer": "tsql",  # NOT "sqlserver" — sqlglot names T-SQL "tsql"
+    "Databricks": "databricks",
+    "Trino": "trino",
+    "Oracle": "oracle",
+}
+
+
+def sqlglot_dialect(storage_type: str) -> str:
+    """Map one declared engine to its sqlglot dialect name.
+
+    Raises DialectUnresolved when the engine has no mapping, so that a `StorageType`
+    added without a dialect decision is caught rather than parsed generically.
+    """
+    dialect = _SQLGLOT_DIALECT.get(storage_type)
+    if dialect is None:
+        raise DialectUnresolved(
+            "the datasource declares a storage engine this build cannot parse SQL for"
+        )
+    return dialect
+
+
+def resolve_datasource_dialect(org: "Datasource") -> str:
+    """Resolve the sqlglot dialect for every statement run against `org`.
+
+    A datasource resolves to a single live database — credentials are looked up once per
+    (organization, profile) and carry no connection name — so all of its declared storage
+    connections must agree on the engine for the guard to know which grammar applies.
+
+    Raises DialectUnresolved when no connection is declared, or when the declared
+    connections name more than one engine.
+    """
+    engines = {sc.storage_type for sc in org.storage_connections}
+    if not engines:
+        raise DialectUnresolved(
+            "the datasource declares no storage connection, so the engine its SQL would "
+            "run on is unknown"
+        )
+    if len(engines) > 1:
+        # Not reachable through a normal deployment today (one credential per datasource
+        # means a second engine has no way to be queried), but a model can express it, so
+        # it is refused rather than resolved by picking one arbitrarily.
+        raise DialectUnresolved(
+            f"the datasource declares {len(engines)} different storage engines, so the "
+            "engine its SQL would run on is ambiguous"
+        )
+    return sqlglot_dialect(engines.pop())
+
+
+def supported_storage_types() -> tuple[str, ...]:
+    """Every engine with an explicit dialect mapping."""
+    return tuple(_SQLGLOT_DIALECT)
+
+
+def unmapped_storage_types() -> tuple[str, ...]:
+    """Declared `StorageType` members that have no dialect mapping.
+
+    Empty by construction; the map's test asserts it stays empty so that adding an engine
+    without a dialect decision fails rather than degrading that engine to generic parsing.
+    """
+    return tuple(t for t in get_args(StorageType) if t not in _SQLGLOT_DIALECT)
+
+
+__all__ = [
+    "DialectUnresolved",
+    "resolve_datasource_dialect",
+    "sqlglot_dialect",
+    "supported_storage_types",
+    "unmapped_storage_types",
+]

--- a/packages/agami-core/src/semantic_model/sql_dialect.py
+++ b/packages/agami-core/src/semantic_model/sql_dialect.py
@@ -99,6 +99,48 @@ def resolve_datasource_dialect(org: "Datasource") -> str:
     return sqlglot_dialect(engines.pop())
 
 
+# The credential `type` values the executor dispatches on, mapped to the same sqlglot dialect
+# names as above. The guard picks its grammar from the *model*; the executor picks its driver
+# from the *credentials*. Those are two independent pieces of operator configuration, so they
+# are compared rather than assumed equal — a model declaring one engine against another's
+# credentials would have the guard vet a statement in a grammar the database does not speak,
+# which is the defect this module exists to prevent, arriving by a different door.
+_CREDENTIAL_DIALECT: dict[str, str] = {
+    "postgres": "postgres",
+    "supabase": "postgres",  # hosted PostgreSQL
+    "redshift": "redshift",
+    "mysql": "mysql",
+    "sqlite": "sqlite",
+    "snowflake": "snowflake",
+    "bigquery": "bigquery",
+    "sqlserver": "tsql",
+    "mssql": "tsql",
+    "oracle": "oracle",
+    "databricks": "databricks",
+    "trino": "trino",
+    "presto": "trino",
+    "duckdb": "duckdb",
+}
+
+
+def credential_dialect(credential_type: str) -> "str | None":
+    """The sqlglot dialect implied by a credential `type`, or None if it is not one we map."""
+    return _CREDENTIAL_DIALECT.get((credential_type or "").strip().lower())
+
+
+def engines_disagree(model_dialect: "str | None", credential_type: str) -> bool:
+    """True when the model's declared engine and the credentials name different engines.
+
+    Unmapped or absent values are not a disagreement — the executor rejects an unusable
+    credential type on its own, and refusing here as well would turn an unrelated
+    configuration error into a governance refusal that misdescribes it.
+    """
+    actual = credential_dialect(credential_type)
+    if model_dialect is None or actual is None:
+        return False
+    return model_dialect != actual
+
+
 def supported_storage_types() -> tuple[str, ...]:
     """Every engine with an explicit dialect mapping."""
     return tuple(_SQLGLOT_DIALECT)

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1345,7 +1345,19 @@ def _model_safety(
         else:
             return sql, Refusal("sensitive_columns", sens.reason, sens.suggestion or ""), None
 
-    new_sql, applied = RT.apply_default_filters(sql, org, area=area, ctx=ctx)
+    try:
+        new_sql, applied = RT.apply_default_filters(sql, org, area=area, ctx=ctx)
+    except RT.RowScopingUnavailable as exc:
+        # The model declares a row filter for a table this query reads, and it could not be
+        # applied. Running anyway would return rows the row scoping exists to withhold, so
+        # this refuses. The fault is in the model, not the query, so the remediation is the
+        # operator's and the statement is not worth re-emitting.
+        return sql, Refusal(
+            "model_unavailable",
+            str(exc),
+            "Correct the table's default_filters in the model so the row filter can be "
+            "applied for this datasource's engine.",
+        ), None
     if applied:
         # default_filters only add WHERE conditions, never change the projection list, so the mask
         # plan's output indices stay valid against the rewritten SQL's result.

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1229,6 +1229,23 @@ def _model_safety(
     # returns the same verdict as one that builds its own.
     ctx = RT.build_guard_context(sql, org)
 
+    # Ungovernable-engine gate — if the datasource does not determine which engine its SQL
+    # runs on, there is no grammar to read the statement in, so no gate below can reach a
+    # trustworthy verdict and the statement is refused rather than run blind. This is
+    # deliberately ahead of, and not subject to, the unscopable posture switch: the posture
+    # is a staged-rollout hatch for queries that cannot be scoped, whereas a datasource that
+    # cannot be parsed at all is a configuration fault the operator must fix. Refusing here
+    # also keeps the guarantee independent of which gate would otherwise have run.
+    if ctx is not None and ctx.dialect is None and ctx.parse_error:
+        return sql, Refusal(
+            "unscopable_sql",
+            ctx.parse_error,
+            # No rewrite of the query helps, so this must not invite a retry — it names the
+            # one change that makes the datasource governable.
+            "Declare the datasource's engine (storage_connections[].storage_type) so its SQL "
+            "can be parsed for the right engine, then retry.",
+        ), None
+
     # Scopability gate — refuse a query that can't be fully scoped (unparseable, or a non-`Table`
     # FROM/JOIN source the scope walk can't reject) rather than run it blind. Runs
     # BEFORE the object-scope gates so an unscopable query fails closed instead of reaching their

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1236,14 +1236,33 @@ def _model_safety(
     # is a staged-rollout hatch for queries that cannot be scoped, whereas a datasource that
     # cannot be parsed at all is a configuration fault the operator must fix. Refusing here
     # also keeps the guarantee independent of which gate would otherwise have run.
-    if ctx is not None and ctx.dialect is None and ctx.parse_error:
+    if ctx is not None and getattr(ctx, "dialect", None) is None and getattr(ctx, "parse_error", None):
         return sql, Refusal(
             "unscopable_sql",
             ctx.parse_error,
             # No rewrite of the query helps, so this must not invite a retry — it names the
             # one change that makes the datasource governable.
+            # No trailing "then retry": the statement is not the problem, and an unactionable
+            # invitation to try again turns a configuration fault into a retry loop.
             "Declare the datasource's engine (storage_connections[].storage_type) so its SQL "
-            "can be parsed for the right engine, then retry.",
+            "can be parsed for the right engine.",
+        ), None
+
+    # Unreadable-statement gate — a statement that did not parse leaves every gate below with
+    # no tree, and they each degrade to allow on one, so nothing downstream would object. Also
+    # ahead of the posture switch: `warn` exists to let through queries that parse but cannot be
+    # scoped, not statements nobody can read. Leaving this behind the switch would make `warn`
+    # weaker than it was before parse errors were reported, because the old silently-truncated
+    # tree still named enough for the scope gates to catch some of these.
+    if ctx is not None and ctx.tree is None:
+        return sql, Refusal(
+            "unscopable_sql",
+            getattr(ctx, "parse_error", None) or "the statement could not be read as SQL",
+            getattr(
+                RT,
+                "_REEMIT_REMEDIATION",
+                "Re-emit the query using the declared table and column names.",
+            ),
         ), None
 
     # Scopability gate — refuse a query that can't be fully scoped (unparseable, or a non-`Table`
@@ -1346,8 +1365,11 @@ def _model_safety(
             return sql, Refusal("sensitive_columns", sens.reason, sens.suggestion or ""), None
 
     try:
+        # `getattr` because this file is vendored into the plugin while runtime.py resolves from
+        # the separately-versioned installed package: a newer plugin can meet an older runtime
+        # that has no such exception, and naming it directly would raise AttributeError instead.
         new_sql, applied = RT.apply_default_filters(sql, org, area=area, ctx=ctx)
-    except RT.RowScopingUnavailable as exc:
+    except getattr(RT, "RowScopingUnavailable", ()) as exc:
         # The model declares a row filter for a table this query reads, and it could not be
         # applied. Running anyway would return rows the row scoping exists to withhold, so
         # this refuses. The fault is in the model, not the query, so the remediation is the
@@ -1436,6 +1458,40 @@ def _execute_trino(creds: dict[str, str], sql: str) -> int:
 
 def _execute_duckdb(creds: dict[str, str], sql: str) -> int:
     return _emit_or_err(lambda: _run_duckdb(creds, sql))
+
+
+def _refuse_if_engines_disagree(profile: str, creds: dict[str, str]) -> None:
+    """Refuse when the model's declared engine is not the one the credentials connect to.
+
+    Raises GuardRefused. Silent when either side is absent or unmapped: the executor rejects an
+    unusable credential type itself, and a missing declaration is already refused upstream.
+    """
+    # Imported here rather than at module scope, like the rest of the guard path: a bare install
+    # legitimately has no model package. `getattr` throughout because this file is vendored into
+    # the plugin while runtime.py resolves from the separately-versioned installed package, so an
+    # older runtime simply skips the check instead of raising.
+    try:
+        from semantic_model import runtime as RT
+    except Exception:
+        return
+    engines_disagree = getattr(RT, "engines_disagree", None)
+    dialect_of = getattr(RT, "_dialect_of", None)
+    if engines_disagree is None or dialect_of is None:
+        return
+    org = _resolve_guard_model(profile)
+    if org is None:
+        return
+    if engines_disagree(dialect_of(org)[0], creds.get("type", "")):
+        raise GuardRefused(
+            Refusal(
+                "model_unavailable",
+                "the datasource's declared engine is not the engine its credentials connect "
+                "to, so the statement was checked against the wrong SQL grammar",
+                "Make the model's storage_connections[].storage_type match the engine the "
+                "credentials point at.",
+            ),
+            code=1,
+        )
 
 
 def _builtin_execute(vetted_sql: str, creds: dict[str, str], *, profile: str) -> ExecResult:
@@ -1535,6 +1591,13 @@ def execute_guarded(
         if refusal is not None:
             raise GuardRefused(refusal, code=1)
     creds = _load_credentials(profile, org_id or "local")
+    if not no_safety:
+        # The guard chose its grammar from the model's declared engine; the executor chooses its
+        # driver from these credentials. They are separate pieces of operator configuration, so a
+        # mismatch means the statement was vetted — and, where a filter or join rewrite fired,
+        # regenerated — in a grammar this database does not speak. Credentials are resolved after
+        # the gates by design, so this is the first point the two can be compared.
+        _refuse_if_engines_disagree(profile, creds)
     try:
         result = executor.execute(sql, creds, profile=profile)
         if mask_plan is not None:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -157,7 +157,10 @@ def db_safety_env(pg_admin, tmp_path, monkeypatch):
     super_dsn = (
         f"postgresql://{sc['user']}:{sc['password']}@{sc['host']}:{sc['port']}/{sc['dbname']}"
     )
-    harness.seed_db_model(super_dsn, ds="acme")
+    # The datasource this env reads is Postgres (DATASOURCE_URL__ACME below), so the model must
+    # declare Postgres: the guard parses in the model's engine and refuses when that is not the
+    # engine the credentials connect to.
+    harness.seed_db_model(super_dsn, ds="acme", storage_type="PostgreSQL")
 
     ro_dsn = f"postgresql://agami_ro:{_RO_PASSWORD}@{sc['host']}:{sc['port']}/{sc['dbname']}"
     monkeypatch.setenv("AGAMI_DB_URL", super_dsn)  # hosted → model + audit from the app DB

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -29,7 +29,7 @@ _TYPE_MAP = {"INTEGER": "integer", "REAL": "float", "TEXT": "string"}
 
 
 # ── model + datasource builders (single-sourced from SCHEMA) ───────────────────────────────────
-def build_org():
+def build_org(storage_type: str = "SQLite"):
     """The semantic model the guards scope against — built from SCHEMA (names + sensitive flags)."""
     from semantic_model import models as m
 
@@ -50,17 +50,18 @@ def build_org():
     return m.Datasource(
         datasource="Shop",
         version=1,
-        # The corpus executes against SQLite (see `seed_sqlite`), and the declared engine is
-        # what the guards parse every statement in — so it must name the engine that actually
-        # runs the SQL, not a placeholder.
-        storage_connections=[m.StorageConnection(name="c", storage_type="SQLite")],
+        # The declared engine is what the guards parse every statement in, and it is now
+        # reconciled against the credentials the executor connects with — so it must name the
+        # engine that actually runs the SQL. The file-served corpus runs SQLite (`seed_sqlite`);
+        # the DB-served corpus in the Postgres job runs Postgres.
+        storage_connections=[m.StorageConnection(name="c", storage_type=storage_type)],
         subject_areas=[
             m.SubjectArea(name="sales", tables_defined=[_table(n, s) for n, s in SCHEMA.items()])
         ],
     )
 
 
-def write_disk_model(root: Path) -> None:
+def write_disk_model(root: Path, storage_type: str = "SQLite") -> None:
     """Write the FILE-served model under `root` (an AGAMI_ARTIFACTS_DIR/<profile> dir)."""
     import yaml
 
@@ -70,7 +71,7 @@ def write_disk_model(root: Path) -> None:
             {
                 "datasource": "Shop",
                 "version": 1,
-                "storage_connections": [{"name": "c", "storage_type": "SQLite"}],
+                "storage_connections": [{"name": "c", "storage_type": storage_type}],
                 "subject_areas": ["subject_areas/sales"],
             }
         )
@@ -122,14 +123,14 @@ def seed_sqlite(path: Path) -> None:
         con.close()
 
 
-def seed_db_model(url: str, ds: str = "acme") -> None:
+def seed_db_model(url: str, ds: str = "acme", storage_type: str = "SQLite") -> None:
     """Write the DB-served model into an app DB at `url` (the hosted path's model source)."""
     import model_store
     from store import Store
 
     s = Store.connect(url)
     s.run_migrations()
-    model_store.write_datasource(s, ds, build_org())
+    model_store.write_datasource(s, ds, build_org(storage_type))
     s.close()
 
 

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -50,6 +50,10 @@ def build_org():
     return m.Datasource(
         datasource="Shop",
         version=1,
+        # The corpus executes against SQLite (see `seed_sqlite`), and the declared engine is
+        # what the guards parse every statement in — so it must name the engine that actually
+        # runs the SQL, not a placeholder.
+        storage_connections=[m.StorageConnection(name="c", storage_type="SQLite")],
         subject_areas=[
             m.SubjectArea(name="sales", tables_defined=[_table(n, s) for n, s in SCHEMA.items()])
         ],
@@ -63,7 +67,12 @@ def write_disk_model(root: Path) -> None:
     (root / "subject_areas" / "sales" / "tables").mkdir(parents=True, exist_ok=True)
     (root / "datasource.yaml").write_text(
         yaml.safe_dump(
-            {"datasource": "Shop", "version": 1, "subject_areas": ["subject_areas/sales"]}
+            {
+                "datasource": "Shop",
+                "version": 1,
+                "storage_connections": [{"name": "c", "storage_type": "SQLite"}],
+                "subject_areas": ["subject_areas/sales"],
+            }
         )
     )
     (root / "subject_areas" / "sales" / "subject_area.yaml").write_text(

--- a/tests/e2e/test_safety_corpus.py
+++ b/tests/e2e/test_safety_corpus.py
@@ -51,14 +51,20 @@ def assert_outcome(env: dict, expect: str, sql: str) -> None:
         assert env["audit_id"]
 
 
-@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+# The two paths read the same corpus but execute against different engines, and identifier
+# quoting is engine-specific — so each path runs the cases that are valid SQL on its engine.
+FILE_PATH_CASES = [c for c in CASES if c.runs_on("SQLite")]
+DB_PATH_CASES = [c for c in CASES if c.runs_on("PostgreSQL")]
+
+
+@pytest.mark.parametrize("case", FILE_PATH_CASES, ids=[c.id for c in FILE_PATH_CASES])
 def test_safety_corpus_file_path(case, surface, file_safety_env):
     # File-served model (disk YAML) + SQLite datasource. Runs in the default (DB-free) test job.
     env = surface(case.sql, datasource="acme", max_rows=case.max_rows)
     assert_outcome(env, case.expect, case.sql)
 
 
-@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+@pytest.mark.parametrize("case", DB_PATH_CASES, ids=[c.id for c in DB_PATH_CASES])
 def test_safety_corpus_db_path(case, surface, db_safety_env):
     # DB-served model (Postgres app DB) + Postgres datasource read as the read-only role. IDENTICAL
     # verdicts to the file path prove file/db parity (a control that reads the model can't behave

--- a/tests/safety/corpus.py
+++ b/tests/safety/corpus.py
@@ -140,4 +140,44 @@ CASES: list[Case] = [
         "join-aggregate",
     ),
     Case("governed", "SELECT COUNT(email) AS n FROM customers", "ok", "sensitive-in-count-ok"),
+    # Ordinary shapes a governed query takes. These carry no attack — they exist so that a
+    # change which tightens parsing has to prove it did not start refusing valid SQL. Without
+    # them the "no false refusal" side of the corpus rests on four statements, and a tightening
+    # that broke ordinary queries could still pass.
+    Case("governed", 'SELECT "id", "amount" FROM "orders"', "ok", "quoted-identifiers"),
+    Case("governed", "SELECT o.id, o.amount FROM orders o", "ok", "aliased-table"),
+    Case("governed", "SELECT id FROM orders WHERE status = 'paid'", "ok", "where-literal"),
+    Case("governed", "SELECT id, amount FROM orders ORDER BY amount DESC", "ok", "order-by"),
+    Case("governed", "SELECT DISTINCT status FROM orders", "ok", "distinct"),
+    Case(
+        "governed",
+        "SELECT status, COUNT(id) AS n FROM orders GROUP BY status HAVING COUNT(id) > 0",
+        "ok",
+        "having",
+    ),
+    Case(
+        "governed",
+        "WITH paid AS (SELECT id, amount FROM orders WHERE status = 'paid') "
+        "SELECT COUNT(id) AS n FROM paid",
+        "ok",
+        "cte",
+    ),
+    Case(
+        "governed",
+        "SELECT id FROM orders WHERE customer_id IN (SELECT id FROM customers WHERE region = 'west')",
+        "ok",
+        "subquery-in-where",
+    ),
+    Case(
+        "governed",
+        "SELECT id, CASE WHEN amount > 60 THEN 'big' ELSE 'small' END AS bucket FROM orders",
+        "ok",
+        "case-expression",
+    ),
+    Case(
+        "governed",
+        "SELECT id FROM orders UNION ALL SELECT id FROM customers",
+        "ok",
+        "union-all",
+    ),
 ]

--- a/tests/safety/corpus.py
+++ b/tests/safety/corpus.py
@@ -140,6 +140,19 @@ CASES: list[Case] = [
         "join-aggregate",
     ),
     Case("governed", "SELECT COUNT(email) AS n FROM customers", "ok", "sensitive-in-count-ok"),
+    # ── class 8: the same verdicts when the statement is written in the engine's own quoting ──
+    # A statement read in the wrong grammar does not describe itself: under a generic parse a
+    # backtick-quoted statement resolves to no tables and no columns, so every scope gate finds
+    # nothing to object to and allows it. These run through the full harness — both surfaces,
+    # both model paths — because that is the only place the guarantee is proved end to end.
+    # (The demo datasource is SQLite, which accepts both quoting styles.)
+    Case("quoting", "SELECT `id` FROM `undeclared`", "table_out_of_scope", "backtick-undeclared-table"),
+    Case("quoting", "SELECT `nosuchcol` FROM `orders`", "column_out_of_scope", "backtick-undeclared-col"),
+    Case("quoting", "SELECT `email` FROM `customers`", "ok", "backtick-sensitive-is-seen"),
+    Case("quoting", "SELECT * FROM `orders`", "select_star", "backtick-star"),
+    Case("quoting", "DELETE FROM `orders`", "permission", "backtick-delete"),
+    Case("quoting", "SELECT [id] FROM [undeclared]", "table_out_of_scope", "bracket-undeclared-table"),
+    Case("quoting", 'SELECT "id" FROM "undeclared"', "table_out_of_scope", "quoted-undeclared-table"),
     # Ordinary shapes a governed query takes. These carry no attack — they exist so that a
     # change which tightens parsing has to prove it did not start refusing valid SQL. Without
     # them the "no false refusal" side of the corpus rests on four statements, and a tightening

--- a/tests/safety/corpus.py
+++ b/tests/safety/corpus.py
@@ -54,6 +54,15 @@ class Case:
     expect: str  # a refusal kind, or "bounded", or "ok"
     note: str = ""
     max_rows: int | None = None  # per-call row cap (the availability row-cap case lowers it)
+    # Engines this case is meaningful on, or None for every engine. Identifier quoting is
+    # engine-specific — a backtick is an identifier quote on MySQL and SQLite but not valid SQL
+    # on Postgres — so a quoting case pinned to one engine would assert a different verdict on
+    # the other. Naming the engine keeps the case honest instead of letting it pass on the path
+    # that happens to accept it.
+    engines: tuple[str, ...] | None = None
+
+    def runs_on(self, engine: str) -> bool:
+        return self.engines is None or engine in self.engines
 
     @property
     def id(self) -> str:
@@ -146,13 +155,22 @@ CASES: list[Case] = [
     # nothing to object to and allows it. These run through the full harness — both surfaces,
     # both model paths — because that is the only place the guarantee is proved end to end.
     # (The demo datasource is SQLite, which accepts both quoting styles.)
-    Case("quoting", "SELECT `id` FROM `undeclared`", "table_out_of_scope", "backtick-undeclared-table"),
-    Case("quoting", "SELECT `nosuchcol` FROM `orders`", "column_out_of_scope", "backtick-undeclared-col"),
-    Case("quoting", "SELECT `email` FROM `customers`", "ok", "backtick-sensitive-is-seen"),
-    Case("quoting", "SELECT * FROM `orders`", "select_star", "backtick-star"),
-    Case("quoting", "DELETE FROM `orders`", "permission", "backtick-delete"),
-    Case("quoting", "SELECT [id] FROM [undeclared]", "table_out_of_scope", "bracket-undeclared-table"),
+    # SQLite accepts backticks and brackets as identifier quoting; Postgres does not, where the
+    # same text is not valid SQL at all — so these are pinned to the engine they mean something on.
+    Case("quoting", "SELECT `id` FROM `undeclared`", "table_out_of_scope",
+         "backtick-undeclared-table", engines=("SQLite",)),
+    Case("quoting", "SELECT `nosuchcol` FROM `orders`", "column_out_of_scope",
+         "backtick-undeclared-col", engines=("SQLite",)),
+    Case("quoting", "SELECT `email` FROM `customers`", "ok",
+         "backtick-sensitive-is-seen", engines=("SQLite",)),
+    Case("quoting", "SELECT * FROM `orders`", "select_star", "backtick-star", engines=("SQLite",)),
+    Case("quoting", "SELECT [id] FROM [undeclared]", "table_out_of_scope",
+         "bracket-undeclared-table", engines=("SQLite",)),
+    # Valid identifier quoting on both engines, so it runs everywhere.
     Case("quoting", 'SELECT "id" FROM "undeclared"', "table_out_of_scope", "quoted-undeclared-table"),
+    # The read-only lexer is a separate code path from the dialect-aware parse; a write stays
+    # refused whatever the quoting, on every engine.
+    Case("quoting", "DELETE FROM `orders`", "permission", "backtick-delete"),
     # Ordinary shapes a governed query takes. These carry no attack — they exist so that a
     # change which tightens parsing has to prove it did not start refusing valid SQL. Without
     # them the "no false refusal" side of the corpus rests on four statements, and a tightening

--- a/tests/test_ace041_masking.py
+++ b/tests/test_ace041_masking.py
@@ -257,7 +257,10 @@ def test_unparseable_with_declared_pii_fails_closed(guarded, monkeypatch):
     # is unchanged (unparseable + declared PII => refused fail-closed, executor never runs); only the
     # refusal *kind* moves from `sensitive_columns` to `unscopable_sql`. The PII parse-failure check
     # remains in _model_safety as defense-in-depth (it fires if the scopable gate is ever disabled).
-    monkeypatch.setattr(rt, "_parse_sql", lambda sql: None)
+    # The guard battery parses through `_parse_reporting` (tree + why-it-failed) and
+    # `_parse_sql` (tree only), so both are stubbed to report a parse failure.
+    monkeypatch.setattr(rt, "_parse_reporting", lambda sql, dialect=None: (None, "forced"))
+    monkeypatch.setattr(rt, "_parse_sql", lambda sql, dialect=None: None)
     spy = _SpyExecutor(_R(["ssn"], [("111",)]))
     with pytest.raises(execute_sql.GuardRefused) as ei:
         guarded("SELECT ssn FROM customers", spy)

--- a/tests/test_ace041_masking.py
+++ b/tests/test_ace041_masking.py
@@ -62,7 +62,11 @@ def _org() -> "m.Datasource":
         columns=[m.Column(name="id", type="integer"), m.Column(name="ssn", type="string")],
     )
     sa = m.SubjectArea(name="area", description="d", tables_defined=[customers, orders, x])
-    return m.Datasource(datasource="AcmeCorp", version=1, subject_areas=[sa])
+    return m.Datasource(
+        datasource="AcmeCorp", version=1,
+        storage_connections=[m.StorageConnection(name="c", storage_type="SQLite")],
+        subject_areas=[sa],
+    )
 
 
 class _SpyExecutor:

--- a/tests/test_ace041_masking.py
+++ b/tests/test_ace041_masking.py
@@ -702,7 +702,7 @@ def _write_disk_model(root: Path) -> None:
         "subject_areas": ["subject_areas/area"],
     }))
     (root / "datasources" / "c" / "storage.yaml").write_text(
-        yaml.safe_dump({"name": "c", "storage_type": "PostgreSQL", "storage_config": {}}))
+        yaml.safe_dump({"name": "c", "storage_type": "SQLite", "storage_config": {}}))
     (root / "subject_areas" / "area" / "subject_area.yaml").write_text(yaml.safe_dump({
         "name": "area", "description": "d",
         "tables": [{"storage_connection": "c", "schema": "public", "table": "customers"}],

--- a/tests/test_ace051_fail_closed.py
+++ b/tests/test_ace051_fail_closed.py
@@ -30,6 +30,7 @@ def _org() -> m.Datasource:
                        description=name, columns=[m.Column(name="id", type="integer")])
     return m.Datasource(
         datasource="Shop",
+        storage_connections=[m.StorageConnection(name="c", storage_type="SQLite")],
         subject_areas=[m.SubjectArea(name="sales", tables_defined=[_t("orders"), _t("customers")])],
     )
 
@@ -49,7 +50,9 @@ def _write_disk(root: Path) -> None:
 
     (root / "subject_areas" / "sales" / "tables").mkdir(parents=True)
     (root / "datasource.yaml").write_text(
-        yaml.safe_dump({"datasource": "Shop", "version": 1, "subject_areas": ["subject_areas/sales"]})
+        yaml.safe_dump({"datasource": "Shop", "version": 1,
+                        "storage_connections": [{"name": "c", "storage_type": "SQLite"}],
+                        "subject_areas": ["subject_areas/sales"]})
     )
     (root / "subject_areas" / "sales" / "subject_area.yaml").write_text(
         yaml.safe_dump({"name": "sales", "tables": [

--- a/tests/test_ah012_executor_seam.py
+++ b/tests/test_ah012_executor_seam.py
@@ -426,6 +426,7 @@ def test_injected_executor_real_pii_gate_masks_a_maskable_projection(monkeypatch
     org = m.Datasource(
         datasource="o",
         version=1,
+        storage_connections=[m.StorageConnection(name="c", storage_type="SQLite")],
         subject_areas=[
             m.SubjectArea(
                 name="area",
@@ -469,6 +470,7 @@ def test_injected_executor_real_pii_gate_refuses_an_untraceable_projection(monke
     org = m.Datasource(
         datasource="o",
         version=1,
+        storage_connections=[m.StorageConnection(name="c", storage_type="SQLite")],
         subject_areas=[
             m.SubjectArea(
                 name="area",

--- a/tests/test_guard_dialect_parsing.py
+++ b/tests/test_guard_dialect_parsing.py
@@ -113,6 +113,18 @@ def test_sensitive_column_is_seen_under_native_quoting(engine):
     )
 
 
+@pytest.mark.parametrize("engine", BACKTICK_ENGINES + BRACKET_ENGINES)
+def test_sensitive_column_is_seen_when_qualified_by_a_quoted_alias(engine):
+    """A qualified column resolves through a different branch of the gate than a bare one, so
+    the aliased form is its own case rather than a restatement of the one above."""
+    org = _org(engine)
+    c, ssn, customers = _quote(engine, "c"), _quote(engine, "ssn"), _quote(engine, "customers")
+    sql = f"SELECT {c}.{ssn} FROM {customers} {c}"
+    assert rt.check_sensitive_projection(sql, org).action != "allow", (
+        f"{engine}: sensitive projection went unnoticed when qualified by a quoted alias"
+    )
+
+
 @pytest.mark.parametrize("engine", ALL_ENGINES)
 def test_receipt_attributes_the_table_under_native_quoting(engine):
     """A receipt that attributes nothing under-reports what the answer read."""
@@ -257,6 +269,111 @@ def test_row_scoping_regenerates_valid_sql_for_the_engine(engine):
     assert {t.name for t in reparsed.find_all(sqlglot.exp.Table)} == {"customers"}
 
 
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_the_fan_trap_rewrite_emits_for_the_engine(engine):
+    """The other rewrite that reaches the executor. It regenerates the statement, so emitting
+    generically would hand the executor SQL in a grammar it does not speak."""
+    dialect = rt._dialect_of(_org(engine))[0]
+    customers, orders = _quote(engine, "customers"), _quote(engine, "orders")
+    sql = f"SELECT COUNT(id) AS n FROM {customers} JOIN {orders} ON {orders}.cust_id = {customers}.id"
+
+    rewritten = rt._drop_fanout_joins(sql, {"orders"}, dialect=dialect)
+    assert rewritten, f"{engine}: the join was not dropped"
+    reparsed, why = rt._parse_reporting(rewritten, dialect)
+    assert reparsed is not None, f"{engine}: rewritten SQL does not parse for its own engine ({why})"
+    assert {t.name for t in reparsed.find_all(sqlglot.exp.Table)} == {"customers"}
+
+
+@pytest.mark.parametrize("engine", BACKTICK_ENGINES + BRACKET_ENGINES)
+def test_set_operation_arms_are_rendered_in_the_engines_grammar(engine):
+    """Each arm is rendered back to text before being re-read. Rendered generically, an arm
+    written in the engine's quoting would be re-read in a grammar it was never written in."""
+    org = _org(engine)
+    customers, orders = _quote(engine, "customers"), _quote(engine, "orders")
+    sql = f"SELECT id FROM {customers} UNION ALL SELECT id FROM {orders}"
+
+    # Both arms read declared tables, so nothing should be refused for being unreadable.
+    result = rt.pre_flight_check(sql, org)
+    assert result.action != "refuse" or result.risk, (
+        f"{engine}: a set operation over declared tables was refused with no risk named"
+    )
+    assert rt.check_table_scope(sql, org) is None, f"{engine}: declared tables read as undeclared"
+
+
+# --- a double-quoted token on a backtick engine is ambiguous, so it is refused -----
+
+
+@pytest.mark.parametrize("engine", BACKTICK_ENGINES)
+def test_double_quoted_projection_is_refused_on_backtick_engines(engine):
+    """On these engines `"x"` is a string literal by default but an identifier under an
+    ANSI-quoting server mode, and the guard cannot see which mode the server runs. Read as a
+    literal, a projected sensitive column is invisible to the column and PII gates while the
+    server may still return it — so the ambiguity is refused rather than guessed."""
+    org = _org(engine)
+    assert rt.check_scopable('SELECT "ssn" FROM customers', org) is not None, (
+        f"{engine}: an ambiguously-quoted projection was allowed"
+    )
+
+
+@pytest.mark.parametrize("engine", BACKTICK_ENGINES)
+def test_a_genuine_string_literal_is_not_refused(engine):
+    """The check must key on the ambiguity, not on quotes: a single-quoted literal means the
+    same thing in either server mode, so it is left alone even when it looks like a column."""
+    org = _org(engine)
+    assert rt.check_scopable("SELECT id, 'ssn' AS label FROM customers", org) is None, (
+        f"{engine}: a genuine string literal was refused"
+    )
+
+
+@pytest.mark.parametrize("engine", ANSI_ENGINES + BRACKET_ENGINES)
+def test_double_quoting_is_untouched_where_it_is_unambiguous(engine):
+    org = _org(engine)
+    assert rt.check_scopable('SELECT "ssn" FROM customers', org) is None
+
+
+@pytest.mark.parametrize("engine", BACKTICK_ENGINES)
+def test_the_ambiguous_projection_never_reaches_the_executor(guarded, engine):
+    org = _org(engine)
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["ssn"], rows=[("000-00-0000",)]))
+    with pytest.raises(execute_sql.GuardRefused):
+        guarded('SELECT "ssn" FROM customers', org, spy, engine)
+    assert spy.calls == [], f"{engine}: an ambiguously-quoted sensitive column was executed"
+
+
+# --- the model's declared engine must be the one the credentials connect to -------
+
+
+def test_a_model_credential_engine_mismatch_is_refused(guarded):
+    """The guard picks its grammar from the model; the executor picks its driver from the
+    credentials. Two independent pieces of operator configuration — so a mismatch means the
+    statement was vetted, and possibly regenerated, in a grammar this database does not speak."""
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        # Model says MySQL, credentials connect to PostgreSQL.
+        guarded("SELECT id FROM customers", _org("MySQL"), spy, "PostgreSQL")
+    assert ei.value.refusal.kind == "model_unavailable"
+    assert spy.calls == []
+
+
+def test_a_matching_engine_runs(guarded):
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
+    guarded("SELECT id FROM customers", _org("MySQL"), spy, "MySQL")
+    assert spy.calls, "a consistent model and credential pair was refused"
+
+
+def test_an_unmapped_credential_type_is_not_treated_as_a_mismatch(guarded, monkeypatch):
+    """The executor rejects an unusable credential type itself; refusing here as well would
+    report an unrelated configuration error as a governance failure."""
+    monkeypatch.setattr(execute_sql, "_resolve_guard_model", lambda profile: _org("MySQL"))
+    monkeypatch.setattr(
+        execute_sql, "_load_credentials",
+        lambda p, org_id="local": {"type": "somethingelse"},
+    )
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
+    execute_sql.execute_guarded("SELECT id FROM customers", "acme", None, executor=spy)
+    assert spy.calls
+
+
 # --- end to end, at the shared chokepoint ----------------------------------------
 
 
@@ -270,13 +387,25 @@ class _SpyExecutor:
         return self._result
 
 
+# The credential `type` the executor would dispatch on for each declared engine. The guard now
+# refuses when the model's engine and the credentials name different databases, so a fixture
+# claiming one engine while connecting to another would be refused for that reason and prove
+# nothing about quoting.
+_CREDS_TYPE = {
+    "PostgreSQL": "postgres", "MySQL": "mysql", "Snowflake": "snowflake",
+    "BigQuery": "bigquery", "Redshift": "redshift", "SQLite": "sqlite",
+    "DuckDB": "duckdb", "SQLServer": "sqlserver", "Databricks": "databricks",
+    "Trino": "trino", "Oracle": "oracle",
+}
+
+
 @pytest.fixture
 def guarded(monkeypatch):
-    def _run(sql: str, org, spy, **kw):
+    def _run(sql: str, org, spy, engine: str = "PostgreSQL", **kw):
         monkeypatch.setattr(execute_sql, "_resolve_guard_model", lambda profile: org)
         monkeypatch.setattr(
             execute_sql, "_load_credentials",
-            lambda p, org_id="local": {"type": "sqlite", "path": ":memory:"},
+            lambda p, org_id="local": {"type": _CREDS_TYPE[engine], "path": ":memory:"},
         )
         return execute_sql.execute_guarded(sql, "acme", None, executor=spy, **kw)
 
@@ -291,7 +420,7 @@ def test_undeclared_table_never_reaches_the_executor(guarded, engine):
     sql = f"SELECT {_quote(engine, 'id')} FROM {_quote(engine, 'undeclared_table')}"
 
     with pytest.raises(execute_sql.GuardRefused):
-        guarded(sql, org, spy)
+        guarded(sql, org, spy, engine)
     assert spy.calls == [], f"{engine}: the executor ran a statement the model does not declare"
 
 
@@ -299,16 +428,16 @@ def test_undeclared_table_never_reaches_the_executor(guarded, engine):
 def test_sensitive_column_is_never_returned_raw(guarded, engine):
     """Masked or refused — never the value itself."""
     org = _org(engine)
-    spy = _SpyExecutor(execute_sql.ExecResult(columns=["ssn"], rows=[("111-22-3333",)]))
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["ssn"], rows=[("000-00-0000",)]))
     sql = f"SELECT {_quote(engine, 'ssn')} FROM {_quote(engine, 'customers')}"
 
     try:
-        env = guarded(sql, org, spy)
+        env = guarded(sql, org, spy, engine)
     except execute_sql.GuardRefused:
         assert spy.calls == []
         return
     returned = [str(v) for row in env.rows for v in row]
-    assert "111-22-3333" not in returned, f"{engine}: sensitive value returned verbatim"
+    assert "000-00-0000" not in returned, f"{engine}: sensitive value returned verbatim"
 
 
 @pytest.mark.parametrize("engine", ALL_ENGINES)
@@ -319,7 +448,7 @@ def test_a_governed_statement_reaches_the_executor_on_every_engine(guarded, engi
     spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
     sql = f"SELECT {_quote(engine, 'id')} FROM {_quote(engine, 'customers')}"
 
-    guarded(sql, org, spy)
+    guarded(sql, org, spy, engine)
     assert spy.calls, f"{engine}: a governed statement was refused"
     vetted = spy.calls[0][0]
     reparsed, why = rt._parse_reporting(vetted, rt._dialect_of(org)[0])
@@ -332,7 +461,7 @@ def test_select_star_is_refused_on_every_engine(guarded, engine):
     org = _org(engine)
     spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
     with pytest.raises(execute_sql.GuardRefused):
-        guarded(f"SELECT * FROM {_quote(engine, 'customers')}", org, spy)
+        guarded(f"SELECT * FROM {_quote(engine, 'customers')}", org, spy, engine)
     assert spy.calls == []
 
 
@@ -342,7 +471,7 @@ def test_a_write_is_refused_on_every_engine(guarded, engine):
     org = _org(engine)
     spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
     with pytest.raises(execute_sql.GuardRefused):
-        guarded(f"DELETE FROM {_quote(engine, 'customers')}", org, spy)
+        guarded(f"DELETE FROM {_quote(engine, 'customers')}", org, spy, engine)
     assert spy.calls == []
 
 

--- a/tests/test_guard_dialect_parsing.py
+++ b/tests/test_guard_dialect_parsing.py
@@ -283,7 +283,7 @@ def guarded(monkeypatch):
     return _run
 
 
-@pytest.mark.parametrize("engine", BACKTICK_ENGINES + BRACKET_ENGINES)
+@pytest.mark.parametrize("engine", ALL_ENGINES)
 def test_undeclared_table_never_reaches_the_executor(guarded, engine):
     """A refused statement is proved refused by the executor never being called."""
     org = _org(engine)
@@ -295,7 +295,7 @@ def test_undeclared_table_never_reaches_the_executor(guarded, engine):
     assert spy.calls == [], f"{engine}: the executor ran a statement the model does not declare"
 
 
-@pytest.mark.parametrize("engine", BACKTICK_ENGINES + BRACKET_ENGINES)
+@pytest.mark.parametrize("engine", ALL_ENGINES)
 def test_sensitive_column_is_never_returned_raw(guarded, engine):
     """Masked or refused — never the value itself."""
     org = _org(engine)
@@ -309,3 +309,59 @@ def test_sensitive_column_is_never_returned_raw(guarded, engine):
         return
     returned = [str(v) for row in env.rows for v in row]
     assert "111-22-3333" not in returned, f"{engine}: sensitive value returned verbatim"
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_a_governed_statement_reaches_the_executor_on_every_engine(guarded, engine):
+    """The other half of the matrix: an allowed statement must arrive, and arrive as the
+    statement the guard vetted — which is how the regeneration paths get asserted."""
+    org = _org(engine)
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
+    sql = f"SELECT {_quote(engine, 'id')} FROM {_quote(engine, 'customers')}"
+
+    guarded(sql, org, spy)
+    assert spy.calls, f"{engine}: a governed statement was refused"
+    vetted = spy.calls[0][0]
+    reparsed, why = rt._parse_reporting(vetted, rt._dialect_of(org)[0])
+    assert reparsed is not None, f"{engine}: executor got SQL invalid for its own engine ({why})"
+    assert {t.name for t in reparsed.find_all(sqlglot.exp.Table)} == {"customers"}
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_select_star_is_refused_on_every_engine(guarded, engine):
+    org = _org(engine)
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
+    with pytest.raises(execute_sql.GuardRefused):
+        guarded(f"SELECT * FROM {_quote(engine, 'customers')}", org, spy)
+    assert spy.calls == []
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_a_write_is_refused_on_every_engine(guarded, engine):
+    """The read-only lexer is a separate path; pin that threading the dialect left it alone."""
+    org = _org(engine)
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
+    with pytest.raises(execute_sql.GuardRefused):
+        guarded(f"DELETE FROM {_quote(engine, 'customers')}", org, spy)
+    assert spy.calls == []
+
+
+# --- constructs that do not diverge today, pinned so a dependency bump cannot regress them ---
+
+
+@pytest.mark.parametrize(
+    "label,sql,engine",
+    [
+        ("qualify", "SELECT id FROM customers QUALIFY ROW_NUMBER() OVER (ORDER BY id) = 1", "Snowflake"),
+        ("fetch-first", "SELECT id FROM customers FETCH FIRST 5 ROWS ONLY", "Oracle"),
+        ("except-replace", "SELECT * EXCEPT(ssn) FROM customers", "BigQuery"),
+        ("three-part-name", "SELECT id FROM catalog.public.customers", "Snowflake"),
+        ("group-by-rollup", "SELECT id, COUNT(*) FROM customers GROUP BY ROLLUP(id)", "PostgreSQL"),
+    ],
+)
+def test_non_diverging_constructs_still_parse(label, sql, engine):
+    """These parse identically today, which is exactly why nobody would re-check them after a
+    sqlglot upgrade. Pinning them is what makes this a regression matrix rather than a
+    snapshot of one afternoon's findings."""
+    tree, why = rt._parse_reporting(sql, rt._dialect_of(_org(engine))[0])
+    assert tree is not None, f"{label} no longer parses on {engine}: {why}"

--- a/tests/test_guard_dialect_parsing.py
+++ b/tests/test_guard_dialect_parsing.py
@@ -1,0 +1,311 @@
+"""The guards read a statement in the engine's own grammar, so quoting cannot hide it.
+
+The model-scoping gates decide by inspecting a parsed tree. Parsed in the wrong grammar the
+tree does not describe the statement, and a gate with nothing to object to allows it. On a
+backtick-quoting engine that is not subtle: ``SELECT `ssn` FROM `customers``` parsed
+generically yields *no tables and no columns*, so table scope, column scope and the
+sensitive-projection gate all pass and the statement returns the column verbatim. The
+bracket-quoting case is worse — the tree is confidently wrong rather than empty, naming a
+column that is really a row-limit keyword.
+
+These tests pin the verdict per engine, for the quoting each engine actually uses. They run
+against the shared executor chokepoint with a recording stub, so a refusal is proved by the
+executor never being reached, and an allowed statement is proved by what reaches it.
+
+Synthetic, generic names only — `customers`, `orders`, `AcmeCorp`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+sqlglot = pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import execute_sql  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as rt  # noqa: E402
+
+# Engines whose identifier quoting differs from the ANSI double quote. These are the ones a
+# generic parse silently mis-reads; the double-quoting engines are the unaffected baseline.
+BACKTICK_ENGINES = ["MySQL", "BigQuery", "Databricks"]
+BRACKET_ENGINES = ["SQLServer"]
+ANSI_ENGINES = ["PostgreSQL", "Snowflake", "Redshift", "DuckDB", "Oracle", "Trino", "SQLite"]
+ALL_ENGINES = BACKTICK_ENGINES + BRACKET_ENGINES + ANSI_ENGINES
+
+
+def _org(storage_type: str = "PostgreSQL") -> "m.Datasource":
+    """`customers` declares a sensitive `ssn`; `orders` is an ordinary joinable table."""
+    customers = m.Table(
+        name="customers", schema="public", storage_connection="c", grain=["id"],
+        columns=[
+            m.Column(name="id", type="integer"),
+            m.Column(name="name", type="string"),
+            m.Column(name="ssn", type="string", sensitive=True),
+        ],
+    )
+    orders = m.Table(
+        name="orders", schema="public", storage_connection="c", grain=["id"],
+        columns=[m.Column(name="id", type="integer"), m.Column(name="cust_id", type="integer")],
+    )
+    sa = m.SubjectArea(name="area", description="d", tables_defined=[customers, orders])
+    return m.Datasource(
+        datasource="AcmeCorp",
+        version=1,
+        storage_connections=[m.StorageConnection(name="c", storage_type=storage_type)],
+        subject_areas=[sa],
+    )
+
+
+def _quote(engine: str, name: str) -> str:
+    if engine in BACKTICK_ENGINES:
+        return f"`{name}`"
+    if engine in BRACKET_ENGINES:
+        return f"[{name}]"
+    return f'"{name}"'
+
+
+# --- the tree the gates inspect actually describes the statement ------------------
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_tables_and_columns_are_attributed_under_native_quoting(engine):
+    """The defect in one assertion: parsed generically this yields no tables at all."""
+    org = _org(engine)
+    sql = f"SELECT {_quote(engine, 'ssn')} FROM {_quote(engine, 'customers')}"
+    ctx = rt.build_guard_context(sql, org)
+
+    assert ctx is not None and ctx.tree is not None, f"{engine}: statement did not parse"
+    tables = {t.name for t in ctx.tree.find_all(sqlglot.exp.Table)}
+    assert tables == {"customers"}, f"{engine}: attributed {tables} instead of the real table"
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_undeclared_table_is_refused_under_native_quoting(engine):
+    org = _org(engine)
+    sql = f"SELECT {_quote(engine, 'id')} FROM {_quote(engine, 'undeclared_table')}"
+    assert rt.check_table_scope(sql, org) is not None, f"{engine}: undeclared table allowed"
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_undeclared_column_is_refused_under_native_quoting(engine):
+    org = _org(engine)
+    sql = f"SELECT {_quote(engine, 'nosuchcol')} FROM {_quote(engine, 'customers')}"
+    assert rt.check_column_scope(sql, org) is not None, f"{engine}: undeclared column allowed"
+
+
+@pytest.mark.parametrize("engine", BACKTICK_ENGINES + BRACKET_ENGINES)
+def test_sensitive_column_is_seen_under_native_quoting(engine):
+    """The disclosure: the PII gate must not report `allow` because it saw no columns."""
+    org = _org(engine)
+    sql = f"SELECT {_quote(engine, 'ssn')} FROM {_quote(engine, 'customers')}"
+    assert rt.check_sensitive_projection(sql, org).action != "allow", (
+        f"{engine}: sensitive projection went unnoticed"
+    )
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_receipt_attributes_the_table_under_native_quoting(engine):
+    """A receipt that attributes nothing under-reports what the answer read."""
+    org = _org(engine)
+    sql = f"SELECT {_quote(engine, 'id')} FROM {_quote(engine, 'customers')}"
+    receipt = rt.assemble_receipt(org, sql)
+    attributed = [t["qname"].lower() for t in receipt.get("tables_used", [])]
+    assert attributed == ["public.customers"], (
+        f"{engine}: receipt attributed {receipt.get('tables_used')}"
+    )
+
+
+# --- the three divergences measured on the generic dialect ------------------------
+
+
+def test_bigquery_dotted_path_in_one_backtick_pair():
+    """Generically this parses to a table literally named '`', so scope has nothing to check."""
+    org = _org("BigQuery")
+    ctx = rt.build_guard_context("SELECT id FROM `proj.ds.customers`", org)
+    names = {t.name for t in ctx.tree.find_all(sqlglot.exp.Table)}
+    assert names == {"customers"}
+    assert rt.check_table_scope("SELECT id FROM `proj.ds.undeclared`", org) is not None
+
+
+def test_sqlserver_top_with_bracket_identifiers():
+    """Generically this yields zero tables *and* a phantom column named TOP."""
+    org = _org("SQLServer")
+    ctx = rt.build_guard_context("SELECT TOP 5 [ssn] FROM [customers]", org)
+    assert {t.name for t in ctx.tree.find_all(sqlglot.exp.Table)} == {"customers"}
+    assert {c.name.lower() for c in ctx.tree.find_all(sqlglot.exp.Column)} == {"ssn"}
+    assert rt.check_sensitive_projection("SELECT TOP 5 [ssn] FROM [customers]", org).action != "allow"
+
+
+def test_mysql_hash_line_comment():
+    """`#` starts a comment in MySQL; generically the parse truncates and attributes nothing."""
+    org = _org("MySQL")
+    sql = "SELECT ssn # trailing comment\nFROM customers"
+    ctx = rt.build_guard_context(sql, org)
+    assert {t.name for t in ctx.tree.find_all(sqlglot.exp.Table)} == {"customers"}
+    assert rt.check_sensitive_projection(sql, org).action != "allow"
+
+
+# --- unchanged behaviour for the engines this defect cannot reach -----------------
+
+
+@pytest.mark.parametrize("engine", ANSI_ENGINES)
+def test_unquoted_and_double_quoted_statements_are_unaffected(engine):
+    org = _org(engine)
+    assert rt.check_table_scope("SELECT id FROM customers", org) is None
+    assert rt.check_column_scope("SELECT id FROM customers", org) is None
+    assert rt.check_table_scope('SELECT "id" FROM "customers"', org) is None
+    assert rt.check_column_scope('SELECT "id" FROM "customers"', org) is None
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_unquoted_statements_are_allowed_on_every_engine(engine):
+    """No over-refusal: the plain form every engine accepts must stay allowed everywhere."""
+    org = _org(engine)
+    assert rt.check_table_scope("SELECT id FROM customers", org) is None
+    assert rt.check_column_scope("SELECT id FROM customers", org) is None
+    assert rt.check_no_select_star("SELECT id FROM customers") is None
+
+
+# --- a parse that fails is reported, not silently truncated -----------------------
+
+
+def test_parse_failure_is_reported_rather_than_truncated():
+    """A string error level is inert — sqlglot compares against the enum, so a string level
+    matches no branch and every collected error is discarded, leaving a truncated tree."""
+    tree, why = rt._parse_reporting("SELECT `ssn` FROM `customers`", "postgres")
+    assert tree is None and why
+
+
+def test_lexical_failure_is_caught_too():
+    """An unterminated literal raises TokenError regardless of error level, so a handler that
+    catches only ParseError would crash instead of refusing."""
+    tree, why = rt._parse_reporting("SELECT 'abc FROM customers", "postgres")
+    assert tree is None and why
+
+
+def test_parse_reports_both_error_classes_across_supported_sqlglot():
+    from sqlglot.errors import ParseError, TokenError
+
+    with pytest.raises(ParseError):
+        sqlglot.parse_one("SELECT FROM WHERE FROM", dialect="postgres",
+                          error_level=sqlglot.errors.ErrorLevel.RAISE)
+    with pytest.raises(TokenError):
+        sqlglot.parse_one("SELECT 'abc FROM t", dialect="postgres",
+                          error_level=sqlglot.errors.ErrorLevel.RAISE)
+
+
+# --- the same verdict with and without the shared context -------------------------
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_ctx_and_standalone_agree(engine):
+    """`ctx=None` must not be a cheaper, weaker path — the dialect reaches both."""
+    org = _org(engine)
+    for sql in (
+        f"SELECT {_quote(engine, 'ssn')} FROM {_quote(engine, 'customers')}",
+        f"SELECT {_quote(engine, 'nosuchcol')} FROM {_quote(engine, 'customers')}",
+        f"SELECT {_quote(engine, 'id')} FROM {_quote(engine, 'undeclared_table')}",
+        "SELECT id FROM customers",
+    ):
+        ctx = rt.build_guard_context(sql, org)
+        assert _verdict(rt.check_table_scope(sql, org)) == _verdict(
+            rt.check_table_scope(sql, org, ctx)
+        ), f"{engine}: table scope differs with ctx"
+        assert _verdict(rt.check_column_scope(sql, org)) == _verdict(
+            rt.check_column_scope(sql, org, ctx)
+        ), f"{engine}: column scope differs with ctx"
+        assert rt.check_sensitive_projection(sql, org).action == rt.check_sensitive_projection(
+            sql, org, ctx
+        ).action, f"{engine}: sensitive projection differs with ctx"
+        assert _verdict(rt.check_no_select_star(sql, dialect=ctx.dialect)) == _verdict(
+            rt.check_no_select_star(sql, ctx)
+        ), f"{engine}: select-star differs with ctx"
+
+
+def _verdict(v):
+    return None if v is None else v.as_dict()
+
+
+# --- the statement the guard vetted round-trips in the same grammar ---------------
+
+
+@pytest.mark.parametrize("engine", ALL_ENGINES)
+def test_row_scoping_regenerates_valid_sql_for_the_engine(engine):
+    """`apply_default_filters` rewrites the statement the executor then runs, so it must emit
+    in the engine's grammar and the result must re-parse there to the same tree."""
+    org = _org(engine)
+    org.subject_areas[0].tables_defined[0].default_filters = ["{alias}.id > 0"]
+    sql = f"SELECT {_quote(engine, 'id')} FROM {_quote(engine, 'customers')}"
+
+    out, applied = rt.apply_default_filters(sql, org)
+    assert applied, f"{engine}: row scoping was not applied"
+
+    dialect = rt._dialect_of(org)[0]
+    reparsed, why = rt._parse_reporting(out, dialect)
+    assert reparsed is not None, f"{engine}: regenerated SQL does not parse for its own engine ({why})"
+    assert reparsed.sql(dialect=dialect) == out
+    assert {t.name for t in reparsed.find_all(sqlglot.exp.Table)} == {"customers"}
+
+
+# --- end to end, at the shared chokepoint ----------------------------------------
+
+
+class _SpyExecutor:
+    def __init__(self, result):
+        self.calls: list[tuple] = []
+        self._result = result
+
+    def execute(self, vetted_sql, creds, *, profile):
+        self.calls.append((vetted_sql, creds, profile))
+        return self._result
+
+
+@pytest.fixture
+def guarded(monkeypatch):
+    def _run(sql: str, org, spy, **kw):
+        monkeypatch.setattr(execute_sql, "_resolve_guard_model", lambda profile: org)
+        monkeypatch.setattr(
+            execute_sql, "_load_credentials",
+            lambda p, org_id="local": {"type": "sqlite", "path": ":memory:"},
+        )
+        return execute_sql.execute_guarded(sql, "acme", None, executor=spy, **kw)
+
+    return _run
+
+
+@pytest.mark.parametrize("engine", BACKTICK_ENGINES + BRACKET_ENGINES)
+def test_undeclared_table_never_reaches_the_executor(guarded, engine):
+    """A refused statement is proved refused by the executor never being called."""
+    org = _org(engine)
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["id"], rows=[(1,)]))
+    sql = f"SELECT {_quote(engine, 'id')} FROM {_quote(engine, 'undeclared_table')}"
+
+    with pytest.raises(execute_sql.GuardRefused):
+        guarded(sql, org, spy)
+    assert spy.calls == [], f"{engine}: the executor ran a statement the model does not declare"
+
+
+@pytest.mark.parametrize("engine", BACKTICK_ENGINES + BRACKET_ENGINES)
+def test_sensitive_column_is_never_returned_raw(guarded, engine):
+    """Masked or refused — never the value itself."""
+    org = _org(engine)
+    spy = _SpyExecutor(execute_sql.ExecResult(columns=["ssn"], rows=[("111-22-3333",)]))
+    sql = f"SELECT {_quote(engine, 'ssn')} FROM {_quote(engine, 'customers')}"
+
+    try:
+        env = guarded(sql, org, spy)
+    except execute_sql.GuardRefused:
+        assert spy.calls == []
+        return
+    returned = [str(v) for row in env.rows for v in row]
+    assert "111-22-3333" not in returned, f"{engine}: sensitive value returned verbatim"

--- a/tests/test_no_false_refusal_on_valid_sql.py
+++ b/tests/test_no_false_refusal_on_valid_sql.py
@@ -1,0 +1,99 @@
+"""Tightening the parse must not start refusing valid SQL.
+
+Reading every statement in the engine's own grammar, and refusing one that does not parse,
+buys nothing if it also refuses queries that were fine. sqlglot re-implements each engine's
+grammar in Python, so wherever its grammar is short of the real one a valid statement now
+refuses where it used to be read as a truncated tree.
+
+This measures that: every statement the repo carries as *valid* is parsed under its
+declared engine with errors raised, and the count that fails must be zero.
+
+What this does and does not establish. The corpus and the seeded examples are SQL written
+by hand and committed to this repo. They are not the SQL a language model generates against
+a real semantic model, which is the population that actually matters for over-refusal, and
+which nothing here samples. A zero here means the parser did not reject the shapes we
+already knew to write down.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+sqlglot = pytest.importorskip("sqlglot")
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+sys.path.insert(0, str(REPO_ROOT / "tests"))
+
+from semantic_model import runtime as rt  # noqa: E402
+
+from safety import corpus  # noqa: E402
+
+# The corpus executes against SQLite; the seeded sample model declares SQLite too. Parsing
+# each statement under the engine it is written for is the whole point — a statement is only
+# valid with respect to some engine.
+CORPUS_DIALECT = "sqlite"
+
+VALID_CORPUS_SQL = [c for c in corpus.CASES if c.expect == "ok"]
+
+SAMPLE_EXAMPLES = sorted(
+    (REPO_ROOT / "plugins" / "agami" / "samples").rglob("prompt_examples/*/examples.yaml")
+)
+
+
+def _seeded_example_sql() -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for path in SAMPLE_EXAMPLES:
+        for entry in yaml.safe_load(path.read_text(encoding="utf-8")) or []:
+            sql = (entry or {}).get("sql")
+            if sql:
+                out.append((str(path.relative_to(REPO_ROOT)), sql))
+    return out
+
+
+SEEDED_SQL = _seeded_example_sql()
+
+
+def test_the_corpus_carries_enough_valid_sql_to_be_evidence():
+    """A delta of zero over a handful of statements would not mean much.
+
+    This is not a style rule — it is what makes the two tests below able to fail. If the
+    valid-SQL set shrinks back to a token few, over-refusal stops being measured.
+    """
+    assert len(VALID_CORPUS_SQL) >= 12, (
+        f"only {len(VALID_CORPUS_SQL)} valid statements in the corpus; a zero refusal delta "
+        "over so few proves almost nothing about over-refusal"
+    )
+
+
+def test_the_seeded_examples_were_found():
+    """Guards against the glob silently matching nothing and the test below passing empty."""
+    assert SEEDED_SQL, "no seeded example SQL found to check"
+
+
+@pytest.mark.parametrize("case", VALID_CORPUS_SQL, ids=lambda c: c.id)
+def test_valid_corpus_sql_still_parses(case):
+    tree, why = rt._parse_reporting(case.sql, CORPUS_DIALECT)
+    assert tree is not None, f"valid corpus SQL now refuses ({why}): {case.sql}"
+
+
+@pytest.mark.parametrize(
+    "path,sql", SEEDED_SQL, ids=[f"{i}" for i in range(len(SEEDED_SQL))]
+)
+def test_seeded_example_sql_still_parses(path, sql):
+    tree, why = rt._parse_reporting(sql, CORPUS_DIALECT)
+    assert tree is not None, f"seeded example in {path} now refuses ({why}): {sql}"
+
+
+def test_the_measured_refusal_delta_is_zero():
+    """The number reported in the pull request, computed rather than asserted by hand."""
+    checked = [c.sql for c in VALID_CORPUS_SQL] + [s for _, s in SEEDED_SQL]
+    refused = [s for s in checked if rt._parse_reporting(s, CORPUS_DIALECT)[0] is None]
+    assert not refused, f"{len(refused)}/{len(checked)} valid statements refused: {refused}"

--- a/tests/test_parse_hygiene.py
+++ b/tests/test_parse_hygiene.py
@@ -34,10 +34,23 @@ SCAN_ROOTS = [
 # edit that moves code does not silently invalidate the entry the way a line number would.
 # A parse reaching a caller's SQL does NOT belong here — it belongs behind the guard's own
 # parse helper, which supplies both the dialect and the error level.
+# Every sqlglot entry point that turns text into a tree. Naming only `parse_one` would let a
+# guard-path `sqlglot.parse(...)` or `transpile(...)` land without a grammar.
+#
+# `parse` is matched only as `sqlglot.parse` — as a bare name it is far too common (this repo
+# has two unrelated local `parse()` helpers), and a scanner that cries wolf gets exempted into
+# uselessness. The other three names are unambiguous enough to match either way.
+_QUALIFIED_PARSE_CALLS = frozenset({"parse_one", "parse", "transpile", "maybe_parse"})
+_BARE_PARSE_CALLS = frozenset({"parse_one", "transpile", "maybe_parse"})
+
 _EXEMPT: dict[str, str] = {
     "packages/agami-core/src/semantic_model/validator.py::_columns_referenced": (
-        "reads model-authored SQL when the model is written, not a caller's statement, and "
-        "runs before any datasource engine is known"
+        "reads model-authored SQL at validation time, not a caller's statement; its signature "
+        "does not receive the model, so it has no declared engine to parse for"
+    ),
+    "plugins/agami/scripts/render_chart.py::_format_sql": (
+        "pretty-prints SQL for display only; the result is never parsed for a verdict nor "
+        "handed to an executor"
     ),
     "packages/agami-core/src/semantic_model/validator.py::_binding_column_refs": (
         "reads a model-authored metric binding at validation time, not a caller's statement"
@@ -75,12 +88,10 @@ def _walk(node, owner: str, relpath: str):
             continue
         if isinstance(child, ast.Call):
             func = child.func
-            name = (
-                func.attr if isinstance(func, ast.Attribute)
-                else func.id if isinstance(func, ast.Name)
-                else None
-            )
-            if name == "parse_one":
+            if isinstance(func, ast.Attribute):
+                if func.attr in _QUALIFIED_PARSE_CALLS:
+                    yield relpath, owner, child
+            elif isinstance(func, ast.Name) and func.id in _BARE_PARSE_CALLS:
                 yield relpath, owner, child
         yield from _walk(child, owner, relpath)
 
@@ -137,6 +148,37 @@ def test_no_exemption_is_stale():
 def test_every_exemption_gives_a_reason():
     for key, reason in _EXEMPT.items():
         assert reason.strip(), f"{key} is exempt without a written reason"
+
+
+def test_the_internal_parse_helpers_are_always_given_a_grammar():
+    """`_parse_sql` / `_parse_reporting` default `dialect` to None so standalone callers keep
+    working, which means a guard that forgets the argument parses generically and the AST rule
+    above cannot see it — it only watches sqlglot's own entry points. This watches ours."""
+    bare: list[str] = []
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            relpath = str(path.relative_to(REPO_ROOT))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = (
+                    func.attr if isinstance(func, ast.Attribute)
+                    else func.id if isinstance(func, ast.Name)
+                    else None
+                )
+                if name not in ("_parse_sql", "_parse_reporting"):
+                    continue
+                # The grammar may be given positionally or by keyword; either states it.
+                if len(node.args) < 2 and not any(k.arg == "dialect" for k in node.keywords):
+                    bare.append(f"{relpath}:{node.lineno}")
+    assert not bare, (
+        "these calls parse without a grammar, so the statement is read in one no engine uses: "
+        + ", ".join(bare)
+    )
 
 
 def test_the_guard_battery_parses_in_exactly_one_place():

--- a/tests/test_parse_hygiene.py
+++ b/tests/test_parse_hygiene.py
@@ -1,0 +1,151 @@
+"""Every SQL parse on the guard path states its grammar and reports its failures.
+
+Two mistakes are invisible at review and silently disable a gate, so they are asserted
+mechanically instead of trusted to a reader:
+
+* **A parse with no dialect.** The generic grammar matches no real engine. A statement in
+  the engine's own quoting parses to something that is not what it says — often to nothing
+  at all — and a gate inspecting that tree finds nothing to object to.
+* **An error level passed as a string.** sqlglot compares the level against `ErrorLevel`
+  members, so a string matches no branch and every collected parse error is discarded,
+  leaving a truncated tree. This one is especially hard to spot: `error_level="raise"`
+  reads like hardening and does nothing at all. Only the enum works.
+
+The scan is over the AST rather than the text, because a regex cannot tell
+`error_level=ErrorLevel.RAISE` from `error_level="RAISE"` inside a multi-line call, and
+cannot attribute a call to the function that contains it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCAN_ROOTS = [
+    REPO_ROOT / "packages" / "agami-core" / "src",
+    REPO_ROOT / "plugins" / "agami" / "lib",
+    REPO_ROOT / "plugins" / "agami" / "scripts",
+]
+
+# Parses that are deliberately not on the guard path, keyed by "<relpath>::<function>" so an
+# edit that moves code does not silently invalidate the entry the way a line number would.
+# A parse reaching a caller's SQL does NOT belong here — it belongs behind the guard's own
+# parse helper, which supplies both the dialect and the error level.
+_EXEMPT: dict[str, str] = {
+    "packages/agami-core/src/semantic_model/validator.py::_columns_referenced": (
+        "reads model-authored SQL when the model is written, not a caller's statement, and "
+        "runs before any datasource engine is known"
+    ),
+    "packages/agami-core/src/semantic_model/validator.py::_binding_column_refs": (
+        "reads a model-authored metric binding at validation time, not a caller's statement"
+    ),
+    "packages/agami-core/src/semantic_model/validator.py::_sqlparse_error": (
+        "already passes the ErrorLevel enum; it has no datasource engine to parse for because "
+        "it validates the model itself"
+    ),
+    "packages/agami-core/src/semantic_model/derived.py::_has_nested_aggregate": (
+        "inspects a model-authored metric fragment at validation time, not a caller's statement"
+    ),
+}
+
+
+def _iter_parse_calls():
+    """Yield (relpath, enclosing function name, ast.Call) for every `parse_one` call.
+
+    Each call is attributed to the innermost function that contains it, so a nested helper
+    is named in its own right rather than folded into its parent.
+    """
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            relpath = str(path.relative_to(REPO_ROOT))
+            yield from _walk(tree, "<module>", relpath)
+
+
+def _walk(node, owner: str, relpath: str):
+    """Descend once, carrying the innermost enclosing function name."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield from _walk(child, child.name, relpath)
+            continue
+        if isinstance(child, ast.Call):
+            func = child.func
+            name = (
+                func.attr if isinstance(func, ast.Attribute)
+                else func.id if isinstance(func, ast.Name)
+                else None
+            )
+            if name == "parse_one":
+                yield relpath, owner, child
+        yield from _walk(child, owner, relpath)
+
+
+def _kwarg(call: ast.Call, name: str):
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+ALL_CALLS = list(_iter_parse_calls())
+
+
+def test_the_scan_actually_found_the_parses():
+    """A scan that silently matches nothing would pass every assertion below."""
+    assert len(ALL_CALLS) >= 4
+
+
+@pytest.mark.parametrize(
+    "relpath,owner,call",
+    [pytest.param(r, o, c, id=f"{r}::{o}") for r, o, c in ALL_CALLS],
+)
+def test_guard_path_parses_state_dialect_and_error_level(relpath, owner, call):
+    if f"{relpath}::{owner}" in _EXEMPT:
+        pytest.skip("declared not to be on the guard path")
+
+    error_level = _kwarg(call, "error_level")
+    assert error_level is not None, (
+        f"{relpath}::{owner} parses without an error level. sqlglot's default raises, but "
+        "state the posture rather than inherit it."
+    )
+    assert not isinstance(error_level, ast.Constant), (
+        f"{relpath}::{owner} passes a *string* error level. sqlglot compares the level "
+        "against ErrorLevel members, so a string matches no branch and every parse error is "
+        "silently discarded — use ErrorLevel.RAISE."
+    )
+    assert isinstance(error_level, ast.Attribute) and error_level.attr == "RAISE", (
+        f"{relpath}::{owner} must pass ErrorLevel.RAISE so a statement that does not parse "
+        "is refused rather than read as a truncated tree."
+    )
+    assert _kwarg(call, "dialect") is not None, (
+        f"{relpath}::{owner} parses without a dialect. The generic grammar matches no engine, "
+        "so the resulting tree can describe a different statement than the one given."
+    )
+
+
+def test_no_exemption_is_stale():
+    """An exemption for code that no longer exists hides a real regression behind a skip."""
+    live = {f"{r}::{o}" for r, o, _ in ALL_CALLS}
+    assert not (set(_EXEMPT) - live), f"exemptions no longer matching any parse: {set(_EXEMPT) - live}"
+
+
+def test_every_exemption_gives_a_reason():
+    for key, reason in _EXEMPT.items():
+        assert reason.strip(), f"{key} is exempt without a written reason"
+
+
+def test_the_guard_battery_parses_in_exactly_one_place():
+    """Funnelling every guard parse through one helper is what makes the rule above hold as
+    code moves: a new gate reuses the helper instead of re-deriving the arguments."""
+    runtime_parses = [
+        (r, o) for r, o, _ in ALL_CALLS
+        if r.endswith("semantic_model/runtime.py")
+    ]
+    assert [o for _, o in runtime_parses] == ["_parse_reporting"], (
+        f"the guard battery should parse only through its helper; found {runtime_parses}"
+    )

--- a/tests/test_parse_hygiene.py
+++ b/tests/test_parse_hygiene.py
@@ -37,11 +37,19 @@ SCAN_ROOTS = [
 # Every sqlglot entry point that turns text into a tree. Naming only `parse_one` would let a
 # guard-path `sqlglot.parse(...)` or `transpile(...)` land without a grammar.
 #
-# `parse` is matched only as `sqlglot.parse` — as a bare name it is far too common (this repo
-# has two unrelated local `parse()` helpers), and a scanner that cries wolf gets exempted into
-# uselessness. The other three names are unambiguous enough to match either way.
-_QUALIFIED_PARSE_CALLS = frozenset({"parse_one", "parse", "transpile", "maybe_parse"})
-_BARE_PARSE_CALLS = frozenset({"parse_one", "transpile", "maybe_parse"})
+# These three names are distinctive enough to match however they are called. `parse` is not —
+# this repo has two unrelated local `parse()` helpers, and any object can have a `.parse()` —
+# so it counts only as `sqlglot.parse`. A scanner that cries wolf gets exempted into uselessness.
+_UNAMBIGUOUS_PARSE_CALLS = frozenset({"parse_one", "transpile", "maybe_parse"})
+
+
+def _receiver_is_sqlglot(node: ast.expr) -> bool:
+    """True for `sqlglot.parse(...)` and `x.sqlglot.parse(...)`, false for any other receiver."""
+    if isinstance(node, ast.Name):
+        return node.id == "sqlglot"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "sqlglot"
+    return False
 
 _EXEMPT: dict[str, str] = {
     "packages/agami-core/src/semantic_model/validator.py::_columns_referenced": (
@@ -89,9 +97,13 @@ def _walk(node, owner: str, relpath: str):
         if isinstance(child, ast.Call):
             func = child.func
             if isinstance(func, ast.Attribute):
-                if func.attr in _QUALIFIED_PARSE_CALLS:
+                # `parse` is common enough that matching every `x.parse(...)` would flag
+                # unrelated parsers, so it counts only when the receiver is sqlglot itself.
+                if func.attr in _UNAMBIGUOUS_PARSE_CALLS or (
+                    func.attr == "parse" and _receiver_is_sqlglot(func.value)
+                ):
                     yield relpath, owner, child
-            elif isinstance(func, ast.Name) and func.id in _BARE_PARSE_CALLS:
+            elif isinstance(func, ast.Name) and func.id in _UNAMBIGUOUS_PARSE_CALLS:
                 yield relpath, owner, child
         yield from _walk(child, owner, relpath)
 
@@ -104,6 +116,30 @@ def _kwarg(call: ast.Call, name: str):
 
 
 ALL_CALLS = list(_iter_parse_calls())
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("sqlglot.parse(sql)", True),
+        ("sqlglot.parse_one(sql)", True),
+        ("parse_one(sql)", True),
+        ("sqlglot.transpile(sql)", True),
+        # A local helper, or any other object's parser, is not a SQL parse we govern. Flagging
+        # these would demand arguments they do not take, and an exemption list grown to silence
+        # false positives is how a scanner stops being read.
+        ("parse(text)", False),
+        ("argparser.parse(text)", False),
+        ("self.parse(text)", False),
+        ("json.loads(text)", False),
+    ],
+)
+def test_the_scan_matches_sql_parses_and_not_look_alikes(source, expected, tmp_path):
+    path = tmp_path / "probe.py"
+    path.write_text(f"def f(sql, text):\n    return {source}\n", encoding="utf-8")
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found = list(_walk(tree, "<module>", "probe.py"))
+    assert bool(found) is expected, f"{source} -> {'matched' if found else 'not matched'}"
 
 
 def test_the_scan_actually_found_the_parses():

--- a/tests/test_sql_dialect_map.py
+++ b/tests/test_sql_dialect_map.py
@@ -1,0 +1,143 @@
+"""The StorageType -> sqlglot dialect map is complete, explicit, and actually parses.
+
+The guards read a statement in the engine's own grammar; the map is what tells them which
+grammar. Its failure mode is silent — an engine with no mapping would fall back to generic
+parsing, where a backtick-quoted statement reads as no tables and no columns and every
+model-scoping gate finds nothing to object to. These tests make that failure loud:
+
+* completeness is asserted against the `StorageType` literal itself, not a hand-written
+  list, so declaring a new engine without a dialect decision fails here;
+* each mapping is exercised by parsing under it, so a name that sqlglot does not recognise
+  fails here rather than at the first query on that engine.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import get_args
+
+import pytest
+
+pytest.importorskip("pydantic")
+sqlglot = pytest.importorskip("sqlglot")
+
+from sqlglot.errors import ErrorLevel  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+from semantic_model import models as m  # noqa: E402
+from semantic_model import sql_dialect as sd  # noqa: E402
+
+STORAGE_TYPES = get_args(m.StorageType)
+
+
+def _org(*storage_types: str) -> m.Datasource:
+    """A datasource declaring one storage connection per engine named."""
+    return m.Datasource(
+        datasource="AcmeCorp",
+        version=1,
+        storage_connections=[
+            m.StorageConnection(name=f"c{i}", storage_type=st)
+            for i, st in enumerate(storage_types)
+        ],
+    )
+
+
+# --- completeness ----------------------------------------------------------------
+
+
+def test_every_declared_storage_type_has_a_dialect():
+    """Adding a StorageType without a dialect decision must fail here.
+
+    Asserted as set equality against the literal rather than as a length or a subset check:
+    a subset check would pass for a newly declared engine, which is the exact regression
+    this guards — that engine would silently parse generically.
+    """
+    assert set(sd.supported_storage_types()) == set(STORAGE_TYPES)
+    assert sd.unmapped_storage_types() == ()
+
+
+@pytest.mark.parametrize("storage_type", STORAGE_TYPES)
+def test_each_storage_type_resolves_and_parses(storage_type):
+    """The mapped name must be one sqlglot actually accepts."""
+    dialect = sd.sqlglot_dialect(storage_type)
+    tree = sqlglot.parse_one(
+        "SELECT a FROM t", dialect=dialect, error_level=ErrorLevel.RAISE
+    )
+    assert tree is not None
+
+
+def test_lowercasing_the_storage_type_is_not_the_mapping():
+    """The reason the map is written by hand rather than derived.
+
+    Two of the eleven engines have a sqlglot name that is not their lowercased
+    StorageType, and they are the most common engine and the most divergent quoter.
+    """
+    assert sd.sqlglot_dialect("PostgreSQL") == "postgres"
+    assert sd.sqlglot_dialect("SQLServer") == "tsql"
+    for rejected in ("postgresql", "sqlserver"):
+        with pytest.raises(ValueError):
+            sqlglot.parse_one("SELECT 1", dialect=rejected)
+
+
+def test_unknown_engine_raises_rather_than_defaulting():
+    with pytest.raises(sd.DialectUnresolved):
+        sd.sqlglot_dialect("Teradata")
+
+
+# --- resolution from a datasource ------------------------------------------------
+
+
+@pytest.mark.parametrize("storage_type", STORAGE_TYPES)
+def test_single_connection_resolves(storage_type):
+    assert sd.resolve_datasource_dialect(_org(storage_type)) == sd.sqlglot_dialect(
+        storage_type
+    )
+
+
+def test_several_connections_on_one_engine_resolve():
+    """Two hosts on the same engine is a legitimate model and must not refuse."""
+    assert sd.resolve_datasource_dialect(_org("PostgreSQL", "PostgreSQL")) == "postgres"
+
+
+def test_no_connection_is_unresolved():
+    with pytest.raises(sd.DialectUnresolved):
+        sd.resolve_datasource_dialect(_org())
+
+
+def test_disagreeing_engines_are_unresolved():
+    """A datasource runs against one database, so two declared engines are ambiguous."""
+    with pytest.raises(sd.DialectUnresolved):
+        sd.resolve_datasource_dialect(_org("PostgreSQL", "MySQL"))
+
+
+def test_override_does_not_steer_the_dialect():
+    """`storage_type_override` is free-form and unvalidated.
+
+    Honouring it would let an arbitrary string change the grammar the guard reads a
+    statement in, which is the same class of defect the explicit map closes.
+    """
+    org = _org("PostgreSQL")
+    org.storage_connections[0].storage_type_override = "mysql"
+    assert sd.resolve_datasource_dialect(org) == "postgres"
+
+
+# --- the refusal reasons must be safe to surface ---------------------------------
+
+
+def test_unresolved_reasons_carry_no_engine_names():
+    """A refusal reason describes the shape of the problem, never model or data values."""
+    with pytest.raises(sd.DialectUnresolved) as no_conn:
+        sd.resolve_datasource_dialect(_org())
+    with pytest.raises(sd.DialectUnresolved) as mixed:
+        sd.resolve_datasource_dialect(_org("PostgreSQL", "MySQL"))
+
+    for excinfo in (no_conn, mixed):
+        reason = str(excinfo.value)
+        assert "PostgreSQL" not in reason
+        assert "MySQL" not in reason
+        assert "AcmeCorp" not in reason
+    # The ambiguous case still tells the operator how many engines were found.
+    assert "2" in str(mixed.value)

--- a/tests/test_ungovernable_engine_fails_closed.py
+++ b/tests/test_ungovernable_engine_fails_closed.py
@@ -57,7 +57,13 @@ def _org(*storage_types: str, sensitive: bool = True) -> "m.Datasource":
         # The first connection is named "c" because that is what the tables above reference;
         # extras get suffixed names. A fixture whose tables point at a connection it never
         # declares would be internally inconsistent, and would quietly stop meaning anything
-        # if the runtime ever resolves the table-to-connection link.
+        # if the runtime ever resolved the table-to-connection link.
+        #
+        # Passing NO storage types is the exception, and deliberately so: it models a
+        # datasource that declares no engine, which is the state these tests exist to refuse.
+        # `Table.storage_connection` is required, so the table necessarily names a connection
+        # that is not declared — that dangling reference IS the condition under test, not an
+        # oversight to tidy away.
         storage_connections=[
             m.StorageConnection(name="c" if i == 0 else f"c{i}", storage_type=st)
             for i, st in enumerate(storage_types)

--- a/tests/test_ungovernable_engine_fails_closed.py
+++ b/tests/test_ungovernable_engine_fails_closed.py
@@ -1,0 +1,197 @@
+"""A statement that cannot be read in a known grammar is refused, not run blind.
+
+The guards decide by reading the statement. If the datasource does not say which engine it
+runs on there is no grammar to read it in, so no gate below can reach a verdict worth
+trusting — and a gate that cannot object is indistinguishable from a gate with nothing to
+object to. The statement is therefore refused before any database is touched, whatever the
+model happens to declare and whichever gate would otherwise have run.
+
+The refusal has to be usable, which means two different situations get two different next
+moves: a statement the caller can re-emit, and a datasource only an operator can fix. The
+second must not invite a retry — an unactionable "try again" turns a configuration fault
+into a retry loop.
+
+Synthetic, generic names only — `customers`, `orders`, `AcmeCorp`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import execute_sql  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as rt  # noqa: E402
+
+SENSITIVE_VALUE = "111-22-3333"
+
+
+def _org(*storage_types: str, sensitive: bool = True) -> "m.Datasource":
+    customers = m.Table(
+        name="customers", schema="public", storage_connection="c", grain=["id"],
+        columns=[
+            m.Column(name="id", type="integer"),
+            m.Column(name="ssn", type="string", sensitive=sensitive),
+        ],
+    )
+    orders = m.Table(
+        name="orders", schema="public", storage_connection="c", grain=["id"],
+        columns=[m.Column(name="id", type="integer")],
+    )
+    sa = m.SubjectArea(name="area", description="d", tables_defined=[customers, orders])
+    return m.Datasource(
+        datasource="AcmeCorp",
+        version=1,
+        storage_connections=[
+            m.StorageConnection(name=f"c{i}", storage_type=st)
+            for i, st in enumerate(storage_types)
+        ],
+        subject_areas=[sa],
+    )
+
+
+class _SpyExecutor:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    def execute(self, vetted_sql, creds, *, profile):
+        self.calls.append((vetted_sql, creds, profile))
+        return execute_sql.ExecResult(columns=["ssn"], rows=[(SENSITIVE_VALUE,)])
+
+
+@pytest.fixture
+def guarded(monkeypatch):
+    def _run(sql: str, org, spy, **kw):
+        monkeypatch.setattr(execute_sql, "_resolve_guard_model", lambda profile: org)
+        monkeypatch.setattr(
+            execute_sql, "_load_credentials",
+            lambda p, org_id="local": {"type": "sqlite", "path": ":memory:"},
+        )
+        return execute_sql.execute_guarded(sql, "acme", None, executor=spy, **kw)
+
+    return _run
+
+
+# --- the refusal is unconditional -------------------------------------------------
+
+
+@pytest.mark.parametrize("sensitive", [True, False], ids=["pii-declared", "no-pii-declared"])
+def test_no_declared_engine_refuses_regardless_of_declared_pii(guarded, sensitive):
+    """Governance cannot be conditional on how diligently the model was authored."""
+    spy = _SpyExecutor()
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        guarded("SELECT id FROM customers", _org(sensitive=sensitive), spy)
+    assert ei.value.refusal.kind == "unscopable_sql"
+    assert spy.calls == [], "the executor ran against an engine the guard could not parse for"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT id FROM customers",       # would have passed every gate
+        "SELECT id FROM undeclared",      # would have been refused by table scope
+        "SELECT ssn FROM customers",      # would have been refused or masked by the PII gate
+        "SELECT * FROM customers",        # would have been refused by the star ban
+    ],
+)
+def test_no_declared_engine_refuses_whichever_gate_would_have_run(guarded, sql):
+    spy = _SpyExecutor()
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        guarded(sql, _org(), spy)
+    assert ei.value.refusal.kind == "unscopable_sql"
+    assert spy.calls == []
+
+
+def test_disagreeing_engines_refuse(guarded):
+    """One datasource resolves to one database, so two declared engines are ambiguous."""
+    spy = _SpyExecutor()
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        guarded("SELECT id FROM customers", _org("PostgreSQL", "MySQL"), spy)
+    assert ei.value.refusal.kind == "unscopable_sql"
+    assert spy.calls == []
+
+
+def test_a_declared_engine_still_runs(guarded):
+    """The fail-closed must not swallow the ordinary case."""
+    spy = _SpyExecutor()
+    guarded("SELECT id FROM customers", _org("PostgreSQL"), spy)
+    assert spy.calls, "a governable statement was refused"
+
+
+# --- the two refusals are distinguishable and actionable --------------------------
+
+
+def test_the_unmapped_engine_refusal_names_the_operator_action_and_invites_no_retry(guarded):
+    spy = _SpyExecutor()
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        guarded("SELECT id FROM customers", _org(), spy)
+    remediation = ei.value.refusal.remediation
+
+    assert "storage_type" in remediation, "the operator is not told what to declare"
+    # It may say "then retry" *after* the fix, but must not offer re-emitting the query as
+    # the remedy — no rewrite of this statement helps.
+    assert "re-emit" not in remediation.lower()
+
+
+def test_the_unparseable_refusal_names_a_query_level_next_move():
+    """Distinct from the above: this one the caller can act on by regenerating."""
+    verdict = rt.check_scopable("SELECT `ssn` FROM `customers`", _org("PostgreSQL"))
+    assert verdict is not None
+    assert "re-emit" in verdict.remediation.lower()
+
+
+def test_neither_refusal_echoes_the_statement_or_the_model(guarded):
+    """A reason crosses the boundary between the model and the customer's database, so it
+    carries the shape of the problem and never its contents."""
+    spy = _SpyExecutor()
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        guarded("SELECT ssn FROM customers", _org(), spy)
+    text = f"{ei.value.refusal.reason} {ei.value.refusal.remediation}"
+    for leaked in ("ssn", "customers", "AcmeCorp", "SELECT"):
+        assert leaked not in text, f"the refusal echoed {leaked!r}"
+
+
+# --- the dialect-independent backstop ---------------------------------------------
+
+
+def test_a_read_that_attributes_no_table_is_refused():
+    """The shape a mis-read produces, caught without relying on the dialect map being
+    complete — so a quoting style nobody has mapped yet still fails closed."""
+    org = _org("PostgreSQL")
+    verdict = rt.check_scopable("SELECT x FROM (SELECT 1 AS x) t", org)
+    assert verdict is not None
+
+
+def test_a_statement_that_reads_nothing_is_left_alone():
+    """`SELECT 1` attributes no table because it reads nothing, not because it was mis-read."""
+    assert rt.check_scopable("SELECT 1", _org("PostgreSQL")) is None
+
+
+def test_an_ordinary_read_is_unaffected():
+    assert rt.check_scopable("SELECT id FROM customers", _org("PostgreSQL")) is None
+
+
+# --- the refusal does not depend on the unscopable posture switch ------------------
+
+
+def test_the_engine_refusal_holds_under_the_unscopable_warn_posture(guarded, monkeypatch):
+    """`AGAMI_SQL_UNSCOPABLE_POSTURE=warn` is a staged-rollout hatch for queries that cannot
+    be scoped. A datasource that cannot be parsed at all is a configuration fault, not a
+    query to wave through, so this refusal sits ahead of that switch."""
+    monkeypatch.setenv("AGAMI_SQL_UNSCOPABLE_POSTURE", "warn")
+    spy = _SpyExecutor()
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        guarded("SELECT ssn FROM customers", _org(), spy)
+    assert ei.value.refusal.kind == "unscopable_sql"
+    assert spy.calls == [], "warn posture let a statement run that could not be parsed at all"

--- a/tests/test_ungovernable_engine_fails_closed.py
+++ b/tests/test_ungovernable_engine_fails_closed.py
@@ -182,6 +182,50 @@ def test_an_ordinary_read_is_unaffected():
     assert rt.check_scopable("SELECT id FROM customers", _org("PostgreSQL")) is None
 
 
+# --- a declared row filter that cannot be applied refuses, rather than running unscoped ---
+
+
+def _org_with_unusable_filter() -> "m.Datasource":
+    org = _org("PostgreSQL")
+    # A filter the parser cannot make sense of. Authoring like this is a mistake — the point
+    # is what happens when the mistake exists, not that it is plausible.
+    org.subject_areas[0].tables_defined[0].default_filters = ["{alias}.id >>>= ("]
+    return org
+
+
+def test_an_unusable_row_filter_refuses_instead_of_running_unfiltered(guarded):
+    """The caller keeps the rewritten SQL only when the applied list is non-empty, so an
+    unusable filter that returned the statement unchanged would be indistinguishable from
+    'this query needed no filter' — and the query would run with the model's row scoping
+    silently absent. That is a fail-open in a governance control."""
+    spy = _SpyExecutor()
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        guarded("SELECT id FROM customers", _org_with_unusable_filter(), spy)
+
+    assert ei.value.refusal.kind == "model_unavailable", (
+        "the fault is in the model, not the query, so it must not be reported as the query's"
+    )
+    assert spy.calls == [], "a query ran without the row scoping its model declares"
+
+
+def test_the_row_scoping_refusal_points_at_the_model_not_the_query(guarded):
+    spy = _SpyExecutor()
+    with pytest.raises(execute_sql.GuardRefused) as ei:
+        guarded("SELECT id FROM customers", _org_with_unusable_filter(), spy)
+    assert "default_filters" in ei.value.refusal.remediation
+
+
+def test_a_usable_row_filter_still_applies(guarded):
+    """The refusal must not swallow the ordinary row-scoping path."""
+    org = _org("PostgreSQL")
+    org.subject_areas[0].tables_defined[0].default_filters = ["{alias}.id > 0"]
+    spy = _SpyExecutor()
+
+    guarded("SELECT id FROM customers", org, spy)
+    assert spy.calls, "a governable statement was refused"
+    assert "id > 0" in spy.calls[0][0].replace('"', ""), "the row filter did not reach the executor"
+
+
 # --- the refusal does not depend on the unscopable posture switch ------------------
 
 

--- a/tests/test_ungovernable_engine_fails_closed.py
+++ b/tests/test_ungovernable_engine_fails_closed.py
@@ -34,7 +34,8 @@ import execute_sql  # noqa: E402
 from semantic_model import models as m  # noqa: E402
 from semantic_model import runtime as rt  # noqa: E402
 
-SENSITIVE_VALUE = "111-22-3333"
+# 000-00-0000 is never issued, so no scanner or reader can mistake it for a real SSN.
+SENSITIVE_VALUE = "000-00-0000"
 
 
 def _org(*storage_types: str, sensitive: bool = True) -> "m.Datasource":
@@ -72,11 +73,13 @@ class _SpyExecutor:
 
 @pytest.fixture
 def guarded(monkeypatch):
-    def _run(sql: str, org, spy, **kw):
+    def _run(sql: str, org, spy, creds_type: str = "postgres", **kw):
         monkeypatch.setattr(execute_sql, "_resolve_guard_model", lambda profile: org)
+        # Credentials for the engine the model declares — the guard refuses a model/credential
+        # engine mismatch, which would otherwise mask what these tests are checking.
         monkeypatch.setattr(
             execute_sql, "_load_credentials",
-            lambda p, org_id="local": {"type": "sqlite", "path": ":memory:"},
+            lambda p, org_id="local": {"type": creds_type, "path": ":memory:"},
         )
         return execute_sql.execute_guarded(sql, "acme", None, executor=spy, **kw)
 

--- a/tests/test_ungovernable_engine_fails_closed.py
+++ b/tests/test_ungovernable_engine_fails_closed.py
@@ -54,8 +54,12 @@ def _org(*storage_types: str, sensitive: bool = True) -> "m.Datasource":
     return m.Datasource(
         datasource="AcmeCorp",
         version=1,
+        # The first connection is named "c" because that is what the tables above reference;
+        # extras get suffixed names. A fixture whose tables point at a connection it never
+        # declares would be internally inconsistent, and would quietly stop meaning anything
+        # if the runtime ever resolves the table-to-connection link.
         storage_connections=[
-            m.StorageConnection(name=f"c{i}", storage_type=st)
+            m.StorageConnection(name="c" if i == 0 else f"c{i}", storage_type=st)
             for i, st in enumerate(storage_types)
         ],
         subject_areas=[sa],


### PR DESCRIPTION
## Summary

The model-scoping guards decide by inspecting a parsed statement, and they parsed every statement in sqlglot's **generic** grammar — which matches no real engine. On a backtick-quoting datasource (MySQL, BigQuery, Databricks) `` SELECT `ssn` FROM `customers` `` parsed to **no tables and no columns**, so table scope, column scope and the sensitive-projection gate each found nothing to object to and allowed it. The column came back verbatim. Measured on the base branch:

```
MySQL datasource, ssn declared sensitive
  undeclared backtick table refused?   False
  undeclared backtick column refused?  False
  sensitive ssn noticed?               False
  receipt tables_used:                 []
```

The read-only lexer is a separate code path and still blocked writes, so this is **disclosure, not integrity**.

Backticks were the first instance, not the class. SQL Server `TOP` + `[brackets]` parsed to a *confidently wrong* tree — zero tables plus a phantom column named `TOP`, so a gate refused for a reason unrelated to the query — and a MySQL `#` comment truncated the parse.

Compounding it, **`error_level` was inert**. sqlglot compares the level against `ErrorLevel` members, so the string these calls passed matched no branch and every collected parse error was silently discarded. Worse, the constructor reads `error_level or ErrorLevel.IMMEDIATE`, so passing the string *overrode a safe default with a value matching nothing*. Swapping `"ignore"` → `"raise"` would have changed nothing and would have passed review looking like hardening.

Every guard-path parse and every SQL regeneration now takes the datasource's dialect and raises on parse failure.

## Changes

**The fix**
- New `semantic_model/sql_dialect.py`: an explicit `StorageType` → sqlglot map, one entry per engine. Hand-written because lowercasing is *not* the mapping — `PostgreSQL` → `postgresql` and `SQLServer` → `sqlserver` are both rejected by sqlglot (it wants `postgres` and `tsql`), and those are the most common engine and the most divergent quoter. Resolution raises rather than falling back to generic.
- All 11 parse sites in `runtime.py` funnel through one helper passing `dialect=` + `ErrorLevel.RAISE`, catching both `ParseError` and `TokenError`. Five duplicated try/except blocks are deleted, so this is a net simplification.
- All **three** emission sites regenerate in the datasource's grammar — including `pre_flight_check`'s `arm.sql()`, which the spec's rewrite list missed. These emit the statement the executor runs; emitting generically hands it SQL the guards never validated.

**Fail closed**
- A datasource whose engine cannot be determined refuses, whatever the model declares and whichever gate would otherwise have run — deliberately **ahead of `AGAMI_SQL_UNSCOPABLE_POSTURE`**, which is a staged-rollout hatch for unscopable *queries*, not for datasources nobody can parse for.
- An **unreadable statement** refuses ahead of that switch too. This is not inherited: raising parse errors *widens* what escapes through `warn`, because the old truncated tree still named enough for table scope to catch some statements, while `tree is None` makes every downstream gate degrade to allow.
- A dialect-independent backstop: a statement that reads from something yet resolves to no named table is refused — the shape a mis-read produces, caught without waiting for the map to be complete.
- Two distinguishable remediations: the regenerable case names a query-level next move; the unmapped-engine case names the operator action and does **not** invite a retry.

**Three holes found during review, all closed here**
1. **Row scoping was fail-open.** When a table's `default_filters` could not be applied, `apply_default_filters` returned the statement unchanged with an empty `applied` list — and the caller keeps the rewrite only `if applied`, so "could not apply" was indistinguishable from "no filter needed". The query ran returning exactly the rows the filter exists to withhold. Now raises; both callers refuse as `model_unavailable`.
2. **The mirror of this defect.** On backtick engines sqlglot reads `"x"` as a *string literal*, so a double-quoted sensitive column resolved to zero columns — where the old generic parse had read it as an identifier and caught it. A regression this change would otherwise have introduced. MySQL under `ANSI_QUOTES` really does treat it as an identifier, so meaning depends on server configuration the guard cannot see. sqlglot does not preserve the quote character (`"x"` and `'x'` arrive identical), so the ambiguity is detected by re-reading under an ANSI-quoting grammar and comparing attributed columns. A genuine single-quoted literal is unaffected.
3. **Nothing reconciled the declared engine with the credentials.** The guard picks its grammar from the model; the executor picks its driver from `creds["type"]`. A mis-declared model had the guard vet — and, where a rewrite fires, *regenerate* — a statement in a grammar the database does not speak. Compared at the chokepoint and refused.

**Mechanical guards**
- An AST scan fails the build on any parse that omits its grammar or passes a *string* error level — the failure is invisible at review, and `error_level="raise"` reads like a fix. Covers sqlglot's whole parse family and our own helpers. Verified by injecting a bad parse.
- Tier 1 asserts an explicit dialect for every `StorageType` via `get_args`, as **set equality**, so a twelfth engine fails CI rather than silently parsing generically.
- The corpus gains backtick and bracket forms, so the guarantee runs over both surfaces rather than only in unit tests.

## Evidence

- **Refusal delta: 0 of 28** valid statements (14 corpus + 14 seeded examples).
- **sqlglot floor unchanged at `>=20`, deliberately.** The intended bump was to guard against `RAISE` strictness drift. Measured on **20.0.0, 23.0.0, 25.0.0, 26.0.0, 30.10.0**: all eleven dialect names resolve, all three attack statements parse correctly, and `RAISE` raises identically on every one. No drift to defend against, so no dependency bump.
- Source diff **+279/−56**; the rest is tests.

## Checklist

- [x] `ruff check` / `ruff format --check` / gitleaks pass
- [x] `dev.py sync-lib` — vendored lib in sync
- [x] No test weakened or deleted; three fixtures corrected to declare the engine they actually run against
- [x] Synthetic examples only; no spec ids in code, comments or commit messages
- [x] **`dev.py check` green** — 2272 passed, 0 failed
- [x] **Postgres integration green** — 180 passed (both surfaces × both model paths + read-only role floor), verified against a real `postgres:16` container

## Also in this PR: the MCP SDK ceiling

`mcp 2.0.0` was published **today at 13:45:28Z**. It removes `Server.list_tools`, which `mcp_http` builds its tool surface with, so every HTTP request fails at import. The declared floor had no ceiling, so a fresh resolve picked it up: the last CI run before that release passed (13:35Z), the next one failed (22:07Z). It would have broken every PR in this repo.

The quiet part is what it did to the safety corpus — half of every case runs over HTTP, so those cases erroring meant the guarantee they assert **was not being checked at all**. Coverage that looks present and tests nothing. Capped at `mcp>=1.2,<2`; raise it deliberately once `mcp_http` is ported.

With the cap: full suite 109 failures → **0**, Postgres integration → **180 passed**. That is also what makes the "on both surfaces" criterion genuinely verified here rather than asserted.

## Known limitations — stated rather than implied

- **Execution parity is unproven on eight of eleven engines.** Tiers 1/2/3a prove the *verdict* everywhere with no database, but only PostgreSQL, SQLite and DuckDB prove the executor runs what the guard vetted — all `"`-quoting, i.e. exactly the family where this defect cannot manifest. The per-engine execution matrix is separate work.
- **The refusal-delta corpus is in-repo test SQL, not LLM-emitted SQL.** It measures the shapes we already knew to write down, not what the model generates against a real semantic model — which is the population that actually matters for over-refusal.
- `_semi_additive_columns` skips an unparseable metric binding rather than refusing: it enriches an advisory check and withholds nothing, unlike the row-scoping path.
- Semi-structured access (`SELECT payload:ssn`) stays invisible to the gates under both grammars — a separate gap in what the gates detect.

Spec: ACE-079
