### PR TITLE
fix(deps): cap mcp below 2.0 — 2.0 dropped Server.list_tools, breaking build_app() and all of CI

### DIFF
--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -37,7 +37,7 @@ model = [
 # The HTTP MCP transport (mcp_http): the official MCP SDK + an ASGI server. Kept out of the base
 # install so the local executor/skill stay stdlib-lean — only a hosted deployment installs it.
 server = [
-  "mcp>=1.2",
+  "mcp>=1.2,<2",        # capped: 2.0 dropped Server.list_tools, which build_server() registers on
   "anyio>=4",           # async_offload.run_blocking offloads blocking work off the loop (ACE-048)
   "uvicorn>=0.30",
   "psycopg2-binary>=2.9",


### PR DESCRIPTION
Fixes #158.

One line: cap the `server` extra's MCP SDK below the 2.0 major.

```diff
-  "mcp>=1.2",
+  "mcp>=1.2,<2",        # capped: 2.0 dropped Server.list_tools, which build_server() registers on
```

## Why

`mcp>=1.2` had no upper bound. mcp 2.0.0 was published 2026-07-28 and removed `Server.list_tools`, which `build_server()` registers on — so every fresh resolve since then produces a tree where `mcp_http.build_app()` raises `AttributeError` at import.

No source change on `main` sits between the last green CI run (2026-07-27 23:11 UTC) and red. The break came entirely from the open floor.

This was never CI-only:

- **CI / the suite on `main`** — 77 failed + 66 errors, every one terminating in the same frame.
- **Fresh installs and image builds** — `deploy/Dockerfile` runs `pip install --no-cache-dir -e ".[server,model]"` unlocked, and the entrypoint's serve step is `exec python -m mcp_http` → `uvicorn.run("mcp_http:build_app", factory=True, ...)`. An image built today crashes at boot in every worker. The root `uv.lock` has no `mcp` entry, so it pinned nothing here either.

Already-built images and already-installed environments were unaffected — this only bit on a fresh resolve.

## Verification

On this branch, through the unmodified `dev.py` path:

```
$ uv run dev.py check
1584 passed, 1 skipped
Detect hardcoded secrets.................................................Passed
✓ all checks passed          (exit 0)
```

Against `main` at the same commit without the pin: `77 failed, 1441 passed, 66 errors`.

## Scope

Deliberately just the cap. Migrating `build_server()` to the mcp 2.x API is separate work and wants a green baseline to be scoped against, not to be folded into an unblock.

Worth a follow-up: the pin fixes today's break but catches nothing about the *next* breaking major. A scheduled job that resolves dependencies unpinned and reports would surface that as its own signal instead of as a red `main`. Raised as the open regression-guard item on #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
