### PR TITLE
ACE-083: classify traps by what a fan-out can actually inflate, and give the scope walk a scope

### DIFF
--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -492,6 +492,16 @@ def resolve_entity_instance(
 
 @dataclass
 class PreFlightResult:
+    """The fan/chasm verdict, plus how well the analysis could see the query.
+
+    `certainty` uses the shared guardrail vocabulary: `"provable"` means every aggregate in the
+    statement was traced to a table the model declares, so `action` is a statement about the
+    QUERY; `"uncertain"` means at least one aggregate's grain could not be established (it reads
+    a CTE whose body the scope walk cannot classify), so `action` is only a statement about what
+    the analysis SAW. An `allow` carrying `"uncertain"` is "I could not tell", not "this is fine",
+    and the policy layer — not this gate — decides what that is worth.
+    """
+
     risk: Optional[str]  # "fan_trap" | "chasm_trap" | None
     action: str  # "auto_rewrite" | "refuse" | "allow"
     original_sql: str
@@ -499,6 +509,7 @@ class PreFlightResult:
     reason: str = ""
     suggestion: Optional[str] = None
     triggering_joins: list[str] = field(default_factory=list)
+    certainty: str = "provable"  # "provable" | "uncertain"
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -509,6 +520,7 @@ class PreFlightResult:
             "reason": self.reason,
             "suggestion": self.suggestion,
             "triggering_joins": self.triggering_joins,
+            "certainty": self.certainty,
         }
 
 
@@ -1321,6 +1333,28 @@ def _one_side_facing_many(
     return hits
 
 
+def _known_table_names(
+    org: Datasource, rels: list[Relationship], ctx: "GuardContext | None" = None
+) -> set[str]:
+    """Every table the cardinality analysis can say anything about.
+
+    The declared tables PLUS the tables named on either end of a declared relationship — the
+    relationships are what the fan/chasm rules actually read, and a model can carry one for a
+    table it has not (yet) described in full."""
+    known = set(ctx.model_table_index if ctx is not None else _model_table_index(org))
+    for r in rels:
+        known.add(_bare(r.from_table))
+        known.add(_bare(r.to_table))
+    return known
+
+
+def _reads_any_table(
+    agg: "exp.AggFunc", tables: set[str], scope: dict[str, str]
+) -> bool:
+    """Does any column inside `agg` bind to one of `tables`?"""
+    return any(_resolve_col_table(col, scope) in tables for col in agg.find_all(exp.Column))
+
+
 def _many_side_facing_one(rels: list[Relationship], table: str, dim: str) -> bool:
     """Is `table` the MANY side of a join to dimension `dim` (the ONE side)?"""
     for r in rels:
@@ -1356,6 +1390,7 @@ def pre_flight_check(sql: str, org: Datasource,
     # Each arm is rendered back to text in the datasource's grammar before being re-read —
     # rendering generically would feed the analysis a statement in a grammar the arm was
     # never written in, the same mis-read this battery exists to prevent.
+    unresolved: Optional[PreFlightResult] = None
     for arm in _output_selects(tree):
         res = _preflight_select(arm, org, arm.sql(dialect=dialect), allow_rewrite=False, ctx=ctx)
         if res.risk and res.action == "refuse":
@@ -1367,7 +1402,21 @@ def pre_flight_check(sql: str, org: Datasource,
                 reason=res.reason,
                 suggestion=res.suggestion,
                 triggering_joins=res.triggering_joins,
+                certainty=res.certainty,
             )
+        if res.certainty == "uncertain" and unresolved is None:
+            unresolved = res
+    # An arm the analysis could not read makes the WHOLE set operation unproven — the arms are
+    # unioned into one answer, so an unexamined arm is an unexamined answer.
+    if unresolved is not None:
+        return PreFlightResult(
+            None,
+            "allow",
+            sql,
+            reason=unresolved.reason,
+            suggestion=unresolved.suggestion,
+            certainty="uncertain",
+        )
     return PreFlightResult(
         None, "allow", sql, reason="no fan/chasm or aggregation issue in any arm"
     )
@@ -1384,9 +1433,13 @@ def _preflight_select(tree: "exp.Select", org: Datasource, sql: str, allow_rewri
     rels = ctx.cardinality_index if ctx is not None else _cardinality_index(org)
     tables_in_scope = _tables_in_scope(tree)  # alias -> table
     table_set = set(tables_in_scope.values())
+    # Sources whose grain the analysis could NOT establish. An aggregate over one of these has
+    # unknown lineage, and the honest answer is "I could not tell".
+    opaque_sources = _unresolved_scope_sources(tree, _known_table_names(org, rels, ctx))
 
-    # aggregates: list of (table, is_aggregate)
-    agg_sources = _aggregate_source_tables(tree, tables_in_scope)
+    # aggregates: (source table, the aggregate node it appears in)
+    agg_pairs = _aggregate_source_tables(tree, tables_in_scope)
+    agg_sources = {t for t, _ in agg_pairs}
     has_raw_columns = _has_raw_non_grouped_columns(tree, tables_in_scope)
     has_aggregate = bool(agg_sources)
     no_aggregation = not has_aggregate
@@ -1420,8 +1473,18 @@ def _preflight_select(tree: "exp.Select", org: Datasource, sql: str, allow_rewri
                 triggering_joins=[f"{s} -> {shared}" for s in srcs],
             )
 
-    # FAN: an aggregate over a measure on the ONE side of a one-to-many in scope
-    for measure_table in agg_sources:
+    # FAN: an aggregate over a measure on the ONE side of a one-to-many in scope.
+    #
+    # Only aggregates a fan-out can actually inflate get a vote. MIN/MAX, a DISTINCT-qualified
+    # aggregate and a boolean fold are idempotent under row duplication, so the join cannot
+    # change their value and the query was already correct.
+    fan_aggs: dict[str, list["exp.AggFunc"]] = {}
+    for table, agg in agg_pairs:
+        if _is_fan_immune(agg):
+            continue
+        fan_aggs.setdefault(table, []).append(agg)
+
+    for measure_table in sorted(fan_aggs):  # sorted: one shape of query, one diagnosis
         others = table_set - {measure_table}
         fan_rels = _one_side_facing_many(rels, measure_table, others)
         if not fan_rels:
@@ -1430,6 +1493,17 @@ def _preflight_select(tree: "exp.Select", org: Datasource, sql: str, allow_rewri
             _bare(r.from_table) if _bare(r.to_table) == measure_table else _bare(r.to_table)
             for r in fan_rels
         }
+        # Measure or co-factor? A one-side column INSIDE the aggregate is not the same as the
+        # one-side column BEING aggregated. `SUM(order_items.quantity * orders.total_amount)`
+        # sums one value per order_items row — a many-side quantity that a per-order rate
+        # scales — and nothing is duplicated. A genuine trap, `SUM(orders.total_amount)`,
+        # names no many-side column, so it still fires; adding one is the author stating a
+        # many-side grain, which is well defined.
+        if all(
+            _reads_any_table(agg, many_tables, tables_in_scope)
+            for agg in fan_aggs[measure_table]
+        ):
+            continue
         # Can we safely auto-rewrite? Only if the many side participates ONLY in
         # the FROM/JOIN (not in SELECT / WHERE / GROUP BY / HAVING / ORDER BY)
         # AND the SELECT is aggregation-only (no raw rows).
@@ -1478,6 +1552,28 @@ def _preflight_select(tree: "exp.Select", org: Datasource, sql: str, allow_rewri
     semantic = _check_aggregation_semantics(tree, org, tables_in_scope, sql, ctx=ctx)
     if semantic is not None:
         return semantic
+
+    # Nothing found — but say WHY nothing was found. If an aggregate reads a source whose grain
+    # could not be established, "no trap" is a claim about what this analysis saw, not about the
+    # query, and returning a bare `allow` would present the second as if it were the first. The
+    # graded response to that lives in the policy layer, not here.
+    unresolved = sorted(agg_sources & opaque_sources)
+    if unresolved:
+        return PreFlightResult(
+            None,
+            "allow",
+            sql,
+            reason=(
+                f"could not establish the grain of {unresolved}: it is a CTE whose body is not a "
+                "grain-preserving select from a declared table, so an aggregate over it cannot "
+                "be proven free of a fan-out."
+            ),
+            suggestion=(
+                "Select the measure from the declared table directly, or pre-aggregate it to the "
+                "join key in the CTE so its grain is explicit."
+            ),
+            certainty="uncertain",
+        )
 
     return PreFlightResult(None, "allow", sql, reason="no fan/chasm or aggregation issue")
 
@@ -1756,7 +1852,10 @@ def assemble_receipt(
     if tree is None:
         return receipt
 
-    scope = _tables_in_scope(tree)  # alias/name -> bare table name
+    # `_tables_anywhere`, not `_tables_in_scope`: the receipt reports what the answer READ, so a
+    # table sourced only inside a CTE body belongs in it. Scoping this walk would silently drop
+    # it from the provenance list.
+    scope = _tables_anywhere(tree)  # alias/name -> bare table name
     used = set(scope.values())
     tidx = _model_table_index(org)
 
@@ -1883,25 +1982,215 @@ def assemble_receipt(
 # ---------------------------------------------------------------------------
 
 
-def _tables_in_scope(tree: "exp.Select") -> dict[str, str]:
-    """alias (or table name) -> bare table name."""
+def _tables_anywhere(tree: "exp.Expression") -> dict[str, str]:
+    """alias (or table name) -> bare table name, harvested from the WHOLE tree.
+
+    Deliberately scope-BLIND: a table named only inside a CTE body or a subquery lands in the
+    same flat map as one the outer query joins. That is wrong for a cardinality question (see
+    `_tables_in_scope`), but it is what the two provenance/coverage callers want — the receipt
+    reports every table the answer read, and the row-scoping pass looks for every table whose
+    declared filter might apply. Narrowing either of those would DROP a table from a report or a
+    filter from a query, so they keep the flat walk; only the trap detector got a real scope."""
     out: dict[str, str] = {}
     for tbl in tree.find_all(exp.Table):
-        name = tbl.name
-        alias = tbl.alias_or_name
-        out[alias] = name
+        out[tbl.alias_or_name] = tbl.name
     return out
 
 
-def _aggregate_source_tables(tree: "exp.Select", scope: dict[str, str]) -> set[str]:
-    """Tables whose columns appear inside an aggregate function in the SELECT."""
-    sources: set[str] = set()
+@dataclass(frozen=True)
+class _CteGrain:
+    """What a CTE alias means to a cardinality question.
+
+    Exactly three outcomes, and the difference between them is the whole of the scope fix:
+
+      * ``source`` set — the body preserves grain (a single-table SELECT with no GROUP BY, no
+        DISTINCT and no aggregate), so the alias has the row cardinality of that base table and
+        every declared relationship on it applies. Resolves transitively.
+      * ``source is None, opaque False`` — the body CHANGES grain (it groups / de-duplicates /
+        aggregates). It is its own entity, at the grain of its GROUP BY keys, and it does NOT
+        inherit the underlying table's cardinality. Reading a pre-aggregated CTE as its source
+        table is what refuses the very remediation this guard suggests.
+      * ``opaque`` — the body joins, unions, reads a derived table, or is self-referential, so
+        the alias cannot be tied to any single declared table. Not resolvable and not safely
+        assumed innocent: the aggregate's lineage is unknown.
+    """
+
+    source: Optional[str]
+    opaque: bool
+
+
+def _own_child(node: "exp.Expression", types: tuple) -> Optional["exp.Expression"]:
+    """`node`'s OWN direct argument of one of `types`, found by NODE TYPE rather than arg key.
+
+    sqlglot has renamed these keys inside the version range this package accepts (`with` ->
+    `with_`, `from` -> `from_`), and a missing key reads as "there is no WITH clause" — which
+    would silently restore the very CTE-body leak this scope walk exists to stop. `_arm_sources`
+    matches on type for the same reason. Direct args only: a nested node belongs to its own
+    scope, not this one."""
+    for value in node.args.values():
+        for item in value if isinstance(value, list) else [value]:
+            if isinstance(item, types):
+                return item
+    return None
+
+
+def _cte_bodies(tree: "exp.Expression") -> dict[str, "exp.Expression"]:
+    """CTE name (case-folded) -> body, for every WITH clause visible from `tree`.
+
+    Walks OUTWARD from `tree` because a set-operation arm carries no WITH of its own — the
+    clause sits on the set-operation root, and the arm still references its names."""
+    bodies: dict[str, "exp.Expression"] = {}
+    node: Optional["exp.Expression"] = tree
+    while node is not None:
+        with_ = _own_child(node, (exp.With,))
+        if with_ is not None:
+            # setdefault, walking inner -> outer, so an inner WITH shadows an outer one
+            for cte in with_.expressions:
+                bodies.setdefault(cte.alias_or_name.lower(), cte.this)
+        node = node.parent
+    return bodies
+
+
+def _single_source_table(body: "exp.Expression") -> Optional["exp.Table"]:
+    """The one base-table source `body` draws from, or None for anything else.
+
+    None covers a join, a union (not an exp.Select at all), a derived table / VALUES / table
+    function, and a body with no FROM — every shape whose rows cannot be attributed to one
+    declared table."""
+    if not isinstance(body, exp.Select):
+        return None
+    sources = _arm_sources(body)
+    if len(sources) != 1:
+        return None
+    node = sources[0].this
+    return node if isinstance(node, exp.Table) else None
+
+
+def _preserves_grain(body: "exp.Select") -> bool:
+    """Is `body` one output row per source row? A WHERE or a LIMIT still is; a GROUP BY, a
+    SELECT DISTINCT or an aggregate is not. Matched by node type, per `_own_child`."""
+    if _own_child(body, (exp.Group, exp.Distinct)) is not None:
+        return False
+    return body.find(exp.AggFunc) is None
+
+
+def _cte_grains(tree: "exp.Expression") -> dict[str, _CteGrain]:
+    """CTE name (case-folded) -> `_CteGrain`, resolved transitively."""
+    bodies = _cte_bodies(tree)
+    grains: dict[str, _CteGrain] = {}
+
+    def resolve(name: str, seen: frozenset[str]) -> _CteGrain:
+        key = name.lower()
+        if key in grains:
+            return grains[key]
+        if key in seen:
+            return _CteGrain(None, True)  # recursive CTE: no fixed cardinality to read off
+        body = bodies[key]
+        src = _single_source_table(body)
+        if src is None:
+            g = _CteGrain(None, True)
+        elif not _preserves_grain(body):
+            g = _CteGrain(None, False)  # its own entity, at its GROUP BY grain
+        elif src.name.lower() in bodies:
+            g = resolve(src.name, seen | {key})  # grain-preserving over another CTE
+        else:
+            g = _CteGrain(src.name, False)
+        grains[key] = g
+        return g
+
+    for name in list(bodies):
+        resolve(name, frozenset())
+    return grains
+
+
+def _scope_bindings(tree: "exp.Expression") -> list[tuple[str, str, Optional[_CteGrain]]]:
+    """(alias, table it binds to, the CTE grain it came from or None) for THIS query's scope.
+
+    The tables inside a CTE body belong to that CTE, not to the query joining it, so they are
+    skipped rather than harvested — a `WITH` clause is a boundary, not decoration. Everything
+    else the old flat walk saw is still seen, so a derived table or an IN-subquery contributes
+    exactly what it did before (full column-level lineage through those is a separate problem
+    and solving it here would fork it into two implementations)."""
+    inside_cte: set[int] = set()
+    with_ = _own_child(tree, (exp.With,))
+    if with_ is not None:
+        for cte in with_.expressions:
+            inside_cte.update(id(t) for t in cte.find_all(exp.Table))
+
+    grains = _cte_grains(tree)
+    out: list[tuple[str, str, Optional[_CteGrain]]] = []
+    for tbl in tree.find_all(exp.Table):
+        if id(tbl) in inside_cte:
+            continue
+        grain = grains.get(tbl.name.lower())
+        # An unresolvable or grain-changing CTE keeps its own name: it is not the source table,
+        # and pretending otherwise is the false refusal this fix exists to remove.
+        out.append((tbl.alias_or_name, (grain.source if grain else None) or tbl.name, grain))
+    return out
+
+
+def _tables_in_scope(tree: "exp.Expression") -> dict[str, str]:
+    """alias (or table name) -> bare table name, for this query's own scope.
+
+    Scoped, unlike `_tables_anywhere`: CTE bodies do not leak out, and a CTE alias resolves to
+    its underlying table only when the CTE preserves grain."""
+    return {alias: table for alias, table, _ in _scope_bindings(tree)}
+
+
+def _unresolved_scope_sources(tree: "exp.Expression", known_tables: set[str]) -> set[str]:
+    """The entries of `_tables_in_scope` whose lineage the cardinality rules cannot establish.
+
+    Two shapes, both meaning "this alias has no cardinality I can read": a CTE whose body could
+    not be classified at all, and a CTE that does resolve but to a table the model says nothing
+    about. Note what is NOT here — a grain-changing CTE. That one IS understood: it is its own
+    entity at its GROUP BY grain, and joining it is not a fan-out."""
+    return {
+        table
+        for _alias, table, grain in _scope_bindings(tree)
+        if grain is not None and (grain.opaque or table not in known_tables)
+    }
+
+
+def _is_fan_immune(agg: "exp.AggFunc") -> bool:
+    """Is `agg` idempotent under row duplication — i.e. does a fan-out leave it unchanged?
+
+    MIN/MAX read an extreme, and duplicating a row cannot move one. A DISTINCT-qualified
+    aggregate folds duplicates away before aggregating, by definition. A boolean fold is an
+    AND/OR over the rows, and both are idempotent.
+
+    NOT immune, and each has a test saying so: SUM, AVG, COUNT(col), and the ordered/array
+    aggregates. AVG is the one a reader gets wrong — a fan duplicates rows UNEVENLY (one order
+    with three line items, another with one), so the mean moves even though "an average" sounds
+    scale-free.
+
+    Decided on the NODE, never on its name: this gate reads each statement in its datasource's
+    own grammar, and a name allowlist breaks on the first engine that spells an aggregate
+    differently. `distinct` is read both ways because sqlglot has expressed it as a wrapped
+    `exp.Distinct` argument and as an `args["distinct"]` flag at different points in the
+    version range this package accepts."""
+    if agg.args.get("distinct") or isinstance(agg.args.get("this"), exp.Distinct):
+        return True
+    return isinstance(agg, (exp.Min, exp.Max, exp.LogicalAnd, exp.LogicalOr))
+
+
+def _aggregate_source_tables(
+    tree: "exp.Select", scope: dict[str, str]
+) -> list[tuple[str, "exp.AggFunc"]]:
+    """(table, the aggregate node it appears in) for every column inside a SELECT-list aggregate.
+
+    Returns the NODE beside the table because the two questions the caller asks — "can a fan-out
+    inflate this aggregate at all?" and "is this table the aggregated value or a scalar co-factor
+    of it?" — are both properties of the aggregate, not of the table. The same table can appear
+    more than once (once per aggregate that reads it)."""
+    sources: list[tuple[str, "exp.AggFunc"]] = []
+    seen: set[tuple[str, int]] = set()  # identity, not equality: sqlglot nodes compare structurally
     for select_expr in tree.expressions:
         for agg in select_expr.find_all(exp.AggFunc):
             for col in agg.find_all(exp.Column):
                 t = _resolve_col_table(col, scope)
-                if t:
-                    sources.add(t)
+                if t and (t, id(agg)) not in seen:
+                    seen.add((t, id(agg)))
+                    sources.append((t, agg))
     return sources
 
 
@@ -2057,7 +2346,10 @@ def apply_default_filters(
     if not isinstance(tree, exp.Select):
         return sql, []
 
-    scope = _tables_in_scope(tree)  # alias -> bare table
+    # `_tables_anywhere`, not `_tables_in_scope`: row scoping is a data-protection control, and
+    # narrowing the set of tables it considers can only ever apply FEWER declared filters. Its
+    # own scoping is owned elsewhere; this pass is deliberately left exactly as it was.
+    scope = _tables_anywhere(tree)  # alias -> bare table
     applied: list[str] = []
     conditions: list[str] = []
     for alias, table_name in scope.items():

--- a/tests/test_semantic_model_runtime.py
+++ b/tests/test_semantic_model_runtime.py
@@ -96,6 +96,159 @@ def test_aggregating_many_side_is_allowed():
     assert pf.action == "allow"
 
 
+# --- pre-flight: what a fan-out can actually inflate ---
+#
+# The fan rule answers "would duplicating rows change this number?". Three inputs decide that,
+# and each block below pins one: WHICH aggregate (duplication-sensitive or idempotent), WHICH
+# value is being aggregated (the one-side measure, or a many-side quantity a one-side rate
+# scales), and WHICH tables are even in scope (a CTE body is not).
+
+_JOIN = "FROM orders JOIN order_items ON order_items.order_id = orders.id"
+
+
+@pytest.mark.parametrize("agg", [
+    "COUNT(DISTINCT orders.id)",     # duplicates are folded away before counting
+    "MIN(orders.total_amount)",      # duplicating a row cannot move an extreme
+    "MAX(orders.total_amount)",
+    "SUM(DISTINCT orders.total_amount)",
+    "AVG(DISTINCT orders.total_amount)",
+    "BOOL_AND(orders.is_paid)",      # an AND/OR fold over the rows is idempotent
+    "BOOL_OR(orders.is_paid)",
+    "ARRAY_AGG(DISTINCT orders.status)",
+])
+def test_fan_immune_aggregates_are_not_fan_traps(agg):
+    """An aggregate idempotent under row duplication is not inflated by a one-to-many join, so
+    the query was already correct and the guard must leave it alone. Refusing it is a refusal of
+    a right answer."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(f"SELECT {agg} {_JOIN}", org)
+    assert pf.risk is None and pf.action == "allow" and pf.certainty == "provable"
+
+
+@pytest.mark.parametrize("agg", [
+    "SUM(orders.total_amount)",      # the genuine trap: the measure IS the one-side column
+    "AVG(orders.total_amount)",      # a fan duplicates rows UNEVENLY, so the mean moves too
+    "COUNT(orders.id)",
+    "STRING_AGG(orders.status, ',')",
+    "ARRAY_AGG(orders.status)",
+])
+def test_fan_sensitive_aggregates_still_trip_the_fan_rule(agg):
+    """The bound on the exemption above. Each of these IS inflated by the join, so each must
+    still be caught — one case per aggregate so the fan-immune set cannot widen unnoticed."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(f"SELECT {agg} {_JOIN}", org)
+    assert pf.risk == "fan_trap" and pf.action != "allow"
+
+
+def test_count_star_over_the_join_is_not_attributed_to_either_side():
+    """`COUNT(*)` names no column, so it belongs to no table and the fan rule has nothing to
+    attribute — it is left alone, exactly as before this change. Pinned so the fan-immune
+    exemption is never mistaken for the reason."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(f"SELECT COUNT(*) {_JOIN}", org)
+    assert pf.risk is None and pf.action == "allow"
+
+
+def test_every_is_not_read_as_an_aggregate_at_all():
+    """`EVERY` is the SQL-standard spelling of `BOOL_AND` and is equally fan-immune, but the
+    parser reads it as an anonymous function rather than an aggregate, so it never reaches the
+    fan rule. Same verdict, different route — pinned so a parser change that starts recognising
+    it does not silently turn a correct query into a refusal."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(f"SELECT EVERY(orders.is_paid) {_JOIN}", org)
+    assert pf.risk is None and pf.action == "allow"
+
+
+def test_many_side_measure_scaled_by_a_one_side_rate_is_not_a_fan_trap():
+    """A one-side column INSIDE the aggregate is not the same as the one-side column BEING
+    aggregated. Here the aggregated value is one per order_items row and the one-side amount is
+    a scalar co-factor scaling it, so nothing is duplicated — the shape every currency
+    conversion and rate-scaled measure takes."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(f"SELECT SUM(order_items.quantity * orders.total_amount) {_JOIN}", org)
+    assert pf.risk is None and pf.action == "allow" and pf.certainty == "provable"
+
+
+def test_one_side_dimension_grouping_a_many_side_measure_stays_allowed():
+    """The correct-and-common shape: the fact is on the many side, the dimension on the one
+    side. Nothing fans."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(
+        "SELECT c.region, SUM(o.amount) FROM orders o JOIN customers c ON c.id = o.customer_id "
+        "GROUP BY c.region", org)
+    assert pf.risk is None and pf.action == "allow"
+
+
+# --- pre-flight: the scope walk ---
+
+
+def test_pre_aggregating_in_a_cte_before_joining_is_not_a_fan_trap():
+    """This is the shape the guard's own refusal text asks for — "pre-aggregate the one-side
+    measure in a CTE before joining". `oi` is grouped to `order_id`, so it is one row per order
+    and the join is 1:1. Reading `order_items` out of the CTE body and back into the outer scope
+    refuses the remediation the guard just recommended."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(
+        "WITH oi AS (SELECT order_id, SUM(quantity) AS q FROM order_items GROUP BY order_id) "
+        "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id", org)
+    assert pf.risk is None and pf.action == "allow" and pf.certainty == "provable"
+
+
+def test_a_grain_preserving_cte_does_not_hide_a_fan_trap():
+    """The other direction, and the worse one. `o` is a plain pass-through of `orders`, so this
+    is the same inflated total as the bare join — but the alias hid the one side entirely and the
+    query came back clean. Every policy is one WITH clause away from bypass until this resolves."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(
+        "WITH o AS (SELECT * FROM orders) "
+        "SELECT SUM(o.total_amount) FROM o JOIN order_items ON order_items.order_id = o.id", org)
+    assert pf.risk == "fan_trap" and pf.action != "allow"
+
+
+def test_a_grain_preserving_cte_resolves_through_another_one():
+    """Resolution is transitive, so chaining pass-through CTEs is not a way around it."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(
+        "WITH o1 AS (SELECT * FROM orders), o2 AS (SELECT id, total_amount FROM o1) "
+        "SELECT SUM(o2.total_amount) FROM o2 JOIN order_items ON order_items.order_id = o2.id",
+        org)
+    assert pf.risk == "fan_trap" and pf.action != "allow"
+
+
+@pytest.mark.parametrize("body,note", [
+    ("SELECT orders.id AS id, orders.total_amount AS total_amount FROM orders "
+     "JOIN customers ON customers.id = orders.customer_id", "joins"),
+    ("SELECT id, total_amount FROM orders UNION ALL SELECT id, total_amount FROM orders", "unions"),
+    ("SELECT id, total_amount FROM mystery_table", "reads a table outside the model"),
+])
+def test_an_unclassifiable_cte_is_uncertain_never_a_silent_allow(body, note):
+    """When the body is anything the scope walk cannot tie to one declared table, the aggregate's
+    grain is unknown. "No trap found" is then a statement about what the analysis SAW, not about
+    the query, and returning a bare allow presents the second as if it were the first. Governance
+    does not fail closed, so the action stays allow — but it says so."""
+    org = _sales_org()
+    pf = rt.pre_flight_check(
+        f"WITH cte AS ({body}) "
+        "SELECT SUM(cte.total_amount) FROM cte JOIN order_items ON order_items.order_id = cte.id",
+        org)
+    assert pf.certainty == "uncertain", note
+    assert pf.action == "allow"
+
+
+def test_tables_in_scope_stops_at_a_cte_body_and_tables_anywhere_does_not():
+    """Asserted on the two functions directly, so the leak cannot come back through a refactor.
+
+    They differ ON PURPOSE. A cardinality question is about the tables the outer query joins, so
+    `order_items` must not leak out of the CTE body. Provenance and row scoping are coverage
+    questions — the answer really did read `order_items`, and its declared filters really might
+    apply — so those keep the flat walk."""
+    sql = ("WITH oi AS (SELECT order_id, SUM(quantity) AS q FROM order_items GROUP BY order_id) "
+           "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id")
+    tree = rt._parse_sql(sql, "postgres")
+    assert "order_items" not in rt._tables_in_scope(tree).values()
+    assert "order_items" in rt._tables_anywhere(tree).values()
+
+
 # --- examples-first ---
 
 


### PR DESCRIPTION
**Spec: ACE-083**

The fan-trap detector decides from *(a one-side column appears in some aggregate) × (one-to-many cardinality)* rather than from *(a duplication-sensitive rollup of a one-side measure at one-side grain) × (one-to-many cardinality)*. Three fixes restore the missing terms. Closes #151.

## What was wrong

Measured through `pre_flight_check` against the test fixture model:

| query | before | why it is wrong |
|---|---|---|
| `COUNT(DISTINCT orders.id) FROM orders JOIN order_items …` | `fan_trap` | `DISTINCT` de-duplicates; a fan-out cannot inflate it |
| `MAX(orders.total_amount)` over the same shape | `fan_trap` | idempotent under row duplication |
| `SUM(order_items.quantity * orders.total_amount)` | `fan_trap` | the aggregated value is at many-side grain; the one-side column is a scalar co-factor |
| pre-aggregated CTE, then join | `fan_trap` | the CTE is grouped to the join key, so the join is 1:1 — **and this is the shape the refusal message itself recommends** |
| `WITH o AS (SELECT * FROM orders) SELECT SUM(o.total_amount) FROM o JOIN order_items …` | `allow` | genuinely inflated, and it passed |

The last two share one root cause: `_tables_in_scope` was a flat `find_all(exp.Table)` over the whole tree with no concept of scope, so CTE-body tables leaked into the outer query (false refusals) while CTE aliases never resolved to their underlying table (false allows).

## Changes

- **Fan-immune aggregates** — `MIN`, `MAX`, `DISTINCT`-qualified aggregates and boolean folds no longer feed the fan rule. Matched on the sqlglot node type and the `distinct` arg, not a name string, so it survives a dialect spelling it differently. `SUM`, `AVG`, `COUNT(*)`, `COUNT(col)`, `STRING_AGG` and `ARRAY_AGG` still trip it — one test each so the exemption cannot silently widen. `AVG` is the one worth naming: a fan duplicates rows *unevenly*, so averages do shift.
- **Measure vs co-factor** — an aggregate is attributed to the one side only when a one-side column is the aggregated value.
- **Scope** — `_tables_in_scope` is outer-scope only; a CTE alias resolves to its underlying table only when the CTE preserves grain (no `GROUP BY` / `DISTINCT` / aggregate), transitively; a grain-changing CTE keeps its own grain instead of inheriting the source table's cardinality; anything unclassifiable yields `certainty="uncertain"` rather than a silent `allow`.

This changes **what counts as a trap**, never what happens once one is found. The `auto_rewrite` branch is untouched.

## Verification

`dev.py check`: **2304 passed, 95 skipped, 2 xfailed**; ruff + gitleaks clean; no vendored-lib drift.

Collected-test delta is exactly the new cases: **2377 → 2401**.

Red-on-base, measured rather than asserted — base source with the new tests: **16 failed, 8 passed**. With the fix: **24 passed**. The 8 passing on base are the guardrail assertions (the fan-sensitive aggregates that must *still* refuse), which are supposed to be green on base.