### PR TITLE
ACE-040: make the DB-required sentinel actually fail, and close five corpus gaps

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -17,6 +17,7 @@ if str(REPO_ROOT / "tests") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "tests"))
 
 import harness  # noqa: E402  (tests/e2e is on sys.path during collection)
+import itdeps  # noqa: E402  (same directory; skip-vs-fail gating for the DB-backed tests)
 
 BASE = "https://demo.example.com"
 
@@ -89,17 +90,22 @@ def pg_admin():
     BUT when AGAMI_IT_PG_REQUIRED is set (the integration-pg CI job sets it), an unavailable DB FAILS
     instead of skips — this job carries the ONLY proof of the role-floor + file/db parity + DB-served
     model, and pytest exits 0 when everything skips, so a service race / env rename / driver hiccup
-    would otherwise turn the F9 done-bar gate green while proving nothing."""
-    psycopg2 = pytest.importorskip("psycopg2")
+    would otherwise turn the F9 done-bar gate green while proving nothing.
+
+    The MISSING-DRIVER case runs through the same sentinel (`itdeps.importorfail`, not
+    `pytest.importorskip`): an absent psycopg2 is exactly the "proved nothing" outcome the sentinel
+    exists to catch, and importorskip would have skipped past it before the sentinel was consulted."""
+    psycopg2 = itdeps.importorfail("psycopg2")
     # In the required job, a missing DB is a hard failure — an all-skip must NOT pass as green.
-    unavailable = pytest.fail if os.environ.get("AGAMI_IT_PG_REQUIRED") else pytest.skip
     if not os.environ.get("AGAMI_IT_PG_PASSWORD"):
-        unavailable("set AGAMI_IT_PG_PASSWORD to run the Postgres safety-corpus / role-floor tests")
+        itdeps.unavailable(
+            "set AGAMI_IT_PG_PASSWORD to run the Postgres safety-corpus / role-floor tests"
+        )
     sc = pg_super_creds()
     try:
         conn = psycopg2.connect(connect_timeout=10, **sc)
     except Exception as exc:  # unreachable DB → skip locally, FAIL in the required CI job
-        unavailable(f"no reachable Postgres ({exc})")
+        itdeps.unavailable(f"no reachable Postgres ({exc})")
     conn.autocommit = True
     try:
         yield psycopg2, conn, sc

--- a/tests/e2e/itdeps.py
+++ b/tests/e2e/itdeps.py
@@ -1,0 +1,49 @@
+"""Dependency gating for the env-gated Postgres integration tests — the one place that decides
+whether a missing prerequisite is a SKIP or a FAILURE.
+
+`AGAMI_IT_PG_REQUIRED` exists so the DB-backed job cannot pass while proving nothing: that job
+carries the only evidence for the Postgres-served safety corpus (file/db parity) and the read-only
+role floor, and pytest exits 0 when every test skips. `pytest.importorskip` defeated that — it skips
+unconditionally, so a missing driver or a missing transport dependency turned the whole job into
+skips and it exited green.
+
+`importorfail` is the drop-in that respects the sentinel: identical to `importorskip` when the
+sentinel is unset (so the DB-free job is unaffected), and a hard failure when it is set — a missing
+prerequisite there means the run did not execute the proof it was there to execute.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+SENTINEL = "AGAMI_IT_PG_REQUIRED"
+
+
+def db_required() -> bool:
+    """True when the caller declared this run MUST execute the DB-backed tests, not skip them."""
+    return bool(os.environ.get(SENTINEL))
+
+
+def unavailable(reason: str, *, module_level: bool = False):
+    """Skip — or FAIL when the sentinel is set. Never returns (both raise).
+
+    `module_level` must be True when called during collection rather than inside a test or fixture:
+    a bare `pytest.skip` there is a collection ERROR, which would turn the DB-free job red for a
+    dependency it is allowed to be missing."""
+    if db_required():
+        pytest.fail(reason)
+    pytest.skip(reason, allow_module_level=module_level)
+
+
+def importorfail(name: str):
+    """`pytest.importorskip`, except a missing module FAILS when the sentinel is set.
+
+    Called at module scope in the DB-backed test modules, so the failure surfaces as a collection
+    error and the job exits non-zero instead of silently reporting a skip."""
+    try:
+        return importlib.import_module(name)
+    except ImportError as exc:
+        unavailable(f"could not import {name!r}: {exc}", module_level=True)

--- a/tests/e2e/test_it_sentinel.py
+++ b/tests/e2e/test_it_sentinel.py
@@ -1,0 +1,134 @@
+"""The sentinel that keeps the DB-backed job honest — proved by execution, not by reading it.
+
+`AGAMI_IT_PG_REQUIRED` exists because pytest exits 0 when every test skips: the job that carries the
+only evidence for the Postgres-served safety corpus and the read-only role floor could otherwise go
+green having run nothing. The sentinel only earns that if a MISSING PREREQUISITE fails the run — and
+`pytest.importorskip` (which skips before anything else is consulted) silently defeated it.
+
+These tests drive the REAL call sites in a subprocess with a dependency made unimportable, and
+assert the exit code both ways: non-zero with the sentinel set, zero (skips) without it. The second
+half matters as much as the first — the DB-free job must keep skipping cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import itdeps  # tests/e2e is on sys.path during collection (same directory as conftest)
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A pytest plugin (loaded via `-p`, so it runs before collection) that makes named modules
+# unimportable — the cheapest faithful stand-in for "the environment is missing this dependency".
+# It raises ModuleNotFoundError, exactly what a genuinely absent module raises: a plain ImportError
+# would NOT be a faithful stand-in, because `pytest.importorskip` narrows on the exception type and
+# would let it escape as an error — making the base behaviour look stricter than it really is.
+_BLOCKER_PLUGIN = '''
+import os
+import sys
+
+_BLOCKED = {n for n in os.environ.get("AGAMI_TEST_BLOCK_IMPORTS", "").split(",") if n}
+
+
+class _Blocker:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in _BLOCKED:
+            raise ModuleNotFoundError(f"blocked by the test harness: {name}", name=name)
+        return None
+
+
+for _mod in [m for m in sys.modules if m.split(".")[0] in _BLOCKED]:
+    del sys.modules[_mod]
+sys.meta_path.insert(0, _Blocker())
+'''
+
+# The DB-backed job's own invocation, mirrored from the workflow — the subprocess runs exactly this,
+# so what is asserted is the JOB's exit code, not a single file's. Running one file in isolation
+# would report pytest's "no tests collected" code (5) when its module skips, which reads as a failure
+# for the wrong reason and hides that the OTHER file still exits the job 0.
+JOB_ARGS = [
+    "tests/e2e/test_safety_corpus.py",
+    "tests/e2e/test_role_floor_pg.py",
+    "-q",
+    "-k",
+    "db_path or role",
+]
+
+# The two prerequisites the job can lose: the driver the role floor + DB-served model need, and a
+# transport dependency the corpus module needs. Losing either used to leave the job green.
+BLOCKED_DEPS = ["psycopg2", "mcp"]
+IDS = ["missing-db-driver", "missing-transport-dep"]
+
+
+def _run_job_with_blocked_import(tmp_path: Path, blocked: str, sentinel: bool):
+    """Run the DB-backed job in a subprocess with `blocked` unimportable; return the CompletedProcess.
+
+    The inherited AGAMI_IT_PG_* config is stripped so the outcome depends only on the blocked import
+    and the sentinel — never on whether the caller happened to have a database configured."""
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir(exist_ok=True)
+    (plugin_dir / "agami_block_imports.py").write_text(_BLOCKER_PLUGIN)
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("AGAMI_IT_PG_")}
+    env["AGAMI_TEST_BLOCK_IMPORTS"] = blocked
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(plugin_dir), env.get("PYTHONPATH", "")]))
+    if sentinel:
+        env[itdeps.SENTINEL] = "1"
+
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *JOB_ARGS,
+         "-p", "agami_block_imports", "-p", "no:cacheprovider"],
+        cwd=REPO_ROOT, env=env, capture_output=True, text=True, timeout=300,
+    )
+
+
+@pytest.mark.parametrize("blocked", BLOCKED_DEPS, ids=IDS)
+def test_missing_prerequisite_fails_the_job_when_the_sentinel_is_set(tmp_path, blocked):
+    # THE POINT: with the sentinel set, an absent prerequisite must FAIL the job. Before the fix this
+    # exited 0 with everything skipped — green, having proved nothing.
+    proc = _run_job_with_blocked_import(tmp_path, blocked, sentinel=True)
+    # Not just "non-zero": exit 5 is pytest's "no tests collected", which would be failing for the
+    # wrong reason. The sentinel must produce a real failure.
+    assert proc.returncode not in (0, 5), (
+        f"the job exited {proc.returncode} with {blocked} unimportable and {itdeps.SENTINEL} set — "
+        f"the sentinel did not bite:\n{proc.stdout}\n{proc.stderr}"
+    )
+    # …and it must fail BECAUSE of the blocked dependency. The two halves of the job fail
+    # independently, so a non-zero exit alone can come from the other half while this one is still
+    # skipping silently — naming the module is what pins the gap this test is about.
+    assert blocked in proc.stdout, (
+        f"the job failed, but not because {blocked} was missing — that half is still skipping "
+        f"silently:\n{proc.stdout}\n{proc.stderr}"
+    )
+
+
+@pytest.mark.parametrize("blocked", BLOCKED_DEPS, ids=IDS)
+def test_missing_prerequisite_still_skips_cleanly_without_the_sentinel(tmp_path, blocked):
+    # The other half of the contract: the DB-free job (no sentinel) must be untouched — a missing
+    # dependency there is expected and still skips, so this fix cannot turn that job red.
+    proc = _run_job_with_blocked_import(tmp_path, blocked, sentinel=False)
+    assert proc.returncode == 0, (
+        f"the job failed without {itdeps.SENTINEL} set — the DB-free job must still skip:\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+    assert "skipped" in proc.stdout
+
+
+def test_importorfail_returns_the_module_when_it_is_importable(monkeypatch):
+    monkeypatch.setenv(itdeps.SENTINEL, "1")
+    assert itdeps.importorfail("json").dumps({"a": 1}) == '{"a": 1}'
+
+
+def test_importorfail_skips_or_fails_on_the_sentinel(monkeypatch):
+    # The two modes of the one helper, pinned side by side: same missing module, opposite outcomes.
+    monkeypatch.delenv(itdeps.SENTINEL, raising=False)
+    with pytest.raises(pytest.skip.Exception):
+        itdeps.importorfail("agami_module_that_does_not_exist")
+
+    monkeypatch.setenv(itdeps.SENTINEL, "1")
+    with pytest.raises(pytest.fail.Exception):
+        itdeps.importorfail("agami_module_that_does_not_exist")

--- a/tests/e2e/test_safety_corpus.py
+++ b/tests/e2e/test_safety_corpus.py
@@ -13,12 +13,16 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import itdeps  # tests/e2e is on sys.path during collection (same directory as conftest)
 import pytest
 
-pytest.importorskip("mcp")
-pytest.importorskip("starlette")
-pytest.importorskip("sqlglot")
-pytest.importorskip("pydantic")
+# Skip when a dependency is absent — but FAIL when AGAMI_IT_PG_REQUIRED says this run must actually
+# execute the DB-served corpus. A missing transport/model dependency skips this whole module, which
+# in that job is indistinguishable from "the corpus proved nothing" and used to still exit 0.
+itdeps.importorfail("mcp")
+itdeps.importorfail("starlette")
+itdeps.importorfail("sqlglot")
+itdeps.importorfail("pydantic")
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT / "tests") not in sys.path:

--- a/tests/safety/corpus.py
+++ b/tests/safety/corpus.py
@@ -66,6 +66,9 @@ class Case:
 
     @property
     def id(self) -> str:
+        # NOTE: this string becomes the pytest test id, and the DB-backed CI job selects its tests
+        # with `-k "db_path or role"` — so a `cls`/`note` containing "role" or "db_path" silently
+        # changes which tests that job runs. Keep those two words out of new labels.
         return f"{self.cls}:{self.note or self.sql[:40]}"
 
 
@@ -139,6 +142,15 @@ CASES: list[Case] = [
     # silently cut. Driven with a low AGAMI_SQL_MAX_ROWS by the harness. (A timeout variant is a
     # separate slow-marked case; the row-cap path is the deterministic availability proof.)
     Case("availability", "SELECT id FROM orders", "bounded", "row-cap-truncate", max_rows=1),
+    # A runaway SHAPE, not just a low cap: a cross join multiplies rows out of the caller's control,
+    # and the bound applied at the shared executor is what keeps the result finite and flagged.
+    Case(
+        "availability",
+        "SELECT o.id FROM orders o CROSS JOIN customers c",
+        "bounded",
+        "cross-join-runaway",
+        max_rows=2,
+    ),
     # ── class 7: governed queries still pass → ok (no false refusals) ────────────────────────────
     Case("governed", "SELECT id, amount FROM orders", "ok", "projection"),
     Case("governed", "SELECT status, COUNT(id) AS n FROM orders GROUP BY status", "ok", "group-by"),
@@ -210,5 +222,40 @@ CASES: list[Case] = [
         "SELECT id FROM orders UNION ALL SELECT id FROM customers",
         "ok",
         "union-all",
+    ),
+    # ── class 9: reaching past the datasource entirely → refused{permission} ─────────────────────
+    # The guard already refuses all of these; the corpus did not carry them, so nothing would have
+    # caught a change that reopened one. Each is a different way to get somewhere the caller's
+    # SELECT was never supposed to reach: the database server's filesystem, another server, the
+    # session/transaction the connection is pooled in, a statement a comment hides from a naive
+    # splitter, or a write smuggled inside a CTE that opens with the allowed keyword.
+    Case("file_fn", "SELECT pg_read_file('/etc/passwd')", "permission", "read-server-file"),
+    Case("file_fn", "SELECT lo_import('/etc/passwd')", "permission", "large-object-import"),
+    Case("network_fn", "SELECT dblink('dbname=x', 'SELECT 1')", "permission", "remote-query"),
+    Case("network_fn", "SELECT dblink_exec('dbname=x', 'SELECT 1')", "permission", "remote-exec"),
+    # TCL escapes the read-only transaction; a session SET corrupts state that outlives the call on
+    # a pooled connection. Neither is an analytics primitive.
+    Case("session", "SELECT id FROM orders; COMMIT", "permission", "tcl-commit"),
+    Case("session", "SET ROLE postgres", "permission", "escalate-via-set"),
+    # The line comment swallows the statement separator, so a splitter that trusts `;` sees ONE
+    # statement — the keyword check reads what is actually there and still refuses.
+    Case(
+        "comment",
+        "SELECT id FROM orders -- ;\nDROP TABLE orders",
+        "permission",
+        "line-comment-hides-separator",
+    ),
+    # Data-modifying CTEs: the statement opens with WITH (allowed) and the write hides in the body.
+    Case(
+        "cte_write",
+        "WITH t AS (DELETE FROM orders RETURNING id) SELECT id FROM t",
+        "permission",
+        "cte-delete",
+    ),
+    Case(
+        "cte_write",
+        "WITH t AS (INSERT INTO orders (id) VALUES (9) RETURNING id) SELECT id FROM t",
+        "permission",
+        "cte-insert",
     ),
 ]


### PR DESCRIPTION
**Spec: ACE-040**

Test and CI infrastructure only — no file under `packages/agami-core/src/` changes.

## The sentinel was defeated by two independent paths

`AGAMI_IT_PG_REQUIRED` exists so the Postgres integration job hard-fails rather than skips when a database is expected. It did not work. With the sentinel set and drivers absent:

```
EXIT=0
7 skipped in 0.65s
SKIPPED [1] test_safety_corpus.py:18: could not import 'mcp'
SKIPPED [1] test_role_floor_pg.py:29: could not import 'psycopg2'
SKIPPED [5] test_role_floor_pg.py:36: could not import 'psycopg2'
```

Two causes, not one: the driver import in `pg_admin`, **and** four module-level `importorskip` calls that take the whole corpus module out before the sentinel is ever consulted. The DB-unreachable path already behaved correctly (exit 1); only the dependency path was open.

`tests/e2e/itdeps.py` adds `importorfail` — `importorskip` when the sentinel is unset, hard failure when set — wired into both. `tests/e2e/test_it_sentinel.py` runs the job's own invocation in a subprocess with a dependency blocked and asserts the exit code both ways. Verified failing on base by reverting only the two call-site edits: both sentinel arms failed, both "still skips" arms passed.

Two things worth recording from building it:
- A blocker raising plain `ImportError` is **not** caught by this pytest's `importorskip`, which defaults `exc_type` to `ModuleNotFoundError` — an early version made base look stricter than it is.
- A bare module-scope `pytest.skip` is a collection **error**, so a first cut would have turned the DB-free job red whenever `mcp` / `starlette` / `sqlglot` / `pydantic` were absent. Hence the explicit `module_level` flag.

## Corpus gaps

Nine cases added — `pg_read_file`, `lo_import`, `dblink`, `dblink_exec`, `SELECT …; COMMIT`, `SET ROLE postgres`, a line comment hiding a statement separator, and CTE-hidden `DELETE` / `INSERT` — plus a cross-join runaway asserting `"bounded"`.

**These are pure coverage gaps and passed immediately. They caught nothing.** Every one was probed first on both paths and already refused with `permission`, identically on SQLite and Postgres.

## A trap for future authors

The CI job selects with `-k "db_path or role"`, so **a case label containing `role` silently pulls file-path tests into the DB job** — an early label did exactly that, 108 → 110. Renamed, and the coupling is now documented on `Case.id` where an author will see it.

## Verification

Postgres job: **88 → 108 passed**. Full `tests/e2e/`: **230 passed**. DB-free suite: **2280 → 2306**.

`dev.py check`: **2306 passed, 115 skipped, 2 xfailed**; ruff + gitleaks clean; no vendored-lib drift.

One unexplained transient: in six job runs, one reported `107 passed, 1 error`; four consecutive re-runs were clean at 108. It followed a working-tree rewrite mid-session, so most likely stale bytecode from local tooling — but the traceback was not captured, so flakiness in the role fixtures (which drop and recreate a global role per test, already marked serial-only) is not ruled out.