### PR TITLE
Per-session identity on the access token + fix the guard model's org lookup

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -883,11 +883,19 @@ def _resolve_guard_model(profile: str):
         try:
             from model_store import load_datasource as _load_db
             from store import Store
+            from tools import _current_org_id
 
             store = Store.from_env()
             if store is not None:
                 try:
-                    org = _load_db(store, profile)
+                    # Scoped to the REQUEST's org, exactly as `tools._load_org` does. Letting this
+                    # default to 'local' looked right while `model_deploy._default_org()` was also
+                    # `AGAMI_ORG_ID or "local"`, but F14/F15 moved the write side onto the deployment's
+                    # resolved id — so rows land under that id and a 'local' read finds nothing. On a
+                    # multi-tenant server it finds nothing for EVERY tenant, and the fail-closed rule
+                    # below then refuses every query. `_default_org`'s own docstring states the contract
+                    # this restores: the write and read org "MUST agree".
+                    org = _load_db(store, profile, org_id=_current_org_id())
                 finally:
                     store.close()
                 if org is not None:

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -63,6 +63,21 @@ _log = logging.getLogger(__name__)
 # only receives (name, arguments), and a contextvar set in the BaseHTTPMiddleware wouldn't reach it.
 _actor_ctx: ContextVar[str | None] = ContextVar("agami_tool_actor", default=None)
 
+# The CLIENT AUTHORIZATION behind the in-flight tool call — what tells two windows under one login apart.
+# Set alongside `_actor_ctx` and for the same reason. None whenever the caller's auth has no session
+# notion (presence auth, a hand-minted bearer): consumers must read that as "no session", not an error.
+_session_ctx: ContextVar[str | None] = ContextVar("agami_tool_session", default=None)
+
+
+def current_session_id() -> str | None:
+    """The session id for the request being served, or None.
+
+    Public because a consumer's tool handler needs it and the request never reaches the handler — only
+    this contextvar does. Same shape as `tools.current_org_id`, so consumers don't have to reach into a
+    private module attribute the way they otherwise would.
+    """
+    return _session_ctx.get()
+
 
 def _actor_from_scope(scope: dict, auth: AuthProvider) -> str | None:
     """The authenticated user's subject for this /mcp request: the principal the auth middleware already
@@ -75,6 +90,22 @@ def _actor_from_scope(scope: dict, auth: AuthProvider) -> str | None:
         if key == b"authorization" and value[:7].lower() == b"bearer ":
             revalidated = auth.validate_token(value[7:].strip().decode("latin-1"))
             return getattr(revalidated, "subject", None) if revalidated is not None else None
+    return None
+
+
+def _session_from_scope(scope: dict, auth: AuthProvider) -> str | None:
+    """The session id for this /mcp request — read off the principal the auth middleware validated, with
+    the same re-validate-the-bearer fallback `_actor_from_scope` uses when the scope state didn't
+    propagate. `getattr` rather than attribute access on purpose: a third-party AuthProvider satisfies a
+    `@runtime_checkable` Protocol that checks method presence only, so its principal may be any object
+    exposing `.subject`."""
+    principal = (scope.get("state") or {}).get("principal")
+    if principal is not None:
+        return getattr(principal, "session_id", None)
+    for key, value in scope.get("headers", []):
+        if key == b"authorization" and value[:7].lower() == b"bearer ":
+            revalidated = auth.validate_token(value[7:].strip().decode("latin-1"))
+            return getattr(revalidated, "session_id", None) if revalidated is not None else None
     return None
 
 
@@ -113,8 +144,10 @@ def _build_org_resolver() -> SingleTenantOrgResolver:
     # Load-bearing for a hand-rolled DB-only deploy: log the resolved id + where it came from, so an
     # operator can see "org_id=local (default)" and realize organization.yaml/AGAMI_ORG_ID isn't reaching the
     # server (see F14's documented residual risk).
-    source = "env" if os.environ.get("AGAMI_ORG_ID", "").strip() else (
-        "default" if org_id == "local" else "organization.yaml"
+    source = (
+        "env"
+        if os.environ.get("AGAMI_ORG_ID", "").strip()
+        else ("default" if org_id == "local" else "organization.yaml")
     )
     _log.info("single-tenant org_id=%s (source=%s)", org_id, source)
     return SingleTenantOrgResolver(Org(id=org_id))
@@ -434,11 +467,13 @@ def create_app(
         actor = _actor_from_scope(scope, auth_provider)
         token = _actor_ctx.set(actor)
         org_token = _current_org_ctx.set(_org_id_from_scope(scope))
+        session_token = _session_ctx.set(_session_from_scope(scope, auth_provider))
         try:
             await session_manager.handle_request(scope, receive, send)
         finally:
             _actor_ctx.reset(token)
             _current_org_ctx.reset(org_token)
+            _session_ctx.reset(session_token)
 
     @contextlib.asynccontextmanager
     async def lifespan(_app: Starlette):

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -79,18 +79,30 @@ def current_session_id() -> str | None:
     return _session_ctx.get()
 
 
-def _actor_from_scope(scope: dict, auth: AuthProvider) -> str | None:
-    """The authenticated user's subject for this /mcp request: the principal the auth middleware already
-    validated (carried on the ASGI scope state), or — if that didn't propagate — re-validated from the
-    bearer header on the scope (robust fallback). None under presence auth or if absent."""
+def _principal_from_scope(scope: dict, auth: AuthProvider) -> object | None:
+    """The authenticated caller for this /mcp request: the principal the auth middleware already validated
+    (carried on the ASGI scope state), or — if that didn't propagate — re-validated from the bearer header
+    on the scope (robust fallback). None under presence auth or if absent.
+
+    ONE validation, from which every derived value is read. The subject and the session must describe the
+    same caller, so deriving them from two independent `validate_token` calls would both double the work on
+    the fallback path (a second signature check, or a second lookup for a DB-backed provider) and let them
+    diverge if a provider's validation isn't deterministic.
+    """
     principal = (scope.get("state") or {}).get("principal")
     if principal is not None:
-        return getattr(principal, "subject", None)
+        return principal
     for key, value in scope.get("headers", []):
         if key == b"authorization" and value[:7].lower() == b"bearer ":
-            revalidated = auth.validate_token(value[7:].strip().decode("latin-1"))
-            return getattr(revalidated, "subject", None) if revalidated is not None else None
+            return auth.validate_token(value[7:].strip().decode("latin-1"))
     return None
+
+
+def _actor_from_scope(scope: dict, auth: AuthProvider) -> str | None:
+    """The authenticated user's subject for this /mcp request, or None. Thin wrapper over
+    `_principal_from_scope` — `handle_mcp` resolves the principal once and reads both values off it, so this
+    exists for callers that want only the subject."""
+    return getattr(_principal_from_scope(scope, auth), "subject", None)
 
 
 def _normalized_session(principal: object | None) -> str | None:
@@ -105,17 +117,9 @@ def _normalized_session(principal: object | None) -> str | None:
 
 
 def _session_from_scope(scope: dict, auth: AuthProvider) -> str | None:
-    """The session id for this /mcp request — read off the principal the auth middleware validated, with
-    the same re-validate-the-bearer fallback `_actor_from_scope` uses when the scope state didn't
-    propagate."""
-    principal = (scope.get("state") or {}).get("principal")
-    if principal is not None:
-        return _normalized_session(principal)
-    for key, value in scope.get("headers", []):
-        if key == b"authorization" and value[:7].lower() == b"bearer ":
-            revalidated = auth.validate_token(value[7:].strip().decode("latin-1"))
-            return _normalized_session(revalidated) if revalidated is not None else None
-    return None
+    """The session id for this /mcp request, or None. Thin wrapper over `_principal_from_scope`, the mirror
+    of `_actor_from_scope`."""
+    return _normalized_session(_principal_from_scope(scope, auth))
 
 
 def _org_id_from_scope(scope: dict) -> str | None:
@@ -473,10 +477,12 @@ def create_app(
         # Set the actor + resolved org for this request's tool calls, then run the MCP dispatch in the same
         # task so the contextvars reach `_call_tool` and the per-process model cache. Prefer what the auth
         # middleware attached to the scope state; the actor falls back to re-validating the bearer.
-        actor = _actor_from_scope(scope, auth_provider)
-        token = _actor_ctx.set(actor)
+        # Resolve the caller ONCE: the subject and the session must describe the same principal, and on the
+        # fallback path two lookups would mean validating the same bearer twice.
+        principal = _principal_from_scope(scope, auth_provider)
+        token = _actor_ctx.set(getattr(principal, "subject", None))
         org_token = _current_org_ctx.set(_org_id_from_scope(scope))
-        session_token = _session_ctx.set(_session_from_scope(scope, auth_provider))
+        session_token = _session_ctx.set(_normalized_session(principal))
         try:
             await session_manager.handle_request(scope, receive, send)
         finally:

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -93,19 +93,28 @@ def _actor_from_scope(scope: dict, auth: AuthProvider) -> str | None:
     return None
 
 
+def _normalized_session(principal: object | None) -> str | None:
+    """A principal's session id, or None — enforcing the `str | None` shape the contextvar promises.
+
+    `AuthProvider` is a `@runtime_checkable` Protocol, so conformance is method presence only: a
+    third-party provider's principal may expose no `session_id` at all, or a non-string one. Without this
+    an unexpected type would reach `_session_ctx` and, through it, consumers using the value as a key.
+    Same rule as `JwtAuthProvider.validate_token`'s read — non-string or blank is "no session"."""
+    sid = getattr(principal, "session_id", None)
+    return sid if isinstance(sid, str) and sid.strip() else None
+
+
 def _session_from_scope(scope: dict, auth: AuthProvider) -> str | None:
     """The session id for this /mcp request — read off the principal the auth middleware validated, with
     the same re-validate-the-bearer fallback `_actor_from_scope` uses when the scope state didn't
-    propagate. `getattr` rather than attribute access on purpose: a third-party AuthProvider satisfies a
-    `@runtime_checkable` Protocol that checks method presence only, so its principal may be any object
-    exposing `.subject`."""
+    propagate."""
     principal = (scope.get("state") or {}).get("principal")
     if principal is not None:
-        return getattr(principal, "session_id", None)
+        return _normalized_session(principal)
     for key, value in scope.get("headers", []):
         if key == b"authorization" and value[:7].lower() == b"bearer ":
             revalidated = auth.validate_token(value[7:].strip().decode("latin-1"))
-            return getattr(revalidated, "session_id", None) if revalidated is not None else None
+            return _normalized_session(revalidated) if revalidated is not None else None
     return None
 
 

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -132,7 +132,10 @@ def issue_jwt(subject: str, *, sid: str | None = None) -> str:
         "iat": int(now.timestamp()),
         "exp": int((now + _access_ttl()).timestamp()),
     }
-    if sid:
+    # Same rule as `validate_token`'s read: a non-string or blank value is "no session", so it must not
+    # be minted either. Otherwise a whitespace-only `sid` would ship in the token and then normalize away
+    # on the way back in — a claim that exists on the wire but never reaches a consumer.
+    if isinstance(sid, str) and sid.strip():
         payload["sid"] = sid
     return jwt.encode(payload, _signing_secret(), algorithm="HS256")
 

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -115,8 +115,14 @@ def _signing_secret() -> str:
     return secret
 
 
-def issue_jwt(subject: str) -> str:
-    """A self-signed HS256 JWT for `subject` — the Bearer token the transport will accept."""
+def issue_jwt(subject: str, *, sid: str | None = None) -> str:
+    """A self-signed HS256 JWT for `subject` — the Bearer token the transport will accept.
+
+    `sid` identifies the CLIENT AUTHORIZATION this token belongs to, so one login driving two clients is
+    distinguishable per request (see `_session_id`). Omitted when there is none — a token minted outside
+    the OAuth flow (a script, a test, an operator's hand-rolled bearer) carries exactly the claims it
+    always did, and consumers must treat its absence as "no session", never as an error.
+    """
     from mcp_http import public_base_url  # lazy: mcp_http imports these handlers at module load
 
     now = _now()
@@ -126,6 +132,8 @@ def issue_jwt(subject: str) -> str:
         "iat": int(now.timestamp()),
         "exp": int((now + _access_ttl()).timestamp()),
     }
+    if sid:
+        payload["sid"] = sid
     return jwt.encode(payload, _signing_secret(), algorithm="HS256")
 
 
@@ -155,7 +163,13 @@ class JwtAuthProvider:
         # malformed identity forward.
         if not isinstance(sub, str) or not sub.strip():
             return None
-        return Principal(subject=sub)
+        # `sid` is OPTIONAL and deliberately absent from the `require` list above: tokens minted before
+        # this claim existed, and any minted outside the OAuth flow, must keep validating. A malformed
+        # one degrades to None (no session) rather than rejecting an otherwise-valid token.
+        sid = claims.get("sid")
+        return Principal(
+            subject=sub, session_id=sid if isinstance(sid, str) and sid.strip() else None
+        )
 
 
 def _b64url_nopad(raw: bytes) -> str:
@@ -405,25 +419,48 @@ def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()
 
 
+def _session_id(family: str) -> str:
+    """The `sid` claim for a refresh-token lineage — a stable, opaque handle for ONE client authorization.
+
+    Derived from the family rather than being the family, because the family is the key reuse detection
+    burns on (`WHERE family = ?`) and it should not leave the server. A hash keeps what callers actually
+    need — the same value for every token in a lineage, a different value per authorization — while giving
+    a client that decodes its own JWT nothing it can present anywhere.
+
+    Why the FAMILY and not a per-token id: the family survives rotation ('rotate' carries it into the
+    successor row, 'overwrite' never rewrites the column), whereas a per-token id would change on every
+    refresh. Anything keyed on it would silently reset each time the access token renewed — which for an
+    active-org selection means quietly moving the user to a different tenant.
+
+    An IDENTITY, not a liveness signal: reuse detection can burn a family while access tokens carrying its
+    `sid` are still unexpired, and `validate_token` does no DB lookup. Never treat a `sid` as proof that
+    the underlying authorization is still live.
+    """
+    return hashlib.sha256(family.encode()).hexdigest()[:16]
+
+
 def _issue_refresh_token(
     store: Store, *, client_id: str, username: str, family: str | None = None
-) -> str:
+) -> tuple[str, str]:
     """Mint + persist (hash only) a refresh token for `username`, in `family` (a fresh lineage when
-    None). The caller commits. Returns the plaintext token — the only place it ever exists."""
+    None). The caller commits. Returns (plaintext token, resolved family) — the token is the only place
+    it ever exists, and the family is returned because a NEW lineage is minted here and the caller
+    otherwise has no way to learn it (it is needed for the access token's `sid`)."""
     token = secrets.token_urlsafe(32)
+    resolved_family = family or secrets.token_urlsafe(16)
     store.execute(
         "INSERT INTO oauth_refresh_token (token_hash, family, client_id, username, expires_at, "
         "revoked, created) VALUES (?, ?, ?, ?, ?, 0, ?)",
         (
             _hash_token(token),
-            family or secrets.token_urlsafe(16),
+            resolved_family,
             client_id,
             username,
             (_now() + _refresh_ttl()).isoformat(),
             _now().isoformat(),
         ),
     )
-    return token
+    return token, resolved_family
 
 
 def _cleanup_expired_revoked(store: Store) -> None:
@@ -438,11 +475,14 @@ def _cleanup_expired_revoked(store: Store) -> None:
     )
 
 
-def _token_body(username: str, refresh_token: str) -> JSONResponse:
-    """The OAuth token response body: a fresh access JWT + the given refresh token."""
+def _token_body(username: str, refresh_token: str, family: str) -> JSONResponse:
+    """The OAuth token response body: a fresh access JWT + the given refresh token.
+
+    `family` is the refresh lineage this token belongs to; it rides the JWT as a hashed `sid` so the
+    server can tell one client authorization from another on a later request."""
     return JSONResponse(
         {
-            "access_token": issue_jwt(username),
+            "access_token": issue_jwt(username, sid=_session_id(family)),
             "token_type": "Bearer",
             "expires_in": int(_access_ttl().total_seconds()),
             "refresh_token": refresh_token,
@@ -456,11 +496,13 @@ def _token_response(
     """The shared token body for the INSERT path (initial issue + 'rotate' refresh): mint a NEW
     refresh row, then commit it together with whatever the caller already staged (code burn /
     rotate / expired-revoked cleanup)."""
-    refresh_token = _issue_refresh_token(
+    refresh_token, resolved_family = _issue_refresh_token(
         store, client_id=client_id, username=username, family=family
     )
     store.commit()
-    return _token_body(username, refresh_token)
+    # `resolved_family`, not `family`: on the authorization_code path the caller passes None and the
+    # lineage is minted inside — so this is the only frame that knows it.
+    return _token_body(username, refresh_token, resolved_family)
 
 
 async def token(request: Request) -> Response:
@@ -580,7 +622,9 @@ def _grant_refresh_token(store: Store, form: dict[str, str]) -> Response:
             store.commit()
             return _oauth_error("invalid_grant", "refresh token is invalid")
         store.commit()
-        return _token_body(row["username"], new_token)
+        # The UPDATE above rewrites only token_hash + expires_at, so the lineage is unchanged — the
+        # renewed access token keeps the same `sid` its predecessor carried.
+        return _token_body(row["username"], new_token, row["family"])
 
     # 'rotate' mode: revoke the presented token and issue a successor in the same family, keeping the
     # revoked row for stolen-token reuse detection. Atomic: only the request that flips revoked 0→1

--- a/packages/agami-core/src/ports.py
+++ b/packages/agami-core/src/ports.py
@@ -56,9 +56,18 @@ class Org:
 @dataclass(frozen=True)
 class Principal:
     """An authenticated caller. By default this is just token presence (one user); real
-    providers populate identity/claims."""
+    providers populate identity/claims.
+
+    `session_id` distinguishes CONCURRENT CLIENTS of the same subject — two windows under one login are
+    otherwise indistinguishable here, so anything the server remembers per-caller (an active selection, a
+    per-conversation binding) would be shared between them, last write wins. Optional because most auth
+    paths have no such notion: presence auth, a hand-minted bearer, and a username/password check all
+    leave it None, and a consumer must read it as "no session", never as an error. It is an identity, not
+    a liveness signal — see `oauth_server._session_id`.
+    """
 
     subject: str
+    session_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -883,11 +883,19 @@ def _resolve_guard_model(profile: str):
         try:
             from model_store import load_datasource as _load_db
             from store import Store
+            from tools import _current_org_id
 
             store = Store.from_env()
             if store is not None:
                 try:
-                    org = _load_db(store, profile)
+                    # Scoped to the REQUEST's org, exactly as `tools._load_org` does. Letting this
+                    # default to 'local' looked right while `model_deploy._default_org()` was also
+                    # `AGAMI_ORG_ID or "local"`, but F14/F15 moved the write side onto the deployment's
+                    # resolved id — so rows land under that id and a 'local' read finds nothing. On a
+                    # multi-tenant server it finds nothing for EVERY tenant, and the fail-closed rule
+                    # below then refuses every query. `_default_org`'s own docstring states the contract
+                    # this restores: the write and read org "MUST agree".
+                    org = _load_db(store, profile, org_id=_current_org_id())
                 finally:
                     store.close()
                 if org is not None:

--- a/tests/test_ace051_fail_closed.py
+++ b/tests/test_ace051_fail_closed.py
@@ -195,3 +195,44 @@ def test_hosted_fail_closed_when_model_package_unimportable(tmp_path, monkeypatc
     _, code = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
     assert code == 1  # fail closed — no DB load is even attempted (we never resolve a model)
     assert json.loads(capsys.readouterr().err.strip())["error"]["kind"] == "model_unavailable"
+
+
+def test_db_model_resolves_under_the_requests_org(tmp_path, monkeypatch, capsys):
+    """The guard must look up the model under the REQUEST's org, not the 'local' sentinel.
+
+    Regression: `_resolve_guard_model` called `load_datasource(store, profile)`, taking the
+    `org_id='local'` default, while `model_deploy._default_org()` — since F14/F15 — stamps rows with the
+    deployment's *resolved* id. `_default_org`'s docstring states the contract the two must keep: "the
+    model is written under one org and read under another and the server sees no model." On a
+    multi-tenant server every tenant's rows live under its own id, so the 'local' read missed for ALL of
+    them and the fail-closed rule above refused every query.
+
+    The artifacts dir is pointed at nothing on purpose: the disk fallback is exactly what masked this on
+    single-tenant deployments for a whole release, so it must not be available to rescue the assertion.
+    """
+    import model_store
+    import tools
+    from store import Store
+
+    url = "sqlite://" + str(tmp_path / "mt.db")
+    s = Store.connect(url)
+    s.run_migrations()
+    model_store.write_datasource(s, "shop", _org(), org_id="contoso")  # a NAMED tenant, never 'local'
+    s.close()
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_disk"))
+    monkeypatch.delenv("AGAMI_ORG_ID", raising=False)
+
+    tools.resolved_org_id.cache_clear()
+    token = tools._current_org_ctx.set("contoso")  # what the multi-tenant resolver set for this request
+    try:
+        _, code = execute_sql._model_safety("SELECT id FROM orders", "shop", None)
+        assert code is None  # resolved under 'contoso': a declared table passes
+
+        # ...and the guards genuinely ran off that model, rather than being inert.
+        _, code = execute_sql._model_safety("SELECT id FROM sqlite_master", "shop", None)
+        assert code == 1
+        assert json.loads(capsys.readouterr().err.strip())["error"]["kind"] == "table_out_of_scope"
+    finally:
+        tools._current_org_ctx.reset(token)
+        tools.resolved_org_id.cache_clear()

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -195,3 +195,80 @@ def test_http_tools_list_is_the_same_four(base_url):
         payload = json.loads(re.search(r"\{.*\}", tl.text, re.DOTALL).group(0))
         names = {t["name"] for t in payload["result"]["tools"]}
     assert names == PRODUCT_TOOLS
+
+
+def test_presence_auth_yields_no_session_id(base_url):
+    """The fallback that matters most: presence auth mints no token at all, so there is no session to
+    report. It must read as "no session" — never break the caller."""
+    from oss_adapters import PresenceAuthProvider
+
+    principal = PresenceAuthProvider().validate_token("present")
+    assert principal is not None and principal.subject == "local"
+    assert principal.session_id is None
+
+
+def test_the_session_id_reaches_a_tool_handler(base_url, monkeypatch):
+    """End to end over the real transport: a tool runs on a WORKER THREAD, so the contextvar set in
+    `handle_mcp` only reaches it because anyio copies the request context across the thread hop. Assert
+    that rather than trusting it — it is the whole delivery mechanism for a consumer's session key."""
+    seen = {}
+
+    def _probe(args: dict) -> str:
+        seen["session"] = mcp_http.current_session_id()
+        return "ok"
+
+    tool = {
+        "handler": _probe,
+        "description": "probe",
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    }
+
+    class _P:
+        subject = "jordan@example.com"
+        session_id = "sess-42"
+
+    class _Auth:
+        def validate_token(self, token):
+            return _P() if (token or "").strip() else None
+
+    from dataclasses import replace
+
+    adapters = replace(mcp_http.default_adapters(), auth_provider=_Auth())
+    app = mcp_http.create_app(extra_tools={"probe": tool}, adapters=adapters)
+    headers = {
+        "Authorization": "Bearer anything",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    with TestClient(app) as c:
+        c.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "t", "version": "1"},
+                },
+            },
+        )
+        c.post(
+            "/mcp", headers=headers, json={"jsonrpc": "2.0", "method": "notifications/initialized"}
+        )
+        r = c.post(
+            "/mcp",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "probe", "arguments": {}},
+            },
+        )
+        assert r.status_code == 200, r.text
+    assert seen["session"] == "sess-42"
+    # ...and it does not leak past the request.
+    assert mcp_http.current_session_id() is None

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -844,3 +844,14 @@ def test_a_malformed_sid_degrades_to_none_rather_than_rejecting(env):
         )
         principal = JwtAuthProvider().validate_token(token)
         assert principal is not None and principal.session_id is None, bad
+
+
+def test_a_blank_sid_is_never_minted(env):
+    """Mint and validate must use the same rule. A whitespace-only `sid` would otherwise ship on the wire
+    and then normalize away on the way back in — a claim that exists but can never reach a consumer."""
+    from oauth_server import issue_jwt
+
+    for bad in ("", "   ", None):
+        claims = jwt.decode(issue_jwt("admin", sid=bad), SECRET, algorithms=["HS256"], issuer=BASE)
+        assert "sid" not in claims, bad
+    assert _sid(issue_jwt("admin", sid="real")) == "real"

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -635,7 +635,9 @@ def test_ace050_hygiene_never_deletes_query_or_activity_logs(env):
 
     s = Store.from_env()
     try:
-        assert s.query("SELECT id FROM query_executions WHERE id = 'q1'"), "query log must be retained"
+        assert s.query("SELECT id FROM query_executions WHERE id = 'q1'"), (
+            "query log must be retained"
+        )
         assert s.query("SELECT id FROM tool_calls WHERE id = 't1'"), "activity log must be retained"
     finally:
         s.close()
@@ -745,3 +747,100 @@ def test_token_ttls_are_env_configurable_and_fail_safe(env, monkeypatch):
 
     monkeypatch.setenv("AGAMI_ACCESS_TOKEN_TTL", "1800")  # and the override reaches the wire
     assert _token_pair(TestClient(mcp_http.build_app()))["expires_in"] == 1800
+
+
+# --- `sid`: telling two clients of one login apart -----------------------------
+
+
+def _sid(access_token: str) -> str | None:
+    return jwt.decode(access_token, SECRET, algorithms=["HS256"], issuer=BASE).get("sid")
+
+
+def test_access_token_carries_the_hashed_refresh_family_as_sid(env):
+    """The claim is derived from the family, never the family itself: that value is what reuse detection
+    burns on (`WHERE family = ?`), so it must not leave the server."""
+    import hashlib
+
+    c = TestClient(mcp_http.build_app())
+    body = _token_pair(c)
+    s = Store.from_env()
+    families = [r["family"] for r in s.query("SELECT family FROM oauth_refresh_token")]
+    s.close()
+    assert len(families) == 1
+    expected = hashlib.sha256(families[0].encode()).hexdigest()[:16]
+    assert _sid(body["access_token"]) == expected
+    assert families[0] not in body["access_token"]  # the raw lineage key never ships
+
+
+def test_sid_survives_a_rotation(env, monkeypatch):
+    """THE property that makes the family the right key and a per-token id the wrong one: a `jti` would
+    change on every refresh, so anything keyed on it would silently reset each hour."""
+    monkeypatch.setenv("AGAMI_REFRESH_TOKEN_MODE", "rotate")
+    c = TestClient(mcp_http.build_app())
+    first = _token_pair(c)
+    second = _refresh(c, first["refresh_token"])
+    third = _refresh(c, second["refresh_token"])
+    assert _sid(first["access_token"])  # present
+    assert _sid(second["access_token"]) == _sid(first["access_token"])
+    assert _sid(third["access_token"]) == _sid(first["access_token"])
+    # ...even though the refresh token itself changed every time.
+    assert first["refresh_token"] != second["refresh_token"] != third["refresh_token"]
+
+
+def test_sid_survives_an_overwrite_renewal(env, monkeypatch):
+    # 'overwrite' is the default and takes a different code path (UPDATE in place, no new row), so the
+    # continuity has to be asserted separately from rotate's.
+    monkeypatch.setenv("AGAMI_REFRESH_TOKEN_MODE", "overwrite")
+    c = TestClient(mcp_http.build_app())
+    first = _token_pair(c)
+    second = _refresh(c, first["refresh_token"])
+    assert _sid(second["access_token"]) == _sid(first["access_token"])
+
+
+def test_two_authorizations_get_different_sids(env):
+    """The requirement itself: one login, two independent client authorizations, two identities. Without
+    this the server cannot tell two concurrent windows apart at all."""
+    c = TestClient(mcp_http.build_app())
+    a, b = _token_pair(c), _token_pair(c)
+    assert _sid(a["access_token"]) and _sid(b["access_token"])
+    assert _sid(a["access_token"]) != _sid(b["access_token"])
+
+
+def test_a_token_minted_without_a_sid_still_validates(env):
+    """Tokens predating this claim, and any minted outside the OAuth flow (scripts, tests, an operator's
+    hand-rolled bearer), must keep working — `sid` is deliberately not in the `require` list."""
+    from oauth_server import JwtAuthProvider, issue_jwt
+
+    token = issue_jwt("admin")
+    assert "sid" not in jwt.decode(token, SECRET, algorithms=["HS256"], issuer=BASE)
+    principal = JwtAuthProvider().validate_token(token)
+    assert principal is not None and principal.subject == "admin"
+    assert principal.session_id is None  # absent reads as "no session", not as an error
+
+
+def test_validate_token_surfaces_the_sid_on_the_principal(env):
+    from oauth_server import JwtAuthProvider, issue_jwt
+
+    token = issue_jwt("admin", sid="abc123")
+    principal = JwtAuthProvider().validate_token(token)
+    assert principal is not None and principal.session_id == "abc123"
+
+
+def test_a_malformed_sid_degrades_to_none_rather_than_rejecting(env):
+    # A blank/non-string claim must not cost an otherwise-valid caller their request.
+    from oauth_server import JwtAuthProvider
+
+    for bad in ("", "   ", 42):
+        token = jwt.encode(
+            {
+                "sub": "admin",
+                "iss": BASE,
+                "iat": 1,
+                "exp": 4102444800,  # 2100-01-01, comfortably unexpired
+                "sid": bad,
+            },
+            SECRET,
+            algorithm="HS256",
+        )
+        principal = JwtAuthProvider().validate_token(token)
+        assert principal is not None and principal.session_id is None, bad

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -231,3 +231,29 @@ def test_session_from_scope_normalizes_a_malformed_session_id():
         mcp_http._session_from_scope({"state": {"principal": ok.validate_token("x")}}, ok)
         == "sess-1"
     )
+
+
+def test_the_fallback_validates_the_bearer_exactly_once():
+    """The subject and the session are read off ONE principal. Deriving them from two independent
+    `validate_token` calls would double the work whenever the middleware's scope state didn't propagate —
+    a second signature check, or a second lookup for a DB-backed provider — and would let the two values
+    describe different callers if a provider's validation isn't deterministic."""
+    calls = {"n": 0}
+
+    class _Counting:
+        def validate_token(self, token):
+            calls["n"] += 1
+            return type("P", (), {"subject": "j@example.com", "session_id": "s-1"})()
+
+    auth = _Counting()
+    scope = {"headers": [(b"authorization", b"Bearer good")]}   # no scope state -> the fallback path
+    principal = mcp_http._principal_from_scope(scope, auth)
+    assert calls["n"] == 1
+    assert getattr(principal, "subject", None) == "j@example.com"
+    assert mcp_http._normalized_session(principal) == "s-1"
+
+    # ...and when the middleware DID propagate, the bearer is never re-validated at all.
+    calls["n"] = 0
+    p = type("P", (), {"subject": "j@example.com", "session_id": "s-2"})()
+    assert mcp_http._principal_from_scope({"state": {"principal": p}}, auth) is p
+    assert calls["n"] == 0

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -165,3 +165,42 @@ def test_a_raising_tool_is_still_logged_as_an_error(db, monkeypatch):
     _mcp_tool_call("jordan@example.com", "list_datasources")
     rows = [r for r in _rows(db) if r["tool_name"] == "list_datasources"]
     assert rows and rows[0]["success"] == 0 and rows[0]["error_kind"] == "exception"
+
+
+# --- the session plumbing ----------------------------------------------------
+
+
+def test_session_from_scope_prefers_state_then_header():
+    """Mirrors `_actor_from_scope`: state first, re-validate the bearer as a fallback, None otherwise."""
+
+    class _PS:
+        subject = "jordan@example.com"
+        session_id = "sess-1"
+
+    class _AuthS:
+        def validate_token(self, token):
+            return _PS() if token == "good" else None
+
+    auth = _AuthS()
+    assert mcp_http._session_from_scope({"state": {"principal": _PS()}}, auth) == "sess-1"
+    scope = {"headers": [(b"authorization", b"Bearer good")]}
+    assert mcp_http._session_from_scope(scope, auth) == "sess-1"
+    assert (
+        mcp_http._session_from_scope({"headers": [(b"authorization", b"Bearer bad")]}, auth) is None
+    )
+    assert mcp_http._session_from_scope({}, auth) is None
+
+
+def test_session_from_scope_tolerates_a_principal_without_the_field():
+    """`AuthProvider` is a @runtime_checkable Protocol — it checks method presence only, so a third-party
+    provider may return any object exposing `.subject`. Reading the session must not explode on one."""
+    auth = _Auth()  # its principal `_P` has `subject` and nothing else
+    assert mcp_http._session_from_scope({"state": {"principal": _P()}}, auth) is None
+    assert (
+        mcp_http._session_from_scope({"headers": [(b"authorization", b"Bearer good")]}, auth)
+        is None
+    )
+
+
+def test_current_session_id_is_none_outside_a_request():
+    assert mcp_http.current_session_id() is None

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -204,3 +204,30 @@ def test_session_from_scope_tolerates_a_principal_without_the_field():
 
 def test_current_session_id_is_none_outside_a_request():
     assert mcp_http.current_session_id() is None
+
+
+def test_session_from_scope_normalizes_a_malformed_session_id():
+    """Mint and read must agree on what "no session" means. A third-party AuthProvider's principal may
+    carry a blank or non-string `session_id`; letting it through would put an unexpected type into the
+    contextvar and, from there, into consumers using it as a key."""
+
+    class _AuthBad:
+        def __init__(self, value):
+            self.value = value
+
+        def validate_token(self, token):
+            return type("P", (), {"subject": "j@example.com", "session_id": self.value})()
+
+    for bad in ("", "   ", 42, None, object()):
+        auth = _AuthBad(bad)
+        principal = auth.validate_token("good")
+        assert mcp_http._session_from_scope({"state": {"principal": principal}}, auth) is None, bad
+        scope = {"headers": [(b"authorization", b"Bearer good")]}
+        assert mcp_http._session_from_scope(scope, auth) is None, bad
+
+    # ...and a well-formed one still comes through untouched.
+    ok = _AuthBad("sess-1")
+    assert (
+        mcp_http._session_from_scope({"state": {"principal": ok.validate_token("x")}}, ok)
+        == "sess-1"
+    )


### PR DESCRIPTION
Two changes to the served path, both found by running a real multi-tenant deployment.

## 1. `fix(ACE-051)`: the safety pass looked the model up under `'local'`

`execute_sql._resolve_guard_model` called `load_datasource(store, profile)`, taking the `org_id='local'`
default, while its own docstring says it mirrors `tools._load_org` — which passes `org_id=_current_org_id()`.

That agreed once. In 0.4.x `model_deploy._default_org()` was also `AGAMI_ORG_ID or 'local'`, so rows were
written under `'local'` and read under `'local'`. F14/F15 moved the write side onto the deployment's resolved id
without moving this reader, producing exactly the failure `_default_org`'s docstring warns about: *"the model
is written under one org and read under another and the server sees no model."*

On a multi-tenant server every tenant's rows live under its own id, so the `'local'` lookup missed for **all**
tenants and the fail-closed rule refused **every** query with `model_unavailable`. Single-tenant deploys were
spared only because the disk fallback quietly rescued them — which is why it survived a release unnoticed.

The regression test seeds a model under a named tenant and asserts the guard resolves it with the artifacts
dir pointed at nothing, so the disk fallback cannot mask it again.

## 2. `feat(auth)`: a per-session identifier

A `Principal` carried one field — `subject` — so two clients of the same login were indistinguishable.
Anything remembered per-caller was therefore shared, last write wins. Observed live: one window selected
tenant A, a second selected tenant B, and the first window — still displaying A — read B's data. No error;
the resolver did exactly what it was told.

Access tokens now carry `sid`, and `Principal` gains an optional `session_id`.

**Why the refresh family, not a `jti`:** a `jti` changes on every refresh, so anything keyed on it silently
resets each hour — the same class of bug being fixed. The family survives rotation (`rotate` carries it into
the successor row; `overwrite` never rewrites the column), so it identifies one client authorization for its
whole life.

**Why hashed** (`sha256(family)[:16]`): the raw family is the key reuse detection burns on (`WHERE family = ?`)
and should not leave the server.

Threading it needed one real change — the family was previously unrecoverable. `_issue_refresh_token`
computed `family or token_urlsafe(16)` inline inside the INSERT tuple and returned only the token, so on the
authorization_code path (the one that *mints* a lineage) no frame ever learned it. It now returns the pair.

`sid` is optional at every step and deliberately absent from the `require` list: presence auth, hand-minted
bearers and username/password all yield `session_id=None`, and a malformed claim degrades to None rather than
costing a valid caller their request. Reads use `getattr` because `AuthProvider` is `@runtime_checkable` —
method presence only — so a third-party principal may expose nothing but `.subject`.

`sid` is an **identity, not a liveness signal**: reuse detection can burn a family while tokens carrying its
`sid` are unexpired, and `validate_token` does no DB lookup. Documented at the mint site.

Nothing consumes it yet — this is the seam. The consumer side lands in agami-hosted after a release.

## Blast radius

Local flows are insulated twice over: the changed branch is gated on `_hosted()` (false with no
`AGAMI_DB_URL`), and the vendored plugin slice ships no `store`/`model_store`/`tools`, so it cannot run that
branch at all. stdio imports neither `oauth_server` nor `mcp_http`. Only the hosted HTTP server is affected.

## Verification

- **1597 passed, 1 skipped, 0 failed**; ruff + gitleaks clean
- Reverting any of the three pieces — the guard's `org_id`, the contextvar set, or the `sid` on the token
  body — fails a test that names the behaviour
- No vendored module drift beyond the intended `execute_sql.py` re-sync

⚠ **Run the suite with `AGAMI_ARTIFACTS_DIR` isolated.** Without it, 32 unrelated tests fail on any machine
with a real agami deployment: core resolves `~/.config/agami/path` and `resolved_org_id()` returns that org
instead of `'local'`, while fixtures seed under `'local'`. CI is green only because a runner has no deployment.
Separate latent issue, worth its own fix (an autouse fixture in `tests/conftest.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)