### PR TITLE
release: 0.5.1 — welded-quoted-identifier read-only-guard fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-07-30
+
 ### Security
 
 - **Closed a read-only-guard bypass via a welded quoted identifier.** A double-quoted

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.5.0"
+version = "0.5.1"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## What & which version

Cuts **v0.5.1**. Bumps the version in all four source-of-truth places (both entries in \`.claude-plugin/marketplace.json\`, \`plugins/agami/.claude-plugin/plugin.json\`, \`packages/agami-core/pyproject.toml\`) so the marketplace cache invalidates and the PyPI/image release tag will match \`pyproject\`.

## User-visible change landing in this version

- **Security — closed a read-only-guard bypass via a welded quoted identifier.** A double-quoted identifier is self-delimiting on both ends, so the guard's lexer could fuse neighbouring tokens (\`FROM\"pg_class\"\` → \`FROMpg_class\`), destroying the word-boundary anchor every deny-list pattern relies on — the gate stopped *seeing* the token and returned no rejection. The lexer now re-supplies a separator on either side only when the quote actually separated two word characters. (Full detail in \`CHANGELOG.md\`.)

## Notes

- Follows the established minimal-release convention (mirrors the 0.5.0 release commit \`ab34595\`): version bumps + retitle the CHANGELOG \`[Unreleased]\` → \`[0.5.1] — 2026-07-30\`.
- \`uv run dev.py check\` is green locally: 1600 passed / 1 skipped, ruff clean, gitleaks clean.
- The tag \`v0.5.1\` (which triggers the PyPI + image release workflows) should be created **after** this merges.