### PR TITLE
feat(mcp): a per-request tool-visibility seam

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -21,6 +21,7 @@ import contextlib
 import logging
 import os
 import time
+from collections.abc import Callable
 from contextvars import ContextVar
 from pathlib import Path
 
@@ -351,18 +352,52 @@ async def _auth_server(request: Request) -> JSONResponse:
     )
 
 
-def build_server(registry: dict | None = None, extra_instructions: str | None = None):
+def build_server(
+    registry: dict | None = None,
+    extra_instructions: str | None = None,
+    visibility: Callable[[str], bool] | None = None,
+):
     """A low-level MCP Server whose tool surface IS the given registry — list_tools / call_tool read
     from it, so HTTP advertises exactly what stdio does (no duplicate defs). Defaults to the shared
     `tools.TOOLS`; `create_app` passes a merged copy (base + a consumer's extra tools).
 
     `extra_instructions` is APPENDED to `SERVER_INSTRUCTIONS` (never replaces it) and surfaced to the
     model in the MCP `initialize` result — append-only so a consumer can add guidance but can't drop
-    the base protocol's safety directives (e.g. the sensitive-column output rule). None = no-op."""
+    the base protocol's safety directives (e.g. the sensitive-column output rule). None = no-op.
+
+    `visibility(tool_name) -> bool` narrows the surface PER REQUEST. None (the default) is exactly
+    today's behaviour: the whole registry, listed and callable. It exists because a registry assembled
+    once at composition time cannot answer "may THIS caller see this tool", and for a consumer running a
+    server-side agent that is the difference between a control and a suggestion: the model decides what
+    to call, so withholding the tool is the control and "it shouldn't call that" is not.
+
+    An empty hook by design — this module decides nothing about who may see what. The predicate is the
+    consumer's, and it reads the request context itself: this callable runs inside the request's task
+    (see `handle_mcp`), so `_actor_ctx` / `_session_ctx` / `tools._current_org_ctx` are all live in it.
+
+    SUBTRACTIVE ONLY. It filters the one shared registry; it never adds, renames, or reshapes a tool. A
+    surviving tool's description and inputSchema pass through untouched, so a consumer cannot fork the
+    surface into a private variant under cover of "visibility".
+    """
     import mcp.types as mt
     from mcp.server.lowlevel import Server
 
     registry = TOOLS if registry is None else registry
+
+    def _visible(name: str) -> bool:
+        """Applied at BOTH seams. Listing alone would leave an unlisted tool callable by name, which is
+        worse than either control on its own — the surface would look narrowed while remaining open."""
+        if visibility is None:
+            return True
+        try:
+            return bool(visibility(name))
+        except Exception:
+            # A consumer's predicate that raises must not be an accidental grant. Refuse the tool and
+            # keep serving; the alternative (propagating) turns one bad classification into a dead
+            # transport for every caller.
+            _log.exception("tool visibility predicate failed for %r; hiding the tool", name)
+            return False
+
     # Appended, never replacing: SERVER_INSTRUCTIONS carries the PII output rule, so replace-semantics
     # would let a consumer silently drop a safety directive.
     instructions = SERVER_INSTRUCTIONS
@@ -375,12 +410,16 @@ def build_server(registry: dict | None = None, extra_instructions: str | None = 
         return [
             mt.Tool(name=name, description=meta["description"], inputSchema=meta["inputSchema"])
             for name, meta in registry.items()
+            if _visible(name)
         ]
 
     @server.call_tool()
     async def _call_tool(name: str, arguments: dict) -> list:
         meta = registry.get(name)
-        if meta is None:
+        # A hidden tool answers as an ABSENT one, not as a refused one: the same `Unknown tool` a typo
+        # gets. Distinguishing them would turn the list into an oracle — a caller could enumerate what
+        # exists but is withheld, which is the fact hiding it was meant to keep.
+        if meta is None or not _visible(name):
             raise ValueError(f"Unknown tool: {name}")
         # Record every tool call to the admin activity log — timed, attributed to the authenticated
         # actor, never allowed to break the tool (logging is best-effort + double-guarded).
@@ -468,7 +507,14 @@ def create_app(
     # Merge the consumer's extra tools over a COPY of TOOLS — the module global is never mutated.
     registry = {**TOOLS, **(extra_tools or {})}
     session_manager = StreamableHTTPSessionManager(
-        app=build_server(registry, extra_instructions=extra_instructions),
+        # `tool_visibility` is read from the adapters rather than taken as a `create_app` parameter, so it
+        # rides the seam a consumer already swaps (`replace(default_adapters(), …)`) instead of adding a
+        # second, parallel way to configure the surface. None on the OSS defaults ⇒ unchanged behaviour.
+        app=build_server(
+            registry,
+            extra_instructions=extra_instructions,
+            visibility=getattr(adapters, "tool_visibility", None),
+        ),
         json_response=True,
         stateless=True,
     )

--- a/packages/agami-core/src/ports.py
+++ b/packages/agami-core/src/ports.py
@@ -23,6 +23,7 @@ consumer needs.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -163,3 +164,11 @@ class Adapters:
     auth_provider: AuthProvider
     governance: GovernancePolicy
     executor: Executor | None = None
+    # `tool_visibility(tool_name) -> bool` narrows the ADVERTISED tool surface per request. None (the
+    # default) is exactly today's behaviour — the whole registry, listed and callable. A registry
+    # assembled once at composition time cannot answer "may THIS caller see this tool", and for a
+    # consumer running a server-side agent that gap is the difference between a control and a
+    # suggestion: the model chooses what to call, so withholding the tool is the control. Subtractive
+    # only — it filters the one shared registry and never adds or reshapes a tool. See
+    # `mcp_http.build_server` for where it is applied (both list AND call, deliberately).
+    tool_visibility: Callable[[str], bool] | None = None

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -14,6 +14,7 @@ pytest.importorskip("mcp")
 pytest.importorskip("starlette")
 
 import mcp_http  # noqa: E402
+import tools  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
 BASE = "https://demo.example.com"
@@ -100,8 +101,11 @@ def test_browser_hitting_mcp_gets_a_branded_html_401(base_url):
     assert "<html" in r.text and "MCP endpoint" in r.text
     assert r.headers.get("www-authenticate", "").startswith("Bearer ")
     # claude.ai (JSON / event-stream Accept) still gets the JSON body it expects.
-    j = c.post("/mcp", headers={"accept": "application/json"},
-               json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    j = c.post(
+        "/mcp",
+        headers={"accept": "application/json"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
     assert j.status_code == 401 and "application/json" in j.headers["content-type"]
 
 
@@ -148,17 +152,22 @@ def test_mcp_bare_path_is_not_307_redirected(base_url):
         "Accept": "application/json, text/event-stream",
     }
     init = {
-        "jsonrpc": "2.0", "id": 1, "method": "initialize",
-        "params": {"protocolVersion": "2025-06-18", "capabilities": {},
-                   "clientInfo": {"name": "t", "version": "1"}},
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "t", "version": "1"},
+        },
     }
     with TestClient(mcp_http.build_app(), follow_redirects=False) as c:
         # Auth still gates the bare path (the shim must not become a bypass) — no bearer → 401, not a 307.
         assert c.post("/mcp", json=init).status_code == 401
         bare = c.post("/mcp", headers=headers, json=init)
         slashed = c.post("/mcp/", headers=headers, json=init)
-    assert bare.status_code != 307              # the fix: the bare path is served, not redirected
-    assert bare.status_code == 200              # reaches `initialize` directly
+    assert bare.status_code != 307  # the fix: the bare path is served, not redirected
+    assert bare.status_code == 200  # reaches `initialize` directly
     assert bare.status_code == slashed.status_code  # parity with the trailing-slash form
 
 
@@ -272,3 +281,115 @@ def test_the_session_id_reaches_a_tool_handler(base_url, monkeypatch):
     assert seen["session"] == "sess-42"
     # ...and it does not leak past the request.
     assert mcp_http.current_session_id() is None
+
+
+# --- the tool-visibility seam --------------------------------------------------
+
+
+def _visibility_app(predicate):
+    """An app whose advertised surface is narrowed by `predicate`, wired the way a consumer would."""
+    from dataclasses import replace
+
+    probe = {
+        "handler": lambda a: "ran",
+        "description": "probe",
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    }
+    adapters = replace(mcp_http.default_adapters(), tool_visibility=predicate)
+    return mcp_http.create_app(extra_tools={"probe": probe}, adapters=adapters)
+
+
+def _mcp(c, method, params=None, rid=1):
+    headers = {
+        "Authorization": "Bearer present",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    body = {"jsonrpc": "2.0", "id": rid, "method": method}
+    if params is not None:
+        body["params"] = params
+    return c.post("/mcp", headers=headers, json=body)
+
+
+def _handshake(c):
+    _mcp(
+        c,
+        "initialize",
+        {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "t", "version": "1"},
+        },
+        rid=1,
+    )
+    _mcp(c, "notifications/initialized")
+
+
+def test_no_visibility_predicate_leaves_the_surface_unchanged(base_url):
+    """The default must be byte-identical to before the seam existed — this is an additive hook."""
+    with TestClient(_visibility_app(None)) as c:
+        _handshake(c)
+        names = {t["name"] for t in _mcp(c, "tools/list", {}, rid=2).json()["result"]["tools"]}
+    assert "probe" in names
+    assert names >= set(tools.TOOLS)  # every core tool still advertised
+
+
+def test_a_hidden_tool_is_absent_from_the_list(base_url):
+    with TestClient(_visibility_app(lambda name: name != "probe")) as c:
+        _handshake(c)
+        listed = _mcp(c, "tools/list", {}, rid=2).json()["result"]["tools"]
+        names = {t["name"] for t in listed}
+    assert "probe" not in names
+    assert "execute_sql" in names  # subtractive: only the named tool goes
+
+
+def test_a_hidden_tool_is_also_not_callable(base_url):
+    """Listing alone would leave it callable by name — a surface that looks narrowed but is not."""
+    with TestClient(_visibility_app(lambda name: name != "probe")) as c:
+        _handshake(c)
+        r = _mcp(c, "tools/call", {"name": "probe", "arguments": {}}, rid=2)
+    assert "Unknown tool" in r.text  # answers as ABSENT, not as refused — the list is no oracle
+
+
+def test_a_visible_tool_still_runs(base_url):
+    with TestClient(_visibility_app(lambda name: True)) as c:
+        _handshake(c)
+        r = _mcp(c, "tools/call", {"name": "probe", "arguments": {}}, rid=2)
+    assert "ran" in r.text
+
+
+def test_a_predicate_that_raises_hides_rather_than_grants(base_url):
+    """A consumer's broken predicate must not be an accidental grant, and must not kill the transport."""
+
+    def boom(name):
+        raise RuntimeError("classification blew up")
+
+    with TestClient(_visibility_app(boom)) as c:
+        _handshake(c)
+        names = {t["name"] for t in _mcp(c, "tools/list", {}, rid=2).json()["result"]["tools"]}
+        called = _mcp(c, "tools/call", {"name": "execute_sql", "arguments": {}}, rid=3)
+    assert names == set()  # everything hidden, nothing granted
+    assert "Unknown tool" in called.text
+
+
+def test_the_predicate_sees_the_request_context(base_url):
+    """The whole point of a per-request hook: the consumer's predicate can read who is asking."""
+    seen = {}
+
+    def by_caller(name):
+        seen["actor"] = mcp_http._actor_ctx.get()
+        return True
+
+    with TestClient(_visibility_app(by_caller)) as c:
+        _handshake(c)
+        _mcp(c, "tools/list", {}, rid=2)
+    assert "actor" in seen  # ran inside the request, not at composition time
+
+
+def test_a_surviving_tools_schema_is_untouched(base_url):
+    """Subtractive only — a filter may remove a tool but never reshape one that survives."""
+    with TestClient(_visibility_app(lambda name: name != "probe")) as c:
+        _handshake(c)
+        listed = {t["name"]: t for t in _mcp(c, "tools/list", {}, rid=2).json()["result"]["tools"]}
+    assert listed["execute_sql"]["inputSchema"] == tools.TOOLS["execute_sql"]["inputSchema"]
+    assert listed["execute_sql"]["description"] == tools.TOOLS["execute_sql"]["description"]


### PR DESCRIPTION
A registry is assembled **once**, at composition time, so nothing downstream can ask *"may THIS caller
see this tool?"* — `_list_tools` returns the whole registry to everyone and `_call_tool` accepts any name
in it. That is the right default for a single-operator server, and it's what this PR leaves in place.

It stops being right for a consumer whose callers are not all equivalent. And the reason is specific to
how these tools are actually driven: **a model chooses what to call.** So a check that refuses on call is
a suggestion — the tool was offered, the model reasonably tried it, the user gets an error. Not putting
the tool in the list is the control.

## The seam

`Adapters.tool_visibility: Callable[[str], bool] | None = None`, applied by `build_server`.

`None` — the OSS default — is byte-for-byte today's behaviour: the whole registry, listed and callable.

Three properties, each of which is why this is a hook and not a feature:

**It is an empty hook.** This module decides nothing about who may see what; there is no policy, no role
model, no config. The predicate is the consumer's.

**It is subtractive only.** It filters the one shared registry — it cannot add a tool, rename one, or
reshape a schema. A surviving tool's `description` and `inputSchema` pass through untouched, so
"visibility" can't become a way to fork the served surface into a private variant. There's a test pinning
exactly that.

**It applies at both seams.** `_list_tools` skips a hidden tool *and* `_call_tool` rejects it. Filtering
only the list would be worse than either control alone — the surface would look narrowed while staying
open to anyone who knows a name.

## Two decisions worth review

**A hidden tool answers `Unknown tool`, not a permission error** — the same thing a typo gets.
Distinguishing them would turn the list into an oracle: a caller could enumerate what exists but is
withheld, which is the fact hiding it was meant to keep.

**A predicate that raises hides the tool** and logs, rather than propagating. A consumer's bug must not
be an accidental grant; propagating would also turn one bad classification into a dead transport for
every caller.

## Where it reads the caller from

Nowhere new. The predicate runs inside the request's own task — `handle_mcp`, where `_actor_ctx` and
`_session_ctx` are set — so it sees the live request context without this PR threading a principal
through `build_server`. Pinned by `test_the_predicate_sees_the_request_context`.

It rides `Adapters` rather than becoming a `create_app` parameter, so it uses the seam a consumer already
swaps (`replace(default_adapters(), …)`) instead of adding a second, parallel way to configure the
served surface.

## Tests

Seven, in `tests/test_mcp_http.py`, all over a real composed app: no predicate ⇒ surface unchanged;
hidden ⇒ absent from the list; hidden ⇒ also not callable; visible ⇒ still runs; raises ⇒ hides rather
than grants; the predicate sees the request context; a surviving tool's schema is untouched.

**1607 passed.** No spec id — this is a seam, not a behaviour change; there is no ACE covering it.
`execute_sql.py`, `sql_guard.py`, `agami_paths.py` and `semantic_model/` are untouched, so the vendored
plugin mirror is unaffected (`dev.py check` would fail on drift).
