### PR TITLE
release: 0.5.2 — per-request tool-visibility seam

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.5.2] — 2026-07-30
+
+### Added
+
+- **Per-request tool-visibility seam (`Adapters.tool_visibility`).** A consumer can now narrow the
+  advertised MCP tool surface per caller via an optional `tool_visibility(tool_name) -> bool` on the
+  adapters, applied in `build_server`. It is applied at *both* the list and the call seam — filtering
+  only the list would leave an unlisted tool callable by name, a surface that looks narrowed while
+  remaining open. A hidden tool answers as *absent* (the same `Unknown tool` a typo gets), not as
+  refused, so the list can't be used as an oracle for what exists but is withheld. A predicate that
+  raises hides the tool rather than granting it, and is logged rather than propagated, so one broken
+  classification can't become an accidental grant or a dead transport for every other caller.
+  Subtractive only — a surviving tool's description and input schema pass through untouched. `None`
+  (the OSS default) is byte-identical to prior behaviour.
+
 ## [0.5.1] — 2026-07-30
 
 ### Security

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.5.1"
+version = "0.5.2"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## What

Cuts release **0.5.2** (patch).

- Bumps the version `0.5.1` → `0.5.2` in all four source-of-truth locations
  (`.claude-plugin/marketplace.json` ×2, `plugins/agami/.claude-plugin/plugin.json`,
  `packages/agami-core/pyproject.toml`) so the directory-marketplace install lands in a fresh cache dir.
- Adds the `CHANGELOG.md` `[0.5.2]` section for the **per-request tool-visibility seam** (#167),
  which merged with code + tests but no changelog entry.

## Why

The tool-visibility seam (`Adapters.tool_visibility`) is a backward-compatible, additive feature —
`None` (the OSS default) is byte-identical to prior behaviour — so a patch bump is the right size. The
version bump is what invalidates a host's plugin cache.

## Verification

- `uv run dev.py check` passes locally: 1607 passed / 1 skipped, ruff clean, gitleaks clean.
- No lingering `0.5.1` in the four version files.