### PR TITLE
AH-022: an override seam on the tool-call log, and honest question provenance

### DIFF
--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -256,11 +256,17 @@ def _session_drawer(s: dict[str, Any], idx: int) -> str:
         question = t.get("question") or "(no question reported)"
         n = len(t["calls"])
         call_cards = "".join(_call_card(c) for c in t["calls"])
-        # The question is Claude-self-reported (best-effort, attacker-influenceable) — mark it so, like
-        # the rest of the activity log; "User asked" is the framing, "· self-reported" the provenance.
+        # Provenance on the question. Where it was copied out of the tool arguments the model wrote it is
+        # a self-report (best-effort, attacker-influenceable) and is marked so, like the rest of the
+        # activity log; where the caller observed the question directly the marker would *understate* the
+        # trust, so it is omitted. `_group_turns` decides, and errs toward keeping the marker.
+        marker = (
+            ' <span class="muted" style="font-size:13px">· self-reported</span>'
+            if t.get("question_self_reported", True)
+            else ""
+        )
         asked = (
-            f'<span class="muted">User asked</span> <strong>{ui.esc(question)}</strong> '
-            '<span class="muted" style="font-size:13px">· self-reported</span>'
+            f'<span class="muted">User asked</span> <strong>{ui.esc(question)}</strong>{marker}'
             if t.get("question")
             else f'<strong class="muted">{ui.esc(question)}</strong>'
         )

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -497,10 +497,17 @@ def _question_is_self_reported(calls: list[dict[str, Any]]) -> bool:
     self-report; a caller that dispatches handlers itself can state it authoritatively instead, and says
     so by recording a different `source`. **Fails toward self-reported:** an unset source (rows written
     before the column existed) and a turn whose calls disagree both count as self-reported, because the
-    marker signals *lower* trust and the honest thing under uncertainty is to keep showing it."""
+    marker signals *lower* trust and the honest thing under uncertainty is to keep showing it.
+
+    "Disagree" means the calls do not all carry the SAME source — not merely that one of them is the
+    default. A turn mixing two different non-default sources is just as ambiguous about who captured
+    the question, and dropping the marker there would overstate the trust rather than understate it.
+    An empty turn has no evidence at all, so it keeps the marker too."""
     from tools import DEFAULT_CALL_SOURCE  # lazy: keeps the stdlib-lean base install importable
 
-    return any((c.get("source") or DEFAULT_CALL_SOURCE) == DEFAULT_CALL_SOURCE for c in calls)
+    sources = {(c.get("source") or DEFAULT_CALL_SOURCE) for c in calls}
+    # Only one case drops the marker: every call agreeing on a single, non-default source.
+    return len(sources) != 1 or DEFAULT_CALL_SOURCE in sources
 
 
 def list_sessions(

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -452,7 +452,7 @@ class DbActivitySink:
 
 _TOOL_CALL_COLS = (
     "id, ts, actor, tool_name, datasource, sql, row_count, execution_ms, success, error_kind, "
-    "user_question, agent_query, thread_id, correlation_id"
+    "user_question, agent_query, thread_id, correlation_id, source"
 )
 
 
@@ -484,9 +484,23 @@ def _group_turns(calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "question": question,
                 "started": tc[0]["ts"],
                 "calls": tc,
+                "question_self_reported": _question_is_self_reported(tc),
             }
         )
     return turns
+
+
+def _question_is_self_reported(calls: list[dict[str, Any]]) -> bool:
+    """Whether a turn's `question` is the model's own claim rather than something the caller observed.
+
+    On the transport path the question is copied out of the tool arguments the model wrote, so it is a
+    self-report; a caller that dispatches handlers itself can state it authoritatively instead, and says
+    so by recording a different `source`. **Fails toward self-reported:** an unset source (rows written
+    before the column existed) and a turn whose calls disagree both count as self-reported, because the
+    marker signals *lower* trust and the honest thing under uncertainty is to keep showing it."""
+    from tools import DEFAULT_CALL_SOURCE  # lazy: keeps the stdlib-lean base install importable
+
+    return any((c.get("source") or DEFAULT_CALL_SOURCE) == DEFAULT_CALL_SOURCE for c in calls)
 
 
 def list_sessions(

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1345,9 +1345,12 @@ def record_tool_call(
         # it is a fact this function was told about what the tool actually did, and no argument can
         # make a call that threw into a successful one. Without this, passing something as innocuous
         # as `row_count` alongside `raised=True` erased the exception and logged a success.
-        # A more specific kind than the generic "exception" is still welcome, so a stated one stands.
+        # A more specific kind than the generic "exception" is still welcome, so a stated one stands
+        # — read from the parameter rather than the derived value, because a caller who contradicts
+        # themselves (`raised=True` with `success=True`) has already had the derived kind cleared by
+        # the success rule above. Their success claim loses; their diagnosis has no reason to.
         derived_success = False
-        derived_error_kind = derived_error_kind or "exception"
+        derived_error_kind = error_kind or derived_error_kind or "exception"
     rec: dict[str, Any] = {
         "ts": _now_iso(),
         "tool_name": name,

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -31,7 +31,7 @@ import sys
 import threading
 import time
 from collections.abc import Callable
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Any
 
@@ -278,6 +278,33 @@ def _model_version(profile: str) -> str | None:
 # The org id for the current request's tool calls (ACE-045). The HTTP server sets this per request from
 # the OrgResolver-resolved org; unset (stdio / single-tenant) it falls back to AGAMI_ORG_ID / "local".
 _current_org_ctx: ContextVar[str | None] = ContextVar("agami_current_org_id", default=None)
+
+# What drove the current tool call, recorded on every activity-log row. The MCP transport is the only
+# caller in this package, so the default is the value this log has always carried; an embedder that
+# dispatches tool handlers itself sets this for the duration of a call so its rows are distinguishable
+# from transport traffic. Unset, every row reads exactly as it did before this seam existed.
+#
+# It lives in this module rather than `contracts` because the base install is stdlib-lean
+# (`dependencies = []`) and `contracts` needs pydantic — which is why every import of it here is
+# function-level. The read path imports this constant the same lazy way.
+DEFAULT_CALL_SOURCE = "mcp_server"
+_source_ctx: ContextVar[str] = ContextVar("agami_call_source", default=DEFAULT_CALL_SOURCE)
+
+
+def current_call_source() -> str:
+    """What drove this tool call — `DEFAULT_CALL_SOURCE` unless an embedder scoped it to something else."""
+    return _source_ctx.get()
+
+
+def set_call_source(source: str) -> Token[str]:
+    """Scope the recorded source for the calls made under it. Reset with the returned token in a
+    `finally`, so a caller that dispatches handlers directly cannot leak its label into later work."""
+    return _source_ctx.set(source)
+
+
+def reset_call_source(token: Token[str]) -> None:
+    """Undo `set_call_source`. Separate from the setter so the pairing is visible at the call site."""
+    _source_ctx.reset(token)
 
 
 @functools.lru_cache(maxsize=None)
@@ -1025,7 +1052,9 @@ def _finalize_execution(
             "question": args.get("raw_query"),
             "sql": sql,
             "row_count": len(data_rows),
-            "source": "mcp_server",
+            # Same provenance the tool-call row carries, so the two logs can't disagree about what
+            # drove one execution. Unset, this is the value it has always been.
+            "source": current_call_source(),
         }
     )
     return json.dumps(result, indent=2, default=str)
@@ -1246,44 +1275,75 @@ def record_tool_call(
     execution_ms: int | None,
     actor: str | None,
     raised: bool = False,
+    source: str | None = None,
+    thread_id: str | None = None,
+    correlation_id: str | None = None,
+    user_question: str | None = None,
+    success: bool | None = None,
+    row_count: int | None = None,
+    error_kind: str | None = None,
 ) -> None:
     """Record one MCP tool call to the activity log (the transport calls this for **every** tool). The
     audit-grade fields are server-observed; `success`/`row_count`/`error_kind` are derived from the
     result (execute_sql returns an `{"error": ...}` body on a bad query without raising). The self-report
     fields (`user_question`/`agent_query`/`thread_id`) are whatever Claude supplied — may be None.
-    **Best-effort and never raises** — a logging failure must not break the tool."""
+    **Best-effort and never raises** — a logging failure must not break the tool.
+
+    The trailing parameters are an **override seam for an embedder that dispatches tool handlers
+    itself** rather than through this package's transport. Each defaults to `None`, meaning *derive it
+    the way this function always has* — so a caller that passes none of them gets byte-identical rows.
+
+    Two groups, for two different reasons:
+
+    - `source` / `thread_id` / `correlation_id` / `user_question` replace values that are otherwise read
+      out of `arguments`, i.e. **self-reported by the model**. A caller that observed them directly can
+      state them authoritatively, and the model can no longer influence how its own calls are grouped.
+    - `success` / `row_count` / `error_kind` replace values otherwise **derived here by parsing
+      `result_text`**. A caller that already classified the outcome passes it rather than handing over a
+      result body to be re-parsed — and, more importantly, one that has *no* body to hand over can still
+      record a failure. Without these, an outcome this function cannot see defaults to success, which is
+      the one direction an audit log must never fail in.
+    """
     args = arguments or {}
-    success, row_count, error_kind = True, None, None
+    derived_success, derived_row_count, derived_error_kind = True, None, None
     if raised:
-        success, error_kind = False, "exception"
+        derived_success, derived_error_kind = False, "exception"
     else:
         try:
             parsed = json.loads(result_text) if result_text else None
             if isinstance(parsed, dict):
                 if isinstance(parsed.get("error"), dict):
-                    success = False
-                    error_kind = parsed["error"].get("kind") or "error"
-                row_count = parsed.get("row_count")
+                    derived_success = False
+                    derived_error_kind = parsed["error"].get("kind") or "error"
+                derived_row_count = parsed.get("row_count")
         except (ValueError, TypeError):
             pass
+    if success is not None:
+        derived_success = success
+    if row_count is not None:
+        derived_row_count = row_count
+    if error_kind is not None:
+        derived_error_kind = error_kind
     _record_tool_call(
         {
             "ts": _now_iso(),
             "tool_name": name,
-            "source": "mcp_server",
+            "source": source or current_call_source(),
             "actor": actor,
             "datasource": args.get("datasource"),
             "sql": args.get("sql"),
-            "row_count": row_count if isinstance(row_count, int) else None,
+            "row_count": derived_row_count if isinstance(derived_row_count, int) else None,
             "execution_ms": execution_ms,
-            "success": success,
-            "error_kind": error_kind,
-            "user_question": args.get("user_question"),
+            "success": derived_success,
+            "error_kind": derived_error_kind,
+            "user_question": user_question if user_question is not None else args.get("user_question"),
             "agent_query": args.get(
                 "raw_query"
             ),  # the existing arg is the agent's framing of the query
-            "thread_id": args.get("thread_id"),
-            "correlation_id": args.get("correlation_id"),  # the turn (one user question)
+            "thread_id": thread_id if thread_id is not None else args.get("thread_id"),
+            "correlation_id": (  # the turn (one user question)
+                correlation_id if correlation_id is not None else args.get("correlation_id")
+            ),
         }
     )
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1303,9 +1303,11 @@ def record_tool_call(
       `result_text`**. A caller that already classified the outcome passes it rather than handing over a
       result body to be re-parsed — and, more importantly, one that has *no* body to hand over can still
       record a failure. Without these, an outcome this function cannot see defaults to success, which is
-      the one direction an audit log must never fail in. They are applied **as a group**: state any one
-      and the derived trio is replaced wholesale, so a stated success cannot leave a derived
-      `error_kind` stranded beside it on the row.
+      the one direction an audit log must never fail in. They are applied **as a group, and forced to
+      be coherent**: state any one and the derived trio is replaced wholesale; an `error_kind` with no
+      explicit `success` reads as a failure rather than defaulting to success; and a success never
+      carries an error kind. So no combination of these arguments can write a row that says
+      "succeeded" beside an error.
     - `org_id` replaces the tenant otherwise stamped downstream from this process's context. A caller
       that read the tenant at the point which actually scoped the work states it, rather than leaving it
       to be re-read later from a context that may no longer be the same one. The fallback when that
@@ -1327,8 +1329,15 @@ def record_tool_call(
         except (ValueError, TypeError):
             pass
     if success is not None or row_count is not None or error_kind is not None:
-        derived_success = True if success is None else success
-        derived_row_count, derived_error_kind = row_count, error_kind
+        # Stating any one of the three replaces all three — and the result is forced to be coherent,
+        # because an audit row that says "succeeded" beside an error kind is worse than either fact
+        # alone. Two rules do that: naming an `error_kind` IS a statement of failure even with no
+        # explicit flag (otherwise the outcome would default to success and reintroduce exactly the
+        # row this seam exists to prevent), and a success cannot carry an error kind, so a caller that
+        # states both loses the kind rather than writing the contradiction.
+        derived_success = success if success is not None else error_kind is None
+        derived_error_kind = None if derived_success else error_kind
+        derived_row_count = row_count
     rec: dict[str, Any] = {
         "ts": _now_iso(),
         "tool_name": name,

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1307,7 +1307,9 @@ def record_tool_call(
       be coherent**: state any one and the derived trio is replaced wholesale; an `error_kind` with no
       explicit `success` reads as a failure rather than defaulting to success; and a success never
       carries an error kind. So no combination of these arguments can write a row that says
-      "succeeded" beside an error.
+      "succeeded" beside an error. **`raised=True` outranks all of them** — a call that threw is a
+      failure whatever the caller passes, though it may still be given a more specific kind than the
+      generic `"exception"`.
     - `org_id` replaces the tenant otherwise stamped downstream from this process's context. A caller
       that read the tenant at the point which actually scoped the work states it, rather than leaving it
       to be re-read later from a context that may no longer be the same one. The fallback when that
@@ -1338,6 +1340,14 @@ def record_tool_call(
         derived_success = success if success is not None else error_kind is None
         derived_error_kind = None if derived_success else error_kind
         derived_row_count = row_count
+    if raised:
+        # A raise outranks every override. `raised` is not a classification the caller is offering —
+        # it is a fact this function was told about what the tool actually did, and no argument can
+        # make a call that threw into a successful one. Without this, passing something as innocuous
+        # as `row_count` alongside `raised=True` erased the exception and logged a success.
+        # A more specific kind than the generic "exception" is still welcome, so a stated one stands.
+        derived_success = False
+        derived_error_kind = derived_error_kind or "exception"
     rec: dict[str, Any] = {
         "ts": _now_iso(),
         "tool_name": name,

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1282,6 +1282,7 @@ def record_tool_call(
     success: bool | None = None,
     row_count: int | None = None,
     error_kind: str | None = None,
+    org_id: str | None = None,
 ) -> None:
     """Record one MCP tool call to the activity log (the transport calls this for **every** tool). The
     audit-grade fields are server-observed; `success`/`row_count`/`error_kind` are derived from the
@@ -1302,7 +1303,14 @@ def record_tool_call(
       `result_text`**. A caller that already classified the outcome passes it rather than handing over a
       result body to be re-parsed — and, more importantly, one that has *no* body to hand over can still
       record a failure. Without these, an outcome this function cannot see defaults to success, which is
-      the one direction an audit log must never fail in.
+      the one direction an audit log must never fail in. They are applied **as a group**: state any one
+      and the derived trio is replaced wholesale, so a stated success cannot leave a derived
+      `error_kind` stranded beside it on the row.
+    - `org_id` replaces the tenant otherwise stamped downstream from this process's context. A caller
+      that read the tenant at the point which actually scoped the work states it, rather than leaving it
+      to be re-read later from a context that may no longer be the same one. The fallback when that
+      read finds nothing is the deployment-wide org, and for an audit row that is the wrong direction
+      to fail in.
     """
     args = arguments or {}
     derived_success, derived_row_count, derived_error_kind = True, None, None
@@ -1318,34 +1326,32 @@ def record_tool_call(
                 derived_row_count = parsed.get("row_count")
         except (ValueError, TypeError):
             pass
-    if success is not None:
-        derived_success = success
-    if row_count is not None:
-        derived_row_count = row_count
-    if error_kind is not None:
-        derived_error_kind = error_kind
-    _record_tool_call(
-        {
-            "ts": _now_iso(),
-            "tool_name": name,
-            "source": source or current_call_source(),
-            "actor": actor,
-            "datasource": args.get("datasource"),
-            "sql": args.get("sql"),
-            "row_count": derived_row_count if isinstance(derived_row_count, int) else None,
-            "execution_ms": execution_ms,
-            "success": derived_success,
-            "error_kind": derived_error_kind,
-            "user_question": user_question if user_question is not None else args.get("user_question"),
-            "agent_query": args.get(
-                "raw_query"
-            ),  # the existing arg is the agent's framing of the query
-            "thread_id": thread_id if thread_id is not None else args.get("thread_id"),
-            "correlation_id": (  # the turn (one user question)
-                correlation_id if correlation_id is not None else args.get("correlation_id")
-            ),
-        }
-    )
+    if success is not None or row_count is not None or error_kind is not None:
+        derived_success = True if success is None else success
+        derived_row_count, derived_error_kind = row_count, error_kind
+    rec: dict[str, Any] = {
+        "ts": _now_iso(),
+        "tool_name": name,
+        "source": current_call_source() if source is None else source,
+        "actor": actor,
+        "datasource": args.get("datasource"),
+        "sql": args.get("sql"),
+        "row_count": derived_row_count if isinstance(derived_row_count, int) else None,
+        "execution_ms": execution_ms,
+        "success": derived_success,
+        "error_kind": derived_error_kind,
+        "user_question": user_question if user_question is not None else args.get("user_question"),
+        "agent_query": args.get("raw_query"),  # the existing arg is the agent's framing of the query
+        "thread_id": thread_id if thread_id is not None else args.get("thread_id"),
+        "correlation_id": (  # the turn (one user question)
+            correlation_id if correlation_id is not None else args.get("correlation_id")
+        ),
+    }
+    if org_id is not None:
+        # Set rather than left absent, so `_record_tool_call`'s `setdefault` keeps it instead of
+        # re-reading the tenant from this process's context later.
+        rec["org_id"] = org_id
+    _record_tool_call(rec)
 
 
 def _record_tool_call(rec: dict[str, Any]) -> None:

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -39,6 +39,17 @@ def _call(s, **kw):
     DbActivitySink(s).record_tool_call(ToolCallRecord(**rec))
 
 
+def _observed(s, **kw):
+    """A call an embedder dispatched itself, so the grouping fields were observed rather than
+    self-reported. Any non-default `source` means that; the value is the embedder's to choose."""
+    _call(s, source="embedded", **kw)
+
+
+def _just_after(html: str, needle: str, n: int = 200) -> str:
+    """The rendered text immediately following `needle` — where a per-question marker would sit."""
+    return html[html.index(needle) : html.index(needle) + n]
+
+
 @pytest.fixture
 def env(tmp_path, monkeypatch):
     url = "sqlite://" + str(tmp_path / "activity.db")
@@ -397,3 +408,61 @@ def test_server_instructions_say_pass_ids_on_every_call():
     import tools
 
     assert "EVERY tool call" in tools.SERVER_INSTRUCTIONS
+
+
+# --- provenance on the turn question -----------------------------------------
+
+
+def test_the_question_marker_tracks_who_reported_it(client, env):
+    """One test, both paths, deliberately: the marker is a trust signal, and a change to either path
+    that silently flipped the other would be exactly the regression worth catching.
+
+    On the transport path the question is copied out of the model's own tool arguments, so it is a
+    self-report and says so. A caller that dispatched the tool itself observed the question directly;
+    there the marker would understate the trust, so it is dropped."""
+    s = Store.connect(env)
+    _call(s, ts="2026-06-28T10:00:00Z", actor="jordan@example.com", sql="Q1", success=True,
+          thread_id="t-mcp", correlation_id="c-mcp", user_question="reported by the model",
+          agent_query="the model's framing")
+    _observed(s, ts="2026-06-28T10:05:00Z", actor="jordan@example.com", sql="Q2", success=True,
+              thread_id="t-obs", correlation_id="c-obs", user_question="observed by the caller",
+              agent_query="still the model's framing")
+    s.close()
+    _login(client)
+    html = client.get("/admin?tab=activity").text
+    assert "reported by the model" in html and "observed by the caller" in html
+    # exactly one turn still carries the marker...
+    assert html.count("· self-reported") == 1
+    # ...and it is the transport one. Checked on the text just after each question rather than by
+    # position: sessions render newest-first, so the two turns' order is not the insertion order.
+    assert "· self-reported" in _just_after(html, "reported by the model")
+    assert "· self-reported" not in _just_after(html, "observed by the caller")
+    # `· agent-reported` is about the agent's framing, not the question — it stays on BOTH paths
+    assert html.count("· agent-reported") == 2
+
+
+def test_a_turn_whose_calls_disagree_keeps_the_marker(env):
+    """The marker signals *lower* trust, so an ambiguous turn keeps it rather than losing it."""
+    s = Store.connect(env)
+    _call(s, ts="2026-06-28T11:00:00Z", actor="a", sql="Q1", success=True,
+          thread_id="t", correlation_id="c", user_question="mixed turn")
+    _observed(s, ts="2026-06-28T11:00:01Z", actor="a", sql="Q2", success=True,
+              thread_id="t", correlation_id="c")
+    (session,) = model_store.list_sessions(s)
+    s.close()
+    (turn,) = session["turns"]
+    assert turn["question_self_reported"] is True
+
+
+def test_a_row_written_before_the_source_column_counts_as_self_reported(env):
+    """Old rows have no source at all. Absent evidence, keep the marker."""
+    s = Store.connect(env)
+    s.execute(
+        "INSERT INTO tool_calls (id, ts, org_id, tool_name, success, thread_id, correlation_id, "
+        "user_question) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("legacy-1", "2026-06-28T12:00:00Z", "local", "execute_sql", 1, "t", "c", "from before"),
+    )
+    s.commit()
+    (session,) = model_store.list_sessions(s)
+    s.close()
+    assert session["turns"][0]["question_self_reported"] is True

--- a/tests/test_admin_activity.py
+++ b/tests/test_admin_activity.py
@@ -466,3 +466,31 @@ def test_a_row_written_before_the_source_column_counts_as_self_reported(env):
     (session,) = model_store.list_sessions(s)
     s.close()
     assert session["turns"][0]["question_self_reported"] is True
+
+
+def test_a_turn_mixing_two_non_default_sources_still_counts_as_self_reported(env):
+    """"Disagree" means the calls do not all carry the SAME source — not merely that one of them is
+    the transport's. A turn mixing two different non-default sources is just as ambiguous about who
+    captured the question, and dropping the marker there would OVERSTATE the trust, which is the one
+    direction this must never fail in."""
+    s = Store.connect(env)
+    _observed(s, ts="2026-06-28T13:00:00Z", actor="a", sql="Q1", success=True,
+              thread_id="t", correlation_id="c", user_question="mixed non-default sources")
+    _call(s, ts="2026-06-28T13:00:01Z", actor="a", sql="Q2", success=True, source="another-embedder",
+          thread_id="t", correlation_id="c")
+    (session,) = model_store.list_sessions(s)
+    s.close()
+    (turn,) = session["turns"]
+    assert turn["question_self_reported"] is True
+
+
+def test_a_turn_with_one_agreed_non_default_source_drops_the_marker(env):
+    """The only case that drops it: every call agreeing on a single non-default source."""
+    s = Store.connect(env)
+    _observed(s, ts="2026-06-28T14:00:00Z", actor="a", sql="Q1", success=True,
+              thread_id="t2", correlation_id="c2", user_question="all observed")
+    _observed(s, ts="2026-06-28T14:00:01Z", actor="a", sql="Q2", success=True,
+              thread_id="t2", correlation_id="c2")
+    (session,) = model_store.list_sessions(s)
+    s.close()
+    assert session["turns"][0]["question_self_reported"] is False

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -368,6 +368,10 @@ def test_no_combination_of_outcome_overrides_writes_an_incoherent_row(
         ({"success": True, "error_kind": None}, "exception"),
         ({"error_kind": "timeout"}, "timeout"),  # a MORE specific kind is still welcome
         ({"success": False, "error_kind": "timeout"}, "timeout"),
+        # A caller contradicting themselves loses the success claim but keeps the diagnosis: there is
+        # no reason for `raised` to also discard the specific kind and fall back to the generic one.
+        ({"success": True, "error_kind": "timeout"}, "timeout"),
+        ({"success": True, "error_kind": "timeout", "row_count": 5}, "timeout"),
     ],
 )
 def test_a_call_that_raised_stays_a_failure_whatever_the_caller_passes(

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -7,6 +7,7 @@ tool dispatch and lands in the log — the one piece of new wiring (a contextvar
 
 from __future__ import annotations
 
+import itertools
 import sys
 from pathlib import Path
 
@@ -448,3 +449,60 @@ def test_the_query_log_carries_the_same_source_as_the_tool_call_log(db, monkeypa
     _log_a_query()
     assert [r["source"] for r in seen] == [tools.DEFAULT_CALL_SOURCE, "embedded",
                                            tools.DEFAULT_CALL_SOURCE]
+
+
+def test_no_combination_of_outcome_arguments_can_write_a_dishonest_row(db):
+    """The whole override space, checked for invariants rather than for expected values.
+
+    Three separate review rounds found defects in this block, every one a combination the in-repo
+    caller never produces: an `error_kind` alone defaulting to success, `raised` flipped by an
+    unrelated `row_count`, a stated kind discarded by a contradictory success. Each was fixed with a
+    test for that case, and the next case slipped through the same way — because the matrix was
+    written from the cases already thought of.
+
+    So this asserts the three properties that must hold for EVERY input instead:
+      1. a successful row never carries an error kind;
+      2. a call that raised is never logged as a success;
+      3. an explicitly stated error kind is never silently replaced on a failed row;
+      4. naming an error kind, without also claiming success, produces a FAILED row.
+
+    Property 4 is the one that matters most and was the last to be written down. The other three are
+    all satisfied by turning a stated error into `success=1, error_kind=NULL` — which is perfectly
+    coherent, and is exactly the first bug found here. Coherence alone is not honesty: a row can
+    contradict itself, or it can quietly agree with itself about the wrong thing.
+    """
+    cases = list(
+        itertools.product(
+            [False, True],                     # raised
+            [None, True, False],               # success
+            [None, "timeout"],                 # error_kind
+            [None, 0, 5],                      # row_count
+            [None, "{}", '{"error": {"kind": "syntax"}}', "not json", '{"row_count": 3}'],
+        )
+    )
+    store = Store.connect(db)
+    try:
+        for raised, success, kind, rows, body in cases:
+            overrides: dict[str, object] = {}
+            if success is not None:
+                overrides["success"] = success
+            if kind is not None:
+                overrides["error_kind"] = kind
+            if rows is not None:
+                overrides["row_count"] = rows
+            tools.record_tool_call(
+                name="a_tool", arguments={}, result_text=body, execution_ms=1, actor="a",
+                raised=raised, **overrides,
+            )
+            r = store.query(
+                "SELECT success, error_kind FROM tool_calls ORDER BY rowid DESC LIMIT 1"
+            )[0]
+            case = f"raised={raised} success={success} kind={kind!r} rows={rows} body={body!r}"
+            assert not (r["success"] == 1 and r["error_kind"]), f"succeeded WITH an error: {case}"
+            assert not (raised and r["success"] == 1), f"a raise logged as success: {case}"
+            if kind is not None and r["success"] == 0:
+                assert r["error_kind"] == kind, f"stated kind dropped: {case}"
+            if kind is not None and success is not True:
+                assert r["success"] == 0, f"a stated error kind logged as a success: {case}"
+    finally:
+        store.close()

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -359,6 +359,32 @@ def test_no_combination_of_outcome_overrides_writes_an_incoherent_row(
     assert not (r["success"] == 1 and r["error_kind"]), "a successful row must carry no error kind"
 
 
+@pytest.mark.parametrize(
+    ("overrides", "expected_error_kind"),
+    [
+        ({}, "exception"),
+        ({"row_count": 5}, "exception"),  # an innocuous argument must not erase the exception
+        ({"success": True}, "exception"),
+        ({"success": True, "error_kind": None}, "exception"),
+        ({"error_kind": "timeout"}, "timeout"),  # a MORE specific kind is still welcome
+        ({"success": False, "error_kind": "timeout"}, "timeout"),
+    ],
+)
+def test_a_call_that_raised_stays_a_failure_whatever_the_caller_passes(
+    db, overrides, expected_error_kind
+):
+    """`raised` is not a classification on offer — it is a fact this function was told about what the
+    tool actually did. No override may turn a call that threw into a successful one, or an exception
+    could be logged as a success and vanish from every error view."""
+    tools.record_tool_call(
+        name="a_tool", arguments={}, result_text=None, execution_ms=1, actor="a",
+        raised=True, **overrides,
+    )
+    (r,) = _rows(db)
+    assert r["success"] == 0, f"a raised call logged as a success: {overrides}"
+    assert r["error_kind"] == expected_error_kind
+
+
 def test_a_stated_tenant_is_not_re_read_from_the_process_context(db, monkeypatch):
     """The tenant is otherwise stamped downstream by re-reading this process's context, whose fallback
     is the deployment-wide org. A caller that read it where the work was actually scoped states it."""

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -257,3 +257,97 @@ def test_the_fallback_validates_the_bearer_exactly_once():
     p = type("P", (), {"subject": "j@example.com", "session_id": "s-2"})()
     assert mcp_http._principal_from_scope({"state": {"principal": p}}, auth) is p
     assert calls["n"] == 0
+
+
+# --- the override seam -------------------------------------------------------
+#
+# `record_tool_call` is also called by embedders that dispatch tool handlers themselves rather than
+# through this package's transport. Such a caller observes the grouping ids and the outcome directly,
+# so it states them instead of having them read out of the model's arguments or parsed back out of a
+# result body. Every override defaults to None, meaning "derive it the way you always have" — the
+# tests below pin both halves: that the overrides win when given, and that nothing moves when they
+# are absent.
+
+
+def test_the_default_path_is_unchanged_when_no_override_is_passed(db):
+    """The regression that protects every existing caller: same call, same row as before the seam."""
+    tools.record_tool_call(
+        name="execute_sql",
+        arguments={"datasource": "SALES_DATA", "sql": "SELECT 1", "user_question": "how many?",
+                   "raw_query": "count", "thread_id": "t1", "correlation_id": "c1"},
+        result_text='{"row_count": 5}', execution_ms=84, actor="jordan@example.com",
+    )
+    (r,) = _rows(db)
+    assert r["source"] == tools.DEFAULT_CALL_SOURCE
+    # every self-report still read straight out of the model's arguments
+    assert r["user_question"] == "how many?" and r["thread_id"] == "t1"
+    assert r["correlation_id"] == "c1" and r["agent_query"] == "count"
+    # ...and the outcome still derived from the result body
+    assert r["success"] == 1 and r["row_count"] == 5 and r["error_kind"] is None
+
+
+def test_stated_ids_beat_the_model_s_self_report(db):
+    """A caller that observed the question and minted the ids outranks whatever the model wrote into
+    its own tool arguments — otherwise the model could choose how its calls are grouped."""
+    tools.record_tool_call(
+        name="execute_sql",
+        arguments={"sql": "SELECT 1", "user_question": "a drifted sub-question",
+                   "raw_query": "count", "thread_id": "model-made-this-up", "correlation_id": "and-this"},
+        result_text="{}", execution_ms=1, actor="a",
+        source="embedded", thread_id="th-1", correlation_id="co-1", user_question="how many widgets?",
+    )
+    (r,) = _rows(db)
+    assert r["source"] == "embedded"
+    assert r["thread_id"] == "th-1" and r["correlation_id"] == "co-1"
+    assert r["user_question"] == "how many widgets?"
+    # agent_query is deliberately NOT overridable — it is the model's framing, and that is the point
+    assert r["agent_query"] == "count"
+
+
+def test_a_stated_outcome_beats_the_derived_one(db):
+    """The reason the outcome is overridable at all: a caller may have classified the result already
+    and have no body left to hand over. Without this the row would default to success — the one
+    direction an audit log must never fail in."""
+    tools.record_tool_call(
+        name="a_tool", arguments={}, result_text=None, execution_ms=1, actor="a",
+        success=False, error_kind="bad_request", row_count=3,
+    )
+    (r,) = _rows(db)
+    assert r["success"] == 0 and r["error_kind"] == "bad_request" and r["row_count"] == 3
+
+
+def test_a_stated_success_survives_an_unparseable_body(db):
+    """Overrides are applied after derivation, so they are not quietly re-derived away."""
+    tools.record_tool_call(
+        name="a_tool", arguments={}, result_text='{"error": {"kind": "syntax"}}',
+        execution_ms=1, actor="a", success=True, error_kind=None,
+    )
+    (r,) = _rows(db)
+    assert r["success"] == 1  # the caller's classification wins over the body's
+
+
+def test_the_call_source_contextvar_scopes_rows_and_resets(db):
+    """The source can also be scoped rather than passed, for the tool logging a caller does not reach
+    (a handler that records its own execution). It must not leak past the scope."""
+    token = tools.set_call_source("embedded")
+    try:
+        tools.record_tool_call(name="a_tool", arguments={}, result_text="{}", execution_ms=1, actor="a")
+        assert tools.current_call_source() == "embedded"
+    finally:
+        tools.reset_call_source(token)
+    assert tools.current_call_source() == tools.DEFAULT_CALL_SOURCE
+    tools.record_tool_call(name="b_tool", arguments={}, result_text="{}", execution_ms=1, actor="a")
+    scoped, after = _rows(db)
+    assert scoped["source"] == "embedded"
+    assert after["source"] == tools.DEFAULT_CALL_SOURCE
+
+
+def test_an_explicit_source_beats_the_contextvar(db):
+    token = tools.set_call_source("embedded")
+    try:
+        tools.record_tool_call(name="a_tool", arguments={}, result_text="{}", execution_ms=1,
+                               actor="a", source="explicit")
+    finally:
+        tools.reset_call_source(token)
+    (r,) = _rows(db)
+    assert r["source"] == "explicit"

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -328,6 +328,37 @@ def test_a_stated_outcome_replaces_the_derived_one_wholesale(db):
     assert r["success"] == 1 and r["error_kind"] is None
 
 
+@pytest.mark.parametrize(
+    ("overrides", "expected_success", "expected_error_kind"),
+    [
+        # An error_kind with no explicit flag IS a statement of failure. Defaulting it to success is
+        # how the "succeeded, syntax error" row came back the first time this was fixed.
+        ({"error_kind": "syntax"}, 0, "syntax"),
+        # ...and a success can never carry one, however the caller phrases it.
+        ({"success": True, "error_kind": "syntax"}, 1, None),
+        ({"success": False, "error_kind": "syntax"}, 0, "syntax"),
+        ({"success": False}, 0, None),
+        ({"success": True}, 1, None),
+        ({"row_count": 5}, 1, None),
+        ({"row_count": 0}, 1, None),  # a falsy value still counts as stated
+    ],
+)
+def test_no_combination_of_outcome_overrides_writes_an_incoherent_row(
+    db, overrides, expected_success, expected_error_kind
+):
+    """Every way a caller can state the outcome, checked for coherence rather than field by field.
+
+    The failure this guards is not hypothetical: the grouped-override logic shipped once with
+    `error_kind` alone defaulting the row to success, which is precisely the contradiction the group
+    was introduced to remove."""
+    tools.record_tool_call(
+        name="a_tool", arguments={}, result_text=None, execution_ms=1, actor="a", **overrides
+    )
+    (r,) = _rows(db)
+    assert (r["success"], r["error_kind"]) == (expected_success, expected_error_kind)
+    assert not (r["success"] == 1 and r["error_kind"]), "a successful row must carry no error kind"
+
+
 def test_a_stated_tenant_is_not_re_read_from_the_process_context(db, monkeypatch):
     """The tenant is otherwise stamped downstream by re-reading this process's context, whose fallback
     is the deployment-wide org. A caller that read it where the work was actually scoped states it."""

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -316,14 +316,27 @@ def test_a_stated_outcome_beats_the_derived_one(db):
     assert r["success"] == 0 and r["error_kind"] == "bad_request" and r["row_count"] == 3
 
 
-def test_a_stated_success_survives_an_unparseable_body(db):
-    """Overrides are applied after derivation, so they are not quietly re-derived away."""
+def test_a_stated_outcome_replaces_the_derived_one_wholesale(db):
+    """The outcome trio is applied as a GROUP, not field by field. Stating success on a body that
+    parses as an error must not leave the derived `error_kind` stranded beside it — that would write a
+    row saying "succeeded, syntax error", which is worse than either alone."""
     tools.record_tool_call(
         name="a_tool", arguments={}, result_text='{"error": {"kind": "syntax"}}',
-        execution_ms=1, actor="a", success=True, error_kind=None,
+        execution_ms=1, actor="a", success=True,
     )
     (r,) = _rows(db)
-    assert r["success"] == 1  # the caller's classification wins over the body's
+    assert r["success"] == 1 and r["error_kind"] is None
+
+
+def test_a_stated_tenant_is_not_re_read_from_the_process_context(db, monkeypatch):
+    """The tenant is otherwise stamped downstream by re-reading this process's context, whose fallback
+    is the deployment-wide org. A caller that read it where the work was actually scoped states it."""
+    monkeypatch.setattr(tools, "_current_org_id", lambda: "the-wrong-tenant")
+    tools.record_tool_call(
+        name="a_tool", arguments={}, result_text="{}", execution_ms=1, actor="a", org_id="acme"
+    )
+    (r,) = _rows(db)
+    assert r["org_id"] == "acme"
 
 
 def test_the_call_source_contextvar_scopes_rows_and_resets(db):
@@ -351,3 +364,26 @@ def test_an_explicit_source_beats_the_contextvar(db):
         tools.reset_call_source(token)
     (r,) = _rows(db)
     assert r["source"] == "explicit"
+
+
+def test_the_query_log_carries_the_same_source_as_the_tool_call_log(db, monkeypatch, tmp_path):
+    """`execute_sql` writes a SECOND log row of its own, from a depth no parameter of the caller's
+    reaches. If it kept a hard-coded source while the tool-call row took a scoped one, the two logs
+    would disagree about what drove one execution — so it reads the same scope. Unset, it is the value
+    it has always been."""
+    seen = []
+    monkeypatch.setattr(tools, "_record_query", lambda rec: seen.append(rec))
+
+    def _log_a_query():
+        tools._record_query({"ts": "t", "profile": "p", "sql": "SELECT 1", "row_count": 0,
+                             "source": tools.current_call_source()})
+
+    _log_a_query()
+    token = tools.set_call_source("embedded")
+    try:
+        _log_a_query()
+    finally:
+        tools.reset_call_source(token)
+    _log_a_query()
+    assert [r["source"] for r in seen] == [tools.DEFAULT_CALL_SOURCE, "embedded",
+                                           tools.DEFAULT_CALL_SOURCE]


### PR DESCRIPTION
Spec: AH-022

## Summary

`record_tool_call` assumed its caller was this package's own MCP transport. It read the conversation
grouping ids out of the model's tool arguments, derived the call's outcome by parsing a result body,
and stamped a hard-coded `source`. An embedder that dispatches tool handlers itself — rather than
through the transport — has better information than any of those: it observed the question, it
minted the ids, it already classified the outcome, and it knows which tenant the work actually ran
as.

This adds that as an **additive, no-op-by-default extension point**. Every new parameter defaults to
`None`, meaning *derive it the way you always have*, so a caller that passes none of them gets a
byte-identical row. Pinned by a regression test.

It also makes the Activity drawer honest. It marked every question `· self-reported` and could not
do otherwise — `_TOOL_CALL_COLS` never selected `source`, so no call dict in a session even had the
key to branch on.

## Changes

| | |
|---|---|
| `tools.py` | eight optional overrides on `record_tool_call`; `_source_ctx` + `current/set/reset_call_source`; `_finalize_execution` reads the same scope |
| `model_store.py` | `source` added to the projected columns; `_group_turns` derives a per-turn provenance flag |
| `admin.py` | the drawer drops `· self-reported` where the caller observed the question |

**Two groups of overrides, for two different reasons.**

- `source` / `thread_id` / `correlation_id` / `user_question` replace values otherwise read out of
  `arguments`, i.e. **self-reported by the model**. `agent_query` deliberately stays argument-read —
  that one *is* the model's framing, and remains marked `· agent-reported` on every path.
- `success` / `row_count` / `error_kind` replace values otherwise **derived by parsing
  `result_text`**, and are applied **as a group**. A caller with no body to hand over previously
  could not record a failure at all: the row defaulted to success, which is the one direction an
  audit log must never fail in. Applying them field-by-field was its own bug — a stated success left
  a derived `error_kind` stranded beside it, a row reading "succeeded, syntax error".
- `org_id` replaces the tenant otherwise stamped downstream by re-reading this process's context at
  write time, in a worker thread, whose fallback is the deployment-wide org. A caller that read the
  tenant where the work was actually scoped states it instead.

**`_record_query` gets a ContextVar rather than a parameter**, because it has no parameter path at
all — its `source` was a dict literal built inside `_finalize_execution`, and the handler is invoked
as `handler(args)`. Reading a scoped value is what stops the two logs disagreeing about what drove
one execution.

**The provenance marker fails toward keeping itself.** An unset `source` (rows written before the
column was projected) and a turn whose calls disagree both count as self-reported — the marker
signals *lower* trust, so the honest thing under uncertainty is to keep showing it.

## Decisions

- **`DEFAULT_CALL_SOURCE` lives in `tools`, not `contracts`.** The base install is stdlib-lean
  (`dependencies = []`) and `contracts` needs pydantic — which is why every import of it in `tools`
  is function-level. The read path imports the constant the same lazy way.
- **The drawer change is three layers, not one.** Making the marker source-aware needs the column
  projected, surfaced per-turn, and branched on. Grouping *semantics* are unchanged; one projected
  column is added, which is what makes the display honest.
- **No business logic in the seam.** The consumer of these parameters lives outside this repo.

## Checklist

- [x] `uv run dev.py check` green (ruff lint + format · 1616 tests · gitleaks)
- [x] Linked to a spec above
- [x] Tests added — override precedence, the grouped outcome, the stated tenant, the ContextVar's
      scope and reset, the default-path regression, and the drawer asserting **both** paths in one
      test so a change to either cannot silently flip the other
- [x] No tests weakened or deleted (all test changes are additions)
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)