### PR TITLE
release: 0.5.3 — tool-call log override seam + honest question provenance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ below corresponds to one such version.
 - **Override seam on the tool-call audit log (`record_tool_call`).** An embedder that dispatches the
   tool handlers itself can now supply the values the log would otherwise infer from the model's own
   tool arguments and result body — `source`, `thread_id`, `correlation_id`, `user_question`,
-  `org_id`, plus the outcome (`success`, `row_count`, `error_kind`, `raised`). Every parameter
-  defaults to `None` = "derive it the way you always have", so the in-repo transport path is
-  regression-pinned identical to before the seam existed. `_record_query`'s source is likewise
+  `org_id`, and the outcome (`success`, `row_count`, `error_kind`). Each of these override
+  parameters defaults to `None` = "derive it the way you always have" (the recorded fact `raised` is
+  a separate boolean, default `False`), so a caller that passes none of them gets byte-identical
+  rows — the in-repo transport path is regression-pinned identical to before the seam existed. `_record_query`'s source is likewise
   readable from a context var, so the query log and the tool-call log can't disagree about what drove
   one execution.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-07-31
+
+### Added
+
+- **Override seam on the tool-call audit log (`record_tool_call`).** An embedder that dispatches the
+  tool handlers itself can now supply the values the log would otherwise infer from the model's own
+  tool arguments and result body — `source`, `thread_id`, `correlation_id`, `user_question`,
+  `org_id`, plus the outcome (`success`, `row_count`, `error_kind`, `raised`). Every parameter
+  defaults to `None` = "derive it the way you always have", so the in-repo transport path is
+  regression-pinned identical to before the seam existed. `_record_query`'s source is likewise
+  readable from a context var, so the query log and the tool-call log can't disagree about what drove
+  one execution.
+
+### Changed
+
+- **The audit row now fails toward honesty.** A caller with no result body to parse can now record a
+  failure (previously the row defaulted to success — the one direction an audit log must never fail
+  in); a raise outranks every override; naming an `error_kind` is itself a statement of failure; and
+  a success never carries an error kind, so the row can't contradict itself.
+- **Honest question provenance in the Activity drawer.** The `· self-reported` trust marker was
+  stamped on every question unconditionally (the `source` column was never even selected). The column
+  is now projected and a per-turn flag derived, so the marker is dropped only where the caller
+  observed the question directly — and kept under any disagreement or uncertainty, because
+  overstating trust is the one direction it must not fail.
+
 ## [0.5.2] — 2026-07-30
 
 ### Added

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.5.2"
+version = "0.5.3"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## What

Cuts release **0.5.3** (patch).

- Bumps the version `0.5.2` → `0.5.3` in all four source-of-truth locations
  (`.claude-plugin/marketplace.json` ×2, `plugins/agami/.claude-plugin/plugin.json`,
  `packages/agami-core/pyproject.toml`) so the directory-marketplace install lands in a fresh cache dir.
- Adds the `CHANGELOG.md` `[0.5.3]` section for **AH-022** (#169) — the tool-call audit-log override
  seam + honest question provenance — which merged with code + tests but no changelog entry.

## Why

AH-022 is additive and backward-compatible: every new `record_tool_call` parameter defaults to `None`
("derive it the way you always have") and the in-repo transport path is regression-pinned identical,
so a patch bump is the right size. The version bump is what invalidates a host's plugin cache.

## Verification

- `uv run dev.py check` passes locally: 1636 passed / 1 skipped, ruff clean, gitleaks clean.
- No lingering `0.5.2` in the four version files.