### PR TITLE
ACE-039: deny recon functions, and stop relaying driver text

### DIFF
--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -220,6 +220,12 @@ class QueryExecutionRecord(_Contract):
     reason: str | None = None  # guardrail.RefusalReason — refusals only
     rule: str | None = None  # guardrail.RULE_* — refusals only
     sql_truncated: bool = False  # `sql` was cut to the audit bound
+    # The RAW driver error, operator-only — never the caller's `failure.message`, which is the
+    # classified value-free sentence. NULL is a claim rather than a gap: it means the chokepoint
+    # holding the raw text and this recorder were not in one process, which on the forked stdio
+    # surface is by design (the child sanitizes, the parent records, and the raw text never
+    # crosses). Bounded by the writer — `tools.AUDIT_ERROR_DETAIL_MAX_CHARS`.
+    error_detail: str | None = None
     org_id: str = "local"  # the tenant this ran for; defaults to the single-tenant org
 
 

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -106,6 +106,18 @@ ALLOWED_PERMS = (0o600, 0o400)
 
 _LOG = logging.getLogger(__name__)
 
+# A logger of its OWN for raw driver text, and the reason is a leak rather than tidiness (ACE-039).
+# This module never calls `basicConfig`, so in a forked child a record on `_LOG` falls through to
+# `logging.lastResort` and is written to STDERR — and `tools._child_failure_message` relays the
+# child's whole stderr into `failure.message` for any classified exit code. Logging the raw text on
+# `_LOG` would therefore hand it straight back to the caller on the DEFAULT surface, undoing the
+# sanitization in the same breath. (The catch-all beneath the classifier escapes this only because
+# its `exc_info=True` trips the traceback guard, at the cost of degrading its message.)
+#
+# `main` silences this logger at CLI entry, so the forked child emits nothing here and the column
+# stays NULL. In-process and hosted, it propagates to the server's root logger as intended.
+_RAW_LOG = logging.getLogger(__name__ + ".raw")
+
 # What a caller is told when something we did not anticipate broke. Deliberately generic and
 # value-free: the raw text of an unanticipated exception is the one string in this module nobody has
 # read, so it may carry a traceback, an absolute path, a DSN or a row value. It goes to the server
@@ -1241,6 +1253,17 @@ _DEFAULT_MAX_ROWS = 1000  # rows materialized per result before truncation
 # exactly as the old module global did.
 _max_rows_override: ContextVar[int | None] = ContextVar("_max_rows_override", default=None)
 
+# The raw driver text of the failure this call classified, for the audit row only (ACE-039). A
+# ContextVar for the same reason as the cap above: request-scoped, so concurrent in-process handlers
+# cannot read each other's. `execute_guarded` CLEARS it on entry, which is the load-bearing half —
+# without that, a call that succeeds after one that failed would attribute the earlier call's error
+# to itself, and the audit row would name a statement that never produced it.
+#
+# It carries the text out-of-band rather than on the Envelope on purpose: `Failure` is `{kind,
+# message}` and stays that way, because a raw field on the contract is a raw field somebody
+# eventually serializes.
+_last_error_detail: ContextVar[str | None] = ContextVar("_last_error_detail", default=None)
+
 
 def _resolve_row_cap() -> int:
     """Effective result-row cap. `AGAMI_SQL_MAX_ROWS` is the operator-configurable DEPLOYMENT cap
@@ -2019,6 +2042,10 @@ def execute_guarded(
     ``failed``/``dsn`` Envelope carrying its detailed message rather than escaping as an exception
     the two callers would each have to translate. The row cap rides the request-scoped
     ``_max_rows_override`` ContextVar the caller sets."""
+    # Clear before anything can set it, so a detail from a PREVIOUS call in this context can never
+    # be attributed to this one. The recorder reads it unconditionally; a stale value would put the
+    # wrong error text on a row that succeeded.
+    _last_error_detail.set(None)
     try:
         import sql_guard
 
@@ -2085,6 +2112,11 @@ def execute_guarded(
         # per-engine sites. That text is an enumeration channel: a PostgreSQL HINT names declared
         # columns the caller never sent. Classify FROM it, return a fixed sentence INSTEAD of it.
         kind = _classify_db_error(exc.msg, exc.code)
+        # Keep the raw text for the operator, on two channels that reach two different places. The
+        # ContextVar is read by `tools._record_execution` when the recorder shares this process, and
+        # `_RAW_LOG` is the server-side trail everywhere else. Neither is the caller's channel.
+        _last_error_detail.set(exc.msg)
+        _RAW_LOG.error("database error (audit detail): %s", exc.msg)
         return _envelope("failed", failure=Failure(
             kind=kind, message=_ERROR_MESSAGES.get(kind, UNEXPECTED_FAILURE_MESSAGE),
         ))
@@ -2131,6 +2163,15 @@ def main() -> int:
     # the one-shot subprocess/CLI entry (one process, one thread), so there's no sibling request to
     # isolate from — unlike the in-process server path, which resets the token in tools._run_in_process.
     _max_rows_override.set(args.max_rows)
+
+    # Silence the raw-detail logger for the whole CLI/child lifetime. Without this it falls through
+    # to `logging.lastResort`, which writes to stderr — and the parent relays the child's stderr into
+    # `failure.message`, so the raw driver text this module just took OUT of the caller's answer
+    # would arrive back in it (ACE-039). The child therefore records no detail at all and the audit
+    # column stays NULL, which is exactly what NULL means on that column: the chokepoint and the
+    # recorder were not in one process.
+    _RAW_LOG.addHandler(logging.NullHandler())
+    _RAW_LOG.propagate = False
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -43,6 +43,16 @@ Exit codes:
          its own precisely so it does not borrow one: with `other` falling to the generic 2, a parent
          reading the exit code back reported an internal break as a datasource-configuration problem
          (`dsn`), and only on the fork transport, while the identical break in-process said `other`.
+    7  — the statement referenced a column the database does not have
+    8  — the statement referenced a table the database does not have
+    9  — the connection's role lacks SELECT on a referenced object
+    10 — the database was unreachable mid-statement (connection refused / reset)
+
+Codes 7-10 exist for the same reason 6 does. The child classifies a driver error at the chokepoint
+and then `main` collapses that classification to an exit code, so a kind without a code of its own is
+a kind the fork silently loses: all four landed on the `other` default and a parent read them back as
+`other`, while the identical error in-process reported the real kind. The in-process tests passed and
+the DEFAULT surface was wrong (ACE-039).
 
 `EXIT_TO_FAILURE_KIND` / `FAILURE_KIND_TO_EXIT` below are that table in code — this module owns the
 exit-code contract because it documents it here and is the only place that produces it.
@@ -180,16 +190,33 @@ EXIT_TO_FAILURE_KIND: dict[int, FailureKind] = {
     # mapped to 2 the parent read it back as ``dsn`` — so an internal break was reported to the
     # caller as a datasource-configuration problem, and only on the fork transport.
     6: "other",
+    # The four kinds the error-hardening slice makes reachable (ACE-039). Each needs a code of its
+    # own for exactly the reason 6 does, and the failure mode is worse because it is silent: the
+    # child classifies the driver error correctly at the chokepoint, `main` collapses the kind to an
+    # exit code, and a kind with no code falls to the `other` default. In-process the caller saw
+    # `column_not_found`; through the fork — the DEFAULT transport — it saw `other`, and no test that
+    # exercised only the in-process path could tell. `_child_failure_message` compounds it: it
+    # relays the child's sanitized text only for a code in this table, so an unmapped code also
+    # replaced the message with the generic unexpected-failure text.
+    7: "column_not_found",
+    8: "table_not_found",
+    9: "permission",  # the ROLE lacks SELECT; distinct from `auth`, where the credentials failed
+    10: "network",
 }
 
 # The inverse, for ``main`` turning a ``Failure`` back into today's exit code. Every failure
-# ``execute_guarded`` can produce is either an ``ExecutorError`` whose code is one of the four
-# classified ones above or the catch-all ``other``, and all five have their own code — so the
-# round-trip is exact for every case this module can reach, in both directions. The default covers
-# only the kinds nothing produces yet (``column_not_found``, ``table_not_found``, ``network``) plus
-# ``timeout``, which is minted at the tool edge by the subprocess supervisor and so never reaches
-# ``main``. It is 6 rather than 2 for the same reason ``other`` has its own code: an unmapped kind is
-# something we could not classify, which is what 6 says, and never a config error.
+# ``execute_guarded`` can produce is either an ``ExecutorError`` whose code is one of the classified
+# ones above or the catch-all ``other``, and all of them have their own code — so the round-trip is
+# exact for every case this module can reach, in both directions.
+#
+# The default now covers exactly ONE kind: ``timeout``, which is minted at the tool edge by the
+# subprocess supervisor when a child never returns, and so never reaches ``main`` to be encoded.
+# That is the whole remaining gap, and it is a gap by construction rather than by omission — a
+# supervisor that stops an unresponsive child cannot attribute the kill to the statement, which is
+# why it is a failure rather than a ``resource_limit`` refusal (guardrail contract §3).
+#
+# It is 6 rather than 2 for the same reason ``other`` has its own code: an unmapped kind is something
+# we could not classify, which is what 6 says, and never a config error.
 FAILURE_KIND_TO_EXIT: dict[str, int] = {kind: code for code, kind in EXIT_TO_FAILURE_KIND.items()}
 _DEFAULT_FAILURE_EXIT = 6
 

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -304,12 +304,20 @@ def _classify_db_error(text: str, code: int) -> FailureKind:
 
     if code == 3 or has("no module named", "modulenotfounderror", "command not found"):
         return "driver_missing"
+    # Ten engines spell an authorization failure ten ways, and getting this wrong is not cosmetic:
+    # a `permission` failure tells the operator to GRANT, while `auth` tells them to re-credential
+    # and `syntax` makes the skill auto-retry the identical statement twice.
     if has(
         "permission denied",
         "insufficient_privileges",
+        "insufficient privileges",  # Oracle ORA-01031, a space rather than an underscore
         "command denied",
         "insufficient_access_or_readonly",
-    ):
+        "permission was denied",  # SQL Server
+        "access denied for user",  # MySQL 1044/1045 — narrower than the bare needle in `auth`
+    ) or ("access denied" in lowered and has("table", "dataset", "cannot select")):
+        # BigQuery and Trino both open with "Access Denied:", which the `auth` arm's bare
+        # "access denied" would otherwise swallow into a credentials problem.
         return "permission"
     if has(
         "canceling statement",
@@ -329,9 +337,13 @@ def _classify_db_error(text: str, code: int) -> FailureKind:
         "undefinedcolumn",
         "invalid identifier",
         "invalid_field",
+        "invalid column name",  # SQL Server 207
+        "cannot be resolved",  # Trino, Databricks (UNRESOLVED_COLUMN)
+        "unrecognized name",  # BigQuery
+        "unresolved_column",
     ) or ("column" in lowered and has("does not exist", "not found")):
         return "column_not_found"
-    if has("no such table", "undefinedtable") or (
+    if has("no such table", "undefinedtable", "invalid object name") or (
         has("relation", "table", "object") and has("does not exist", "doesn't exist", "not found")
     ):
         return "table_not_found"
@@ -352,7 +364,10 @@ def _classify_db_error(text: str, code: int) -> FailureKind:
         "password authentication failed",
         "no pg_hba",
         "incorrect username or password",
-        "access denied",
+        # NOT a bare "access denied": BigQuery, Trino, SQL Server and MySQL 1044 all use that
+        # wording for an AUTHORIZATION failure on an object, which the arm above now claims.
+        "authentication failed",
+        "login failed",
     ):
         return "auth"
     return EXIT_TO_FAILURE_KIND.get(code, "other")

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -220,6 +220,131 @@ EXIT_TO_FAILURE_KIND: dict[int, FailureKind] = {
 FAILURE_KIND_TO_EXIT: dict[str, int] = {kind: code for code, kind in EXIT_TO_FAILURE_KIND.items()}
 _DEFAULT_FAILURE_EXIT = 6
 
+# --- Error sanitization (ACE-039) -------------------------------------------
+#
+# A raw driver error is an enumeration channel. PostgreSQL's `HINT: Perhaps you meant to reference
+# the column "orders.internal_ref"` names a DECLARED column the caller never sent, which is the
+# model leaking through the operational channel rather than the refusal channel. Measured before
+# this landed, by a `strict=True` xfail in tests/test_ace035_no_enumeration.py.
+#
+# WHOSE TEXT IS IT. Codes 2 and 3 are authored by this module — the credential remediation naming
+# DATASOURCE_URL, the chmod-600 fix, the `pip install` lines — and are relayed deliberately, because
+# they tell an operator what to do and contain nothing the database said. Codes 4 and 5 are the
+# twenty f-string sites that interpolate the driver's own exception. The module's docstring table
+# already draws exactly this line, so the discriminator is documented rather than invented.
+_AUTHORED_EXIT_CODES = frozenset({2, 3})
+
+# One value-free sentence per kind. NO REMEDIATION: `Failure` has no such field, and that absence is
+# what lets a caller tell a decision of ours from the database's outcome. Where the reference
+# implementation's remediation carried real information it is folded into the message, which is
+# already value-free.
+#
+# There is deliberately no `timeout` entry. A per-statement deadline is a `resource_limit` REFUSAL
+# (ACE-038 owns it, classified from a watchdog flag rather than a driver string), and the only
+# `timeout` failure is the subprocess supervisor's kill at the tool edge, which never reaches here.
+_ERROR_MESSAGES: dict[str, str] = {
+    "syntax": "The generated SQL was not valid for this database. Re-run the query.",
+    "column_not_found": (
+        "The statement referenced a column this database does not have. If the model was built "
+        "against an older schema, re-introspect the datasource."
+    ),
+    "table_not_found": (
+        "The statement referenced a table this database does not have. If the model was built "
+        "against an older schema, re-introspect the datasource."
+    ),
+    "permission": (
+        "The database refused to read an object this statement referenced. The connection's role "
+        "needs SELECT on it."
+    ),
+    "auth": "The database rejected the connection's credentials.",
+    "network": "The database was unreachable.",
+    "dsn": "The datasource host or path could not be resolved.",
+    "driver_missing": "The database driver is not installed on the server.",
+}
+
+
+def _classify_db_error(text: str, code: int) -> FailureKind:
+    """Classify a driver error into a `FailureKind`, from text that is never relayed.
+
+    Classifying FROM driver text is not the same as returning it: the output is one of a fixed set
+    of labels, and the caller receives `_ERROR_MESSAGES[kind]` rather than anything the database
+    said. The raw text is captured server-side only.
+
+    Order matters and two positions are load-bearing:
+
+    * **Cancellation is checked early and lands on `other`.** Every cancellation signature was ceded
+      to ACE-038, whose rule is that a deadline is classified from a signal rather than a string.
+      But simply DELETING the arm does not leave these statements unclassified — it leaves them
+      mis-classified: "canceling statement due to statement timeout" contains "timed out" and would
+      fall to `network`, or, failing that, to the exit-5 prior and out as `syntax`. An
+      unattributable server-side cancellation is honestly `other`.
+    * **`table_not_found` precedes `syntax`**, because Snowflake prefixes an unknown object with
+      "SQL compilation error" and would otherwise be read as a syntax error.
+
+    `"timed out"` is deliberately NOT a `network` needle. A driver-level connect or login timeout is
+    what the executor already reports as `auth` (exit 4) and stays there; adding the needle would
+    silently move it and contradict the contract's account of what `timeout` means.
+    """
+    lowered = (text or "").lower()
+
+    def has(*needles: str) -> bool:
+        return any(needle in lowered for needle in needles)
+
+    if code == 3 or has("no module named", "modulenotfounderror", "command not found"):
+        return "driver_missing"
+    if has(
+        "permission denied",
+        "insufficient_privileges",
+        "command denied",
+        "insufficient_access_or_readonly",
+    ):
+        return "permission"
+    if has(
+        "canceling statement",
+        "statement_timeout",
+        "query was canceled",
+        "querycanceled",
+        # MySQL 2013, whose actual text is "Lost connection to MySQL server DURING QUERY". The
+        # reference's needle read "lost connection during query" and so never matched it. Kept
+        # specific on purpose: a bare "lost connection" also covers "…at 'reading initial
+        # communication packet'", which is a genuine network failure and not a cancellation.
+        "lost connection to mysql server during query",
+    ):
+        return "other"
+    if has(
+        "no such column",
+        "unknown column",
+        "undefinedcolumn",
+        "invalid identifier",
+        "invalid_field",
+    ) or ("column" in lowered and has("does not exist", "not found")):
+        return "column_not_found"
+    if has("no such table", "undefinedtable") or (
+        has("relation", "table", "object") and has("does not exist", "doesn't exist", "not found")
+    ):
+        return "table_not_found"
+    if has("syntax error", "syntaxerror", "compilation error", "error in your sql syntax"):
+        return "syntax"
+    if has(
+        "could not translate host",
+        "name or service not known",
+        "getaddrinfo",
+        "unknown mysql server host",
+        "can't connect",
+        "no such file or directory",
+    ):
+        return "dsn"
+    if has("connection refused", "connection reset", "could not connect", "wrong_version_number"):
+        return "network"
+    if has(
+        "password authentication failed",
+        "no pg_hba",
+        "incorrect username or password",
+        "access denied",
+    ):
+        return "auth"
+    return EXIT_TO_FAILURE_KIND.get(code, "other")
+
 
 def _env_token(profile: str) -> str:
     """The env-var suffix for a datasource: the profile id upper-cased with every non-alphanumeric char
@@ -762,8 +887,19 @@ def _run_bigquery(creds: dict[str, str], sql: str) -> ExecResult:
                 sa_path_expanded
             )
             client_kwargs["credentials"] = creds_obj
-        except Exception as e:
-            raise ExecutorError(f"BigQuery credentials load failed: {e}", code=2)
+        except Exception:
+            # The ONE code-2 site that interpolated a third-party exception. google-auth's text can
+            # carry the absolute path of the service-account key, and code 2 is the band this module
+            # relays verbatim on the strength of having authored it — so an interpolated exception
+            # here made "codes 2 and 3 are ours" true only approximately (ACE-039). Authored prose
+            # out, the original to the server log.
+            _LOG.error("BigQuery service-account credentials failed to load", exc_info=True)
+            raise ExecutorError(
+                "BigQuery credentials could not be loaded. Check `service_account_path` for this "
+                "profile in <artifacts_dir>/local/credentials — the file must exist and be a valid "
+                "service-account key.",
+                code=2,
+            )
 
     try:
         client = bigquery.Client(**client_kwargs)
@@ -1936,12 +2072,21 @@ def execute_guarded(
         # refusal is the answer and cannot be overwritten by a later one.
         return _envelope("refused", refusal=_resource_limit_refusal(exc))
     except ExecutorError as exc:
-        # The classified branch: `msg` is authored by this module (a missing driver, a connect
-        # failure, the credential-resolution remediation naming DATASOURCE_URL) or relayed from the
-        # driver, and both callers already surface it. Sanitizing DRIVER text is a separate, larger
-        # job (ACE-039) and is deliberately not attempted here.
+        # Two kinds of text arrive here and only one of them is ours (ACE-039).
+        #
+        # Codes 2 and 3 are AUTHORED by this module — "No warehouse credentials for profile […]",
+        # the chmod-600 fix, the `pip install` line. They name an operator action and contain
+        # nothing the database said, so they are relayed verbatim exactly as before.
+        if exc.code in _AUTHORED_EXIT_CODES:
+            return _envelope("failed", failure=Failure(
+                kind=EXIT_TO_FAILURE_KIND.get(exc.code, "other"), message=exc.msg,
+            ))
+        # Codes 4 and 5 carry the driver's own exception, interpolated at one of the twenty
+        # per-engine sites. That text is an enumeration channel: a PostgreSQL HINT names declared
+        # columns the caller never sent. Classify FROM it, return a fixed sentence INSTEAD of it.
+        kind = _classify_db_error(exc.msg, exc.code)
         return _envelope("failed", failure=Failure(
-            kind=EXIT_TO_FAILURE_KIND.get(exc.code, "other"), message=exc.msg,
+            kind=kind, message=_ERROR_MESSAGES.get(kind, UNEXPECTED_FAILURE_MESSAGE),
         ))
     except Exception:
         # Unanticipated, so unreadable: nobody has vetted what this exception's text contains, and

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1889,6 +1889,13 @@ def execute_guarded(
         refusal = sql_guard.check_read_only(sql)
         if refusal is not None:
             return _envelope("refused", refusal=refusal)
+        # Metadata / recon functions, ABOVE the `no_safety` branch on purpose. `no_safety` skips the
+        # semantic-model pass and nothing else; server fingerprinting and object-existence probing
+        # are a hard gate for the same reason write and RCE protection are. Running second is what
+        # makes the label deterministic when a name is on both lists (principle 9).
+        refusal = sql_guard.check_no_recon(sql)
+        if refusal is not None:
+            return _envelope("refused", refusal=refusal)
         if not no_safety:
             sql, verdict = _model_safety(sql, profile, area)
             if isinstance(verdict, Refusal):

--- a/packages/agami-core/src/guardrail.py
+++ b/packages/agami-core/src/guardrail.py
@@ -62,11 +62,18 @@ RULE_MODEL_UNAVAILABLE = "model_unavailable"
 RULE_RESOURCE_LIMIT = "resource_limit"
 RULE_UNPARSEABLE = "unparseable"
 
-# Named by the contract, produced by a later gate — declared here so that work fills a constant
-# rather than inventing a string. Deliberately absent from `REASON_FOR_RULE` below: their reason is
-# the owning gate's call (`recon` is arguably `unsafe` or `out_of_scope` depending on framing), and
-# leaving them unpinned makes `refuse()` fail loudly rather than let that gate choose one silently.
+# Metadata / recon functions: `version()`, `current_user`, `has_table_privilege(…)`, the register-type
+# casts. Pinned `unsafe` by ACE-039, the gate that produces it. The reason was genuinely arguable —
+# a recon call is a reach in one framing and a hazard in another — which is why it was left for the
+# owning gate to settle in a reviewed diff rather than guessed at here. It is `unsafe` because the
+# statement is not asking the model a question it could ask differently: a semantic model declares
+# tables and columns and never declares functions, so there is no in-scope spelling of `version()`
+# for a 4b `out_of_scope` refusal to point the caller toward.
 RULE_RECON = "recon"
+# Named by the contract, produced by a later gate — declared here so that work fills a constant
+# rather than inventing a string. Deliberately absent from `REASON_FOR_RULE` below: its reason is the
+# owning gate's call, and leaving it unpinned makes `refuse()` fail loudly rather than let that gate
+# choose one silently.
 RULE_ENGINE_MISMATCH = "engine_mismatch"
 # `unscopable` is the third of these, and it is NOT a synonym for `unparseable`: an unparseable
 # statement is one sqlglot cannot read at all, while an unscopable one parses perfectly and still
@@ -93,6 +100,7 @@ REASON_FOR_RULE: dict[str, RefusalReason] = {
     # refusal in a later slice, and emitting `undetermined` now would silently pre-empt it.
     RULE_SELECT_STAR: "out_of_scope",
     RULE_MODEL_UNAVAILABLE: "undetermined",
+    RULE_RECON: "unsafe",
     # A bound we imposed, not a property of the statement: neither unsafe nor out of scope — we
     # simply did not determine the answer within the bound. Pinned before it had a producer, so the
     # gate that imposes the per-statement timeout filled a constant rather than inventing one.

--- a/packages/agami-core/src/migrations/core/016_query_executions_error_detail.sql
+++ b/packages/agami-core/src/migrations/core/016_query_executions_error_detail.sql
@@ -1,0 +1,29 @@
+-- Keep the raw driver error where only an operator can read it (ACE-039). The caller now receives a
+-- classified, value-free `failure.message` — "the statement referenced a column this database does
+-- not have" — because the driver's own text is an enumeration channel: PostgreSQL appends
+-- `HINT: Perhaps you meant to reference the column "orders.internal_ref"`, naming a DECLARED column
+-- the caller never sent. Sanitizing it on the way out would leave the operator debugging a real
+-- customer failure with nothing to read, so the raw text is kept here instead of discarded.
+--
+-- COLUMN, NOT A SECOND TABLE — the same argument 014 makes, for the same reason. The detail is 1:1
+-- with the execution, and `Envelope.audit_id` IS `query_executions.id`, so a `query_errors` table
+-- would be a join that can only ever match a single row, keyed on an id that already lives here.
+--
+-- NULL IS A CLAIM, NOT A GAP, and it means something specific: the chokepoint that holds the raw
+-- text and the recorder that writes this row were not in the same process. On the in-process and
+-- HTTP surfaces they are, and the column is populated. On the DEFAULT stdio surface the tool edge
+-- forks: the child classifies and sanitizes, the parent writes the row, and the child deliberately
+-- writes no audit row of its own — so the raw text never crosses, by design rather than by
+-- oversight. There the child logs it server-side and this column stays NULL. Rows written before
+-- this migration ran are NULL for the older reason 014 describes, and a back-fill would be
+-- inventing history either way.
+--
+-- BOUNDED BY THE WRITER, like `sql` before it (`tools.AUDIT_ERROR_DETAIL_MAX_CHARS`). A driver error
+-- carrying a full HINT / CONTEXT / parameter dump is unbounded, and 015's argument applies verbatim:
+-- a failed statement must not become a way to grow the store.
+--
+-- Forward-only and portable (runs on SQLite + Postgres unchanged) — same shape as
+-- 014_query_executions_guardrail.sql. No `IF NOT EXISTS`: SQLite's ALTER TABLE does not accept it,
+-- and re-run safety comes from the runner's `schema_migrations` ledger, which skips an applied file.
+
+ALTER TABLE query_executions ADD COLUMN error_detail TEXT;

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -407,8 +407,8 @@ class DbActivitySink:
         # which made the id unreferenceable the moment it existed.
         self._store.execute(
             "INSERT INTO query_executions (id, ts, org_id, datasource, question, sql, row_count, "
-            "source, status, reason, rule, sql_truncated) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "source, status, reason, rule, sql_truncated, error_detail) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 record.id,
                 record.ts,
@@ -424,6 +424,9 @@ class DbActivitySink:
                 # A portable 0/1 rather than a boolean literal — the same reason `record_tool_call`
                 # below writes `success` that way (SQLite has no boolean type).
                 1 if getattr(record, "sql_truncated", False) else 0,
+                # The raw driver error, operator-only. NULL on the forked surface, where the
+                # chokepoint holding it and this recorder are different processes (ACE-039).
+                getattr(record, "error_detail", None),
             ),
         )
         self._store.commit()

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import re
 from typing import NamedTuple
 
-from guardrail import RULE_READ_ONLY, Refusal, refuse
+from guardrail import RULE_READ_ONLY, RULE_RECON, RULE_UNPARSEABLE, Refusal, refuse
 
 # Hard cap on SQL length. Prevents a compromised client from POSTing a multi-MB
 # SQL blob that takes the parser / planner / this gate down a slow path. Real
@@ -452,3 +452,209 @@ def check_read_only(sql: str | None) -> Refusal | None:
             remediation=_REMEDIATION["dangerous_function"],
         )
     return None
+
+
+# --- Recon / metadata functions (ACE-039) -----------------------------------
+#
+# FUNCTIONS ONLY. No schema names, no relation names, no relation-name prefixes, no system
+# variables. Catalog RELATIONS are the model's to refuse, not this gate's: `check_table_scope`
+# already rejects `pg_class` and `information_schema.tables` as tables the model does not declare,
+# which is the same refusal reached by the gate that owns it. The relation half was therefore
+# redundant where the model gate runs — and where it does not run, it was actively harmful: matching
+# bare schema names on every engine refused a datasource whose `sys` schema holds ordinary user
+# tables. A schema the model declares is a schema the caller may query.
+#
+# The residual is stated rather than hidden: on the vendored plugin layout `semantic_model.runtime`
+# is absent by construction (it needs sqlglot and pydantic; the mirror is stdlib-only), so catalog
+# relations have no gate there at all. Recon denial protects an operator from a caller who is not
+# them, and on that layout the user owns the machine, the credentials and the role.
+#
+# Niladic keywords and register-type casts are in scope because they are the same primitive in a
+# spelling the function matcher never sees: `current_user` is `current_user()` without the parens,
+# and `'x'::regclass` is `to_regclass('x')` without them either — the cast errors when the object is
+# absent, which is an object-existence oracle that rides inside a fully-scoped query.
+
+
+def _recon_group(names: frozenset[str]) -> str:
+    """Alternation body for a set of names, longest first.
+
+    Longest-first is load-bearing rather than tidy: regex alternation takes the first branch that
+    matches at a position, so `current_schema` listed before `current_schemas` would shadow it and
+    the longer name would never match as a whole token.
+    """
+    return "|".join(sorted(names, key=len, reverse=True))
+
+
+# Server / session / account metadata, matched only in their CALL form.
+_RECON_PAREN_FNS = frozenset(
+    {
+        "version",
+        "current_database",
+        "current_schemas",  # pg, plural, takes a bool — the niladic `current_schema` is below
+        "database",
+        "schema",
+        "user",  # MySQL user() / system_user() — the CALL form only
+        "connection_id",
+        "system_user",
+        "current_account",  # snowflake
+        "current_region",
+        "current_version",
+        "current_warehouse",
+        "inet_server_addr",  # server / client network fingerprint (pg)
+        "inet_server_port",
+        "inet_client_addr",
+        "inet_client_port",
+    }
+)
+
+# Niladic metadata keywords — the special function spelled without parens. Bare `user`, `schema` and
+# `database` are DELIBERATELY absent: they are Postgres niladic synonyms but far too common as
+# intended column names, so only their call form (above) is denied. A known, minor
+# username-fingerprint residual, taken knowingly in exchange for not refusing ordinary schemas.
+_RECON_NILADIC = frozenset(
+    {"current_user", "session_user", "current_catalog", "current_schema", "current_role"}
+)
+
+# The privilege-check family, enumerated rather than globbed. `has_\w+_privilege` also matched
+# `has_active_privilege(...)` — a plausible user-defined function, and an over-refusal is the failure
+# mode this list has already produced in real use.
+_RECON_PRIVILEGE_FNS = frozenset(
+    {
+        "has_any_column_privilege",
+        "has_column_privilege",
+        "has_database_privilege",
+        "has_foreign_data_wrapper_privilege",
+        "has_function_privilege",
+        "has_language_privilege",
+        "has_largeobject_privilege",
+        "has_parameter_privilege",
+        "has_schema_privilege",
+        "has_sequence_privilege",
+        "has_server_privilege",
+        "has_table_privilege",
+        "has_tablespace_privilege",
+        "has_type_privilege",
+    }
+)
+
+# Call FAMILIES matched by prefix, each still requiring the trailing `(`. `pg_*` is a namespace ban
+# and deliberately overlaps the dangerous-function list: `check_read_only` runs first and owns the
+# label for what it names, and this is the backstop underneath — including for builtins that ship
+# after this list is written. `to_reg*` resolves a name to an OID, the call form of the casts below.
+_RECON_CALL_FAMILIES = (r"pg_\w+", r"to_reg\w+")
+
+# Register types. `'secret'::regclass` errors when the object is absent, so it answers "does this
+# exist?" without ever naming it in a FROM clause.
+_RECON_REGTYPES = frozenset(
+    {
+        "regclass",
+        "regcollation",
+        "regconfig",
+        "regdictionary",
+        "regnamespace",
+        "regoper",
+        "regoperator",
+        "regproc",
+        "regprocedure",
+        "regrole",
+        "regtype",
+    }
+)
+
+# A quoted name with a trailing `(` is STILL A CALL, so the paren matcher covers the niladic
+# keywords too. Without that union `SELECT "current_schema"()` would be skipped by the niladic
+# matcher (it is a quoted span) and missed by the paren matcher (`current_schemas` needs its `s`) —
+# a hole the false-positive fix would otherwise open. This union is where the FP rule and the
+# deny-list interact, and it is the only place they do.
+_RECON_PAREN_RE = re.compile(
+    r"\b("
+    + _recon_group(_RECON_PAREN_FNS | _RECON_NILADIC | _RECON_PRIVILEGE_FNS)
+    + "|"
+    + "|".join(_RECON_CALL_FAMILIES)
+    + r")\s*\(",
+    re.IGNORECASE,
+)
+# `(?<!\.)` lets a qualified column through (`t.current_user`); the quoted-span check in
+# `_recon_niladic_hit` handles the bare quoted spelling (`"current_user"`), which the neutralizer
+# has by then unwrapped into something this pattern would otherwise match.
+_RECON_NILADIC_RE = re.compile(
+    r"(?<!\.)\b(" + _recon_group(_RECON_NILADIC) + r")\b", re.IGNORECASE
+)
+# Both cast spellings. `::reg*` anchors on the type name because `_neutralize` blanks the literal
+# before it, so `'x'::regclass` arrives as ` ::regclass`. The `CAST(x AS reg*)` arm requires the
+# closing paren so a column aliased `AS regclass` is not caught.
+_RECON_CAST_RE = re.compile(
+    r"::\s*(" + _recon_group(_RECON_REGTYPES) + r")\b"
+    r"|\bAS\s+(" + _recon_group(_RECON_REGTYPES) + r")\s*\)",
+    re.IGNORECASE,
+)
+
+_RECON_REMEDIATION = (
+    "Remove the server-metadata call — query only the tables and columns your model declares. "
+    "Server version, session identity, privilege probes and object-existence casts are never "
+    "executed here."
+)
+
+
+def _recon_niladic_hit(neutral: _Neutralized) -> re.Match[str] | None:
+    """The niladic keyword, skipping any occurrence that was a quoted identifier.
+
+    The ONLY consumer of `_Neutralized.quoted`. A double-quoted bare word is unambiguously an
+    identifier — `SELECT "current_user" FROM audit_log` reads a column — while the same word
+    unquoted is the special function. The neutralizer drops the delimiters (that unwrapping is what
+    keeps a welded `"pg_read_file"(...)` visible to the read-only gate), so the distinction survives
+    only in the spans it reports.
+
+    Containment must be FULL. A partial overlap means the span and the match disagree about where
+    the token is, and the safe reading of a disagreement is not to skip.
+    """
+    for match in _RECON_NILADIC_RE.finditer(neutral.text):
+        if not any(s <= match.start() and match.end() <= e for s, e in neutral.quoted):
+            return match
+    return None
+
+
+def check_no_recon(sql: str | None) -> Refusal | None:
+    """Return ``None`` when ``sql`` calls no metadata / recon function, else a ``Refusal``.
+
+    Runs immediately after :func:`check_read_only` at the shared executor chokepoint, over the SAME
+    neutralized text — comments and literals blanked, quoted identifiers unwrapped — so a recon token
+    hidden in a string cannot smuggle past and a legitimate mention inside one cannot false-trip.
+    No second parser: this module is regex over `_neutralize`, and the sqlglot pass lives in
+    `semantic_model.runtime`, which the vendored mirror cannot import.
+
+    Order is fixed, so the label is deterministic: a name on both this list and the
+    dangerous-function list refuses as ``read_only``, because that gate runs first and owns what it
+    names (principle 9).
+    """
+    if not sql or not sql.strip():
+        return None  # empty — `check_read_only` owns that rejection, and its remediation
+
+    try:
+        neutral = _neutralize(sql)
+    except _GuardReject as reject:
+        # A statement we cannot read is not a statement we caught fingerprinting the server. It
+        # fails closed either way, but as `undetermined`/`unparseable` — labelling it `recon` told
+        # the caller it had tried something it had not, and handed it a recon fix for a parse
+        # problem. Unreachable at the chokepoint, where `check_read_only` runs the same neutralizer
+        # and refuses first; reachable, and covered, as a standalone call.
+        return refuse(
+            RULE_UNPARSEABLE, detail=reject.detail, remediation=reject.remediation
+        )
+
+    match = (
+        _RECON_PAREN_RE.search(neutral.text)
+        or _recon_niladic_hit(neutral)
+        or _RECON_CAST_RE.search(neutral.text)
+    )
+    if match is None:
+        return None
+
+    # Echo the token the caller itself sent, never the alternatives. A refusal that lists what IS
+    # allowed is a schema-listing endpoint.
+    hit = match.group(0).strip(" .(:")
+    return refuse(
+        RULE_RECON,
+        detail=f"metadata/recon access is not allowed (`{hit}`)",
+        remediation=_RECON_REMEDIATION,
+    )

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -209,6 +209,7 @@ def _neutralize(sql: str) -> _Neutralized:
             i = j
         elif sql[i] == '"':  # double-quoted identifier — keep content, drop quotes
             j, buf = i + 1, []
+            closed = False
             while j < n:
                 if sql[j] == '"':
                     if j + 1 < n and sql[j + 1] == '"':  # doubled "" escape
@@ -216,6 +217,7 @@ def _neutralize(sql: str) -> _Neutralized:
                         j += 2
                         continue
                     j += 1
+                    closed = True
                     break
                 buf.append(sql[j])
                 j += 1
@@ -244,7 +246,15 @@ def _neutralize(sql: str) -> _Neutralized:
             # `quoted` names the identifier and never the boundary this branch re-supplied.
             start = width
             emit("".join(buf))
-            spans.append((start, width))
+            # Record a span ONLY for an identifier whose closing delimiter we actually consumed.
+            # An unterminated `"` swallows the rest of the statement into `buf`, and a span over
+            # that tail would tell the niladic matcher to skip every keyword inside it — an
+            # UNDER-refusal, the one direction this design must never fail in. It is reachable:
+            # MySQL's default sql_mode treats `"` as a string delimiter with backslash escapes, so
+            # `SELECT "a\"b" , current_user FROM t` re-opens a runaway identifier here while MySQL
+            # executes it and returns CURRENT_USER(). No span means no skip, so the gate refuses.
+            if closed:
+                spans.append((start, width))
             nxt = sql[j] if j < n else ""
             if nxt.isalnum() or nxt == "_":
                 emit(" ")
@@ -583,9 +593,14 @@ _RECON_NILADIC_RE = re.compile(
 # Both cast spellings. `::reg*` anchors on the type name because `_neutralize` blanks the literal
 # before it, so `'x'::regclass` arrives as ` ::regclass`. The `CAST(x AS reg*)` arm requires the
 # closing paren so a column aliased `AS regclass` is not caught.
+# The optional `\w+\s*\.\s*` is a SCHEMA QUALIFIER, and it is load-bearing:
+# `'secret_table'::pg_catalog.regclass` is the same object-existence oracle in the spelling a
+# deny-list that anchors straight after `::` never sees. `_neutralize` has already unwrapped quotes
+# by this point, so `"pg_catalog"."regclass"` arrives here as `pg_catalog.regclass` and is covered
+# by the same branch. The call matcher tolerated qualification already; this arm did not.
 _RECON_CAST_RE = re.compile(
-    r"::\s*(" + _recon_group(_RECON_REGTYPES) + r")\b"
-    r"|\bAS\s+(" + _recon_group(_RECON_REGTYPES) + r")\s*\)",
+    r"::\s*(?:\w+\s*\.\s*)?(" + _recon_group(_RECON_REGTYPES) + r")\b"
+    r"|\bAS\s+(?:\w+\s*\.\s*)?(" + _recon_group(_RECON_REGTYPES) + r")\s*\)",
     re.IGNORECASE,
 )
 

--- a/packages/agami-core/src/sql_guard.py
+++ b/packages/agami-core/src/sql_guard.py
@@ -21,6 +21,7 @@ whole object rather than re-deriving a shape of their own.
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 from guardrail import RULE_READ_ONLY, Refusal, refuse
 
@@ -89,7 +90,33 @@ class _GuardReject(Exception):
         super().__init__(detail)
 
 
-def _neutralize(sql: str) -> str:
+class _Neutralized(NamedTuple):
+    """The analysis copy of a statement, plus where its quoted identifiers ended up.
+
+    `text` is the neutralized statement, **already stripped**. `quoted` holds one
+    `[start, end)` per double-quoted identifier, naming that identifier's CONTENT in
+    `text`'s own coordinates — never the re-supplied separators around it.
+
+    **One coordinate frame, deliberately.** The scan re-supplies separator spaces and
+    drops delimiters, so input offsets are not output offsets, and stripping afterwards
+    would shift them a third time. Doing the strip *inside* this function and reporting
+    spans against the stripped result is what makes a span usable without any caller
+    reconciling frames. A span in the wrong frame does not fail loudly; it mis-identifies
+    a token, so the frame is collapsed to one rather than documented.
+
+    **Only the niladic recon matcher reads `quoted`.** Every other consumer — the
+    read-only gate above all — matches `text` with the quotes already dropped, because
+    that unwrapping is what keeps `SELECT*FROM"pg_read_file"(...)` visible to a
+    `\\b`-anchored pattern. A quoted bare word is unambiguously an identifier; a quoted
+    name with a trailing `(` is still a call. That distinction is the consumer's to make,
+    which is why this type reports provenance and decides nothing.
+    """
+
+    text: str
+    quoted: tuple[tuple[int, int], ...]
+
+
+def _neutralize(sql: str) -> _Neutralized:
     """Blank out comments and string / dollar-quoted literals, and drop the quote
     delimiters of double-quoted identifiers (keeping their content), in a SINGLE
     left-to-right pass so the FIRST-opened construct wins — exactly how the database
@@ -111,6 +138,9 @@ def _neutralize(sql: str) -> str:
     identifier are treated as doubled-delimiter escapes (standard SQL). Backslash is
     deliberately NOT an escape here — engines disagree (MySQL yes, standard PG no),
     and not honoring it can only stop a literal *early* (fail safe), never late.
+
+    Returns a `_Neutralized` — the stripped text plus the quoted-identifier spans. See
+    that type for why the strip happens here rather than at the call site.
     """
     def _last_emitted(chunks: list[str]) -> str:
         """The last character actually emitted, skipping empty chunks.
@@ -125,6 +155,14 @@ def _neutralize(sql: str) -> str:
         return ""
 
     out: list[str] = []
+    spans: list[tuple[int, int]] = []
+    width = 0  # running len("".join(out)), so a span can be recorded as it is emitted
+
+    def emit(chunk: str) -> None:
+        nonlocal width
+        out.append(chunk)
+        width += len(chunk)
+
     i, n = 0, len(sql)
     while i < n:
         two = sql[i : i + 2]
@@ -143,7 +181,7 @@ def _neutralize(sql: str) -> str:
             j = i + 2
             while j < n and sql[j] not in "\r\n":
                 j += 1
-            out.append(" ")
+            emit(" ")
             i = j
         elif two == "/*":  # block comment
             # `/*! ... */` (and versioned `/*!NNNNN ... */`) is a MySQL *executable*
@@ -156,7 +194,7 @@ def _neutralize(sql: str) -> str:
                 )
             end = sql.find("*/", i + 2)
             i = n if end == -1 else end + 2
-            out.append(" ")
+            emit(" ")
         elif sql[i] == "'":  # single-quoted string literal
             j = i + 1
             while j < n:
@@ -167,7 +205,7 @@ def _neutralize(sql: str) -> str:
                     j += 1
                     break
                 j += 1
-            out.append(" ")
+            emit(" ")
             i = j
         elif sql[i] == '"':  # double-quoted identifier — keep content, drop quotes
             j, buf = i + 1, []
@@ -201,11 +239,15 @@ def _neutralize(sql: str) -> str:
             # pinned by an explicit output test, since no current rule distinguishes the
             # two spellings on its own.
             if _last_emitted(out).isalnum() or _last_emitted(out) == "_":
-                out.append(" ")
-            out.append("".join(buf))
+                emit(" ")
+            # Record the span AROUND the content only, between the two separator emits, so
+            # `quoted` names the identifier and never the boundary this branch re-supplied.
+            start = width
+            emit("".join(buf))
+            spans.append((start, width))
             nxt = sql[j] if j < n else ""
             if nxt.isalnum() or nxt == "_":
-                out.append(" ")
+                emit(" ")
             i = j
         elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)
             # Only a `$tag$` with a MATCHING close delimiter is a literal we can blank.
@@ -217,14 +259,25 @@ def _neutralize(sql: str) -> str:
             close = sql.find(m.group(0), m.end()) if m else -1
             if m and close != -1:
                 i = close + len(m.group(0))
-                out.append(" ")
+                emit(" ")
             else:
-                out.append("$")
+                emit("$")
                 i += 1
         else:
-            out.append(sql[i])
+            emit(sql[i])
             i += 1
-    return "".join(out)
+    raw = "".join(out)
+    text = raw.strip()
+    lead = len(raw) - len(raw.lstrip())
+    limit = len(text)
+    # Shift every span into the stripped frame, and DROP any the strip disturbed rather
+    # than clamping it. Dropping is the safe direction: a missing span means the niladic
+    # matcher does not skip that token, so the gate over-refuses. Clamping a span that ran
+    # off either end would instead widen the skipped region and could hide a live keyword.
+    kept = tuple(
+        (s - lead, e - lead) for s, e in spans if 0 <= s - lead < e - lead <= limit
+    )
+    return _Neutralized(text, kept)
 
 
 # Allowed opening keyword. `WITH` covers CTEs whose final clause is a SELECT.
@@ -343,7 +396,7 @@ def check_read_only(sql: str | None) -> Refusal | None:
     # nothing hidden inside a literal or comment can reach the checks below. See
     # `_neutralize` for why a single scan is required rather than layered regexes.
     try:
-        stripped = _neutralize(sql).strip()
+        stripped = _neutralize(sql).text
     except _GuardReject as reject:
         return refuse(RULE_READ_ONLY, detail=reject.detail, remediation=reject.remediation)
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1246,6 +1246,12 @@ def _emit(
 # generated SELECT is a few KB), and the verdict columns, not the blob, are what make the row useful.
 AUDIT_SQL_MAX_CHARS = 8_000
 
+# The raw driver error is unbounded in a way the statement is not: a PostgreSQL failure can carry a
+# HINT, a CONTEXT chain and every bound parameter. 015's argument applies verbatim — a failed
+# statement must not become a way to grow the store — and this is the operator's diagnostic, so a
+# couple of thousand characters is the whole of what is worth keeping.
+AUDIT_ERROR_DETAIL_MAX_CHARS = 2_000
+
 
 def _bounded_audit_sql(sql: str) -> tuple[str, bool]:
     """The statement as it will be stored, plus whether it had to be cut.
@@ -1283,9 +1289,20 @@ def _record_execution(
     """
     refusal = env.refusal
     stored_sql, sql_truncated = _bounded_audit_sql(sql or "")
+    # The RAW driver text, for the operator only — the caller's `failure.message` is the classified
+    # value-free sentence and stays that way. Present only when the chokepoint ran in THIS process:
+    # across the fork the child sanitizes and the parent records, so the raw text never crosses and
+    # this is None. `execute_guarded` clears the var on entry, so a stale detail cannot attach to a
+    # later call.
+    from execute_sql import _last_error_detail
+
+    raw_detail = _last_error_detail.get()
     _record_query(
         {
             "id": env.audit_id,
+            "error_detail": (
+                raw_detail[:AUDIT_ERROR_DETAIL_MAX_CHARS] if raw_detail else None
+            ),
             "ts": _now_iso(),
             "profile": profile or "",
             "question": (args or {}).get("raw_query"),
@@ -1351,6 +1368,15 @@ def tool_execute_sql(args: dict[str, Any]) -> str:
     a caller sees the same shape — and, for a refusal, the same rule and the same remediation —
     whichever path ran.
     """
+    # Clear the raw-detail carrier for THIS call, at the one point both paths pass through.
+    # `execute_guarded` also clears it on entry, but that only covers the in-process path — on the
+    # fork the parent never calls it, so without this a forked call would record the driver text
+    # left behind by an earlier IN-PROCESS failure in the same server process. Two paths, one
+    # ContextVar, so the reset belongs where the call begins rather than where one of them does.
+    from execute_sql import _last_error_detail
+
+    _last_error_detail.set(None)
+
     sql = args.get("sql")
     if not isinstance(sql, str) or not sql.strip():
         # An argument the caller got wrong, before any gate or database is involved: not a refusal

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1037,15 +1037,32 @@ def _child_failure_message(returncode: int, stderr: str | None) -> str:
         which is a field the caller is shown.
 
     What is deliberately still relayed is the child's *authored* config-error text ("No warehouse
-    credentials for profile […]. Set DATASOURCE_URL…", "Postgres connect failed: …"). That is the
-    remediation a misconfigured user needs, and it is the same text the in-process path surfaces
-    from `ExecutorError.msg` — the two paths agreeing on it is a property this slice exists to keep.
-    Sanitizing *driver* text is a separate job and belongs to the error-hardening slice; see the
-    coverage note in `tests/test_ace035_no_enumeration.py`.
+    credentials for profile […]. Set DATASOURCE_URL…"). That is the remediation a misconfigured user
+    needs, and it is the same text the in-process path surfaces from `ExecutorError.msg` — the two
+    paths agreeing on it is a property this slice exists to keep.
+
+    **The sanitized band is RECONSTRUCTED, never relayed (ACE-039).** For every code whose message
+    the child derives from `_ERROR_MESSAGES`, the parent can rebuild that exact sentence from the
+    exit code alone, so relaying stderr for those codes buys nothing and carries real risk: stderr
+    is a *shared* stream, and the child writes to it before the failure line. `_model_safety`'s
+    `[agami] applied default_filters: …` notice is the concrete case — it put a declared row-level
+    predicate, which the caller never sent, into `failure.message` on the DEFAULT transport, while
+    the in-process path returned the clean sentence. Anything else a library logs to stderr had the
+    same reach; the traceback guard below only ever caught the two `exc_info=True` sites.
     """
-    from execute_sql import EXIT_TO_FAILURE_KIND, UNEXPECTED_FAILURE_MESSAGE
+    from execute_sql import (
+        _AUTHORED_EXIT_CODES,
+        _ERROR_MESSAGES,
+        EXIT_TO_FAILURE_KIND,
+        UNEXPECTED_FAILURE_MESSAGE,
+    )
 
     text = (stderr or "").strip()
+    # Rebuild rather than relay. The child produced this sentence from the kind, so the kind is all
+    # the parent needs, and the child's stream never touches the caller's answer.
+    kind = EXIT_TO_FAILURE_KIND.get(returncode)
+    if returncode not in _AUTHORED_EXIT_CODES and kind in _ERROR_MESSAGES:
+        return _ERROR_MESSAGES[kind]
     classified = returncode in EXIT_TO_FAILURE_KIND
     # `Traceback (most recent call last):` is the stable header of every Python traceback, and a
     # `  File "…", line N` frame is the line that carries the absolute path. Either one is enough.

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -106,6 +106,18 @@ ALLOWED_PERMS = (0o600, 0o400)
 
 _LOG = logging.getLogger(__name__)
 
+# A logger of its OWN for raw driver text, and the reason is a leak rather than tidiness (ACE-039).
+# This module never calls `basicConfig`, so in a forked child a record on `_LOG` falls through to
+# `logging.lastResort` and is written to STDERR — and `tools._child_failure_message` relays the
+# child's whole stderr into `failure.message` for any classified exit code. Logging the raw text on
+# `_LOG` would therefore hand it straight back to the caller on the DEFAULT surface, undoing the
+# sanitization in the same breath. (The catch-all beneath the classifier escapes this only because
+# its `exc_info=True` trips the traceback guard, at the cost of degrading its message.)
+#
+# `main` silences this logger at CLI entry, so the forked child emits nothing here and the column
+# stays NULL. In-process and hosted, it propagates to the server's root logger as intended.
+_RAW_LOG = logging.getLogger(__name__ + ".raw")
+
 # What a caller is told when something we did not anticipate broke. Deliberately generic and
 # value-free: the raw text of an unanticipated exception is the one string in this module nobody has
 # read, so it may carry a traceback, an absolute path, a DSN or a row value. It goes to the server
@@ -1241,6 +1253,17 @@ _DEFAULT_MAX_ROWS = 1000  # rows materialized per result before truncation
 # exactly as the old module global did.
 _max_rows_override: ContextVar[int | None] = ContextVar("_max_rows_override", default=None)
 
+# The raw driver text of the failure this call classified, for the audit row only (ACE-039). A
+# ContextVar for the same reason as the cap above: request-scoped, so concurrent in-process handlers
+# cannot read each other's. `execute_guarded` CLEARS it on entry, which is the load-bearing half —
+# without that, a call that succeeds after one that failed would attribute the earlier call's error
+# to itself, and the audit row would name a statement that never produced it.
+#
+# It carries the text out-of-band rather than on the Envelope on purpose: `Failure` is `{kind,
+# message}` and stays that way, because a raw field on the contract is a raw field somebody
+# eventually serializes.
+_last_error_detail: ContextVar[str | None] = ContextVar("_last_error_detail", default=None)
+
 
 def _resolve_row_cap() -> int:
     """Effective result-row cap. `AGAMI_SQL_MAX_ROWS` is the operator-configurable DEPLOYMENT cap
@@ -2019,6 +2042,10 @@ def execute_guarded(
     ``failed``/``dsn`` Envelope carrying its detailed message rather than escaping as an exception
     the two callers would each have to translate. The row cap rides the request-scoped
     ``_max_rows_override`` ContextVar the caller sets."""
+    # Clear before anything can set it, so a detail from a PREVIOUS call in this context can never
+    # be attributed to this one. The recorder reads it unconditionally; a stale value would put the
+    # wrong error text on a row that succeeded.
+    _last_error_detail.set(None)
     try:
         import sql_guard
 
@@ -2085,6 +2112,11 @@ def execute_guarded(
         # per-engine sites. That text is an enumeration channel: a PostgreSQL HINT names declared
         # columns the caller never sent. Classify FROM it, return a fixed sentence INSTEAD of it.
         kind = _classify_db_error(exc.msg, exc.code)
+        # Keep the raw text for the operator, on two channels that reach two different places. The
+        # ContextVar is read by `tools._record_execution` when the recorder shares this process, and
+        # `_RAW_LOG` is the server-side trail everywhere else. Neither is the caller's channel.
+        _last_error_detail.set(exc.msg)
+        _RAW_LOG.error("database error (audit detail): %s", exc.msg)
         return _envelope("failed", failure=Failure(
             kind=kind, message=_ERROR_MESSAGES.get(kind, UNEXPECTED_FAILURE_MESSAGE),
         ))
@@ -2131,6 +2163,15 @@ def main() -> int:
     # the one-shot subprocess/CLI entry (one process, one thread), so there's no sibling request to
     # isolate from — unlike the in-process server path, which resets the token in tools._run_in_process.
     _max_rows_override.set(args.max_rows)
+
+    # Silence the raw-detail logger for the whole CLI/child lifetime. Without this it falls through
+    # to `logging.lastResort`, which writes to stderr — and the parent relays the child's stderr into
+    # `failure.message`, so the raw driver text this module just took OUT of the caller's answer
+    # would arrive back in it (ACE-039). The child therefore records no detail at all and the audit
+    # column stays NULL, which is exactly what NULL means on that column: the chokepoint and the
+    # recorder were not in one process.
+    _RAW_LOG.addHandler(logging.NullHandler())
+    _RAW_LOG.propagate = False
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -43,6 +43,16 @@ Exit codes:
          its own precisely so it does not borrow one: with `other` falling to the generic 2, a parent
          reading the exit code back reported an internal break as a datasource-configuration problem
          (`dsn`), and only on the fork transport, while the identical break in-process said `other`.
+    7  — the statement referenced a column the database does not have
+    8  — the statement referenced a table the database does not have
+    9  — the connection's role lacks SELECT on a referenced object
+    10 — the database was unreachable mid-statement (connection refused / reset)
+
+Codes 7-10 exist for the same reason 6 does. The child classifies a driver error at the chokepoint
+and then `main` collapses that classification to an exit code, so a kind without a code of its own is
+a kind the fork silently loses: all four landed on the `other` default and a parent read them back as
+`other`, while the identical error in-process reported the real kind. The in-process tests passed and
+the DEFAULT surface was wrong (ACE-039).
 
 `EXIT_TO_FAILURE_KIND` / `FAILURE_KIND_TO_EXIT` below are that table in code — this module owns the
 exit-code contract because it documents it here and is the only place that produces it.
@@ -180,16 +190,33 @@ EXIT_TO_FAILURE_KIND: dict[int, FailureKind] = {
     # mapped to 2 the parent read it back as ``dsn`` — so an internal break was reported to the
     # caller as a datasource-configuration problem, and only on the fork transport.
     6: "other",
+    # The four kinds the error-hardening slice makes reachable (ACE-039). Each needs a code of its
+    # own for exactly the reason 6 does, and the failure mode is worse because it is silent: the
+    # child classifies the driver error correctly at the chokepoint, `main` collapses the kind to an
+    # exit code, and a kind with no code falls to the `other` default. In-process the caller saw
+    # `column_not_found`; through the fork — the DEFAULT transport — it saw `other`, and no test that
+    # exercised only the in-process path could tell. `_child_failure_message` compounds it: it
+    # relays the child's sanitized text only for a code in this table, so an unmapped code also
+    # replaced the message with the generic unexpected-failure text.
+    7: "column_not_found",
+    8: "table_not_found",
+    9: "permission",  # the ROLE lacks SELECT; distinct from `auth`, where the credentials failed
+    10: "network",
 }
 
 # The inverse, for ``main`` turning a ``Failure`` back into today's exit code. Every failure
-# ``execute_guarded`` can produce is either an ``ExecutorError`` whose code is one of the four
-# classified ones above or the catch-all ``other``, and all five have their own code — so the
-# round-trip is exact for every case this module can reach, in both directions. The default covers
-# only the kinds nothing produces yet (``column_not_found``, ``table_not_found``, ``network``) plus
-# ``timeout``, which is minted at the tool edge by the subprocess supervisor and so never reaches
-# ``main``. It is 6 rather than 2 for the same reason ``other`` has its own code: an unmapped kind is
-# something we could not classify, which is what 6 says, and never a config error.
+# ``execute_guarded`` can produce is either an ``ExecutorError`` whose code is one of the classified
+# ones above or the catch-all ``other``, and all of them have their own code — so the round-trip is
+# exact for every case this module can reach, in both directions.
+#
+# The default now covers exactly ONE kind: ``timeout``, which is minted at the tool edge by the
+# subprocess supervisor when a child never returns, and so never reaches ``main`` to be encoded.
+# That is the whole remaining gap, and it is a gap by construction rather than by omission — a
+# supervisor that stops an unresponsive child cannot attribute the kill to the statement, which is
+# why it is a failure rather than a ``resource_limit`` refusal (guardrail contract §3).
+#
+# It is 6 rather than 2 for the same reason ``other`` has its own code: an unmapped kind is something
+# we could not classify, which is what 6 says, and never a config error.
 FAILURE_KIND_TO_EXIT: dict[str, int] = {kind: code for code, kind in EXIT_TO_FAILURE_KIND.items()}
 _DEFAULT_FAILURE_EXIT = 6
 

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -304,12 +304,20 @@ def _classify_db_error(text: str, code: int) -> FailureKind:
 
     if code == 3 or has("no module named", "modulenotfounderror", "command not found"):
         return "driver_missing"
+    # Ten engines spell an authorization failure ten ways, and getting this wrong is not cosmetic:
+    # a `permission` failure tells the operator to GRANT, while `auth` tells them to re-credential
+    # and `syntax` makes the skill auto-retry the identical statement twice.
     if has(
         "permission denied",
         "insufficient_privileges",
+        "insufficient privileges",  # Oracle ORA-01031, a space rather than an underscore
         "command denied",
         "insufficient_access_or_readonly",
-    ):
+        "permission was denied",  # SQL Server
+        "access denied for user",  # MySQL 1044/1045 — narrower than the bare needle in `auth`
+    ) or ("access denied" in lowered and has("table", "dataset", "cannot select")):
+        # BigQuery and Trino both open with "Access Denied:", which the `auth` arm's bare
+        # "access denied" would otherwise swallow into a credentials problem.
         return "permission"
     if has(
         "canceling statement",
@@ -329,9 +337,13 @@ def _classify_db_error(text: str, code: int) -> FailureKind:
         "undefinedcolumn",
         "invalid identifier",
         "invalid_field",
+        "invalid column name",  # SQL Server 207
+        "cannot be resolved",  # Trino, Databricks (UNRESOLVED_COLUMN)
+        "unrecognized name",  # BigQuery
+        "unresolved_column",
     ) or ("column" in lowered and has("does not exist", "not found")):
         return "column_not_found"
-    if has("no such table", "undefinedtable") or (
+    if has("no such table", "undefinedtable", "invalid object name") or (
         has("relation", "table", "object") and has("does not exist", "doesn't exist", "not found")
     ):
         return "table_not_found"
@@ -352,7 +364,10 @@ def _classify_db_error(text: str, code: int) -> FailureKind:
         "password authentication failed",
         "no pg_hba",
         "incorrect username or password",
-        "access denied",
+        # NOT a bare "access denied": BigQuery, Trino, SQL Server and MySQL 1044 all use that
+        # wording for an AUTHORIZATION failure on an object, which the arm above now claims.
+        "authentication failed",
+        "login failed",
     ):
         return "auth"
     return EXIT_TO_FAILURE_KIND.get(code, "other")

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -220,6 +220,131 @@ EXIT_TO_FAILURE_KIND: dict[int, FailureKind] = {
 FAILURE_KIND_TO_EXIT: dict[str, int] = {kind: code for code, kind in EXIT_TO_FAILURE_KIND.items()}
 _DEFAULT_FAILURE_EXIT = 6
 
+# --- Error sanitization (ACE-039) -------------------------------------------
+#
+# A raw driver error is an enumeration channel. PostgreSQL's `HINT: Perhaps you meant to reference
+# the column "orders.internal_ref"` names a DECLARED column the caller never sent, which is the
+# model leaking through the operational channel rather than the refusal channel. Measured before
+# this landed, by a `strict=True` xfail in tests/test_ace035_no_enumeration.py.
+#
+# WHOSE TEXT IS IT. Codes 2 and 3 are authored by this module — the credential remediation naming
+# DATASOURCE_URL, the chmod-600 fix, the `pip install` lines — and are relayed deliberately, because
+# they tell an operator what to do and contain nothing the database said. Codes 4 and 5 are the
+# twenty f-string sites that interpolate the driver's own exception. The module's docstring table
+# already draws exactly this line, so the discriminator is documented rather than invented.
+_AUTHORED_EXIT_CODES = frozenset({2, 3})
+
+# One value-free sentence per kind. NO REMEDIATION: `Failure` has no such field, and that absence is
+# what lets a caller tell a decision of ours from the database's outcome. Where the reference
+# implementation's remediation carried real information it is folded into the message, which is
+# already value-free.
+#
+# There is deliberately no `timeout` entry. A per-statement deadline is a `resource_limit` REFUSAL
+# (ACE-038 owns it, classified from a watchdog flag rather than a driver string), and the only
+# `timeout` failure is the subprocess supervisor's kill at the tool edge, which never reaches here.
+_ERROR_MESSAGES: dict[str, str] = {
+    "syntax": "The generated SQL was not valid for this database. Re-run the query.",
+    "column_not_found": (
+        "The statement referenced a column this database does not have. If the model was built "
+        "against an older schema, re-introspect the datasource."
+    ),
+    "table_not_found": (
+        "The statement referenced a table this database does not have. If the model was built "
+        "against an older schema, re-introspect the datasource."
+    ),
+    "permission": (
+        "The database refused to read an object this statement referenced. The connection's role "
+        "needs SELECT on it."
+    ),
+    "auth": "The database rejected the connection's credentials.",
+    "network": "The database was unreachable.",
+    "dsn": "The datasource host or path could not be resolved.",
+    "driver_missing": "The database driver is not installed on the server.",
+}
+
+
+def _classify_db_error(text: str, code: int) -> FailureKind:
+    """Classify a driver error into a `FailureKind`, from text that is never relayed.
+
+    Classifying FROM driver text is not the same as returning it: the output is one of a fixed set
+    of labels, and the caller receives `_ERROR_MESSAGES[kind]` rather than anything the database
+    said. The raw text is captured server-side only.
+
+    Order matters and two positions are load-bearing:
+
+    * **Cancellation is checked early and lands on `other`.** Every cancellation signature was ceded
+      to ACE-038, whose rule is that a deadline is classified from a signal rather than a string.
+      But simply DELETING the arm does not leave these statements unclassified — it leaves them
+      mis-classified: "canceling statement due to statement timeout" contains "timed out" and would
+      fall to `network`, or, failing that, to the exit-5 prior and out as `syntax`. An
+      unattributable server-side cancellation is honestly `other`.
+    * **`table_not_found` precedes `syntax`**, because Snowflake prefixes an unknown object with
+      "SQL compilation error" and would otherwise be read as a syntax error.
+
+    `"timed out"` is deliberately NOT a `network` needle. A driver-level connect or login timeout is
+    what the executor already reports as `auth` (exit 4) and stays there; adding the needle would
+    silently move it and contradict the contract's account of what `timeout` means.
+    """
+    lowered = (text or "").lower()
+
+    def has(*needles: str) -> bool:
+        return any(needle in lowered for needle in needles)
+
+    if code == 3 or has("no module named", "modulenotfounderror", "command not found"):
+        return "driver_missing"
+    if has(
+        "permission denied",
+        "insufficient_privileges",
+        "command denied",
+        "insufficient_access_or_readonly",
+    ):
+        return "permission"
+    if has(
+        "canceling statement",
+        "statement_timeout",
+        "query was canceled",
+        "querycanceled",
+        # MySQL 2013, whose actual text is "Lost connection to MySQL server DURING QUERY". The
+        # reference's needle read "lost connection during query" and so never matched it. Kept
+        # specific on purpose: a bare "lost connection" also covers "…at 'reading initial
+        # communication packet'", which is a genuine network failure and not a cancellation.
+        "lost connection to mysql server during query",
+    ):
+        return "other"
+    if has(
+        "no such column",
+        "unknown column",
+        "undefinedcolumn",
+        "invalid identifier",
+        "invalid_field",
+    ) or ("column" in lowered and has("does not exist", "not found")):
+        return "column_not_found"
+    if has("no such table", "undefinedtable") or (
+        has("relation", "table", "object") and has("does not exist", "doesn't exist", "not found")
+    ):
+        return "table_not_found"
+    if has("syntax error", "syntaxerror", "compilation error", "error in your sql syntax"):
+        return "syntax"
+    if has(
+        "could not translate host",
+        "name or service not known",
+        "getaddrinfo",
+        "unknown mysql server host",
+        "can't connect",
+        "no such file or directory",
+    ):
+        return "dsn"
+    if has("connection refused", "connection reset", "could not connect", "wrong_version_number"):
+        return "network"
+    if has(
+        "password authentication failed",
+        "no pg_hba",
+        "incorrect username or password",
+        "access denied",
+    ):
+        return "auth"
+    return EXIT_TO_FAILURE_KIND.get(code, "other")
+
 
 def _env_token(profile: str) -> str:
     """The env-var suffix for a datasource: the profile id upper-cased with every non-alphanumeric char
@@ -762,8 +887,19 @@ def _run_bigquery(creds: dict[str, str], sql: str) -> ExecResult:
                 sa_path_expanded
             )
             client_kwargs["credentials"] = creds_obj
-        except Exception as e:
-            raise ExecutorError(f"BigQuery credentials load failed: {e}", code=2)
+        except Exception:
+            # The ONE code-2 site that interpolated a third-party exception. google-auth's text can
+            # carry the absolute path of the service-account key, and code 2 is the band this module
+            # relays verbatim on the strength of having authored it — so an interpolated exception
+            # here made "codes 2 and 3 are ours" true only approximately (ACE-039). Authored prose
+            # out, the original to the server log.
+            _LOG.error("BigQuery service-account credentials failed to load", exc_info=True)
+            raise ExecutorError(
+                "BigQuery credentials could not be loaded. Check `service_account_path` for this "
+                "profile in <artifacts_dir>/local/credentials — the file must exist and be a valid "
+                "service-account key.",
+                code=2,
+            )
 
     try:
         client = bigquery.Client(**client_kwargs)
@@ -1936,12 +2072,21 @@ def execute_guarded(
         # refusal is the answer and cannot be overwritten by a later one.
         return _envelope("refused", refusal=_resource_limit_refusal(exc))
     except ExecutorError as exc:
-        # The classified branch: `msg` is authored by this module (a missing driver, a connect
-        # failure, the credential-resolution remediation naming DATASOURCE_URL) or relayed from the
-        # driver, and both callers already surface it. Sanitizing DRIVER text is a separate, larger
-        # job (ACE-039) and is deliberately not attempted here.
+        # Two kinds of text arrive here and only one of them is ours (ACE-039).
+        #
+        # Codes 2 and 3 are AUTHORED by this module — "No warehouse credentials for profile […]",
+        # the chmod-600 fix, the `pip install` line. They name an operator action and contain
+        # nothing the database said, so they are relayed verbatim exactly as before.
+        if exc.code in _AUTHORED_EXIT_CODES:
+            return _envelope("failed", failure=Failure(
+                kind=EXIT_TO_FAILURE_KIND.get(exc.code, "other"), message=exc.msg,
+            ))
+        # Codes 4 and 5 carry the driver's own exception, interpolated at one of the twenty
+        # per-engine sites. That text is an enumeration channel: a PostgreSQL HINT names declared
+        # columns the caller never sent. Classify FROM it, return a fixed sentence INSTEAD of it.
+        kind = _classify_db_error(exc.msg, exc.code)
         return _envelope("failed", failure=Failure(
-            kind=EXIT_TO_FAILURE_KIND.get(exc.code, "other"), message=exc.msg,
+            kind=kind, message=_ERROR_MESSAGES.get(kind, UNEXPECTED_FAILURE_MESSAGE),
         ))
     except Exception:
         # Unanticipated, so unreadable: nobody has vetted what this exception's text contains, and

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1889,6 +1889,13 @@ def execute_guarded(
         refusal = sql_guard.check_read_only(sql)
         if refusal is not None:
             return _envelope("refused", refusal=refusal)
+        # Metadata / recon functions, ABOVE the `no_safety` branch on purpose. `no_safety` skips the
+        # semantic-model pass and nothing else; server fingerprinting and object-existence probing
+        # are a hard gate for the same reason write and RCE protection are. Running second is what
+        # makes the label deterministic when a name is on both lists (principle 9).
+        refusal = sql_guard.check_no_recon(sql)
+        if refusal is not None:
+            return _envelope("refused", refusal=refusal)
         if not no_safety:
             sql, verdict = _model_safety(sql, profile, area)
             if isinstance(verdict, Refusal):

--- a/plugins/agami/lib/guardrail.py
+++ b/plugins/agami/lib/guardrail.py
@@ -62,11 +62,18 @@ RULE_MODEL_UNAVAILABLE = "model_unavailable"
 RULE_RESOURCE_LIMIT = "resource_limit"
 RULE_UNPARSEABLE = "unparseable"
 
-# Named by the contract, produced by a later gate — declared here so that work fills a constant
-# rather than inventing a string. Deliberately absent from `REASON_FOR_RULE` below: their reason is
-# the owning gate's call (`recon` is arguably `unsafe` or `out_of_scope` depending on framing), and
-# leaving them unpinned makes `refuse()` fail loudly rather than let that gate choose one silently.
+# Metadata / recon functions: `version()`, `current_user`, `has_table_privilege(…)`, the register-type
+# casts. Pinned `unsafe` by ACE-039, the gate that produces it. The reason was genuinely arguable —
+# a recon call is a reach in one framing and a hazard in another — which is why it was left for the
+# owning gate to settle in a reviewed diff rather than guessed at here. It is `unsafe` because the
+# statement is not asking the model a question it could ask differently: a semantic model declares
+# tables and columns and never declares functions, so there is no in-scope spelling of `version()`
+# for a 4b `out_of_scope` refusal to point the caller toward.
 RULE_RECON = "recon"
+# Named by the contract, produced by a later gate — declared here so that work fills a constant
+# rather than inventing a string. Deliberately absent from `REASON_FOR_RULE` below: its reason is the
+# owning gate's call, and leaving it unpinned makes `refuse()` fail loudly rather than let that gate
+# choose one silently.
 RULE_ENGINE_MISMATCH = "engine_mismatch"
 # `unscopable` is the third of these, and it is NOT a synonym for `unparseable`: an unparseable
 # statement is one sqlglot cannot read at all, while an unscopable one parses perfectly and still
@@ -93,6 +100,7 @@ REASON_FOR_RULE: dict[str, RefusalReason] = {
     # refusal in a later slice, and emitting `undetermined` now would silently pre-empt it.
     RULE_SELECT_STAR: "out_of_scope",
     RULE_MODEL_UNAVAILABLE: "undetermined",
+    RULE_RECON: "unsafe",
     # A bound we imposed, not a property of the statement: neither unsafe nor out of scope — we
     # simply did not determine the answer within the bound. Pinned before it had a producer, so the
     # gate that imposes the per-statement timeout filled a constant rather than inventing one.

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import re
 from typing import NamedTuple
 
-from guardrail import RULE_READ_ONLY, Refusal, refuse
+from guardrail import RULE_READ_ONLY, RULE_RECON, RULE_UNPARSEABLE, Refusal, refuse
 
 # Hard cap on SQL length. Prevents a compromised client from POSTing a multi-MB
 # SQL blob that takes the parser / planner / this gate down a slow path. Real
@@ -452,3 +452,209 @@ def check_read_only(sql: str | None) -> Refusal | None:
             remediation=_REMEDIATION["dangerous_function"],
         )
     return None
+
+
+# --- Recon / metadata functions (ACE-039) -----------------------------------
+#
+# FUNCTIONS ONLY. No schema names, no relation names, no relation-name prefixes, no system
+# variables. Catalog RELATIONS are the model's to refuse, not this gate's: `check_table_scope`
+# already rejects `pg_class` and `information_schema.tables` as tables the model does not declare,
+# which is the same refusal reached by the gate that owns it. The relation half was therefore
+# redundant where the model gate runs — and where it does not run, it was actively harmful: matching
+# bare schema names on every engine refused a datasource whose `sys` schema holds ordinary user
+# tables. A schema the model declares is a schema the caller may query.
+#
+# The residual is stated rather than hidden: on the vendored plugin layout `semantic_model.runtime`
+# is absent by construction (it needs sqlglot and pydantic; the mirror is stdlib-only), so catalog
+# relations have no gate there at all. Recon denial protects an operator from a caller who is not
+# them, and on that layout the user owns the machine, the credentials and the role.
+#
+# Niladic keywords and register-type casts are in scope because they are the same primitive in a
+# spelling the function matcher never sees: `current_user` is `current_user()` without the parens,
+# and `'x'::regclass` is `to_regclass('x')` without them either — the cast errors when the object is
+# absent, which is an object-existence oracle that rides inside a fully-scoped query.
+
+
+def _recon_group(names: frozenset[str]) -> str:
+    """Alternation body for a set of names, longest first.
+
+    Longest-first is load-bearing rather than tidy: regex alternation takes the first branch that
+    matches at a position, so `current_schema` listed before `current_schemas` would shadow it and
+    the longer name would never match as a whole token.
+    """
+    return "|".join(sorted(names, key=len, reverse=True))
+
+
+# Server / session / account metadata, matched only in their CALL form.
+_RECON_PAREN_FNS = frozenset(
+    {
+        "version",
+        "current_database",
+        "current_schemas",  # pg, plural, takes a bool — the niladic `current_schema` is below
+        "database",
+        "schema",
+        "user",  # MySQL user() / system_user() — the CALL form only
+        "connection_id",
+        "system_user",
+        "current_account",  # snowflake
+        "current_region",
+        "current_version",
+        "current_warehouse",
+        "inet_server_addr",  # server / client network fingerprint (pg)
+        "inet_server_port",
+        "inet_client_addr",
+        "inet_client_port",
+    }
+)
+
+# Niladic metadata keywords — the special function spelled without parens. Bare `user`, `schema` and
+# `database` are DELIBERATELY absent: they are Postgres niladic synonyms but far too common as
+# intended column names, so only their call form (above) is denied. A known, minor
+# username-fingerprint residual, taken knowingly in exchange for not refusing ordinary schemas.
+_RECON_NILADIC = frozenset(
+    {"current_user", "session_user", "current_catalog", "current_schema", "current_role"}
+)
+
+# The privilege-check family, enumerated rather than globbed. `has_\w+_privilege` also matched
+# `has_active_privilege(...)` — a plausible user-defined function, and an over-refusal is the failure
+# mode this list has already produced in real use.
+_RECON_PRIVILEGE_FNS = frozenset(
+    {
+        "has_any_column_privilege",
+        "has_column_privilege",
+        "has_database_privilege",
+        "has_foreign_data_wrapper_privilege",
+        "has_function_privilege",
+        "has_language_privilege",
+        "has_largeobject_privilege",
+        "has_parameter_privilege",
+        "has_schema_privilege",
+        "has_sequence_privilege",
+        "has_server_privilege",
+        "has_table_privilege",
+        "has_tablespace_privilege",
+        "has_type_privilege",
+    }
+)
+
+# Call FAMILIES matched by prefix, each still requiring the trailing `(`. `pg_*` is a namespace ban
+# and deliberately overlaps the dangerous-function list: `check_read_only` runs first and owns the
+# label for what it names, and this is the backstop underneath — including for builtins that ship
+# after this list is written. `to_reg*` resolves a name to an OID, the call form of the casts below.
+_RECON_CALL_FAMILIES = (r"pg_\w+", r"to_reg\w+")
+
+# Register types. `'secret'::regclass` errors when the object is absent, so it answers "does this
+# exist?" without ever naming it in a FROM clause.
+_RECON_REGTYPES = frozenset(
+    {
+        "regclass",
+        "regcollation",
+        "regconfig",
+        "regdictionary",
+        "regnamespace",
+        "regoper",
+        "regoperator",
+        "regproc",
+        "regprocedure",
+        "regrole",
+        "regtype",
+    }
+)
+
+# A quoted name with a trailing `(` is STILL A CALL, so the paren matcher covers the niladic
+# keywords too. Without that union `SELECT "current_schema"()` would be skipped by the niladic
+# matcher (it is a quoted span) and missed by the paren matcher (`current_schemas` needs its `s`) —
+# a hole the false-positive fix would otherwise open. This union is where the FP rule and the
+# deny-list interact, and it is the only place they do.
+_RECON_PAREN_RE = re.compile(
+    r"\b("
+    + _recon_group(_RECON_PAREN_FNS | _RECON_NILADIC | _RECON_PRIVILEGE_FNS)
+    + "|"
+    + "|".join(_RECON_CALL_FAMILIES)
+    + r")\s*\(",
+    re.IGNORECASE,
+)
+# `(?<!\.)` lets a qualified column through (`t.current_user`); the quoted-span check in
+# `_recon_niladic_hit` handles the bare quoted spelling (`"current_user"`), which the neutralizer
+# has by then unwrapped into something this pattern would otherwise match.
+_RECON_NILADIC_RE = re.compile(
+    r"(?<!\.)\b(" + _recon_group(_RECON_NILADIC) + r")\b", re.IGNORECASE
+)
+# Both cast spellings. `::reg*` anchors on the type name because `_neutralize` blanks the literal
+# before it, so `'x'::regclass` arrives as ` ::regclass`. The `CAST(x AS reg*)` arm requires the
+# closing paren so a column aliased `AS regclass` is not caught.
+_RECON_CAST_RE = re.compile(
+    r"::\s*(" + _recon_group(_RECON_REGTYPES) + r")\b"
+    r"|\bAS\s+(" + _recon_group(_RECON_REGTYPES) + r")\s*\)",
+    re.IGNORECASE,
+)
+
+_RECON_REMEDIATION = (
+    "Remove the server-metadata call — query only the tables and columns your model declares. "
+    "Server version, session identity, privilege probes and object-existence casts are never "
+    "executed here."
+)
+
+
+def _recon_niladic_hit(neutral: _Neutralized) -> re.Match[str] | None:
+    """The niladic keyword, skipping any occurrence that was a quoted identifier.
+
+    The ONLY consumer of `_Neutralized.quoted`. A double-quoted bare word is unambiguously an
+    identifier — `SELECT "current_user" FROM audit_log` reads a column — while the same word
+    unquoted is the special function. The neutralizer drops the delimiters (that unwrapping is what
+    keeps a welded `"pg_read_file"(...)` visible to the read-only gate), so the distinction survives
+    only in the spans it reports.
+
+    Containment must be FULL. A partial overlap means the span and the match disagree about where
+    the token is, and the safe reading of a disagreement is not to skip.
+    """
+    for match in _RECON_NILADIC_RE.finditer(neutral.text):
+        if not any(s <= match.start() and match.end() <= e for s, e in neutral.quoted):
+            return match
+    return None
+
+
+def check_no_recon(sql: str | None) -> Refusal | None:
+    """Return ``None`` when ``sql`` calls no metadata / recon function, else a ``Refusal``.
+
+    Runs immediately after :func:`check_read_only` at the shared executor chokepoint, over the SAME
+    neutralized text — comments and literals blanked, quoted identifiers unwrapped — so a recon token
+    hidden in a string cannot smuggle past and a legitimate mention inside one cannot false-trip.
+    No second parser: this module is regex over `_neutralize`, and the sqlglot pass lives in
+    `semantic_model.runtime`, which the vendored mirror cannot import.
+
+    Order is fixed, so the label is deterministic: a name on both this list and the
+    dangerous-function list refuses as ``read_only``, because that gate runs first and owns what it
+    names (principle 9).
+    """
+    if not sql or not sql.strip():
+        return None  # empty — `check_read_only` owns that rejection, and its remediation
+
+    try:
+        neutral = _neutralize(sql)
+    except _GuardReject as reject:
+        # A statement we cannot read is not a statement we caught fingerprinting the server. It
+        # fails closed either way, but as `undetermined`/`unparseable` — labelling it `recon` told
+        # the caller it had tried something it had not, and handed it a recon fix for a parse
+        # problem. Unreachable at the chokepoint, where `check_read_only` runs the same neutralizer
+        # and refuses first; reachable, and covered, as a standalone call.
+        return refuse(
+            RULE_UNPARSEABLE, detail=reject.detail, remediation=reject.remediation
+        )
+
+    match = (
+        _RECON_PAREN_RE.search(neutral.text)
+        or _recon_niladic_hit(neutral)
+        or _RECON_CAST_RE.search(neutral.text)
+    )
+    if match is None:
+        return None
+
+    # Echo the token the caller itself sent, never the alternatives. A refusal that lists what IS
+    # allowed is a schema-listing endpoint.
+    hit = match.group(0).strip(" .(:")
+    return refuse(
+        RULE_RECON,
+        detail=f"metadata/recon access is not allowed (`{hit}`)",
+        remediation=_RECON_REMEDIATION,
+    )

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -209,6 +209,7 @@ def _neutralize(sql: str) -> _Neutralized:
             i = j
         elif sql[i] == '"':  # double-quoted identifier — keep content, drop quotes
             j, buf = i + 1, []
+            closed = False
             while j < n:
                 if sql[j] == '"':
                     if j + 1 < n and sql[j + 1] == '"':  # doubled "" escape
@@ -216,6 +217,7 @@ def _neutralize(sql: str) -> _Neutralized:
                         j += 2
                         continue
                     j += 1
+                    closed = True
                     break
                 buf.append(sql[j])
                 j += 1
@@ -244,7 +246,15 @@ def _neutralize(sql: str) -> _Neutralized:
             # `quoted` names the identifier and never the boundary this branch re-supplied.
             start = width
             emit("".join(buf))
-            spans.append((start, width))
+            # Record a span ONLY for an identifier whose closing delimiter we actually consumed.
+            # An unterminated `"` swallows the rest of the statement into `buf`, and a span over
+            # that tail would tell the niladic matcher to skip every keyword inside it — an
+            # UNDER-refusal, the one direction this design must never fail in. It is reachable:
+            # MySQL's default sql_mode treats `"` as a string delimiter with backslash escapes, so
+            # `SELECT "a\"b" , current_user FROM t` re-opens a runaway identifier here while MySQL
+            # executes it and returns CURRENT_USER(). No span means no skip, so the gate refuses.
+            if closed:
+                spans.append((start, width))
             nxt = sql[j] if j < n else ""
             if nxt.isalnum() or nxt == "_":
                 emit(" ")
@@ -583,9 +593,14 @@ _RECON_NILADIC_RE = re.compile(
 # Both cast spellings. `::reg*` anchors on the type name because `_neutralize` blanks the literal
 # before it, so `'x'::regclass` arrives as ` ::regclass`. The `CAST(x AS reg*)` arm requires the
 # closing paren so a column aliased `AS regclass` is not caught.
+# The optional `\w+\s*\.\s*` is a SCHEMA QUALIFIER, and it is load-bearing:
+# `'secret_table'::pg_catalog.regclass` is the same object-existence oracle in the spelling a
+# deny-list that anchors straight after `::` never sees. `_neutralize` has already unwrapped quotes
+# by this point, so `"pg_catalog"."regclass"` arrives here as `pg_catalog.regclass` and is covered
+# by the same branch. The call matcher tolerated qualification already; this arm did not.
 _RECON_CAST_RE = re.compile(
-    r"::\s*(" + _recon_group(_RECON_REGTYPES) + r")\b"
-    r"|\bAS\s+(" + _recon_group(_RECON_REGTYPES) + r")\s*\)",
+    r"::\s*(?:\w+\s*\.\s*)?(" + _recon_group(_RECON_REGTYPES) + r")\b"
+    r"|\bAS\s+(?:\w+\s*\.\s*)?(" + _recon_group(_RECON_REGTYPES) + r")\s*\)",
     re.IGNORECASE,
 )
 

--- a/plugins/agami/lib/sql_guard.py
+++ b/plugins/agami/lib/sql_guard.py
@@ -21,6 +21,7 @@ whole object rather than re-deriving a shape of their own.
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
 
 from guardrail import RULE_READ_ONLY, Refusal, refuse
 
@@ -89,7 +90,33 @@ class _GuardReject(Exception):
         super().__init__(detail)
 
 
-def _neutralize(sql: str) -> str:
+class _Neutralized(NamedTuple):
+    """The analysis copy of a statement, plus where its quoted identifiers ended up.
+
+    `text` is the neutralized statement, **already stripped**. `quoted` holds one
+    `[start, end)` per double-quoted identifier, naming that identifier's CONTENT in
+    `text`'s own coordinates — never the re-supplied separators around it.
+
+    **One coordinate frame, deliberately.** The scan re-supplies separator spaces and
+    drops delimiters, so input offsets are not output offsets, and stripping afterwards
+    would shift them a third time. Doing the strip *inside* this function and reporting
+    spans against the stripped result is what makes a span usable without any caller
+    reconciling frames. A span in the wrong frame does not fail loudly; it mis-identifies
+    a token, so the frame is collapsed to one rather than documented.
+
+    **Only the niladic recon matcher reads `quoted`.** Every other consumer — the
+    read-only gate above all — matches `text` with the quotes already dropped, because
+    that unwrapping is what keeps `SELECT*FROM"pg_read_file"(...)` visible to a
+    `\\b`-anchored pattern. A quoted bare word is unambiguously an identifier; a quoted
+    name with a trailing `(` is still a call. That distinction is the consumer's to make,
+    which is why this type reports provenance and decides nothing.
+    """
+
+    text: str
+    quoted: tuple[tuple[int, int], ...]
+
+
+def _neutralize(sql: str) -> _Neutralized:
     """Blank out comments and string / dollar-quoted literals, and drop the quote
     delimiters of double-quoted identifiers (keeping their content), in a SINGLE
     left-to-right pass so the FIRST-opened construct wins — exactly how the database
@@ -111,6 +138,9 @@ def _neutralize(sql: str) -> str:
     identifier are treated as doubled-delimiter escapes (standard SQL). Backslash is
     deliberately NOT an escape here — engines disagree (MySQL yes, standard PG no),
     and not honoring it can only stop a literal *early* (fail safe), never late.
+
+    Returns a `_Neutralized` — the stripped text plus the quoted-identifier spans. See
+    that type for why the strip happens here rather than at the call site.
     """
     def _last_emitted(chunks: list[str]) -> str:
         """The last character actually emitted, skipping empty chunks.
@@ -125,6 +155,14 @@ def _neutralize(sql: str) -> str:
         return ""
 
     out: list[str] = []
+    spans: list[tuple[int, int]] = []
+    width = 0  # running len("".join(out)), so a span can be recorded as it is emitted
+
+    def emit(chunk: str) -> None:
+        nonlocal width
+        out.append(chunk)
+        width += len(chunk)
+
     i, n = 0, len(sql)
     while i < n:
         two = sql[i : i + 2]
@@ -143,7 +181,7 @@ def _neutralize(sql: str) -> str:
             j = i + 2
             while j < n and sql[j] not in "\r\n":
                 j += 1
-            out.append(" ")
+            emit(" ")
             i = j
         elif two == "/*":  # block comment
             # `/*! ... */` (and versioned `/*!NNNNN ... */`) is a MySQL *executable*
@@ -156,7 +194,7 @@ def _neutralize(sql: str) -> str:
                 )
             end = sql.find("*/", i + 2)
             i = n if end == -1 else end + 2
-            out.append(" ")
+            emit(" ")
         elif sql[i] == "'":  # single-quoted string literal
             j = i + 1
             while j < n:
@@ -167,7 +205,7 @@ def _neutralize(sql: str) -> str:
                     j += 1
                     break
                 j += 1
-            out.append(" ")
+            emit(" ")
             i = j
         elif sql[i] == '"':  # double-quoted identifier — keep content, drop quotes
             j, buf = i + 1, []
@@ -201,11 +239,15 @@ def _neutralize(sql: str) -> str:
             # pinned by an explicit output test, since no current rule distinguishes the
             # two spellings on its own.
             if _last_emitted(out).isalnum() or _last_emitted(out) == "_":
-                out.append(" ")
-            out.append("".join(buf))
+                emit(" ")
+            # Record the span AROUND the content only, between the two separator emits, so
+            # `quoted` names the identifier and never the boundary this branch re-supplied.
+            start = width
+            emit("".join(buf))
+            spans.append((start, width))
             nxt = sql[j] if j < n else ""
             if nxt.isalnum() or nxt == "_":
-                out.append(" ")
+                emit(" ")
             i = j
         elif sql[i] == "$":  # dollar-quoted string literal ($$...$$ or $tag$...$tag$)
             # Only a `$tag$` with a MATCHING close delimiter is a literal we can blank.
@@ -217,14 +259,25 @@ def _neutralize(sql: str) -> str:
             close = sql.find(m.group(0), m.end()) if m else -1
             if m and close != -1:
                 i = close + len(m.group(0))
-                out.append(" ")
+                emit(" ")
             else:
-                out.append("$")
+                emit("$")
                 i += 1
         else:
-            out.append(sql[i])
+            emit(sql[i])
             i += 1
-    return "".join(out)
+    raw = "".join(out)
+    text = raw.strip()
+    lead = len(raw) - len(raw.lstrip())
+    limit = len(text)
+    # Shift every span into the stripped frame, and DROP any the strip disturbed rather
+    # than clamping it. Dropping is the safe direction: a missing span means the niladic
+    # matcher does not skip that token, so the gate over-refuses. Clamping a span that ran
+    # off either end would instead widen the skipped region and could hide a live keyword.
+    kept = tuple(
+        (s - lead, e - lead) for s, e in spans if 0 <= s - lead < e - lead <= limit
+    )
+    return _Neutralized(text, kept)
 
 
 # Allowed opening keyword. `WITH` covers CTEs whose final clause is a SELECT.
@@ -343,7 +396,7 @@ def check_read_only(sql: str | None) -> Refusal | None:
     # nothing hidden inside a literal or comment can reach the checks below. See
     # `_neutralize` for why a single scan is required rather than layered regexes.
     try:
-        stripped = _neutralize(sql).strip()
+        stripped = _neutralize(sql).text
     except _GuardReject as reject:
         return refuse(RULE_READ_ONLY, detail=reject.detail, remediation=reject.remediation)
 

--- a/plugins/agami/shared/db_error_classifier.md
+++ b/plugins/agami/shared/db_error_classifier.md
@@ -27,8 +27,21 @@ Credentials live in `<artifacts_dir>/local/credentials` (per-profile `[section]`
 | `column_not_found` | psycopg2 `UndefinedColumn`; mysql `1054` `Unknown column`; snowflake `Invalid identifier`; BigQuery `Name <x> not found`; sqlite `no such column`; SF `INVALID_FIELD` | If the missing column **is** in the local semantic model YAML: `"Your model references <col> but it's no longer in the live database — schema drift. Re-introspect with /agami-connect to sync."` Otherwise: `"Generated SQL referenced a column that doesn't exist. Re-run the query — it'll auto-retry with corrected SQL."` |
 | `table_not_found` | psycopg2 `UndefinedTable`; mysql `1146` `Table doesn't exist`; snowflake `Object <x> does not exist`; BigQuery `Table <x> not found`; sqlite `no such table` | If the missing table **is** in the local semantic model: `"Your model references <table> but it's no longer in the live database — schema drift. Re-introspect with /agami-connect to sync."` Otherwise: `"Generated SQL referenced a table that doesn't exist in this datasource. Re-run the query."` |
 | `syntax` | psycopg2 `SyntaxError` (DB-side); mysql `1064` `You have an error in your SQL syntax`; snowflake `compilation error`; sqlite `near "X": syntax error` | `"SQL syntax error from the generator. Re-run the query — auto-retry usually fixes generator slips."` |
-| `timeout` | psycopg2 `QueryCanceled`; mysql `2013 Lost connection during query`; snowflake `query was canceled`; explicit `statement_timeout` errors | `"Query timed out. Add a tighter filter, a LIMIT, or a date range — large unfiltered scans hit the DB's statement_timeout. If a big table keeps timing out, give it a recommended_filters entry in its semantic-model YAML."` |
 | `other` | anything else | `"<original error message>. For deeper per-datasource troubleshooting see the connection reference (plugins/agami/shared/connection-reference.md) and docs/troubleshooting.md."` |
+
+**There is no `timeout` row, deliberately.** It used to detect psycopg2 `QueryCanceled`, MySQL 2013,
+Snowflake `query was canceled` and explicit `statement_timeout` errors — every one of which is a
+*cancellation signature*, and a deadline is now classified from the watchdog signal that fired it
+rather than from whatever string the driver happened to return. `timeout` survives as a
+`FailureKind` with exactly one producer, the subprocess supervisor stopping an executor that never
+returned, which no rule in this table can see. A per-statement deadline is a `resource_limit`
+**refusal**, not a classified error: it is a decision the server made, so it carries a remediation,
+which is precisely what a failure does not.
+
+An unattributable server-side cancellation therefore classifies as `other`. That is the honest
+label — deleting the row without saying so would have let those errors fall through to `network`
+(the "timed out" wording) or to `syntax` (the exit-code prior), and both read as a diagnosis this
+table cannot actually make.
 
 ## Drift-aware column / table classification
 
@@ -64,6 +77,11 @@ The classifier returns:
 
 ```python
 {
+  # The vocabulary is owned by `guardrail.FailureKind` — this document does not declare its own.
+  # Two surfaces read the same kinds and present them differently, which is the point: locally the
+  # raw error is already in front of the user and a remediation is worth giving, while
+  # `execute_sql`'s failure crosses the LLM boundary and carries `{kind, message}` with no
+  # remediation and no value text. Detection rules are shared; presentation is per-surface.
   "kind": "auth | dsn | network | driver_missing | permission | column_not_found | table_not_found | syntax | timeout | other",
   "remediation": "<one-line user-facing remediation message>",
   "raw_message": "<original exception message, truncated to 500 chars>",

--- a/plugins/agami/skills/agami-query/SKILL.md
+++ b/plugins/agami/skills/agami-query/SKILL.md
@@ -389,8 +389,13 @@ Route any non-zero exit through [`shared/db_error_classifier.md`](../../shared/d
 | `driver_missing` | Fall through to the next available method (native CLI → DuckDB → Python driver). |
 | `permission` | Stop. DB user lacks SELECT on the touched dataset. |
 | `column_not_found`, `table_not_found`, `syntax` | Auto-retry up to **2** times. Pass the error back to the SQL generator: "The previous SQL failed with `<one-line classifier message>`. Regenerate using only table / column names from the schema context above." |
-| `timeout` | Stop. Suggest adding a filter using the `recommended_filters` from the dataset's performance hints. |
 | `other` | Stop. Surface raw error truncated to 200 chars. |
+
+A statement stopped for taking too long no longer arrives here as an error. A per-statement deadline
+is a **`resource_limit` refusal**, which carries its own remediation because it is a decision the
+server made — handle it as a refusal, not as a classified failure. The `timeout` failure kind now
+has one producer, the supervisor stopping an executor that never responded, and there is nothing
+query-specific to suggest for it.
 
 After 2 retries with no success, stop. Don't loop.
 

--- a/tests/test_ace035_envelope.py
+++ b/tests/test_ace035_envelope.py
@@ -236,7 +236,11 @@ def test_tool_edge_failed_shape(monkeypatch, _emitted):
     assert set(out) == {"status", "failure", "sql", "execution_ms", "audit_id"}
     assert out["status"] == "failed"
     assert set(out["failure"]) == {"kind", "message"}
-    assert out["failure"]["kind"] == "syntax"
+    # Was `syntax`, which was just the exit-5 prior showing through: nothing read the text, so
+    # every code-5 error got the same label. ACE-039 classifies it, and "no such column" is a
+    # missing column rather than a syntax error — a distinction the caller can act on.
+    assert out["failure"]["kind"] == "column_not_found"
+    assert "no such column" not in out["failure"]["message"]
     assert len(_emitted) == 1
 
 

--- a/tests/test_ace035_guardrail_audit.py
+++ b/tests/test_ace035_guardrail_audit.py
@@ -234,6 +234,11 @@ _STATUSES = [
     ("ok", "SELECT id FROM orders", "ok", None),
     ("refused-column-scope", "SELECT nope FROM orders", "refused", guardrail.RULE_COLUMN_SCOPE),
     ("refused-read-only", "DELETE FROM orders", "refused", guardrail.RULE_READ_ONLY),
+    # A third refusal, from a third place again: the recon gate sits at the chokepoint between the
+    # other two, after the read-only gate and before the model pass, and it is the only refusal that
+    # is NOT skippable by `--no-safety` yet is also not a write. Its row is what proves a refusal is
+    # audited on the strength of being a refusal rather than of which gate produced it.
+    ("refused-recon", "SELECT id, version() FROM orders", "refused", guardrail.RULE_RECON),
     ("failed", "SELECT amount FROM orders", "failed", None),
 ]
 _STATUS_IDS = [label for label, _, _, _ in _STATUSES]

--- a/tests/test_ace035_guardrail_contract.py
+++ b/tests/test_ace035_guardrail_contract.py
@@ -165,21 +165,23 @@ def test_every_rule_this_slice_can_emit_has_a_pinned_reason():
     """`refuse()` raises KeyError on an unpinned rule, so `REASON_FOR_RULE` is the list a new gate
     must extend. Everything emittable today is pinned."""
     assert _declared_rules() - set(REASON_FOR_RULE) == {
-        guardrail.RULE_RECON,
         guardrail.RULE_ENGINE_MISMATCH,
         guardrail.RULE_UNSCOPABLE,
     }
 
 
-@pytest.mark.parametrize("rule", ["recon", "engine_mismatch", "unscopable"])
+@pytest.mark.parametrize("rule", ["engine_mismatch", "unscopable"])
 def test_a_named_but_unproduced_rule_is_deliberately_unpinned(rule):
-    """`recon`, `engine_mismatch` and `unscopable` are named by the contract but produced by later
-    slices. For the first two the reason is genuinely those slices' call — `recon` could be `unsafe`
-    or `out_of_scope` depending on how it is framed. `unscopable` is a different case: the contract
-    already says `undetermined`, so leaving it out of `REASON_FOR_RULE` is not deferring a decision,
-    it is making the owning gate write the one line the contract dictates in a diff a reviewer sees,
-    alongside the gate that first emits it. Either way `refuse()` fails loudly rather than letting a
-    slice pick a reason without pinning it here."""
+    """`engine_mismatch` and `unscopable` are named by the contract but produced by later slices.
+    For the first the reason is genuinely that slice's call. `unscopable` is a different case: the
+    contract already says `undetermined`, so leaving it out of `REASON_FOR_RULE` is not deferring a
+    decision, it is making the owning gate write the one line the contract dictates in a diff a
+    reviewer sees, alongside the gate that first emits it. Either way `refuse()` fails loudly rather
+    than letting a slice pick a reason without pinning it here.
+
+    `recon` LEFT this list in ACE-039, which is the slice that produces it. Its reason was the one
+    genuinely arguable case — a recon call is a reach in one framing and a hazard in another — and
+    it settled as `unsafe`, pinned in the table below."""
     assert rule not in REASON_FOR_RULE
     with pytest.raises(KeyError):
         refuse(rule, detail="d", remediation="r")
@@ -197,6 +199,10 @@ def test_a_named_but_unproduced_rule_is_deliberately_unpinned(rule):
         ("model_unavailable", "undetermined"),
         ("resource_limit", "undetermined"),
         ("unparseable", "undetermined"),
+        # Pinned by ACE-039, the gate that produces it. `unsafe` rather than `out_of_scope`
+        # because a model declares tables and columns and never declares functions, so there is
+        # no in-scope spelling of `version()` for an out-of-scope refusal to point toward.
+        ("recon", "unsafe"),
     ],
 )
 def test_the_reason_for_each_rule_is_pinned(rule, reason):

--- a/tests/test_ace035_no_enumeration.py
+++ b/tests/test_ace035_no_enumeration.py
@@ -36,13 +36,13 @@ is enumeration reaching the caller through the operational channel rather than t
 
 **What it does NOT cover, in two different senses.**
 
-*Not yet fixed.* Driver text is relayed to `failure.message` unsanitized, so a driver that
-volunteers a declared name puts it in front of the caller. That is measured here rather than
-assumed: `test_a_driver_hint_enumerates_the_model_until_ace039_lands` drives exactly that shape and
-is `xfail(strict=True)`. Sanitizing driver text is the error-hardening slice's job (ACE-039), not
-this one's — and the strict marker means the day it lands, that test flips green and says so.
-Everything this slice *does* author into `failure.message` is value-free: the guarded path's
-catch-all message is a fixed string, and the forked path no longer relays unstructured child stderr.
+*Fixed by ACE-039.* Driver text used to be relayed to `failure.message` unsanitized, so a driver
+that volunteered a declared name put it in front of the caller. That was measured here rather than
+assumed, as an `xfail(strict=True)`; the error-hardening slice now classifies FROM the driver text
+and returns a fixed value-free sentence INSTEAD of it, the marker is gone, and
+`test_a_driver_hint_never_reaches_the_caller` asserts the closed shape. Everything reaching
+`failure.message` is now value-free on every path: the classified sentences, the guarded path's
+catch-all fixed string, and the forked path, which no longer relays unstructured child stderr.
 
 *Not fixable here.* The table- and column-scope details confirm "this identifier is not in the
 model", which is a one-bit membership oracle per probed identifier: a caller willing to send N
@@ -457,24 +457,22 @@ class _PostgresLikeExecutor:
         raise execute_sql.ExecutorError(_PG_HINT_ERROR, code=5)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ACE-039 owns sanitizing driver text; until it lands, a driver HINT reaches the caller "
-           "through failure.message. Measured rather than assumed — this flips green when it lands.",
-)
-def test_a_driver_hint_enumerates_the_model_until_ace039_lands(declared):
-    """The known gap, driven rather than described.
+def test_a_driver_hint_never_reaches_the_caller(declared):
+    """The gap this file measured as an `xfail(strict=True)`, now closed.
 
     PostgreSQL routinely appends `HINT: Perhaps you meant to reference the column "…"` to an
     undefined-column error, and that hint names a column of the table — a declared name the caller
-    did not send. It arrives on `failure.message`, which is relayed from the driver verbatim: the
-    guardrail refuses to enumerate, and then the operational channel does it anyway.
+    did not send. It arrived on `failure.message`, relayed from the driver verbatim: the guardrail
+    refused to enumerate, and then the operational channel did it anyway.
 
-    Deliberately NOT fixed here. Classifying and sanitizing driver text across ten engines is the
-    error-hardening slice's whole job, and a partial regex in this slice would look like coverage
-    while missing the engines nobody thought of. So the vector stays, marked `strict` so it cannot
-    rot in either direction: if it starts passing, ACE-039 has landed and this marker must go; if
-    the assertion changes shape, it fails loudly.
+    ACE-039 classifies FROM that text and returns a fixed value-free sentence INSTEAD of it, so the
+    channel closes without the caller losing the ability to tell a missing column from a syntax
+    error. The `strict` marker is gone with the gap — a strict xfail that passes is a CI error, and
+    that is exactly the alarm it was there to raise.
+
+    The executor here raises with `code=5` and no special flag, which is why the discriminator is
+    the exit code rather than something the adapter opts into: an adapter that does nothing unusual
+    is still sanitized.
 
     One route is enough. The fork path relays the same child-classified text for the same exit code,
     so this pins the field, not the transport.

--- a/tests/test_ace035_no_enumeration.py
+++ b/tests/test_ace035_no_enumeration.py
@@ -332,6 +332,11 @@ VECTORS = (
     (guardrail.RULE_SELECT_STAR, "SELECT * FROM orders"),
     (guardrail.RULE_COLUMN_SCOPE, "SELECT ref_no FROM orders"),
     (guardrail.RULE_RESOURCE_LIMIT, _RUNAWAY_SQL),
+    # recon — `version()` is not on the dangerous-function list, so the read-only gate passes it,
+    # and the recon gate runs before the model pass, so it fires first. `id` and `orders` are
+    # declared AND sent by the caller, so echoing them is legitimate; the token the detail actually
+    # echoes is `version`, which is the caller's own.
+    (guardrail.RULE_RECON, "SELECT id, version() FROM orders"),
 )
 
 UNAVAILABLE_SQL = "SELECT id FROM orders"
@@ -734,9 +739,15 @@ def test_echoing_the_callers_own_identifier_is_allowed():
 # to the completeness assertion is the point.
 _NO_VECTOR = {
     guardrail.RULE_UNPARSEABLE: (
-        "No producer. Every gate degrades to ALLOW when sqlglot cannot read the statement rather "
-        "than refusing, so nothing constructs this rule yet; turning that fail-open into a refusal "
-        "is the unparseable-statement slice's job, and the refusal it introduces needs a vector here."
+        "One producer, unreachable on every route. `sql_guard.check_no_recon` refuses `unparseable` "
+        "when the neutralizer cannot read the statement (ACE-039) — but at the chokepoint "
+        "`check_read_only` runs the SAME neutralizer first and refuses as `read_only`, so no route "
+        "reaches it and a vector here could not drive it. Its detail is the neutralizer's own static "
+        "prose, carrying no model-derived text. Covered as a standalone call by "
+        "test_ace039_recon.py::test_an_unreadable_statement_is_undetermined_not_recon. The "
+        "sqlglot-level gates still degrade to ALLOW rather than refusing; turning that fail-open "
+        "into a refusal is the unparseable-statement slice's job, and the refusal it introduces "
+        "will be reachable and will need a vector here."
     ),
     guardrail.RULE_MODEL_SAFETY: (
         "Reachable, but its detail is authored as static prose at a single construction site in "
@@ -769,7 +780,7 @@ def test_every_rule_and_every_route_is_covered():
     assert not covered & set(_NO_VECTOR)
     assert all(reason.strip() for reason in _NO_VECTOR.values())
     assert set(ROUTES) == {"in_process", "fork", "stdio", "http"}
-    assert len(_MATRIX) == len(VECTORS) * len(ROUTES) == 20
+    assert len(_MATRIX) == len(VECTORS) * len(ROUTES) == 24
     # The `failed` channel is covered by its own matrix rather than this one, because it has no
     # rule. Its vector must not be one of these: a statement that a gate refuses would report on the
     # refusal channel a second time and leave `failure.message` unscanned again, which is exactly

--- a/tests/test_ace035_read_only_refusal.py
+++ b/tests/test_ace035_read_only_refusal.py
@@ -174,20 +174,40 @@ def test_parent_rejects_a_malformed_refusal() -> None:
 
 
 def test_the_childs_own_config_diagnostic_is_relayed() -> None:
-    """A classified exit carries text the child authored and the caller needs.
+    """An AUTHORED exit carries text the child wrote and the caller needs.
 
-    Exit 2/3/4/5 are the codes `execute_sql.main` reaches by writing `env.failure.message`, so the
-    text is something the child classified and chose — a missing driver, a connect failure, or the
-    credential remediation naming the env var to set. Relaying it is also what keeps the two
-    execution paths saying the same thing: the in-process path surfaces the same string from
-    `ExecutorError.msg` (pinned in tests/test_ah012_executor_seam.py).
+    Exit 2 and 3 are the codes whose message this module composed — a missing driver, or the
+    credential remediation naming the env var to set. They contain nothing the database said, so
+    relaying them is what keeps the two execution paths saying the same thing: the in-process path
+    surfaces the same string from `ExecutorError.msg` (pinned in tests/test_ah012_executor_seam.py).
+
+    Codes 4 and 5 USED to be asserted here too, on the reading that they were equally the child's
+    own. ACE-039 separated them: those carry the driver's exception, so the child replaces them with
+    a fixed sentence and the parent rebuilds that sentence from the exit code rather than relaying
+    the stream. That case now lives in `test_the_sanitized_band_is_rebuilt_not_relayed` below.
     """
     detailed = ("No warehouse credentials for profile [acme]. Set DATASOURCE_URL "
                 "(or DATASOURCE_URL__ACME) in the environment.")
     assert tools._child_failure_message(2, detailed) == detailed
-    assert tools._child_failure_message(4, "Postgres connect failed: refused") == (
-        "Postgres connect failed: refused"
-    )
+    driver_missing = "pymysql not installed. Run: pip install pymysql"
+    assert tools._child_failure_message(3, driver_missing) == driver_missing
+
+
+@pytest.mark.parametrize("code", [4, 5, 7, 8, 9, 10])
+def test_the_sanitized_band_is_rebuilt_not_relayed(code: int) -> None:
+    """For a driver-originated failure the parent reconstructs; it never reads the child's stream.
+
+    The child's stderr is SHARED — the model-safety pass writes its own notices there before the
+    failure line — so relaying it handed the caller text it never sent. Since the child derives its
+    message from the kind, the exit code alone is enough to rebuild the identical sentence, which
+    makes the stream irrelevant to the answer rather than merely filtered.
+    """
+    import execute_sql
+
+    kind = execute_sql.EXIT_TO_FAILURE_KIND[code]
+    noisy = f"[agami] applied default_filters: [\"t.tenant = 'X'\"]\n{execute_sql._ERROR_MESSAGES[kind]}"
+    assert tools._child_failure_message(code, noisy) == execute_sql._ERROR_MESSAGES[kind]
+    assert "tenant" not in tools._child_failure_message(code, noisy)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ace038_timeout.py
+++ b/tests/test_ace038_timeout.py
@@ -201,6 +201,11 @@ def test_the_budget_has_exactly_one_configuration_surface():
     context_vars = {
         name for name, value in vars(execute_sql).items() if isinstance(value, ContextVar)
     }
+    # `_last_error_detail` (ACE-039) is a ContextVar but not a CONFIGURATION surface: it carries the
+    # raw driver text OUT of a failed call for the audit row, is written after the budget has already
+    # been resolved and spent, and is never read to compute a bound. The hazard this test names is a
+    # second INPUT to the budget that the fork cannot carry; an output carrier is not one.
+    context_vars -= {"_last_error_detail"}
     assert context_vars == {"_max_rows_override"}, (
         "a second, higher-precedence configuration surface for the budget cannot cross the fork; "
         f"found {sorted(context_vars)}"
@@ -1084,8 +1089,16 @@ def test_an_executor_error_keeps_its_type_across_the_worker(warehouse):
     )
 
     assert env.status == "failed"
-    assert env.failure.kind == "syntax"  # the classified branch, i.e. `except ExecutorError` matched
-    assert env.failure.message == "no such column: nope"
+    # The classified branch, i.e. `except ExecutorError` matched. Was `syntax` before ACE-039, which
+    # was the exit-5 prior showing through rather than a read of the text; `SELECT c FROM orders`
+    # against a warehouse with no `c` is a missing column.
+    assert env.failure.kind == "column_not_found"
+    # The message is the classified sentence, not the driver's text (ACE-039). What this test is
+    # actually about survives unchanged: the exception kept its TYPE across the worker thread, which
+    # is what `except ExecutorError` matching at all proves — had it been re-wrapped, the catch-all
+    # would have produced `other` and the generic unexpected-failure message instead.
+    assert env.failure.message == execute_sql._ERROR_MESSAGES["column_not_found"]
+    assert "nope" not in env.failure.message
     assert env.failure.message != execute_sql.UNEXPECTED_FAILURE_MESSAGE
 
 

--- a/tests/test_ace039_error_detail.py
+++ b/tests/test_ace039_error_detail.py
@@ -270,3 +270,57 @@ def test_migrations_are_re_runnable(tmp_path):
     finally:
         conn.close()
     assert cols.count("error_detail") == 1
+
+
+def test_the_fork_does_not_relay_the_models_own_notices_to_the_caller(tmp_path, monkeypatch):
+    """The child's stderr is a SHARED stream, so relaying it leaked declared model surface.
+
+    `_model_safety` writes `[agami] applied default_filters: …` to stderr before execution, and
+    `main` appends the sanitized failure line after it. `_child_failure_message` relayed the
+    whole stream, so the caller received a row-level tenancy predicate it never sent — on the
+    DEFAULT transport, while the in-process path returned the clean sentence. The fork/in-process
+    parity this slice exists to establish was false exactly where it mattered.
+
+    The parent now RECONSTRUCTS the message from the exit code for the sanitized band. The child
+    derived that sentence from the kind, so the kind is all the parent needs, and nothing the
+    child writes to stderr can reach the answer.
+    """
+    import yaml
+    from store import Store
+
+    app_db = tmp_path / "app.db"
+    store = Store.connect(f"sqlite:///{app_db}")
+    store.run_migrations()
+    store.close()
+
+    artifacts = tmp_path / "artifacts"
+    _write_model(artifacts / PROFILE)
+    # A declared row filter, which is business logic the caller never sends and must never see.
+    table = artifacts / PROFILE / "subject_areas" / "sales" / "tables" / "orders.yaml"
+    model = yaml.safe_load(table.read_text())
+    model["default_filters"] = ["orders.tenant_id = 'ACME-INTERNAL-7742'"]
+    table.write_text(yaml.safe_dump(model))
+
+    warehouse = tmp_path / "warehouse.db"
+    conn = sqlite3.connect(warehouse)
+    conn.execute("CREATE TABLE orders (id INTEGER, tenant_id TEXT)")
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("AGAMI_DB_URL", f"sqlite:///{app_db}")
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(artifacts))
+    monkeypatch.setenv(f"DATASOURCE_URL__{PROFILE.upper()}", f"sqlite:///{warehouse}")
+
+    body = json.loads(
+        tools.tool_execute_sql({"sql": "SELECT amount FROM orders", "datasource": PROFILE})
+    )
+
+    assert body["status"] == "failed"
+    message = body["failure"]["message"]
+    assert "ACME-INTERNAL-7742" not in message, "the model's row filter reached the caller"
+    assert "tenant_id" not in message
+    assert "default_filters" not in message
+    assert "[agami]" not in message
+    # And it is exactly the sentence the in-process path would have returned.
+    assert message == execute_sql._ERROR_MESSAGES[body["failure"]["kind"]]

--- a/tests/test_ace039_error_detail.py
+++ b/tests/test_ace039_error_detail.py
@@ -1,0 +1,272 @@
+"""The raw driver error is kept where only an operator can read it.
+
+The caller receives a classified value-free sentence, so sanitizing without capturing would
+leave an operator debugging a real customer failure with nothing at all. The detail goes to
+`query_executions.error_detail` — a column on the row that already exists, keyed by the same
+`audit_id` the caller was handed, because the record is 1:1 with the execution.
+
+NULL is a claim, not a gap: it means the chokepoint holding the raw text and the recorder
+writing the row were not in one process. On the forked stdio surface that is by design.
+
+The sharpest test here is `test_the_forked_child_leaks_nothing_through_its_logger`. Logging
+raw text in the child is not obviously safe: this module never calls `basicConfig`, so a
+record falls through to `logging.lastResort` and lands on stderr, and the parent relays the
+child's stderr into `failure.message`. Handing the text back to the caller on the default
+surface would have undone the whole slice, in the very code meant to protect it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+
+import execute_sql
+import pytest
+import tools
+import yaml
+
+PROFILE = "acme"
+PG_ERROR = (
+    'Postgres execution error: column "amount" does not exist\n'
+    'HINT:  Perhaps you meant to reference the column "orders.internal_ref".'
+)
+
+
+class _Raiser:
+    def execute(self, vetted_sql, creds, *, profile):  # noqa: ANN001, ANN201
+        raise execute_sql.ExecutorError(PG_ERROR, code=5)
+
+
+def _write_model(root) -> None:
+    """`orders` declared with `id` and `amount`; the warehouse below has only `id`.
+
+    That gap is what lets a statement pass every gate and be rejected by the DATABASE, which is
+    the branch these tests need — and it has to be a real model on disk rather than a stubbed
+    `_model_safety`, because the forked child is a fresh process and inherits no monkeypatch.
+    """
+    (root / "subject_areas" / "sales" / "tables").mkdir(parents=True)
+    (root / "datasource.yaml").write_text(
+        yaml.safe_dump({"datasource": "Shop", "version": 1,
+                        "subject_areas": ["subject_areas/sales"]})
+    )
+    (root / "subject_areas" / "sales" / "subject_area.yaml").write_text(
+        yaml.safe_dump({"name": "sales", "tables": [
+            {"storage_connection": "c", "schema": "public", "table": "orders"}]})
+    )
+    (root / "subject_areas" / "sales" / "tables" / "orders.yaml").write_text(
+        yaml.safe_dump({
+            "name": "orders", "schema": "public", "storage_connection": "c", "grain": ["id"],
+            "description": "orders",
+            "columns": [
+                {"name": "id", "type": "integer", "primary_key": True},
+                {"name": "amount", "type": "integer"},
+            ],
+        })
+    )
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """An app database to audit into, a model on disk, and a real sqlite warehouse."""
+    app_db = tmp_path / "app.db"
+    from store import Store
+
+    store = Store.connect(f"sqlite:///{app_db}")
+    store.run_migrations()
+    store.close()
+
+    artifacts = tmp_path / "artifacts"
+    _write_model(artifacts / PROFILE)
+
+    warehouse = tmp_path / "warehouse.db"
+    conn = sqlite3.connect(warehouse)
+    conn.execute("CREATE TABLE orders (id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("AGAMI_DB_URL", f"sqlite:///{app_db}")
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(artifacts))
+    monkeypatch.setenv(f"DATASOURCE_URL__{PROFILE.upper()}", f"sqlite:///{warehouse}")
+    return {"app_db": app_db, "artifacts": artifacts}
+
+
+def _rows(app_db):
+    conn = sqlite3.connect(app_db)
+    try:
+        return conn.execute(
+            "SELECT id, status, error_detail FROM query_executions ORDER BY ts"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def test_the_migration_adds_the_column(env):
+    conn = sqlite3.connect(env["app_db"])
+    try:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(query_executions)")]
+    finally:
+        conn.close()
+    assert "error_detail" in cols
+
+
+def test_the_in_process_path_records_the_raw_detail(env):
+    """Where the chokepoint and the recorder share a process, the column is populated."""
+    tools.set_injected_executor(_Raiser())
+    try:
+        body = json.loads(tools.tool_execute_sql({"sql": "SELECT id FROM orders", "datasource": PROFILE}))
+    finally:
+        tools.set_injected_executor(None)
+
+    rows = _rows(env["app_db"])
+    assert len(rows) == 1
+    audit_id, status, detail = rows[0]
+    assert status == "failed"
+    assert audit_id == body["audit_id"], "the row's key is the id the caller was handed"
+    # The operator gets the whole thing, including the HINT that names a declared column.
+    assert "internal_ref" in detail
+    # The caller gets none of it.
+    assert "internal_ref" not in body["failure"]["message"]
+    assert body["failure"]["kind"] == "column_not_found"
+
+
+def test_error_detail_never_appears_in_the_emitted_json(env):
+    """The column is an audit field, not a response field. Neither the key nor the value."""
+    tools.set_injected_executor(_Raiser())
+    try:
+        body = json.loads(tools.tool_execute_sql({"sql": "SELECT id FROM orders", "datasource": PROFILE}))
+    finally:
+        tools.set_injected_executor(None)
+
+    serialized = json.dumps(body)
+    assert "error_detail" not in serialized
+    assert "internal_ref" not in serialized
+    assert "HINT" not in serialized
+
+
+def test_a_successful_call_records_no_detail(env):
+    """The ContextVar is cleared on entry, so a previous failure cannot attach to a later row.
+
+    Without that clear, the second row here would carry the first call's driver text — an audit
+    row naming an error the statement it records never produced.
+    """
+    tools.set_injected_executor(_Raiser())
+    try:
+        tools.tool_execute_sql({"sql": "SELECT id FROM orders", "datasource": PROFILE})
+    finally:
+        tools.set_injected_executor(None)
+
+    tools.set_injected_executor(execute_sql.BUILTIN_EXECUTOR)
+    try:
+        tools.tool_execute_sql({"sql": "SELECT id FROM orders", "datasource": PROFILE})
+    finally:
+        tools.set_injected_executor(None)
+
+    rows = _rows(env["app_db"])
+    assert len(rows) == 2
+    statuses = {status: detail for _, status, detail in rows}
+    assert "internal_ref" in statuses["failed"]
+    assert statuses["ok"] is None
+
+
+def test_a_forked_call_does_not_inherit_an_earlier_in_process_detail(env):
+    """The stale-carrier bug, which shipped silently until a test happened to order two calls.
+
+    `execute_guarded` clears the carrier on entry, but on the fork the PARENT never calls it —
+    it spawns a child and then records the row itself. So a forked call following an
+    in-process failure in the same server process read the earlier call's driver text and wrote
+    it onto the later call's audit row: an operator would be debugging a statement against an
+    error it never produced. The reset therefore belongs at the tool edge, where both paths
+    begin, not inside the one path that happens to pass through the chokepoint.
+    """
+    tools.set_injected_executor(_Raiser())
+    try:
+        tools.tool_execute_sql({"sql": "SELECT id FROM orders", "datasource": PROFILE})
+    finally:
+        tools.set_injected_executor(None)
+
+    # Now a FORKED call whose statement the database also rejects, in the same process.
+    tools.tool_execute_sql({"sql": "SELECT amount FROM orders", "datasource": PROFILE})
+
+    rows = _rows(env["app_db"])
+    assert len(rows) == 2
+    forked_detail = rows[1][2]
+    assert forked_detail is None, "the forked row inherited the in-process call's driver text"
+
+
+def test_the_stored_detail_is_bounded(env):
+    """A driver error with a full HINT / CONTEXT / parameter dump is unbounded.
+
+    015's argument applies verbatim: a failed statement must not become a way to grow the store.
+    """
+    huge = "x" * 50_000
+
+    class _Huge:
+        def execute(self, vetted_sql, creds, *, profile):  # noqa: ANN001, ANN201
+            raise execute_sql.ExecutorError(huge, code=5)
+
+    tools.set_injected_executor(_Huge())
+    try:
+        tools.tool_execute_sql({"sql": "SELECT id FROM orders", "datasource": PROFILE})
+    finally:
+        tools.set_injected_executor(None)
+
+    _, _, detail = _rows(env["app_db"])[0]
+    assert len(detail) == tools.AUDIT_ERROR_DETAIL_MAX_CHARS
+
+
+def test_the_forked_child_leaks_nothing_through_its_logger(env):
+    """THE hazard this slice's design exists to avoid, driven as a real subprocess.
+
+    `execute_sql` never calls `basicConfig`, so a record on the module logger falls through to
+    `logging.lastResort` and is written to stderr — and `tools._child_failure_message` relays
+    the child's stderr into `failure.message` for any classified exit code. A raw-detail log on
+    the ordinary logger would therefore return the driver text to the caller on the DEFAULT
+    surface. `_RAW_LOG` is silenced for the CLI lifetime instead, so the child emits nothing.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-m", "execute_sql", "--profile", PROFILE,
+         "--sql", "SELECT amount FROM orders"],
+        capture_output=True, text=True, timeout=120,
+        env={**os.environ, "AGAMI_ARTIFACTS_DIR": str(env["artifacts"])},
+    )
+    assert proc.returncode == execute_sql.FAILURE_KIND_TO_EXIT["column_not_found"]
+    # The whole stream, not just the message: anything here is relayed to the caller.
+    assert "amount" not in proc.stderr
+    assert "audit detail" not in proc.stderr
+    assert proc.stderr.strip() == execute_sql._ERROR_MESSAGES["column_not_found"]
+
+
+def test_the_forked_path_records_null(env):
+    """NULL is the claim that the two halves were in different processes."""
+    body = json.loads(
+        tools.tool_execute_sql({"sql": "SELECT amount FROM orders", "datasource": PROFILE})
+    )
+    assert body["status"] == "failed"
+    assert body["failure"]["kind"] == "column_not_found"
+
+    rows = _rows(env["app_db"])
+    assert len(rows) == 1
+    assert rows[0][2] is None
+    assert "amount" not in body["failure"]["message"]
+
+
+def test_migrations_are_re_runnable(tmp_path):
+    """Forward-only, and the ledger makes a second run a no-op rather than an error."""
+    from store import Store
+
+    url = f"sqlite:///{tmp_path / 'twice.db'}"
+    for _ in range(2):
+        store = Store.connect(url)
+        store.run_migrations()
+        store.close()
+
+    conn = sqlite3.connect(tmp_path / "twice.db")
+    try:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(query_executions)")]
+    finally:
+        conn.close()
+    assert cols.count("error_detail") == 1

--- a/tests/test_ace039_error_sanitization.py
+++ b/tests/test_ace039_error_sanitization.py
@@ -50,6 +50,24 @@ _DRIVER_ERRORS = [
     ("could not translate host name \"warehouse.internal\" to address", 4, "dsn"),
     ("connection refused", 4, "network"),
     ("password authentication failed for user \"analytics\"", 4, "auth"),
+    # One vector per remaining supported engine. Without these the not-found needles covered
+    # PG / MySQL / SQLite / Snowflake only, and SQL Server, Trino, Databricks and BigQuery fell
+    # to the exit-5 prior and were labelled `syntax` — which tells the caller to re-run the
+    # identical failing statement instead of to re-introspect a drifted model.
+    ("Invalid column name 'ssn'.", 5, "column_not_found"),                      # SQL Server 207
+    ("Invalid object name 'dbo.payroll'.", 5, "table_not_found"),               # SQL Server 208
+    ("line 1:8: Column 'ssn' cannot be resolved", 5, "column_not_found"),       # Trino
+    ("[UNRESOLVED_COLUMN.WITH_SUGGESTION] A column with name `ssn` cannot be resolved.",
+     5, "column_not_found"),                                                   # Databricks
+    ("400 Unrecognized name: ssn at [1:8]", 5, "column_not_found"),             # BigQuery
+    # Authorization, which must not read as a credentials problem: the operator action is a
+    # GRANT, and the skill stops on `auth` but auto-retries twice on `syntax`.
+    ("Access Denied: Table p: User does not have bigquery.tables.get permission",
+     5, "permission"),                                                         # BigQuery
+    ("Access Denied: Cannot select from table payroll", 5, "permission"),       # Trino
+    ("The SELECT permission was denied on the object 'payroll'", 5, "permission"),  # SQL Server
+    ("ORA-01031: insufficient privileges", 5, "permission"),                    # Oracle
+    ("Access denied for user 'app'@'%' to database 'payroll'", 5, "permission"),  # MySQL 1044
 ]
 
 # Ceded to ACE-038: a deadline is classified from a watchdog signal, never a driver string.

--- a/tests/test_ace039_error_sanitization.py
+++ b/tests/test_ace039_error_sanitization.py
@@ -1,0 +1,222 @@
+"""A database error is classified from driver text that never crosses the boundary.
+
+The failure channel was the one place the model could still leak. A guardrail refusal is
+built from static prose and echoes only what the caller sent; `failure.message` was relayed
+from the driver verbatim, and PostgreSQL volunteers declared column names in a `HINT`.
+
+Classifying FROM driver text is not the same as returning it. The output is one of a fixed
+set of labels and the caller receives `_ERROR_MESSAGES[kind]`, so the caller still learns
+enough to act (a missing column is not a syntax error) while learning nothing about the
+schema.
+
+Two properties here are easy to get wrong and silent when wrong:
+
+* **The authored/driver split.** Codes 2 and 3 are text this module wrote and must keep being
+  relayed, or an operator loses the one line telling them to set `DATASOURCE_URL`. Codes 4
+  and 5 carry the driver's exception and must not be.
+* **Fork parity.** The child classifies correctly and encodes the kind as an exit code. A
+  test that only exercises the in-process path cannot see the default surface being wrong.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sqlite3
+import subprocess
+import sys
+
+import execute_sql
+import guardrail
+import pytest
+import tools
+
+PROFILE = "acme"
+
+# (driver text, exit code, expected kind). The text is real driver output, lower-cased matching
+# aside, because the classifier's whole job is to read what engines actually emit.
+_DRIVER_ERRORS = [
+    ('column "amount" does not exist\nHINT:  Perhaps you meant "orders.internal_ref".', 5, "column_not_found"),
+    ("psycopg2.errors.UndefinedColumn: no such column: secret_col", 5, "column_not_found"),
+    ("Unknown column 'ssn' in 'field list'", 5, "column_not_found"),
+    ('relation "payroll" does not exist', 5, "table_not_found"),
+    ("no such table: internal_ledger", 5, "table_not_found"),
+    ("Object 'FINANCE.SALARIES' does not exist or not authorized.", 5, "table_not_found"),
+    ("permission denied for table employee_comp", 5, "permission"),
+    ("SELECT command denied to user 'app'@'%' for table 'payroll'", 5, "permission"),
+    ('syntax error at or near "SELCT"', 5, "syntax"),
+    ("You have an error in your SQL syntax; check the manual", 5, "syntax"),
+    ("could not translate host name \"warehouse.internal\" to address", 4, "dsn"),
+    ("connection refused", 4, "network"),
+    ("password authentication failed for user \"analytics\"", 4, "auth"),
+]
+
+# Ceded to ACE-038: a deadline is classified from a watchdog signal, never a driver string.
+_CANCELLATIONS = [
+    "canceling statement due to statement timeout",
+    "ERROR:  canceling statement due to user request",
+    "query was canceled",
+    "psycopg2.extensions.QueryCanceledError",
+    "Lost connection to MySQL server during query",
+]
+
+
+class _Raiser:
+    """An adapter that fails the way a real one does: an ExecutorError, no special flag."""
+
+    def __init__(self, message: str, code: int) -> None:
+        self._message, self._code = message, code
+
+    def execute(self, vetted_sql, creds, *, profile):  # noqa: ANN001, ANN201
+        raise execute_sql.ExecutorError(self._message, code=self._code)
+
+
+@pytest.fixture
+def warehouse(tmp_path, monkeypatch):
+    """A real sqlite datasource both processes can reach, so the fork path is drivable."""
+    db = tmp_path / "warehouse.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE orders (id INTEGER)")
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    monkeypatch.setenv(f"DATASOURCE_URL__{PROFILE.upper()}", f"sqlite:///{db}")
+    monkeypatch.setattr(execute_sql, "_model_safety", lambda s, p, a: (s, None))
+    return tmp_path
+
+
+@pytest.mark.parametrize(("text", "code", "kind"), _DRIVER_ERRORS, ids=lambda v: str(v)[:44])
+def test_each_kind_is_classified_from_text_that_never_crosses(text, code, kind, warehouse):
+    env = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, None, executor=_Raiser(text, code), no_safety=True
+    )
+    assert env.status == "failed"
+    assert env.failure.kind == kind
+    assert env.failure.message == execute_sql._ERROR_MESSAGES[kind]
+    # The point of the slice: no fragment of the driver's text survives into the message.
+    for token in ("amount", "internal_ref", "secret_col", "ssn", "payroll", "SALARIES",
+                  "employee_comp", "internal_ledger", "SELCT", "warehouse.internal", "analytics"):
+        assert token not in env.failure.message
+
+
+@pytest.mark.parametrize("text", _CANCELLATIONS, ids=lambda s: s[:44])
+def test_no_cancellation_signature_produces_timeout(text, warehouse):
+    """Ceded to ACE-038, and NOT by deleting the arm.
+
+    Deleting it would not leave these unclassified, it would leave them mis-classified: the
+    text contains "timed out" or "lost connection", which earlier drafts routed to `network`,
+    and failing that it falls to the exit-5 prior and reads as `syntax`. An unattributable
+    server-side cancellation is honestly `other`.
+    """
+    env = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, None, executor=_Raiser(text, 5), no_safety=True
+    )
+    assert env.failure.kind != "timeout"
+    assert env.failure.kind == "other"
+
+
+def test_a_connect_timeout_is_still_auth(warehouse):
+    """The needle removal, locked from this side.
+
+    Porting the reference's `network` needles verbatim would have added "timed out" and
+    silently moved every driver connect timeout from `auth` to `network`, contradicting the
+    contract's account of what each kind means.
+    """
+    env = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, None,
+        executor=_Raiser("connection to server timed out", 4), no_safety=True,
+    )
+    assert env.failure.kind == "auth"
+
+
+@pytest.mark.parametrize(
+    ("text", "code"),
+    [
+        ("No warehouse credentials for profile [acme]. Set DATASOURCE_URL…", 2),
+        ("pymysql not installed. Run: pip install pymysql", 3),
+    ],
+)
+def test_text_this_module_authored_is_still_relayed(text, code, warehouse):
+    """The other half of the split, and the half a blanket sanitizer would break.
+
+    These name an operator action and contain nothing the database said. Sanitizing them
+    would leave an operator with a classified kind and no idea what to do about it.
+    """
+    env = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, None, executor=_Raiser(text, code), no_safety=True
+    )
+    assert env.failure.message == text
+
+
+def test_a_failure_carries_no_remediation(warehouse):
+    """Enforced by the type, not by discipline — `Failure` has no such field.
+
+    That absence is what lets a caller tell a decision of ours (which always names its fix)
+    from the database's outcome (which we can only relay).
+    """
+    env = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, None,
+        executor=_Raiser('column "x" does not exist', 5), no_safety=True,
+    )
+    assert set(env.failure.__dict__ if hasattr(env.failure, "__dict__") else
+               env.failure._asdict() if hasattr(env.failure, "_asdict") else
+               {"kind": env.failure.kind, "message": env.failure.message}) == {"kind", "message"}
+    assert not hasattr(env.failure, "remediation")
+
+
+def test_the_same_driver_error_yields_the_same_kind_in_process_and_forked(warehouse, monkeypatch):
+    """FORK PARITY — the criterion S2's exit codes exist to make satisfiable.
+
+    Before the exit-code table was widened, this reported `column_not_found` in-process and
+    `other` through the fork, and no in-process-only test could see it. The statement asks for
+    a column the sqlite warehouse does not have, so the database itself produces the error on
+    both routes; nothing is stubbed on the fork side.
+    """
+    sql = "SELECT missing_column FROM orders"
+
+    tools.set_injected_executor(execute_sql.BUILTIN_EXECUTOR)
+    try:
+        in_process = json.loads(tools.tool_execute_sql({"sql": sql, "datasource": PROFILE}))
+    finally:
+        tools.set_injected_executor(None)
+
+    forked = json.loads(tools.tool_execute_sql({"sql": sql, "datasource": PROFILE}))
+
+    assert in_process["status"] == forked["status"] == "failed"
+    assert in_process["failure"]["kind"] == forked["failure"]["kind"] == "column_not_found"
+    assert in_process["failure"]["message"] == forked["failure"]["message"]
+    # The response echoes the caller's own `sql` back, which discloses nothing it did not
+    # send. What must not appear is the driver's text, so scan the message specifically.
+    assert "missing_column" not in forked["failure"]["message"]
+    assert "no such column" not in forked["failure"]["message"].lower()
+
+
+def test_the_forked_child_writes_no_raw_driver_text_to_stderr(warehouse):
+    """Driven as a real subprocess, because the leak this guards is a transport property.
+
+    The parent relays the child's stderr into `failure.message` for any classified code, so
+    anything the child prints there reaches the caller. The child must print the sanitized
+    line and nothing else.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-m", "execute_sql", "--profile", PROFILE,
+         "--sql", "SELECT missing_column FROM orders"],
+        capture_output=True, text=True, timeout=120,
+        env={**os.environ, "AGAMI_ARTIFACTS_DIR": str(warehouse)},
+        cwd=str(pathlib.Path(execute_sql.__file__).parent),
+    )
+    assert proc.returncode == guardrail_exit_for("column_not_found")
+    assert "missing_column" not in proc.stderr
+    assert proc.stderr.strip() == execute_sql._ERROR_MESSAGES["column_not_found"]
+
+
+def guardrail_exit_for(kind: str) -> int:
+    return execute_sql.FAILURE_KIND_TO_EXIT[kind]
+
+
+def test_every_classified_kind_has_a_message() -> None:
+    """A kind the classifier can return but the message table lacks would fall back to the
+    generic unexpected-failure text, which reads as a bug rather than a database error."""
+    classifiable = set(guardrail._FAILURE_KINDS) - {"timeout", "other"}
+    assert classifiable == set(execute_sql._ERROR_MESSAGES)

--- a/tests/test_ace039_exit_codes.py
+++ b/tests/test_ace039_exit_codes.py
@@ -1,0 +1,86 @@
+"""The exit-code table is the fork's whole vocabulary, so every kind needs a code.
+
+`execute_guarded` classifies a driver error at the chokepoint and returns a `Failure`. On
+the in-process and HTTP surfaces the caller receives that object directly. On the DEFAULT
+stdio surface the tool edge forks, and `main` collapses the kind to an exit code the parent
+reads back through this table — so a kind with no code of its own is a kind the fork
+silently loses.
+
+That is why these tests exist as a slice of their own, landing before anything produces the
+new kinds. The failure they prevent is invisible to any test that exercises only the
+in-process path: the classification is correct where it is made and wrong where it arrives.
+"""
+
+from __future__ import annotations
+
+import re
+
+import execute_sql
+import guardrail
+import pytest
+import tools
+from execute_sql import EXIT_TO_FAILURE_KIND, FAILURE_KIND_TO_EXIT
+
+# Minted by the subprocess supervisor at the tool edge when a child never returns, so it
+# never reaches `main` and never needs an encoding. See the comment on FAILURE_KIND_TO_EXIT.
+_NOT_ENCODABLE = {"timeout"}
+
+
+def test_every_failure_kind_but_timeout_has_an_exit_code() -> None:
+    """The round trip is total, and the one exclusion is named rather than left as a gap."""
+    encodable = set(guardrail._FAILURE_KINDS) - _NOT_ENCODABLE
+    assert set(FAILURE_KIND_TO_EXIT) == encodable
+
+
+def test_the_round_trip_is_exact_in_both_directions() -> None:
+    for code, kind in EXIT_TO_FAILURE_KIND.items():
+        assert FAILURE_KIND_TO_EXIT[kind] == code
+    assert len(FAILURE_KIND_TO_EXIT) == len(EXIT_TO_FAILURE_KIND), "a kind is double-mapped"
+
+
+def test_the_documented_table_is_the_table_in_code() -> None:
+    """The module claims to own the contract "because it documents it here". Check the claim.
+
+    A table maintained in a docstring drifts from the dict beside it the first time someone
+    edits one and not the other, and the docstring is what the two out-of-repo consumers
+    (the agami-query skill's error classifier, `semantic_model.cli`) are written against.
+    """
+    documented = {
+        int(m.group(1))
+        for m in re.finditer(r"^\s{4}(\d+)\s+—", execute_sql.__doc__ or "", re.MULTILINE)
+    }
+    # 0 (success) and 1 (refused) are contract codes with no failure kind behind them.
+    assert documented - {0, 1} == set(EXIT_TO_FAILURE_KIND)
+
+
+@pytest.mark.parametrize(
+    ("code", "kind"),
+    [(7, "column_not_found"), (8, "table_not_found"), (9, "permission"), (10, "network")],
+)
+def test_the_tool_edge_reads_the_new_codes_back(code: int, kind: str) -> None:
+    """`tools._classify_exit` delegates to this table rather than keeping a second copy.
+
+    Asserted rather than assumed: the delegation is what makes extending the table
+    sufficient, and a re-introduced local copy would pass every other test in this file.
+    """
+    assert tools._classify_exit(code) == kind
+
+
+@pytest.mark.parametrize("code", [7, 8, 9, 10])
+def test_a_child_exiting_a_new_code_has_its_text_relayed(code: int) -> None:
+    """The second half of the bug, and the easier half to miss.
+
+    `_child_failure_message` relays the child's already-sanitized line only for a code in
+    the table. Before this slice the four new codes were not in it, so the parent discarded
+    the message and substituted the generic unexpected-failure text — losing the kind AND
+    the message in one step.
+    """
+    relayed = tools._child_failure_message(code, "the child's sanitized line")
+    assert relayed == "the child's sanitized line"
+    assert relayed != execute_sql.UNEXPECTED_FAILURE_MESSAGE
+
+
+def test_an_unmapped_code_is_still_other_not_dsn() -> None:
+    """The property the `6` code was introduced to hold, unchanged by widening the table."""
+    assert tools._classify_exit(99) == "other"
+    assert execute_sql._DEFAULT_FAILURE_EXIT == 6

--- a/tests/test_ace039_exit_codes.py
+++ b/tests/test_ace039_exit_codes.py
@@ -67,17 +67,22 @@ def test_the_tool_edge_reads_the_new_codes_back(code: int, kind: str) -> None:
 
 
 @pytest.mark.parametrize("code", [7, 8, 9, 10])
-def test_a_child_exiting_a_new_code_has_its_text_relayed(code: int) -> None:
+def test_a_child_exiting_a_new_code_gets_its_message_rebuilt(code: int) -> None:
     """The second half of the bug, and the easier half to miss.
 
-    `_child_failure_message` relays the child's already-sanitized line only for a code in
-    the table. Before this slice the four new codes were not in it, so the parent discarded
-    the message and substituted the generic unexpected-failure text — losing the kind AND
-    the message in one step.
+    Before this slice the four new codes were absent from the table, so the parent could
+    neither name the kind nor keep the message: `_child_failure_message` substituted the
+    generic unexpected-failure text for any unmapped code. One missing entry lost both.
+
+    The parent REBUILDS the sentence from the code rather than relaying the child's stream.
+    Security review found the stream is shared — the model-safety pass writes notices to it
+    before the failure line — so relaying it leaked declared model surface. Rebuilding yields
+    the identical text and makes the stream irrelevant to the answer rather than filtered.
     """
-    relayed = tools._child_failure_message(code, "the child's sanitized line")
-    assert relayed == "the child's sanitized line"
-    assert relayed != execute_sql.UNEXPECTED_FAILURE_MESSAGE
+    kind = execute_sql.EXIT_TO_FAILURE_KIND[code]
+    rebuilt = tools._child_failure_message(code, "anything at all on the child's stderr")
+    assert rebuilt == execute_sql._ERROR_MESSAGES[kind]
+    assert rebuilt != execute_sql.UNEXPECTED_FAILURE_MESSAGE
 
 
 def test_an_unmapped_code_is_still_other_not_dsn() -> None:

--- a/tests/test_ace039_neutralizer_spans.py
+++ b/tests/test_ace039_neutralizer_spans.py
@@ -1,0 +1,137 @@
+"""`_neutralize` reports where the quoted identifiers went, in one coordinate frame.
+
+The recon gate's niladic matcher needs to tell `SELECT "current_user" FROM audit_log` (a
+column that happens to share a keyword's name) from `SELECT current_user` (the keyword
+itself). The neutralizer drops quote delimiters on purpose — that unwrapping is what keeps
+`SELECT*FROM"pg_read_file"('/etc/passwd')` visible to a `\\b`-anchored pattern — so the
+information has to be carried alongside the text rather than left in it.
+
+Two properties are load-bearing and neither fails loudly on its own:
+
+1. **A span names its identifier's content, in the returned text's coordinates.** The scan
+   re-supplies separator spaces and drops delimiters, so input offsets are not output
+   offsets, and the strip would shift them again. A span in the wrong frame silently
+   mis-identifies a token.
+2. **The unwrapping is unchanged for every other consumer.** Reversing it, or applying the
+   quoted-is-an-identifier rule to a call matcher, reopens the read-only-guard bypass that
+   `c42f96c` closed against a verified PostgreSQL 16 file read. The welded corpus below is
+   that regression guard, and it lives here — beside the change — rather than with the gate
+   that will eventually consume the spans.
+"""
+
+from __future__ import annotations
+
+import pytest
+from guardrail import RULE_READ_ONLY
+from sql_guard import _neutralize, check_read_only
+
+
+def _identifiers(sql: str) -> list[str]:
+    """The text each reported span actually indexes — the property, stated directly."""
+    neutral = _neutralize(sql)
+    return [neutral.text[start:end] for start, end in neutral.quoted]
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        ('SELECT t."current_user" FROM t', ["current_user"]),
+        ('SELECT * FROM"pg_class"', ["pg_class"]),
+        ('SELECT "x"INTO evil FROM t', ["x"]),
+        # Two adjacent spans inside one qualified name: the separator is NOT re-supplied
+        # between them, so a naive "span plus one" would swallow the dot.
+        ('SELECT "schema"."table" FROM t', ["schema", "table"]),
+        # The doubled-quote escape is content, not a delimiter — the span must cover the
+        # collapsed form (`a"b`), which is three characters, not the five that were written.
+        ('SELECT "a""b" FROM t', ['a"b']),
+        ('SELECT "current_user", "version" FROM audit_log', ["current_user", "version"]),
+    ],
+)
+def test_every_span_indexes_the_identifier_it_came_from(sql: str, expected: list[str]) -> None:
+    assert _identifiers(sql) == expected
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        '   SELECT "current_user" FROM audit_log',
+        '/* lead */ SELECT "current_user" FROM audit_log',
+        'SELECT "current_user" FROM audit_log ;   ',
+        '\n\t SELECT "current_user" FROM audit_log \n',
+        '  /* both */ SELECT "current_user" FROM audit_log ;  ',
+    ],
+)
+def test_the_spans_survive_the_strip(sql: str) -> None:
+    """The strip happens inside `_neutralize`, so spans are reported against its result.
+
+    Leading whitespace and a leading comment both shift every offset left; asserting the
+    slice rather than a literal index is what makes this independent of by how much.
+    """
+    assert _identifiers(sql) == ["current_user"]
+
+
+def test_an_unquoted_statement_reports_no_spans() -> None:
+    assert _neutralize("SELECT current_user FROM t").quoted == ()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 'quoted \"current_user\" text' FROM t",
+        "SELECT id FROM t /* a \"current_user\" mention */",
+        "SELECT id FROM t -- trailing \"current_user\"\n",
+    ],
+)
+def test_a_literal_or_comment_contributes_no_span(sql: str) -> None:
+    """Literals and comments blank to a space, so there is no identifier to point at.
+
+    This matters in the safe direction: if a blanked region produced a span, the niladic
+    matcher would skip a region of text that no longer exists, which is how an off-by-one
+    becomes an under-refusal.
+    """
+    assert _neutralize(sql).quoted == ()
+
+
+def test_the_text_is_already_stripped() -> None:
+    """One frame, which is the whole point — the caller no longer strips."""
+    neutral = _neutralize('   SELECT "x" FROM t   ')
+    assert neutral.text == neutral.text.strip()
+    assert neutral.text.startswith("SELECT")
+
+
+# The forms `c42f96c` closed. A delimited identifier is self-delimiting, so these are valid
+# statements with no whitespace before the quote; dropping the delimiters without
+# re-supplying a boundary fused two tokens into one and destroyed the `\b` anchor, and the
+# gate stopped SEEING the function rather than allowing it.
+REJECT_WELDED_AFTER_SPAN_TRACKING = [
+    "SELECT*FROM\"pg_read_file\"('/etc/passwd')",
+    'SELECT*FROM"pg_ls_dir"(\'/\')',
+    'SELECT 1 AS"a"INTO evil',
+    'SELECT "x"INTO evil FROM t',
+    'SELECT*FROM"dblink"(\'\',\'\')',
+]
+
+
+@pytest.mark.parametrize("sql", REJECT_WELDED_AFTER_SPAN_TRACKING)
+def test_the_welded_forms_are_still_refused(sql: str) -> None:
+    """The regression guard for the whole slice.
+
+    Span tracking must not change what the read-only gate matches on. It reads `.text`,
+    with the quotes dropped exactly as before, and never reads `.quoted`.
+    """
+    refusal = check_read_only(sql)
+    assert refusal is not None, f"welded form no longer refused: {sql!r}"
+    assert refusal.rule == RULE_READ_ONLY
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        'SELECT t."current_user" FROM t',
+        'SELECT "schema"."table" FROM "schema"."table"',
+        'SELECT c."email" FROM customers c',
+    ],
+)
+def test_legitimate_quoted_identifiers_are_still_allowed(sql: str) -> None:
+    """The other direction of the same change: reporting a span refuses nothing by itself."""
+    assert check_read_only(sql) is None

--- a/tests/test_ace039_recon.py
+++ b/tests/test_ace039_recon.py
@@ -1,0 +1,209 @@
+"""The recon gate: metadata FUNCTIONS are refused, catalog RELATIONS are the model's job.
+
+Three corpora, because this gate has three ways to be wrong and only one of them is the
+obvious one.
+
+**Deny** — the functions, niladic keywords and register-type casts that must refuse. Every
+vector here is verified to pass `check_read_only` first, so it genuinely proves the recon
+gate rather than borrowing another gate's refusal.
+
+**Collide** — names on BOTH this list and the dangerous-function list. They refuse as
+`read_only`, because that gate runs first and owns the label for what it names. Asserting it
+pins the order rather than leaving it to whoever reads the chokepoint next (principle 9).
+
+**Pass** — the false-positive bar. Over-refusal is the safe direction, which is exactly why
+it needs a criterion: the one regression this gate has caused in real use was an
+over-refusal, found by a user rather than a test.
+
+The corpora are deliberately NOT named `REJECT_*`. `test_sql_guard.py` auto-scans that prefix
+into a corpus that `test_ace035_read_only_refusal.py` holds to `rule == read_only`, so a
+`REJECT_RECON` list here would be silently adopted by that contract and break it.
+"""
+
+from __future__ import annotations
+
+import guardrail
+import pytest
+from sql_guard import check_no_recon, check_read_only
+
+# One vector per member of every deny set, so a name added without a vector is visible.
+RECON_DENY = [
+    # Server / session / account metadata, call form.
+    "SELECT version()",
+    "SELECT current_database()",
+    "SELECT current_schemas(true)",
+    "SELECT connection_id()",
+    "SELECT system_user()",
+    "SELECT current_account()",
+    "SELECT current_warehouse()",
+    "SELECT inet_server_addr()",
+    "SELECT inet_client_port()",
+    # Niladic keywords — the same primitive without the parens.
+    "SELECT current_user",
+    "SELECT session_user",
+    "SELECT current_catalog",
+    "SELECT current_schema",
+    "SELECT current_role",
+    # The privilege family, enumerated.
+    "SELECT has_table_privilege('orders', 'SELECT')",
+    "SELECT has_column_privilege('orders', 'id', 'SELECT')",
+    "SELECT has_schema_privilege('public', 'USAGE')",
+    # Call families.
+    "SELECT pg_get_viewdef('v')",
+    "SELECT to_regclass('orders')",
+    "SELECT to_regprocedure('now()')",
+    # Register-type casts, both spellings. The cast errors when the object is absent, so it
+    # answers "does this exist?" without naming the object in a FROM clause.
+    "SELECT 'secret_table'::regclass",
+    "SELECT 'x'::regproc",
+    "SELECT 'x'::regnamespace",
+    "SELECT CAST('secret_table' AS regclass)",
+    # A quoted CALL is still a call — quoting suppresses the niladic matcher, never a call
+    # matcher. Without the paren/niladic union this one slips both.
+    'SELECT "current_schema"()',
+    'SELECT "version"()',
+    # Riding inside an otherwise legitimately-scoped query, which is the shape that makes
+    # this gate necessary: every model gate passes it.
+    "SELECT o.id, version() FROM orders o",
+    "SELECT o.id FROM orders o WHERE o.name = current_user",
+]
+
+# On the dangerous-function list too. `check_read_only` runs first and owns these.
+RECON_COLLIDES_WITH_READ_ONLY = [
+    "SELECT current_setting('data_directory')",
+    "SELECT set_config('a', 'b', false)",
+    "SELECT pg_sleep(10)",
+    "SELECT pg_read_file('/etc/passwd')",
+    "SELECT pg_ls_dir('/')",
+    "SELECT pg_stat_file('/etc/passwd')",
+    "SELECT pg_terminate_backend(1)",
+    "SELECT pg_cancel_backend(1)",
+    "SELECT pg_reload_conf()",
+]
+
+# Must pass BOTH gates. Each is a plausible statement against a real declared model.
+RECON_PASSES = [
+    # A declared column whose name collides with a niladic keyword. Quoted, it is an
+    # identifier; this is the false positive the span tracking exists to fix.
+    'SELECT "current_user" FROM audit_log',
+    'SELECT "session_user", id FROM audit_log',
+    # Qualified, it was already fine — pinned so the lookbehind is not lost in a refactor.
+    "SELECT t.current_user FROM t",
+    "SELECT o.version FROM orders o",
+    # A user-defined function whose name sits between `has_` and `_privilege`. The wildcard
+    # matched this; the enumerated list does not.
+    "SELECT has_active_privilege(user_id) FROM memberships",
+    "SELECT has_billing_privilege(1) FROM t",
+    # `reg*` as an ordinary alias or column, not a cast.
+    "SELECT id AS regclass_id FROM t",
+    "SELECT regclass_name FROM t",
+    # Ordinary columns that merely start with a reserved-looking prefix.
+    "SELECT reltuples FROM stats",
+    "SELECT pg_status FROM t",
+    # A recon token mentioned inside a literal or comment cannot reach the matcher, and
+    # equally must not false-trip it.
+    "SELECT 'current_user' AS label FROM t",
+    "SELECT id FROM t /* current_user is not called here */",
+]
+
+
+@pytest.mark.parametrize("sql", RECON_DENY, ids=lambda s: s[:48])
+def test_a_recon_function_is_refused(sql: str) -> None:
+    assert check_read_only(sql) is None, (
+        "vector is caught by the read-only gate first, so it does not prove the recon gate"
+    )
+    refusal = check_no_recon(sql)
+    assert refusal is not None, f"recon not refused: {sql!r}"
+    assert refusal.rule == guardrail.RULE_RECON
+    assert refusal.reason == "unsafe"
+    assert refusal.detail.strip()
+    assert refusal.remediation.strip()
+
+
+@pytest.mark.parametrize("sql", RECON_COLLIDES_WITH_READ_ONLY, ids=lambda s: s[:48])
+def test_a_name_on_both_lists_refuses_as_read_only(sql: str) -> None:
+    """The order is fixed, so the label is deterministic (principle 9).
+
+    Both gates would refuse these; the chokepoint runs `check_read_only` first, so the caller
+    always sees the same rule for the same statement rather than one that depends on which
+    list was consulted.
+    """
+    refusal = check_read_only(sql)
+    assert refusal is not None
+    assert refusal.rule == guardrail.RULE_READ_ONLY
+
+
+@pytest.mark.parametrize("sql", RECON_PASSES, ids=lambda s: s[:48])
+def test_no_false_positives(sql: str) -> None:
+    assert check_read_only(sql) is None, f"read-only gate over-refused: {sql!r}"
+    assert check_no_recon(sql) is None, f"recon gate over-refused: {sql!r}"
+
+
+def test_a_quoted_bare_word_is_an_identifier_but_a_quoted_call_is_a_call() -> None:
+    """The exact boundary of the false-positive fix, in one place.
+
+    Quoting suppresses the NILADIC matcher only. A quoted name with a trailing `(` is still a
+    call, and treating it otherwise is the hole the paren/niladic union closes.
+    """
+    assert check_no_recon('SELECT "current_user" FROM audit_log') is None
+    assert check_no_recon('SELECT "current_schema"()').rule == guardrail.RULE_RECON
+
+
+def test_a_model_may_declare_a_schema_named_sys() -> None:
+    """The model is the authority on relations, so a declared schema is queryable.
+
+    Bare schema names are not on this list precisely so that a schema the model declares is a
+    schema the caller may query, whatever it happens to be called.
+    """
+    assert check_no_recon("SELECT id FROM sys.user_group") is None
+    assert check_no_recon("SELECT u.id FROM sys.sys_user u JOIN sys.sys_group g ON g.id = u.gid") is None
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT relname FROM pg_class",
+        "SELECT table_name FROM information_schema.tables",
+        "SELECT name FROM sqlite_master",
+    ],
+)
+def test_catalog_relations_are_not_this_gates_job(sql: str) -> None:
+    """Relations belong to `semantic_model.runtime.check_table_scope`, not here.
+
+    They are tables the model does not declare, which is a 4b out-of-scope refusal from a gate
+    that was already built. Denying them here as well was redundant where that gate runs, and
+    where it does not run it was harmful: matching bare schema names refused a datasource whose
+    `sys` schema holds ordinary user tables.
+
+    Residual, stated: on the vendored plugin layout `runtime` is absent by construction, so
+    catalog relations have no gate there at all.
+    """
+    assert check_no_recon(sql) is None
+
+
+def test_an_unreadable_statement_is_undetermined_not_recon() -> None:
+    """A statement we cannot read is not one we caught fingerprinting the server.
+
+    It fails closed either way; only the label and the fix change. Unreachable at the
+    chokepoint, where `check_read_only` runs the same neutralizer and refuses first — so this
+    is asserted as a standalone call, which is the only place it can be observed.
+    """
+    refusal = check_no_recon("SELECT 1 --x\nFROM t")
+    assert refusal is not None
+    assert refusal.rule == guardrail.RULE_UNPARSEABLE
+    assert refusal.reason == "undetermined"
+
+
+def test_an_empty_statement_is_left_to_the_read_only_gate() -> None:
+    """It owns that rejection and its remediation; two gates answering is two answers."""
+    assert check_no_recon("") is None
+    assert check_no_recon("   ") is None
+    assert check_no_recon(None) is None
+
+
+def test_the_refusal_echoes_the_caller_s_own_token_and_enumerates_nothing() -> None:
+    """A refusal that lists what IS allowed is a schema-listing endpoint."""
+    refusal = check_no_recon("SELECT o.id, version() FROM orders o")
+    assert "version" in refusal.detail
+    for leak in ("orders", "customers", "public", "information_schema"):
+        assert leak not in refusal.remediation

--- a/tests/test_ace039_recon.py
+++ b/tests/test_ace039_recon.py
@@ -58,6 +58,11 @@ RECON_DENY = [
     "SELECT 'x'::regproc",
     "SELECT 'x'::regnamespace",
     "SELECT CAST('secret_table' AS regclass)",
+    # SCHEMA-QUALIFIED, the spelling an arm anchored straight after `::` never sees. Valid
+    # PostgreSQL, same oracle, and it names no relation for the model gate to bite on.
+    "SELECT 'secret_table'::pg_catalog.regclass",
+    "SELECT CAST('secret_table' AS pg_catalog.regproc)",
+    'SELECT \'x\'::"pg_catalog"."regclass"',
     # A quoted CALL is still a call — quoting suppresses the niladic matcher, never a call
     # matcher. Without the paren/niladic union this one slips both.
     'SELECT "current_schema"()',
@@ -137,6 +142,31 @@ def test_a_name_on_both_lists_refuses_as_read_only(sql: str) -> None:
 def test_no_false_positives(sql: str) -> None:
     assert check_read_only(sql) is None, f"read-only gate over-refused: {sql!r}"
     assert check_no_recon(sql) is None, f"recon gate over-refused: {sql!r}"
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        'SELECT "current_user',                      # runs to EOF
+        'SELECT "a\\"b" , current_user FROM t',       # MySQL re-opens a runaway identifier
+        'SELECT o.id FROM orders o WHERE o.n = "x current_user',
+    ],
+    ids=["eof", "mysql_backslash", "tail"],
+)
+def test_an_unterminated_quote_does_not_suppress_the_keyword(sql: str) -> None:
+    """The under-refusal direction, which is the only one that matters here.
+
+    An unterminated `"` swallows the rest of the statement into the identifier buffer. If that
+    produced a span, the niladic matcher would treat every keyword inside it as quoted and skip
+    it. Reachable rather than theoretical: MySQL's default sql_mode treats `"` as a STRING
+    delimiter with backslash escapes, so the second vector is a statement MySQL runs and answers
+    with CURRENT_USER() while the neutralizer reads a runaway identifier.
+
+    No closing delimiter means no span, so nothing is skipped and the gate refuses.
+    """
+    refusal = check_no_recon(sql)
+    assert refusal is not None, f"an unterminated quote suppressed the keyword: {sql!r}"
+    assert refusal.rule == guardrail.RULE_RECON
 
 
 def test_a_quoted_bare_word_is_an_identifier_but_a_quoted_call_is_a_call() -> None:

--- a/tests/test_ah012_executor_seam.py
+++ b/tests/test_ah012_executor_seam.py
@@ -329,7 +329,11 @@ def test_injected_executor_error_maps_to_the_same_envelope(monkeypatch):
 
     assert out["status"] == "failed"
     assert out["failure"]["kind"] == tools._classify_exit(4)
-    assert "connect failed" in out["failure"]["message"]
+    # The message is now the fixed value-free sentence for the kind, not the driver's text
+    # (ACE-039). Code 4 carries the driver's own exception, so relaying it was the enumeration
+    # channel; the KIND still round-trips, which is what this test is actually about.
+    assert out["failure"]["message"] == execute_sql._ERROR_MESSAGES["auth"]
+    assert "connect failed" not in out["failure"]["message"]
 
 
 def test_set_injected_executor_rejects_a_bad_shape():
@@ -562,7 +566,11 @@ def test_an_executor_error_becomes_the_failed_envelope_main_renders(tmp_path, mo
     rc = execute_sql.main()
 
     assert rc == 4
-    assert capsys.readouterr().err == "Postgres connect failed: refused\n"
+    # `main` still writes the bare message and returns the classified code — the CLI contract is
+    # unchanged, and that matters because the parent relays this stream to the caller. What changed
+    # is WHICH message reaches it: code 4 carries the driver's own exception, so it is classified
+    # and replaced with the fixed sentence rather than relayed (ACE-039).
+    assert capsys.readouterr().err == execute_sql._ERROR_MESSAGES["auth"] + "\n"
 
 
 @pytest.mark.parametrize("code", sorted(execute_sql.EXIT_TO_FAILURE_KIND))

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -475,8 +475,14 @@ def test_neutralize_preserves_token_structure(sql: str, expected: str) -> None:
     tokens where the statement meant one. Any rule that reasons about qualification (a
     pattern anchored on a preceding `.`, say) would then read a qualified column as a bare
     identifier. Asserting the neutralized string keeps that decision checkable.
+
+    The assertion compares `.text` rather than the bare return value: ACE-039 gave
+    `_neutralize` a second output (the quoted-identifier spans the recon gate's niladic
+    matcher consults) and folded the caller's `.strip()` inside, so one coordinate frame
+    exists instead of three. A deliberate contract change, not a weakening — the six cases
+    and the property they pin are untouched.
     """
-    assert _neutralize(sql) == expected
+    assert _neutralize(sql).text == expected
 
 
 REJECT_COMMENT_BREAKS_GATE = [


### PR DESCRIPTION
## Summary

Two leakage channels at the SQL executor, both crossing the LLM boundary.

**Recon.** Under read-only plus object scope a statement could still call `version()`, `current_user`, `has_table_privilege(…)` or `'x'::regclass` to fingerprint the server or probe for objects. A model declares tables and columns and never declares functions, so object scope had nothing to reject.

**Driver text.** `failure.message` was relayed from the driver verbatim, and PostgreSQL volunteers declared column names in a `HINT`. Measured on `9d3fd8d` before any code:

```
failure.kind -> syntax                    # wrong; nothing read the text, so every code-5 was `syntax`
message      -> 'Postgres execution error: column "amount" does not exist
                 HINT:  Perhaps you meant to reference the column "orders.internal_ref".'
```

`orders.internal_ref` is **declared** and the caller never sent it. After: kind `column_not_found`, message a fixed value-free sentence. `tests/test_ace035_no_enumeration.py` carried this as an `xfail(strict=True)`; it flips green here and the marker is removed in the same commit.

Ported from #120, which is superseded and closes with this. That branch predates the rewritten contract by eleven review deltas and has no mergeable base.

## Changes

Seven commits, each a green checkpoint.

**S1 `_neutralize` reports its quoted spans, in one coordinate frame.** The recon gate needs to tell `SELECT "current_user" FROM audit_log` (a column) from `SELECT current_user` (the keyword), and the neutralizer drops quote delimiters on purpose. Returns a stdlib `NamedTuple` of already-stripped text plus spans in *that text's* coordinates, so nothing reconciles frames. A span the strip disturbed is **dropped, never clamped** — dropping means the matcher does not skip, so the gate over-refuses.

**S2 four exit codes.** The child classifies at the chokepoint and `main` collapses the kind to an exit code; `column_not_found`, `table_not_found`, `permission` and `network` had none, so all four became `other` across the fork while in-process reported the truth. Behaviour-neutral on its own.

**S3 the recon gate, functions only.** Catalog *relations* stay `check_table_scope`'s job. Three things the reference did not have: the paren matcher is the union of call names **and** niladic keywords (without it `SELECT "current_schema"()` slips both matchers); `has_\w+_privilege` narrows to the fourteen real builtins; register casts are covered in both spellings. `REASON_FOR_RULE[RULE_RECON] = "unsafe"`.

**S4 the classifier.** Codes 2 and 3 are authored here and still relayed; codes 4 and 5 carry the driver's exception and are classified from it, never returned. Cancellation is ceded to ACE-038 but the signatures are **kept** as an explicit `→ other` arm, because deleting them mis-classifies rather than declassifies.

**S5 migration 016 + `error_detail`.** A column on `query_executions`, not a second table — 014's argument, and `audit_id` *is* `query_executions.id`.

**S6** the two consuming documents.

**S7 four defects from review**, below.

## Decisions worth a reviewer's eye

- **The parent rebuilds the failure message rather than relaying the child's stderr.** Security review found stderr is a *shared* stream: `_model_safety` writes `[agami] applied default_filters: […]` to it before execution, so the caller received a declared row-level tenancy predicate it never sent — on the **default** transport, while in-process returned the clean sentence. Since the child derives its message from the kind, the exit code alone rebuilds it, which makes the stream irrelevant rather than filtered. **This one most wants a nod.**
- **An unterminated `"` records no span.** It previously produced one span over the whole tail and the niladic matcher skipped every keyword inside it. Reachable: MySQL's default `sql_mode` treats `"` as a string delimiter with backslash escapes, so `SELECT "a\"b" , current_user FROM t` is a statement MySQL runs and answers with `CURRENT_USER()`.
- **On the forked path raw detail is not captured at all.** `_RAW_LOG` is silenced for the CLI lifetime, so the child logs nothing and the column is NULL. This narrows the spec's earlier decision that the child would log server-side — doing so put the text back on stderr, which the parent relayed. An accepted gap, stated rather than claimed.
- **One code-2 site moved.** BigQuery's credential load interpolated a google-auth exception carrying the key path, while code 2 is the band relayed verbatim. Authored prose out, original to the log.
- **`_neutralize`'s equality test compares `.text`.** A deliberate contract change; the six cases and the property are untouched.

## Verification

`uv run dev.py check` green — **2263 passed**, 1 skipped, **0 xfailed** (the strict xfail is gone with the gap it measured). From 2064 at the ACE-035 base.

Every criterion measured on `9d3fd8d` first, so the delta is shown rather than claimed: `refuse('recon')` raised `KeyError`; `check_no_recon` did not exist; `EXIT_TO_FAILURE_KIND.get(7)` was `None` and `tools._classify_exit(7)` returned `other`; `query_executions` had 12 columns; `_neutralize` returned `str`; and the HINT leak was driven end to end.

- **Fork parity** — the same missing column through both routes yields the same kind and the same message, asserted against a real subprocess.
- **Weld regression** — the `c42f96c` corpus is re-asserted in the same commit that changes `_neutralize`. Security review additionally fuzzed `_neutralize(sql).text` on HEAD against `_neutralize(sql).strip()` on main over 647,988 inputs: 0 divergences.
- **Enumeration sentinel** — a recon vector across all four routes (16 cells to 20).
- **Audit** — one row per call on every branch, including the new refusal.
- **Ten-engine classifier corpus**, one vector per supported engine.

## Checklist

- [x] `uv run dev.py check` green (ruff · pytest · gitleaks · lib-drift)
- [x] Vendored mirror synced; slice stays stdlib-only and 3.9-importable
- [x] Tests re-pointed, never weakened — every changed shipped assertion is justified in its diff
- [x] New tests verified to fail on the base commit
- [x] Decisions recorded in the spec's `## Decisions`
- [x] Nothing internal disclosed (public repo)

## Verified against real PostgreSQL 16.12

Run after the rebase, via `context/local-e2e-guardrail-testbed.md` — real database, the shipped
read-only grant recipe applied verbatim, the shipped synthetic sample.

**The oracle is real, and the engine cannot stop it.** As `agami_ro` through plain `psql`, app guard
entirely out of the loop:

```
'orders'::regclass    -> orders
'salaries'::regclass  -> ERROR: relation "salaries" does not exist
version()             -> PostgreSQL 16.12 (Homebrew) on aarch64-apple-darwin25.2.0…
current_user          -> agami_ro
pg_read_file(...)     -> ERROR: permission denied for function
```

Exists and does-not-exist are distinguishable, and the least-privilege role reads `version()` and
`current_user` freely while the engine *does* block `pg_read_file`. That is F9's Q1 finding measured
rather than asserted, and it is the whole reason recon must be denied app-side.

**Through the guard, on that same engine:** all six recon vectors refuse as `recon`, including
`'salaries'::pg_catalog.regclass` — the qualified-cast gap review found, closed and proven where the
oracle demonstrably works. Both welded forms from `c42f96c` refuse as `read_only`; stacked statements
and a CTE-wrapped `DELETE` too; `pg_shadow` refuses as `table_scope`, which is functions-only working
as designed. A legitimate aggregate returns real rows.

**A genuine PostgreSQL HINT, closed:**

```
raw:  ERROR:  invalid reference to FROM-clause entry for table "orders"
      HINT:  Perhaps you meant to reference the table alias "o".
ours: exit 5 — "The generated SQL was not valid for this database. Re-run the query."
```

A real `UndefinedColumn` returns **exit 7** with the identifier gone. That code exists only because of
S2, so the fork encoding is verified against a real engine rather than a canned string.

**No `/agami-connect` regression** — introspection ran clean under the read-only role with the gate in
place. Also smoked on the packaged plugin layout under stock **Python 3.9.6** with `-S`, where a real
declared column named `current_user` returns rows (the false-positive fix, end to end).

## Notes for the reviewer

- **Rebased onto `main` @ `961c6c3`** (ACE-038 #174 has merged). The predicted `_MATRIX` conflict
  resolved by keeping **both** vectors, 16 -> 24 cells. The rebase then surfaced two ACE-038/ACE-039
  interactions no unit test on either branch could see alone — see S8; both are correct-to-change and
  neither weakens what its test was about.
- **Still only canned strings for nine of ten engines.** Postgres is now real; SQL Server, Trino,
  Databricks, BigQuery, Oracle and the rest are exercised only by driver text in the corpus. That is
  the honest edge of this verification.
- **Right-sizing.** +2129/−104 across 23 files, but ~220 lines of executable production code: tests
  are +1002, the vendored mirror +518 (machine-generated by `sync-lib`), ~330 comments and
  docstrings. Had it been split, the cut is the spec's own "two independent hardenings": S1+S3
  (recon) and S2+S4+S5+S6 (sanitization); they share no code.
- **High lane: security sign-off required.** The agent review panel ran and its four findings are
  fixed in S7, two of them leaks. No human has read the diff yet.

Spec: ACE-039
