### PR TITLE
ACE-095: delete the dead GovernancePolicy port and its seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ below corresponds to one such version.
   core call site ever evaluated it, so removing it changes no behaviour and touches nothing on the
   `execute_sql` enforcement path. `Adapters` is public API, so a consumer that constructed it with
   `governance=...` drops that keyword; the remaining ports (`ActivitySink`, `OrgResolver`,
-  `AuthProvider`, `Executor`) are unchanged.
+  `AuthProvider`, `Executor`) are unchanged. **`Adapters` is not keyword-only, so a consumer that
+  built it POSITIONALLY must also re-check its call**: the 4th positional slot was `governance` and
+  is now `executor`, so `Adapters(sink, resolver, auth, my_policy)` still constructs but binds the
+  policy as the executor and fails later at query time with `AttributeError: 'MyPolicy' object has
+  no attribute 'execute'`. Construct `Adapters` by keyword.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Removed
+
+- **The `GovernancePolicy` port and the `Adapters.governance` field (ACE-095).** `GovernancePolicy`,
+  its `GovernanceVerdict` value type, and the `WarnOnlyGovernancePolicy` default adapter are gone,
+  along with the `governance` field on `ports.Adapters`. The port was declared but never called: no
+  core call site ever evaluated it, so removing it changes no behaviour and touches nothing on the
+  `execute_sql` enforcement path. `Adapters` is public API, so a consumer that constructed it with
+  `governance=...` drops that keyword; the remaining ports (`ActivitySink`, `OrgResolver`,
+  `AuthProvider`, `Executor`) are unchanged.
+
 ### Docs
 
 - **Read-only datasource role is now a stated deploy obligation, not a suggestion (ACE-036).** The

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1869,7 +1869,7 @@ def _builtin_execute(vetted_sql: str, creds: dict[str, str], *, profile: str) ->
 
 class _BuiltinExecutor:
     """The default ``ports.Executor``: wraps the connect-per-query dispatch as an object so it
-    satisfies the port by shape (method-style, like the other four ports). Stateless — one shared
+    satisfies the port by shape (method-style, like the other three ports). Stateless — one shared
     ``BUILTIN_EXECUTOR`` instance."""
 
     def execute(self, vetted_sql: str, creds: dict[str, str], *, profile: str) -> ExecResult:

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -34,7 +34,6 @@ from oss_adapters import (
     FileActivitySink,
     PresenceAuthProvider,
     SingleTenantOrgResolver,
-    WarnOnlyGovernancePolicy,
 )
 from ports import Adapters, AuthProvider, Org, OrgResolver
 from starlette.applications import Starlette
@@ -170,7 +169,7 @@ def _build_org_resolver() -> SingleTenantOrgResolver:
 def default_adapters() -> Adapters:
     """The OSS default adapters bundled for the composition root (env-driven auth + org). Used only by
     `create_app(adapters=None)` — the HTTP server's defaults. `create_app` wires `auth_provider` +
-    `org_resolver` into the request path and registers `executor`; `activity_sink` + `governance` are
+    `org_resolver` into the request path and registers `executor`; `activity_sink` is
     carried on the container for consumers.
 
     `executor=BUILTIN_EXECUTOR` (ACE-028) makes the HTTP server run execution **in-process** by default
@@ -181,7 +180,6 @@ def default_adapters() -> Adapters:
         activity_sink=FileActivitySink(),
         org_resolver=_build_org_resolver(),
         auth_provider=_build_auth_provider(),
-        governance=WarnOnlyGovernancePolicy(),
         executor=BUILTIN_EXECUTOR,
     )
 

--- a/packages/agami-core/src/oss_adapters.py
+++ b/packages/agami-core/src/oss_adapters.py
@@ -1,4 +1,7 @@
-"""OSS default adapters for the three ports.
+"""OSS default adapters for three of the four ports.
+
+The fourth port, ``Executor``, has its OSS default (``BUILTIN_EXECUTOR``) in ``execute_sql``
+instead: that module ships in the stdlib-lean plugin mirror, which cannot import this one.
 
 These defaults make the local product run out of the box — the single-tenant resolver, the
 file/jsonl activity sink, and presence-only auth. They live in agami-core

--- a/packages/agami-core/src/oss_adapters.py
+++ b/packages/agami-core/src/oss_adapters.py
@@ -1,7 +1,7 @@
-"""OSS default adapters for the four ports.
+"""OSS default adapters for the three ports.
 
 These defaults make the local product run out of the box — the single-tenant resolver, the
-file/jsonl activity sink, presence-only auth, and warn-only governance. They live in agami-core
+file/jsonl activity sink, and presence-only auth. They live in agami-core
 (not the ``agami-oss-adapters`` placeholder) so ``pip install agami-core`` is enough to run
 locally; richer adapters (a Postgres sink, real auth providers, enforcement) are supplied by
 their own consumers.
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import agami_paths
 from contracts import QueryExecutionRecord
-from ports import GovernanceVerdict, Org, Principal
+from ports import Org, Principal
 
 
 def _append_jsonl(path: Path, record: dict) -> bool:
@@ -67,11 +67,3 @@ class PresenceAuthProvider:
 
     def validate_token(self, token: str) -> Principal | None:
         return Principal(subject=self._subject) if (token or "").strip() else None
-
-
-class WarnOnlyGovernancePolicy:
-    """Default ``GovernancePolicy`` — never blocks (``allowed=True``); any warnings are advisory
-    ("basic governance warning"). Enforcement is a paid tier."""
-
-    def evaluate(self, ctx: object | None = None) -> GovernanceVerdict:
-        return GovernanceVerdict(allowed=True, warnings=[])

--- a/packages/agami-core/src/ports.py
+++ b/packages/agami-core/src/ports.py
@@ -1,4 +1,4 @@
-"""The five port Protocols — the seams adapters plug into.
+"""The four port Protocols — the seams adapters plug into.
 
 agami-core keeps one MCP implementation across deployments; deployment-specific behavior is
 swapped at the composition root through these ports, never by forking a tool:
@@ -6,7 +6,6 @@ swapped at the composition root through these ports, never by forking a tool:
   - ``ActivitySink``     — where query-execution records go (file by default)
   - ``OrgResolver``      — single vs multi tenancy as a config flag, not a schema fork
   - ``AuthProvider``     — bearer token → principal (presence by default)
-  - ``GovernancePolicy`` — warn-only by default; enforcement is a paid concern
   - ``Executor``         — the connect-and-run step, *behind* the shared guard (built-in by default;
                            a consumer injects a pooled/RBAC/tunnel executor without forking the guard)
 
@@ -14,7 +13,7 @@ These are **interfaces only** — `typing.Protocol`, so an adapter satisfies a p
 no import coupling back to core. The OSS default adapters live in ``oss_adapters`` (so the local
 product runs out of the box); a downstream consumer supplies its own.
 
-The seam value types (``Org`` / ``Principal`` / ``GovernanceVerdict``) are stdlib dataclasses, not
+The seam value types (``Org`` / ``Principal``) are stdlib dataclasses, not
 pydantic models, so this module imports with **zero dependencies** — a consumer can depend on the
 seams without pulling the model deps. The wire shapes that need validation (the 4-tool I/O) live
 in ``contracts`` (pydantic). Each type is kept minimal — only what a default adapter or a
@@ -24,7 +23,7 @@ consumer needs.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -71,17 +70,8 @@ class Principal:
     session_id: str | None = None
 
 
-@dataclass(frozen=True)
-class GovernanceVerdict:
-    """The outcome of a governance check. The default is **warn-only** — ``allowed`` is always
-    True and ``warnings`` is advisory; only a paid enforcement tier may set allowed=False."""
-
-    allowed: bool = True
-    warnings: list[str] = field(default_factory=list)
-
-
 # ---------------------------------------------------------------------------
-# The five ports
+# The four ports
 # ---------------------------------------------------------------------------
 
 
@@ -113,15 +103,6 @@ class AuthProvider(Protocol):
     OSS default = presence only (enough for a token-gated server); real providers come later."""
 
     def validate_token(self, token: str) -> Principal | None: ...
-
-
-@runtime_checkable
-class GovernancePolicy(Protocol):
-    """Evaluate a request and return a ``GovernanceVerdict`` (warnings; never blocks by default).
-
-    OSS default = warn-only ("basic governance warning"); enforcement is a paid tier."""
-
-    def evaluate(self, ctx: object | None = None) -> GovernanceVerdict: ...
 
 
 @runtime_checkable
@@ -164,11 +145,10 @@ class Adapters:
     """The port adapters, bundled so ``mcp_http.create_app`` takes them as one argument.
 
     A consumer builds this with its own implementations of the ports (its own ``OrgResolver``,
-    ``AuthProvider``, ``ActivitySink``, ``GovernancePolicy``, and optionally an ``Executor``);
+    ``AuthProvider``, ``ActivitySink``, and optionally an ``Executor``);
     passing ``adapters=None`` to ``create_app`` uses the OSS defaults (``mcp_http.default_adapters``).
     Today ``create_app`` wires ``auth_provider`` + ``org_resolver`` into the request path;
-    ``activity_sink`` + ``governance`` are carried here for consumers and not yet referenced by a
-    core call site.
+    ``activity_sink`` is carried here for consumers and not yet referenced by a core call site.
 
     ``executor`` is optional and defaults to ``None`` — meaning "use the built-in executor" (the
     subprocess/direct connect-per-query path, byte-identical to today). A consumer sets it to run
@@ -177,7 +157,6 @@ class Adapters:
     activity_sink: ActivitySink
     org_resolver: OrgResolver
     auth_provider: AuthProvider
-    governance: GovernancePolicy
     executor: Executor | None = None
     # `tool_visibility(tool_name) -> bool` narrows the ADVERTISED tool surface per request. None (the
     # default) is exactly today's behaviour — the whole registry, listed and callable. A registry

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1869,7 +1869,7 @@ def _builtin_execute(vetted_sql: str, creds: dict[str, str], *, profile: str) ->
 
 class _BuiltinExecutor:
     """The default ``ports.Executor``: wraps the connect-per-query dispatch as an object so it
-    satisfies the port by shape (method-style, like the other four ports). Stateless — one shared
+    satisfies the port by shape (method-style, like the other three ports). Stateless — one shared
     ``BUILTIN_EXECUTOR`` instance."""
 
     def execute(self, vetted_sql: str, creds: dict[str, str], *, profile: str) -> ExecResult:

--- a/tests/test_ah012_executor_seam.py
+++ b/tests/test_ah012_executor_seam.py
@@ -255,7 +255,6 @@ def test_create_app_wires_injected_executor_and_defaults_to_builtin(monkeypatch)
         activity_sink=base.activity_sink,
         org_resolver=base.org_resolver,
         auth_provider=base.auth_provider,
-        governance=base.governance,
         executor=fake,
     )
     mcp_http.create_app(adapters=adapters)

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,4 +1,4 @@
-"""The four port Protocols + their OSS default adapters.
+"""The three port Protocols + their OSS default adapters.
 
 Proves: the Protocols are importable (and dependency-free), and each OSS default adapter
 type-checks against its Protocol via @runtime_checkable + behaves as specified.
@@ -13,8 +13,6 @@ import sys
 from ports import (
     ActivitySink,
     AuthProvider,
-    GovernancePolicy,
-    GovernanceVerdict,
     Org,
     OrgResolver,
     Principal,
@@ -23,7 +21,7 @@ from ports import (
 
 def test_protocols_importable_and_runtime_checkable():
     # Each is a runtime_checkable typing.Protocol (so the isinstance checks below are valid).
-    for proto in (ActivitySink, OrgResolver, AuthProvider, GovernancePolicy):
+    for proto in (ActivitySink, OrgResolver, AuthProvider):
         assert proto.__module__ == "ports"
         assert getattr(proto, "_is_runtime_protocol", False), (
             f"{proto.__name__} not runtime_checkable"
@@ -60,13 +58,11 @@ def test_default_adapters_satisfy_protocols():
         FileActivitySink,
         PresenceAuthProvider,
         SingleTenantOrgResolver,
-        WarnOnlyGovernancePolicy,
     )
 
     assert isinstance(FileActivitySink(), ActivitySink)
     assert isinstance(SingleTenantOrgResolver(), OrgResolver)
     assert isinstance(PresenceAuthProvider(), AuthProvider)
-    assert isinstance(WarnOnlyGovernancePolicy(), GovernancePolicy)
 
 
 # --- adapter behavior -------------------------------------------------------
@@ -91,14 +87,6 @@ def test_presence_auth_accepts_nonempty_rejects_empty():
     assert isinstance(p.validate_token("any-token"), Principal)
     assert p.validate_token("") is None
     assert p.validate_token("   ") is None
-
-
-def test_warn_only_governance_never_blocks():
-    from oss_adapters import WarnOnlyGovernancePolicy
-
-    v = WarnOnlyGovernancePolicy().evaluate()
-    assert isinstance(v, GovernanceVerdict)
-    assert v.allowed is True
 
 
 def test_file_activity_sink_writes_jsonl(tmp_path):

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,7 +1,8 @@
-"""The three port Protocols + their OSS default adapters.
+"""Covers three of the four port Protocols + their OSS default adapters.
 
 Proves: the Protocols are importable (and dependency-free), and each OSS default adapter
-type-checks against its Protocol via @runtime_checkable + behaves as specified.
+type-checks against its Protocol via @runtime_checkable + behaves as specified. The fourth port,
+``Executor``, is exercised in ``test_ah012_executor_seam.py`` alongside the guarded path it sits in.
 """
 
 from __future__ import annotations

--- a/tests/test_tool_extension_seam.py
+++ b/tests/test_tool_extension_seam.py
@@ -22,7 +22,6 @@ from oss_adapters import (  # noqa: E402
     FileActivitySink,
     PresenceAuthProvider,
     SingleTenantOrgResolver,
-    WarnOnlyGovernancePolicy,
 )
 from ports import Adapters, Org  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
@@ -167,7 +166,6 @@ def test_adapters_none_uses_the_oss_defaults(base_url):
     assert isinstance(a.org_resolver, SingleTenantOrgResolver)
     assert isinstance(a.auth_provider, PresenceAuthProvider)  # presence when no signing secret
     assert isinstance(a.activity_sink, FileActivitySink)
-    assert isinstance(a.governance, WarnOnlyGovernancePolicy)
 
 
 def test_create_app_uses_the_passed_adapters(base_url):
@@ -177,7 +175,6 @@ def test_create_app_uses_the_passed_adapters(base_url):
         activity_sink=FileActivitySink(),
         org_resolver=resolver,
         auth_provider=auth,
-        governance=WarnOnlyGovernancePolicy(),
     )
     kwargs = _auth_middleware_kwargs(mcp_http.create_app(adapters=adapters))
     assert kwargs["resolver"] is resolver  # the passed adapters are used at the composition root
@@ -202,7 +199,6 @@ def test_a_refusing_resolver_gives_403_not_500(base_url):
         activity_sink=FileActivitySink(),
         org_resolver=_RefusingResolver(),
         auth_provider=PresenceAuthProvider(),
-        governance=WarnOnlyGovernancePolicy(),
     )
     c = TestClient(mcp_http.create_app(adapters=adapters))
     r = c.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}, headers=AUTH)


### PR DESCRIPTION
Spec: ACE-095

## Summary

`GovernancePolicy`, `GovernanceVerdict` and `WarnOnlyGovernancePolicy` were wired into the HTTP
adapter set, but `.evaluate()` was never called in the product. Its only caller was a single test.
The seam was built for the graded, tiered verdict the governance principles removed, and its
successor spec is abandoned, so nothing was holding it open. Left in place, it invites the next
reader to implement against a port that enforces nothing.

This deletes the port, its value type, its OSS default adapter, the `Adapters.governance` field,
and every construction site and test that referenced them.

The removed code was inert. Verified against the base commit: `Adapters.governance` had exactly two
readers repo-wide, both in tests, and `.evaluate()` had exactly one caller, the test deleted here.
No product call site read the field or invoked the port, so nothing that was enforced before is
unenforced now. The single `execute_sql` enforcement chokepoint is untouched apart from one
docstring word.

## Changes

**Deleted**
- `ports.py`: the `GovernancePolicy` Protocol and the `GovernanceVerdict` dataclass.
- `oss_adapters.py`: the `WarnOnlyGovernancePolicy` default adapter.
- `ports.py`: the `governance` field on `Adapters`, plus all four construction sites that passed it
  (`mcp_http.default_adapters()`, two in `test_tool_extension_seam.py`, one in
  `test_ah012_executor_seam.py`). Three passed the type; the fourth passed `base.governance`, so a
  grep for the symbol names alone misses it.
- `field` from the `dataclasses` import in `ports.py`, whose only use was `GovernanceVerdict.warnings`.

**Test contract change**
- `tests/test_ports.py::test_warn_only_governance_never_blocks` is **deleted, not adapted**. It was
  the sole caller of `.evaluate()`; with the port gone it has no contract left to assert. Recorded
  in the spec's `## Decisions` per the rule that a deleted test is a contract change.
- The two seam suites are kept and only drop the `governance=` kwarg. They cover the tool-extension
  and executor seams, not governance, and still assert their original behavior (adapter defaults,
  sentinel identity, the 403 path, injected-executor vs `BUILTIN_EXECUTOR`).

**Docs**
- Corrected the port-arity docstrings the deletion made wrong, including the one in the vendored
  `execute_sql.py` (mirror regenerated; the two copies are byte-identical).
- `oss_adapters.py` now explains why the fourth port's default lives elsewhere: `Executor`'s
  `BUILTIN_EXECUTOR` sits in `execute_sql.py` because that module ships in the stdlib-lean plugin
  mirror, which cannot import `oss_adapters`.
- `CHANGELOG.md` gains a `Removed` entry. It flags that `Adapters` is not keyword-only, so a
  consumer that constructed it positionally must re-check the call: the 4th positional slot was
  `governance` and is now `executor`, which still constructs but fails later at query time.

## Checklist

- [x] `ports.py::GovernancePolicy`, `ports.py::GovernanceVerdict` and
      `oss_adapters.py::WarnOnlyGovernancePolicy` are gone; grep-clean in `packages/agami-core/src`.
- [x] `ports.py::Adapters` loses its `governance` field, and all four construction sites stop
      passing it.
- [x] The sole test exercising `.evaluate()` is deleted, not adapted.
- [x] `uv run dev.py check` green (2412 passed, 4 skipped; ruff clean, gitleaks clean).
- [x] No dangling import, and no dangling reference in `docs/`, `README.md`, any `SKILL.md`,
      `pyproject.toml` or deploy config.
- [x] Vendored mirror in sync (`plugins/agami/lib/execute_sql.py` byte-identical to source).
- [x] `execute_sql` enforcement chokepoint untouched; no gate weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
