### PR TITLE
ACE-097: recording becomes mandatory — a server that cannot record does not execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Changed
+
+- **A self-hosted server that cannot record a query no longer runs it (ACE-097).** Recording was
+  best-effort in three places, and two of them were silent, so a deployment could execute SQL
+  against your database and keep no record of having done so with nothing anywhere saying the
+  record was lost.
+
+  On a **server** (one with `AGAMI_DB_URL` or `APP_DATABASE_URL` configured), the audit store is now
+  checked before the statement runs. If it cannot be opened the call is refused, with
+  `rule: audit_unavailable` and a remediation naming the operator action, and the statement never
+  reaches your database. If the store was reachable at that check and the write fails afterwards,
+  the call fails rather than returning an answer whose statement left no trace. The connection is
+  read-only, so nothing was changed and re-running costs only the round trip.
+
+  **Local single-player use is unchanged.** With no database configured there is no audit store to
+  reach: the log is a local jsonl file, a write failure is still logged and never breaks your query,
+  and a read-only artifacts directory cannot stop you asking questions.
+
+  For operators this is an availability change, and a deliberate one: a briefly unreachable audit
+  database now produces refusals rather than unrecorded answers.
+
 ### Added
 
 - **The receipt now tells you which of a table's declared filters your statement actually applied

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1623,14 +1623,31 @@ def _audit_store_reachable() -> bool:
 
         store = Store.from_env()
     except Exception:
-        # Every way the store can be unopenable arrives here as one answer, because there is only
-        # one thing to do about any of them. The cause is the operator's to read in the refusal's
-        # remediation and their own logs; it is deliberately NOT relayed to the caller, since a DSN
-        # scheme, a driver name or a host is exactly what `Refusal.detail` may never carry.
+        # Every way the store can be unopenable produces the same refusal, because there is only one
+        # thing a caller can do about any of them. But the CAUSE has to land somewhere, or this
+        # reintroduces the defect the spec exists to remove in a new place: a bad DSN scheme, an
+        # unreachable host and a missing driver would all read as one opaque refusal and an operator
+        # would have nothing to work from. Server log, with the traceback — the same treatment
+        # `_record_query` gives a swallowed write, and for the same reason.
+        #
+        # `_RAW_LOG`, not `_LOG`, and for BOTH of that logger's reasons. The exception text carries
+        # the host, the port and the DSN scheme — raw text, the operator's and never the caller's
+        # (ACE-039). And this module never calls `basicConfig`, so a record on `_LOG` falls through
+        # to `logging.lastResort` and lands on STDERR, which on the CLI/fork path is a wire carrying
+        # exactly one JSON object: a diagnostic line there does not merely add noise, it makes the
+        # refusal unparseable and the parent loses it entirely. `main` silences `_RAW_LOG` for the
+        # child's lifetime, so the child stays clean while in-process and hosted still get the cause
+        # on the server's root logger — which is where the operator being told to "restore the audit
+        # database" actually reads it.
+        _RAW_LOG.warning("audit store is not reachable; refusing to execute unrecorded",
+                         exc_info=True)
         return False
     if store is None:
-        # `_hosted()` was true, so a URL is configured and `from_env` cannot return None. Belt and
-        # braces on a security gate: an unexpected None must read as unreachable, never as fine.
+        # Reachable, not defensive: `_hosted()` tests the variable for truthiness while `from_env`
+        # strips it, so a whitespace-only `AGAMI_DB_URL` lands exactly here. A configured-but-empty
+        # store is a misconfiguration, and on a security gate a misconfiguration reads as
+        # unreachable, never as fine.
+        _RAW_LOG.warning("the audit store url is set but empty; treating it as unreachable")
         return False
     store.close()
     return True

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -86,6 +86,7 @@ from guardrail import (
     RECEIPT_BUILD_FAILED,
     RECEIPT_NO_MODEL,
     RECEIPT_NO_RUNTIME,
+    RULE_AUDIT_UNAVAILABLE,
     RULE_MODEL_UNAVAILABLE,
     RULE_RESOURCE_LIMIT,
     Envelope,
@@ -1590,6 +1591,51 @@ def _hosted() -> bool:
     return bool(os.environ.get("AGAMI_DB_URL") or os.environ.get("APP_DATABASE_URL"))
 
 
+def _audit_store_reachable() -> bool:
+    """Whether the audit store can be opened right now — the pre-execution half of principle 7
+    (ACE-097).
+
+    Recording happens at the tool edge, AFTER the statement ran: `tools._record_execution` is called
+    from `tools._emit`, the serializer. So closing the swallows there can only turn a lost record
+    into a raised exception on a statement that already reached the customer's database. Refusing
+    *instead of* executing needs the question asked before execution, and this is that question.
+
+    `Store.from_env()` is the probe rather than a DSN parse because it is not a parse:
+    `Store.connect` calls `psycopg2.connect` / `sqlite3.connect` eagerly, so constructing one either
+    reaches the database or raises. It is also the identical call `_record_query` will make, which
+    is what makes the answer relevant rather than merely adjacent — a probe that opens a different
+    connection than the writer would is a probe of something else.
+
+    **Costs one connect per served call.** Deliberate and measured against the alternatives: a cached
+    health flag is stale in exactly the direction that matters (it says yes while the store is
+    already gone), and anything cheaper does not establish reachability at all. The deployment
+    already pays a comparable per-request open in `tools._model_version`; pooling the pair is
+    ACE-028's, not this slice's.
+
+    Local is always True and never opens anything. `governance-principles.md` scopes the principles
+    to the served deployment, and locally there is no store to reach: `_record_query` writes jsonl,
+    and a read-only artifacts directory must not stop a laptop from answering.
+    """
+    if not _hosted():
+        return True
+    try:
+        from store import Store
+
+        store = Store.from_env()
+    except Exception:
+        # Every way the store can be unopenable arrives here as one answer, because there is only
+        # one thing to do about any of them. The cause is the operator's to read in the refusal's
+        # remediation and their own logs; it is deliberately NOT relayed to the caller, since a DSN
+        # scheme, a driver name or a host is exactly what `Refusal.detail` may never carry.
+        return False
+    if store is None:
+        # `_hosted()` was true, so a URL is configured and `from_env` cannot return None. Belt and
+        # braces on a security gate: an unexpected None must read as unreachable, never as fine.
+        return False
+    store.close()
+    return True
+
+
 def _resolve_guard_model(profile: str):
     """Resolve the semantic model for the safety pass, mirroring `tools._load_org` (ACE-051): from
     the DB when one is configured (hosted — the `/artifacts` disk mount may be absent), else the
@@ -2208,6 +2254,24 @@ def execute_guarded(
     # that says what it is for.
     received_sql = sql
     try:
+        # FIRST, above the read-only gate, because principle 7 records "every call ... whether it
+        # executed or was refused" — so gating only execution would leave the refusals unrecorded
+        # too, and the outcomes most worth reviewing are exactly the ones a reviewer could not find.
+        # A `DROP TABLE` therefore comes back `audit_unavailable` rather than `read_only` while the
+        # store is down. Nothing is weakened by that ordering: both are refusals, nothing runs, and
+        # the security gates below are unreachable only in the state where NOTHING is reachable.
+        #
+        # Outside the `no_safety` branch on purpose. That flag skips the semantic-model pass and
+        # nothing else; an audit guarantee is not a model check, and a caller able to opt out of
+        # being recorded is the hole this spec closes.
+        if not _audit_store_reachable():
+            refusal = refuse(
+                RULE_AUDIT_UNAVAILABLE,
+                detail="the audit store is not reachable, so this call cannot be recorded",
+                remediation="Restore the audit database, then run the statement again.",
+            )
+            return _envelope("refused", refusal=refusal,
+                             receipt=_refusal_receipt(refusal, received_sql, profile))
         import sql_guard
 
         refusal = sql_guard.check_read_only(sql)

--- a/packages/agami-core/src/guardrail.py
+++ b/packages/agami-core/src/guardrail.py
@@ -50,6 +50,18 @@ RULE_TABLE_SCOPE = "table_scope"
 RULE_COLUMN_SCOPE = "column_scope"
 RULE_SELECT_STAR = "select_star"
 RULE_MODEL_UNAVAILABLE = "model_unavailable"
+# The audit store cannot take the record, so the statement does not run (ACE-097, principle 7). A
+# DEPLOYMENT-state rule, the sibling of `model_unavailable` rather than of the scope gates: neither
+# says anything about the statement, and both mean this deployment cannot do a thing it promises. It
+# is a rule and not a fourth REASON on purpose — `RefusalReason` stays closed at three, and the cost
+# of a deployment-state refusal is one entry here plus one in `REASON_FOR_RULE`, which is a diff a
+# reviewer reads.
+#
+# It is also the ONE refusal that is exempt from being recorded, by construction: writing a row to
+# say the row could not be written is the same write failing twice. `tools._record_execution` skips
+# it, and that exemption is the whole of the carve-out — every other outcome, refusals included,
+# still writes.
+RULE_AUDIT_UNAVAILABLE = "audit_unavailable"
 # Produced by the **per-statement** timeout the executor imposes: a watchdog cancels a statement that
 # outlives the configured budget, and `execute_sql.execute_guarded` turns that into this refusal. Its
 # subject is the statement, which is what earns it a rule at all — "narrow the query" is a fix we can
@@ -86,14 +98,17 @@ RULE_ENGINE_MISMATCH = "engine_mismatch"
 # entry is `undetermined`, so that is a one-line change, not a decision to re-litigate).
 RULE_UNSCOPABLE = "unscopable"
 
-PRE_MODEL_RULES: frozenset[str] = frozenset({RULE_READ_ONLY, RULE_RECON})
+PRE_MODEL_RULES: frozenset[str] = frozenset(
+    {RULE_READ_ONLY, RULE_RECON, RULE_AUDIT_UNAVAILABLE}
+)
 """The rules decided BEFORE any semantic model is consulted, and the home for the next one.
 
-Both gates run above the semantic-model pass — a write and a server-fingerprinting probe are stopped
-without asking what the model declares — so a statement either one refuses never resolved a model at
-all. That is a fact about the DECISION rather than about the deployment, and it has to be stated the
-same way whichever process decided it: the in-process path knows no model was loaded because it holds
-the gate, while the fork path holds only the rule the child sent back. Consulting this set is what
+All three gates run above the semantic-model pass — a write, a server-fingerprinting probe and an
+unrecordable call are stopped without asking what the model declares — so a statement any of them
+refuses never resolved a model at all. That is a fact about the DECISION rather than about the
+deployment, and it has to be stated the same way whichever process decided it: the in-process path
+knows no model was loaded because it holds the gate, while the fork path holds only the rule the
+child sent back. Consulting this set is what
 lets the two reach the same receipt, and it is what keeps the fork path from loading a model in order
 to describe a refusal that never looked at one (see `RECEIPT_BEFORE_MODEL`).
 
@@ -112,6 +127,10 @@ REASON_FOR_RULE: dict[str, RefusalReason] = {
     # wrong about its own reason.
     RULE_SELECT_STAR: "undetermined",
     RULE_MODEL_UNAVAILABLE: "undetermined",
+    # Same reason as its sibling above, and for the same argument: we did not determine that the
+    # statement was safe or in scope, because we stopped before asking. Not `unsafe` — nothing about
+    # the statement is in question — and not `out_of_scope`, which is a claim about the model.
+    RULE_AUDIT_UNAVAILABLE: "undetermined",
     RULE_RECON: "unsafe",
     # A bound we imposed, not a property of the statement: neither unsafe nor out of scope — we
     # simply did not determine the answer within the bound. Pinned before it had a producer, so the

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -440,19 +440,28 @@ def build_server(
         finally:
             # The per-call audit write opens a fresh Store + INSERT + close; run it off the event loop so
             # it doesn't add DB latency to every tool call on the loop (ACE-048). `_actor_ctx.get()` is read
-            # here (on the loop) and passed in. Still best-effort — a logging failure never breaks the tool.
-            try:
-                await run_blocking(
-                    record_tool_call,
-                    name=name,
-                    arguments=arguments,
-                    result_text=result_text,
-                    execution_ms=int((time.monotonic() - started) * 1000),
-                    actor=_actor_ctx.get(),
-                    raised=raised,
-                )
-            except Exception:
-                pass
+            # here (on the loop) and passed in.
+            #
+            # NOT wrapped (ACE-097). This `try` held an `except Exception: pass`, the second of the
+            # two swallows that made a lost audit row invisible: it caught whatever
+            # `_record_tool_call` raised, and `_record_tool_call` swallowed internally so it never
+            # raised anything for this to catch. Each made the other unobservable, which is why
+            # removing either alone changed nothing and neither was ever removed.
+            #
+            # `record_tool_call` decides what a failure means, by deployment: served, it raises and
+            # the call fails; local, it warns and returns. That decision belongs there, beside the
+            # write, rather than being pre-empted here by a transport that cannot tell the two
+            # deployments apart. Raising from a `finally` replaces the handler's own result, which is
+            # the intended outcome: a call whose record was lost must not read as a success.
+            await run_blocking(
+                record_tool_call,
+                name=name,
+                arguments=arguments,
+                result_text=result_text,
+                execution_ms=int((time.monotonic() - started) * 1000),
+                actor=_actor_ctx.get(),
+                raised=raised,
+            )
 
     return server
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1996,7 +1996,21 @@ def _record_tool_call(rec: dict[str, Any]) -> None:
     of the two swallows this spec closes, and the reason neither had been closed before is that they
     masked each other exactly: this one hid inside the transport's, and the transport's had nothing
     to catch once this one stopped raising. Removing either alone was a PR with no observable
-    change, which is indistinguishable from not having done the work."""
+    change, which is indistinguishable from not having done the work.
+
+    The `audit_unavailable` exemption applies here too, and it has to. `_record_execution` skipping
+    the query row is not enough on its own: the HTTP transport writes a tool-call row in a `finally`
+    for EVERY call, so on that surface the row this exemption exists to avoid was written anyway,
+    failed, and raised — replacing the clean fail-closed refusal with a transport error and losing
+    the remediation that tells the operator what to restore. On the surface where an operator most
+    needs it. Found by driving a real server whose store died under it; no unit test saw it, because
+    the exemption looked complete at the one write path a unit test drives.
+
+    Read off `error_kind` because that IS the rule for a refusal — `record_tool_call` derives it as
+    `refusal["rule"]`. ACE-098 replaces that derivation with the typed refusal, and this check moves
+    with it rather than needing its own signal."""
+    if rec.get("error_kind") == RULE_AUDIT_UNAVAILABLE:
+        return
     try:
         from store import Store
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -52,6 +52,7 @@ from guardrail import (
     RECEIPT_BEFORE_MODEL,
     RECEIPT_BUILD_FAILED,
     RECEIPT_NO_MODEL,
+    RULE_AUDIT_UNAVAILABLE,
     Envelope,
     Failure,
     Receipt,
@@ -1489,6 +1490,16 @@ def _record_execution(
     `sql` is BOUNDED before it is stored — see `AUDIT_SQL_MAX_CHARS`.
     """
     refusal = env.refusal
+    if refusal is not None and refusal.rule == RULE_AUDIT_UNAVAILABLE:
+        # The ONE outcome that writes no row, and the only exemption there is (ACE-097). This
+        # refusal means the store could not be opened, so writing a row to say so is the same write
+        # failing a second time — and on the hosted path a failing write now raises, which would
+        # turn the tidy fail-closed refusal into an unhandled exception at the serializer. Every
+        # other outcome, refusals included, still records.
+        #
+        # Keyed on the RULE rather than on a flag threaded down from the gate: the rule is the fact,
+        # a flag would be a second way to say it, and the two could disagree.
+        return
     stored_sql, sql_truncated = _bounded_audit_sql(sql or "")
     # The RAW driver text, for the operator only — the caller's `failure.message` is the classified
     # value-free sentence and stays that way. Present only when the chokepoint ran in THIS process:
@@ -1772,20 +1783,41 @@ def _append_jsonl(path: Path, record: dict[str, Any]) -> bool:
         return False
 
 
+def _audit_is_load_bearing() -> bool:
+    """Whether a failed audit write must break the call — the served deployment, and only it.
+
+    Reads `execute_sql._hosted()` rather than re-testing the environment here, so the question "is
+    this a served deployment?" has ONE answer in the codebase. The same function decides whether
+    `execute_guarded` runs the pre-execution reachability check, and the two must not be able to
+    disagree: a deployment that fails closed at the gate but shrugs at the write would refuse
+    healthy calls and quietly lose the record on the broken ones.
+    """
+    from execute_sql import _hosted
+
+    return _hosted()
+
+
 def _record_query(rec: dict[str, Any]) -> None:
-    """Log a query execution through the DB sink (AGAMI_DB_URL) or the local jsonl. **Best-effort:**
-    a logging failure must never break an otherwise-successful query, and must never turn a refusal
-    into an exception.
+    """Log a query execution through the DB sink (AGAMI_DB_URL) or the local jsonl.
+
+    **Served: the write is load-bearing and its failure is raised** (ACE-097, principle 7). An answer
+    that reached the caller with no record of the statement that produced it is the thing the
+    principle forbids, and a warning is not a substitute: the operator reads it hours later, the
+    caller acted on the answer immediately. `execute_guarded` establishes the store is reachable
+    BEFORE executing, so this raise is the narrow residual — the store died between that check and
+    this write — rather than the common path.
+
+    **Local stays best-effort**, and unchanged. `governance-principles.md` scopes the principles to
+    the served deployment; here there is no store and this writes jsonl, so a read-only artifacts
+    directory would otherwise stop a laptop answering. A swallowed failure is still LOGGED at WARNING
+    with its traceback, never passed silently: a sink broken for a month must not look identical to a
+    working one.
 
     The WHOLE body sits inside the try, `Store.from_env()` included. Constructing the store can
     itself raise — a malformed DSN, an uninstalled driver — and with that call outside the try the
-    exception escaped onto the success path: a deployment with a bad `AGAMI_DB_URL` broke every query
-    it logged, rather than every log it wrote. `_record_tool_call` has this shape already; this is
-    the same fix for the same reason.
-
-    A swallowed failure is LOGGED at WARNING with its traceback, not passed silently. The audit trail
-    is the point of the write, so a sink that has been broken for a month must not look identical to
-    one that is working."""
+    exception escaped onto the success path even locally, breaking every query the deployment logged
+    rather than every log it wrote. That shape is what now lets the served path re-raise deliberately
+    from one place instead of leaking from an arbitrary one."""
     try:
         from store import Store
 
@@ -1810,8 +1842,15 @@ def _record_query(rec: dict[str, Any]) -> None:
         finally:
             store.close()
     except Exception:
-        # No SQL, no question, no org — the record's own fields are the caller's data, and this line
-        # goes to the server log. The exception and the stack say where the write broke.
+        if _audit_is_load_bearing():
+            # Served: no record, no answer. Raised rather than logged, and deliberately not wrapped
+            # in a friendlier exception — this escapes past `_emit`, so the caller gets a transport
+            # error and the operator gets the traceback. Converting it into a tidy refusal Envelope
+            # is not available: that Envelope would itself need an audit row, written through this
+            # same broken sink.
+            raise
+        # Local: no SQL, no question, no org — the record's own fields are the caller's data, and
+        # this line goes to the server log. The exception and the stack say where the write broke.
         _LOG.warning("query-execution audit write failed; the answer is unaffected", exc_info=True)
 
 
@@ -1837,7 +1876,9 @@ def record_tool_call(
     result (a tool returns a refusal or failure body without raising, so `raised` alone would see
     almost nothing). The self-report fields (`user_question`/`agent_query`/`thread_id`) are whatever
     Claude supplied — may be None.
-    **Best-effort and never raises** — a logging failure must not break the tool.
+    **Best-effort locally; load-bearing on the served path** (ACE-097). Locally a logging failure
+    must not break the tool and is warned about. Served, principle 7 makes the row part of the call:
+    the write's failure is raised, and the tool call fails with it.
 
     The trailing parameters are an **override seam for an embedder that dispatches tool handlers
     itself** rather than through this package's transport. Each defaults to `None`, meaning *derive it
@@ -1948,8 +1989,14 @@ def record_tool_call(
 
 
 def _record_tool_call(rec: dict[str, Any]) -> None:
-    """Write a tool-call record through the DB sink (AGAMI_DB_URL) or the local jsonl. Wrapped so the
-    whole thing is best-effort — even opening the store can't surface an error to the caller."""
+    """Write a tool-call record through the DB sink (AGAMI_DB_URL) or the local jsonl.
+
+    Served: the failure is raised, for the reason `_record_query` gives. Local: swallowed, and now
+    logged rather than passed silently — the `except Exception: pass` this replaced was the quieter
+    of the two swallows this spec closes, and the reason neither had been closed before is that they
+    masked each other exactly: this one hid inside the transport's, and the transport's had nothing
+    to catch once this one stopped raising. Removing either alone was a PR with no observable
+    change, which is indistinguishable from not having done the work."""
     try:
         from store import Store
 
@@ -1966,7 +2013,9 @@ def _record_tool_call(rec: dict[str, Any]) -> None:
         finally:
             store.close()
     except Exception:
-        pass  # best-effort: never fail the tool because logging failed
+        if _audit_is_load_bearing():
+            raise
+        _LOG.warning("tool-call audit write failed; the answer is unaffected", exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1623,14 +1623,31 @@ def _audit_store_reachable() -> bool:
 
         store = Store.from_env()
     except Exception:
-        # Every way the store can be unopenable arrives here as one answer, because there is only
-        # one thing to do about any of them. The cause is the operator's to read in the refusal's
-        # remediation and their own logs; it is deliberately NOT relayed to the caller, since a DSN
-        # scheme, a driver name or a host is exactly what `Refusal.detail` may never carry.
+        # Every way the store can be unopenable produces the same refusal, because there is only one
+        # thing a caller can do about any of them. But the CAUSE has to land somewhere, or this
+        # reintroduces the defect the spec exists to remove in a new place: a bad DSN scheme, an
+        # unreachable host and a missing driver would all read as one opaque refusal and an operator
+        # would have nothing to work from. Server log, with the traceback — the same treatment
+        # `_record_query` gives a swallowed write, and for the same reason.
+        #
+        # `_RAW_LOG`, not `_LOG`, and for BOTH of that logger's reasons. The exception text carries
+        # the host, the port and the DSN scheme — raw text, the operator's and never the caller's
+        # (ACE-039). And this module never calls `basicConfig`, so a record on `_LOG` falls through
+        # to `logging.lastResort` and lands on STDERR, which on the CLI/fork path is a wire carrying
+        # exactly one JSON object: a diagnostic line there does not merely add noise, it makes the
+        # refusal unparseable and the parent loses it entirely. `main` silences `_RAW_LOG` for the
+        # child's lifetime, so the child stays clean while in-process and hosted still get the cause
+        # on the server's root logger — which is where the operator being told to "restore the audit
+        # database" actually reads it.
+        _RAW_LOG.warning("audit store is not reachable; refusing to execute unrecorded",
+                         exc_info=True)
         return False
     if store is None:
-        # `_hosted()` was true, so a URL is configured and `from_env` cannot return None. Belt and
-        # braces on a security gate: an unexpected None must read as unreachable, never as fine.
+        # Reachable, not defensive: `_hosted()` tests the variable for truthiness while `from_env`
+        # strips it, so a whitespace-only `AGAMI_DB_URL` lands exactly here. A configured-but-empty
+        # store is a misconfiguration, and on a security gate a misconfiguration reads as
+        # unreachable, never as fine.
+        _RAW_LOG.warning("the audit store url is set but empty; treating it as unreachable")
         return False
     store.close()
     return True

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -86,6 +86,7 @@ from guardrail import (
     RECEIPT_BUILD_FAILED,
     RECEIPT_NO_MODEL,
     RECEIPT_NO_RUNTIME,
+    RULE_AUDIT_UNAVAILABLE,
     RULE_MODEL_UNAVAILABLE,
     RULE_RESOURCE_LIMIT,
     Envelope,
@@ -1590,6 +1591,51 @@ def _hosted() -> bool:
     return bool(os.environ.get("AGAMI_DB_URL") or os.environ.get("APP_DATABASE_URL"))
 
 
+def _audit_store_reachable() -> bool:
+    """Whether the audit store can be opened right now — the pre-execution half of principle 7
+    (ACE-097).
+
+    Recording happens at the tool edge, AFTER the statement ran: `tools._record_execution` is called
+    from `tools._emit`, the serializer. So closing the swallows there can only turn a lost record
+    into a raised exception on a statement that already reached the customer's database. Refusing
+    *instead of* executing needs the question asked before execution, and this is that question.
+
+    `Store.from_env()` is the probe rather than a DSN parse because it is not a parse:
+    `Store.connect` calls `psycopg2.connect` / `sqlite3.connect` eagerly, so constructing one either
+    reaches the database or raises. It is also the identical call `_record_query` will make, which
+    is what makes the answer relevant rather than merely adjacent — a probe that opens a different
+    connection than the writer would is a probe of something else.
+
+    **Costs one connect per served call.** Deliberate and measured against the alternatives: a cached
+    health flag is stale in exactly the direction that matters (it says yes while the store is
+    already gone), and anything cheaper does not establish reachability at all. The deployment
+    already pays a comparable per-request open in `tools._model_version`; pooling the pair is
+    ACE-028's, not this slice's.
+
+    Local is always True and never opens anything. `governance-principles.md` scopes the principles
+    to the served deployment, and locally there is no store to reach: `_record_query` writes jsonl,
+    and a read-only artifacts directory must not stop a laptop from answering.
+    """
+    if not _hosted():
+        return True
+    try:
+        from store import Store
+
+        store = Store.from_env()
+    except Exception:
+        # Every way the store can be unopenable arrives here as one answer, because there is only
+        # one thing to do about any of them. The cause is the operator's to read in the refusal's
+        # remediation and their own logs; it is deliberately NOT relayed to the caller, since a DSN
+        # scheme, a driver name or a host is exactly what `Refusal.detail` may never carry.
+        return False
+    if store is None:
+        # `_hosted()` was true, so a URL is configured and `from_env` cannot return None. Belt and
+        # braces on a security gate: an unexpected None must read as unreachable, never as fine.
+        return False
+    store.close()
+    return True
+
+
 def _resolve_guard_model(profile: str):
     """Resolve the semantic model for the safety pass, mirroring `tools._load_org` (ACE-051): from
     the DB when one is configured (hosted — the `/artifacts` disk mount may be absent), else the
@@ -2208,6 +2254,24 @@ def execute_guarded(
     # that says what it is for.
     received_sql = sql
     try:
+        # FIRST, above the read-only gate, because principle 7 records "every call ... whether it
+        # executed or was refused" — so gating only execution would leave the refusals unrecorded
+        # too, and the outcomes most worth reviewing are exactly the ones a reviewer could not find.
+        # A `DROP TABLE` therefore comes back `audit_unavailable` rather than `read_only` while the
+        # store is down. Nothing is weakened by that ordering: both are refusals, nothing runs, and
+        # the security gates below are unreachable only in the state where NOTHING is reachable.
+        #
+        # Outside the `no_safety` branch on purpose. That flag skips the semantic-model pass and
+        # nothing else; an audit guarantee is not a model check, and a caller able to opt out of
+        # being recorded is the hole this spec closes.
+        if not _audit_store_reachable():
+            refusal = refuse(
+                RULE_AUDIT_UNAVAILABLE,
+                detail="the audit store is not reachable, so this call cannot be recorded",
+                remediation="Restore the audit database, then run the statement again.",
+            )
+            return _envelope("refused", refusal=refusal,
+                             receipt=_refusal_receipt(refusal, received_sql, profile))
         import sql_guard
 
         refusal = sql_guard.check_read_only(sql)

--- a/plugins/agami/lib/guardrail.py
+++ b/plugins/agami/lib/guardrail.py
@@ -50,6 +50,18 @@ RULE_TABLE_SCOPE = "table_scope"
 RULE_COLUMN_SCOPE = "column_scope"
 RULE_SELECT_STAR = "select_star"
 RULE_MODEL_UNAVAILABLE = "model_unavailable"
+# The audit store cannot take the record, so the statement does not run (ACE-097, principle 7). A
+# DEPLOYMENT-state rule, the sibling of `model_unavailable` rather than of the scope gates: neither
+# says anything about the statement, and both mean this deployment cannot do a thing it promises. It
+# is a rule and not a fourth REASON on purpose — `RefusalReason` stays closed at three, and the cost
+# of a deployment-state refusal is one entry here plus one in `REASON_FOR_RULE`, which is a diff a
+# reviewer reads.
+#
+# It is also the ONE refusal that is exempt from being recorded, by construction: writing a row to
+# say the row could not be written is the same write failing twice. `tools._record_execution` skips
+# it, and that exemption is the whole of the carve-out — every other outcome, refusals included,
+# still writes.
+RULE_AUDIT_UNAVAILABLE = "audit_unavailable"
 # Produced by the **per-statement** timeout the executor imposes: a watchdog cancels a statement that
 # outlives the configured budget, and `execute_sql.execute_guarded` turns that into this refusal. Its
 # subject is the statement, which is what earns it a rule at all — "narrow the query" is a fix we can
@@ -86,14 +98,17 @@ RULE_ENGINE_MISMATCH = "engine_mismatch"
 # entry is `undetermined`, so that is a one-line change, not a decision to re-litigate).
 RULE_UNSCOPABLE = "unscopable"
 
-PRE_MODEL_RULES: frozenset[str] = frozenset({RULE_READ_ONLY, RULE_RECON})
+PRE_MODEL_RULES: frozenset[str] = frozenset(
+    {RULE_READ_ONLY, RULE_RECON, RULE_AUDIT_UNAVAILABLE}
+)
 """The rules decided BEFORE any semantic model is consulted, and the home for the next one.
 
-Both gates run above the semantic-model pass — a write and a server-fingerprinting probe are stopped
-without asking what the model declares — so a statement either one refuses never resolved a model at
-all. That is a fact about the DECISION rather than about the deployment, and it has to be stated the
-same way whichever process decided it: the in-process path knows no model was loaded because it holds
-the gate, while the fork path holds only the rule the child sent back. Consulting this set is what
+All three gates run above the semantic-model pass — a write, a server-fingerprinting probe and an
+unrecordable call are stopped without asking what the model declares — so a statement any of them
+refuses never resolved a model at all. That is a fact about the DECISION rather than about the
+deployment, and it has to be stated the same way whichever process decided it: the in-process path
+knows no model was loaded because it holds the gate, while the fork path holds only the rule the
+child sent back. Consulting this set is what
 lets the two reach the same receipt, and it is what keeps the fork path from loading a model in order
 to describe a refusal that never looked at one (see `RECEIPT_BEFORE_MODEL`).
 
@@ -112,6 +127,10 @@ REASON_FOR_RULE: dict[str, RefusalReason] = {
     # wrong about its own reason.
     RULE_SELECT_STAR: "undetermined",
     RULE_MODEL_UNAVAILABLE: "undetermined",
+    # Same reason as its sibling above, and for the same argument: we did not determine that the
+    # statement was safe or in scope, because we stopped before asking. Not `unsafe` — nothing about
+    # the statement is in question — and not `out_of_scope`, which is a claim about the model.
+    RULE_AUDIT_UNAVAILABLE: "undetermined",
     RULE_RECON: "unsafe",
     # A bound we imposed, not a property of the statement: neither unsafe nor out of scope — we
     # simply did not determine the answer within the bound. Pinned before it had a producer, so the

--- a/tests/test_ace035_guardrail_audit.py
+++ b/tests/test_ace035_guardrail_audit.py
@@ -12,10 +12,13 @@ Three claims, in order of how load-bearing they are:
      the sink writes the caller's id as the row's primary key, so a caller can look up the record of
      its own execution. The sink used to mint a uuid inside the INSERT and discard it, which made
      the id unreferenceable the moment it existed.
-  3. **Best-effort never means silent, and never means fragile.** A broken sink must not change the
-     answer by one byte, must not be indistinguishable from a working one, and must not be able to
-     break a query merely by failing to OPEN — the bug that shipped when `Store.from_env()` sat
-     outside its try.
+  3. **A broken sink is never silent, and on a served deployment it is never survivable.** ACE-097
+     split what was one claim: locally, best-effort still means the answer is unchanged to the byte
+     and the failure is still logged; served, principle 7 makes the row part of the call, so a write
+     that fails takes the call with it. Both halves are pinned below. What did not change is that
+     the failure must never be able to break a query merely by failing to OPEN in an uncontrolled
+     place — the bug that shipped when `Store.from_env()` sat outside its try, and the reason the
+     served path can now re-raise deliberately from one place.
 
 Both surfaces are driven for real — a `python -m mcp_harness` subprocess speaking JSON-RPC on stdin,
 and `TestClient` over `create_app()`'s `/mcp` — rather than by calling the handler, because "the row
@@ -632,10 +635,22 @@ def _warnings(caplog) -> list[logging.LogRecord]:
     return [r for r in caplog.records if r.name == "tools"]
 
 
-def test_a_sink_whose_write_raises_changes_nothing_and_says_so(env, caplog, monkeypatch):
-    """The INSERT fails. The caller must not be able to tell from the answer — and an operator must."""
+def test_a_sink_whose_write_raises_fails_the_call(env, monkeypatch):
+    """The INSERT fails after the statement ran. The call fails; the caller is not handed an answer.
+
+    **This assertion is inverted from what ACE-035 shipped**, deliberately (ACE-097). It read
+    `broken == healthy` — a byte-identical answer, because "the caller must not be able to tell from
+    the answer". That was right while the audit row was a convenience. Principle 7 makes it
+    load-bearing: an answer whose statement left no record is the thing the principle forbids, and
+    the operator who reads the warning later cannot un-inform the caller who already acted. So the
+    caller now CAN tell, which is the point.
+
+    `execute_guarded` checks the store is reachable before executing, so this is the residual that
+    check cannot close: the sink was healthy at the gate and broke before the write.
+    """
     healthy = tools._emit(_refused_envelope(), sql="DELETE FROM orders", execution_ms=None)
     assert len(_rows(env.app_db)) == 1
+    assert healthy  # the positive control: a working sink still answers
 
     import model_store
 
@@ -644,25 +659,27 @@ def test_a_sink_whose_write_raises_changes_nothing_and_says_so(env, caplog, monk
 
     monkeypatch.setattr(model_store.DbActivitySink, "record_query_execution", _boom)
 
-    with caplog.at_level(logging.WARNING):
-        broken = tools._emit(_refused_envelope(), sql="DELETE FROM orders", execution_ms=None)
+    with pytest.raises(RuntimeError):
+        tools._emit(_refused_envelope(), sql="DELETE FROM orders", execution_ms=None)
 
-    assert broken == healthy  # byte-identical answer
-    assert len(_rows(env.app_db)) == 1  # nothing new landed
-    assert [r.levelname for r in _warnings(caplog)] == ["WARNING"]
-    assert _warnings(caplog)[0].exc_info is not None  # the cause is in the log, not just the fact
+    assert len(_rows(env.app_db)) == 1  # and nothing new landed
 
 
-def test_a_store_that_cannot_even_be_opened_changes_nothing_and_says_so(env, caplog, monkeypatch):
-    """The failure that used to escape: `Store.from_env()` raising.
+def test_a_store_that_cannot_even_be_opened_fails_the_call(env, monkeypatch):
+    """The failure that used to escape, and now escapes on purpose: `Store.from_env()` raising.
 
-    It sat OUTSIDE its try, so a malformed DSN or an uninstalled driver broke every query the server
-    logged rather than every log it wrote — on the success path, where the answer was already
-    computed. This is the test that proves the outer try covers store CONSTRUCTION, not just the
-    write; the sibling test above would still pass with the old shape.
+    Its original subject is unchanged and still worth pinning: this call sat OUTSIDE the try, so a
+    malformed DSN or an uninstalled driver broke every query the server logged rather than every log
+    it wrote. The body is inside the try, which is what lets the served path re-raise from ONE place
+    rather than leak from an arbitrary one — and the sibling test above would still pass with the
+    old shape, so this one is still the test that proves construction is covered.
+
+    What changed with ACE-097 is the direction: it asserted the answer was unaffected, and now
+    asserts the call fails. Same reasoning as its sibling.
     """
     healthy = tools._emit(_refused_envelope(), sql="DELETE FROM orders", execution_ms=None)
     assert len(_rows(env.app_db)) == 1
+    assert healthy
 
     import store as store_module
 
@@ -671,12 +688,35 @@ def test_a_store_that_cannot_even_be_opened_changes_nothing_and_says_so(env, cap
 
     monkeypatch.setattr(store_module.Store, "from_env", classmethod(_boom))
 
+    with pytest.raises(RuntimeError):
+        tools._emit(_refused_envelope(), sql="DELETE FROM orders", execution_ms=None)
+
+    assert len(_rows(env.app_db)) == 1
+
+
+def test_locally_a_broken_sink_still_changes_nothing_and_says_so(env, caplog, monkeypatch):
+    """The half of the old contract that survives, kept as its own test rather than deleted.
+
+    `governance-principles.md` scopes the principles to the served deployment. With no store
+    configured this is the local path, the sink is jsonl, and the original claim holds in full: a
+    broken sink must not change the answer by one byte, and must not be indistinguishable from a
+    working one.
+    """
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    healthy = tools._emit(_refused_envelope(), sql="DELETE FROM orders", execution_ms=None)
+
+    def _boom(path, record):
+        raise OSError("the log directory is read-only")
+
+    monkeypatch.setattr(tools, "_append_jsonl", _boom)
+
     with caplog.at_level(logging.WARNING):
         broken = tools._emit(_refused_envelope(), sql="DELETE FROM orders", execution_ms=None)
 
-    assert broken == healthy
-    assert len(_rows(env.app_db)) == 1
+    assert broken == healthy  # byte-identical answer
     assert [r.levelname for r in _warnings(caplog)] == ["WARNING"]
+    assert _warnings(caplog)[0].exc_info is not None  # the cause is in the log, not just the fact
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ace035_guardrail_contract.py
+++ b/tests/test_ace035_guardrail_contract.py
@@ -217,6 +217,7 @@ CONTRACT_RULES = frozenset({
     "unscopable",
     "model_unavailable",
     "engine_mismatch",
+    "audit_unavailable",
 })
 
 # Rules this module declares that the contract does NOT name. There are NONE, and that is the
@@ -281,6 +282,10 @@ def test_a_named_but_unproduced_rule_is_deliberately_unpinned(rule):
         # and the model alone. The ban is a determinability refusal, not a reach.
         ("select_star", "undetermined"),
         ("model_unavailable", "undetermined"),
+        # ACE-097's sibling of the line above, on the same argument: the deployment cannot record,
+        # so we stopped before asking whether the statement was unsafe or out of scope. Neither of
+        # those two reasons is a claim we made.
+        ("audit_unavailable", "undetermined"),
         ("resource_limit", "undetermined"),
         ("unparseable", "undetermined"),
         # Pinned by ACE-039, the gate that produces it. `unsafe` rather than `out_of_scope`

--- a/tests/test_ace035_no_enumeration.py
+++ b/tests/test_ace035_no_enumeration.py
@@ -736,6 +736,20 @@ def test_echoing_the_callers_own_identifier_is_allowed():
 # five-rule literal could not see. It is unproduced today, so nothing leaked; that it was invisible
 # to the completeness assertion is the point.
 _NO_VECTOR = {
+    guardrail.RULE_AUDIT_UNAVAILABLE: (
+        "Not drivable from this matrix, and it has nothing to enumerate FROM. Every vector here "
+        "runs against the fixture's healthy app database, and breaking that database is what "
+        "produces this rule — so a vector for it would have to dismantle the environment the other "
+        "five need, and would then be measuring the fixture rather than the refusal. What makes the "
+        "exemption safe rather than convenient is that this refusal interpolates NOTHING: its "
+        "detail and remediation are two authored sentences that touch neither the model nor the "
+        "caller's statement, so there is no value for a crafted query to steer into them. That is a "
+        "property rather than an observation, and it is asserted directly in "
+        "test_ace097_recording_mandatory.py::test_the_refusal_says_nothing_about_where_the_store_lives, "
+        "which checks the whole serialized refusal against the DSN, the scheme, the artifacts path "
+        "and the app database url. A future gate that interpolates anything into this rule's text "
+        "has to delete this entry and earn a vector."
+    ),
     guardrail.RULE_UNPARSEABLE: (
         "One producer, unreachable on every route. `sql_guard.check_no_recon` refuses `unparseable` "
         "when the neutralizer cannot read the statement (ACE-039) — but at the chokepoint "

--- a/tests/test_ace051_fail_closed.py
+++ b/tests/test_ace051_fail_closed.py
@@ -227,12 +227,20 @@ def test_hosted_refusal_stderr_is_a_single_clean_json_object(tmp_path):
 
     `_model_safety` no longer writes, so the single-clean-object property is now `main`'s to keep —
     and this is where it must be pinned, because this is where a caller actually reads it. The
-    child is given an unreachable DB and no disk model, which is the same fail-closed condition the
-    in-process test above exercises.
+    child is given a REACHABLE but empty app database and no disk model, so the only thing missing
+    is the model.
+
+    It used to be given an unreachable one, which was the same fail-closed condition until ACE-097:
+    an unreachable app DB is now BOTH "no model source" and "no audit store", and the audit gate
+    runs above the model pass, so the child refused `audit_unavailable` and this test's subject
+    became unreachable. Isolating the cause is what keeps it testing what it says — the sibling
+    in-process tests above call `_model_safety` directly and never met the new gate, which is why
+    only this one moved.
     """
+    app_db = tmp_path / "app.db"
     env = {
         **os.environ,
-        "AGAMI_DB_URL": "postgres://user:pw@127.0.0.1:1/nope",
+        "AGAMI_DB_URL": f"sqlite://{app_db}",
         "AGAMI_ARTIFACTS_DIR": str(tmp_path / "no_disk"),
     }
     proc = subprocess.run(

--- a/tests/test_ace097_recording_mandatory.py
+++ b/tests/test_ace097_recording_mandatory.py
@@ -1,0 +1,313 @@
+"""Recording is mandatory: a served deployment that cannot write the audit row does not execute.
+
+Principle 7 says every call is recorded, executed or refused. That is only true if a call which
+cannot be recorded does not happen — and the ordering is what makes this a real change rather than a
+tidier `except`. The audit write runs at the tool edge, AFTER the statement: `tools._record_execution`
+is called from `tools._emit`, the serializer. So closing the swallows alone can only turn a lost
+record into an exception on a statement that already reached the customer's database.
+
+This file pins the half that runs BEFORE execution:
+
+  1. **The statement never runs.** With the store unopenable, `execute_guarded` returns
+     `refused` / `audit_unavailable` and the executor is never called — asserted for the in-process
+     path with a spy, and for the subprocess path by the warehouse file never coming into existence.
+  2. **Local is untouched.** `governance-principles.md` scopes the principles to the served
+     deployment, and locally there is no store to reach. A laptop with no `AGAMI_DB_URL` still
+     answers.
+  3. **The refusal is shaped like its sibling.** `audit_unavailable` is a deployment-state rule, so
+     it reads `undetermined`, carries a value-free detail, and gets the before-the-model receipt —
+     the gate runs above the semantic-model pass, so claiming "no model could be resolved" would be
+     a different fact and an untrue one.
+
+The store is broken with an UNSUPPORTED SCHEME rather than an unreachable host: `Store.connect`
+raises on it deterministically, with no driver installed and no network wait, and it is one of the
+two causes `_record_query`'s own docstring names (a malformed DSN, an uninstalled driver).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import execute_sql  # noqa: E402
+import guardrail  # noqa: E402
+import tools  # noqa: E402
+from store import Store  # noqa: E402
+
+PROFILE = "acme"
+QUESTION = "how many orders"
+# Unsupported on purpose: `Store.connect` raises `ValueError` for it before touching a driver or a
+# socket, so "the store cannot be opened" is deterministic and instant on both processes. `_hosted()`
+# only asks whether the variable is set, so this is a served deployment as far as the gate is
+# concerned — which is the state under test.
+BROKEN_DB_URL = "mysql://not-a-supported-scheme/agami"
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    """`_INJECTED_EXECUTOR` is a process global; a test that injects one must not leak it."""
+    tools.set_injected_executor(None)
+    yield
+    tools.set_injected_executor(None)
+
+
+def _write_model(root: Path) -> None:
+    """A one-table model on disk, so the gates below the audit check have something to run against.
+
+    It has to be a REAL model: the point of several tests here is that the audit gate fires before
+    the model pass, and a deployment with no model at all would refuse for `model_unavailable`
+    instead, which would pass the assertion for the wrong reason.
+    """
+    import yaml
+
+    (root / "subject_areas" / "sales" / "tables").mkdir(parents=True)
+    (root / "datasource.yaml").write_text(
+        yaml.safe_dump({"datasource": "Shop", "version": 1, "subject_areas": ["subject_areas/sales"]})
+    )
+    (root / "subject_areas" / "sales" / "subject_area.yaml").write_text(
+        yaml.safe_dump({"name": "sales", "tables": [
+            {"storage_connection": "c", "schema": "public", "table": "orders"}]})
+    )
+    (root / "subject_areas" / "sales" / "tables" / "orders.yaml").write_text(
+        yaml.safe_dump({
+            "name": "orders", "schema": "public", "storage_connection": "c", "grain": ["id"],
+            "description": "orders",
+            "columns": [{"name": "id", "type": "integer", "primary_key": True}],
+        })
+    )
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """A served install whose audit store is healthy, plus the knobs to break it.
+
+    `warehouse` deliberately does NOT exist yet. sqlite creates a database file on connect, so its
+    continued absence is a filesystem-level proof that nothing tried to execute — the one assertion
+    that works across a process boundary, where a spy executor cannot reach.
+    """
+    app_db = "sqlite://" + str(tmp_path / "app.db")
+    store = Store.connect(app_db)
+    store.run_migrations()
+    store.close()
+
+    artifacts = tmp_path / "artifacts"
+    _write_model(artifacts / PROFILE)
+
+    warehouse = tmp_path / "warehouse.db"
+
+    monkeypatch.setenv("AGAMI_DB_URL", app_db)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(artifacts))
+    monkeypatch.setenv("DATASOURCE_URL__ACME", f"sqlite:///{warehouse}")
+    monkeypatch.delenv("AGAMI_ORG_ID", raising=False)
+    return SimpleNamespace(app_db=app_db, artifacts=artifacts, warehouse=warehouse)
+
+
+def _seed_warehouse(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE orders (id INTEGER)")
+    con.executemany("INSERT INTO orders (id) VALUES (?)", [(1,), (2,)])
+    con.commit()
+    con.close()
+
+
+class _SpyExecutor:
+    """An executor that records being asked and refuses to do anything else.
+
+    Raising rather than returning an empty result is deliberate: if the gate under test regresses,
+    the test must fail on the call itself rather than on a downstream assertion about rows, which
+    could be satisfied for an unrelated reason.
+    """
+
+    def __init__(self) -> None:
+        self.called = False
+
+    def execute(self, sql, creds, *, profile=None, **kwargs):
+        self.called = True
+        raise AssertionError("the executor was reached with the audit store unopenable")
+
+
+# ---------------------------------------------------------------------------
+# 1. The statement does not run
+# ---------------------------------------------------------------------------
+
+
+def test_in_process_the_statement_never_reaches_the_executor(env, monkeypatch):
+    """The in-process path: `execute_guarded` refuses and the executor is never called."""
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+    spy = _SpyExecutor()
+
+    envelope = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, "sales", executor=spy
+    )
+
+    assert envelope.status == "refused"
+    assert envelope.refusal is not None
+    assert envelope.refusal.rule == guardrail.RULE_AUDIT_UNAVAILABLE
+    assert envelope.refusal.reason == "undetermined"
+    assert spy.called is False
+
+
+def test_in_process_a_write_is_refused_for_the_audit_gate_not_the_read_only_one(env, monkeypatch):
+    """The gate sits ABOVE `check_read_only`, and this pins that ordering rather than assuming it.
+
+    Principle 7 records every call "whether it executed or was refused", so a gate that only stopped
+    executions would leave the refusals unrecorded too — and the outcomes most worth reviewing are
+    exactly the ones a reviewer could not find. Nothing is weakened by the ordering: both are
+    refusals, the statement runs either way never, and the read-only gate is unreachable only in the
+    state where nothing is reachable.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+    spy = _SpyExecutor()
+
+    envelope = execute_sql.execute_guarded(
+        "DROP TABLE orders", PROFILE, "sales", executor=spy
+    )
+
+    assert envelope.status == "refused"
+    assert envelope.refusal.rule == guardrail.RULE_AUDIT_UNAVAILABLE
+    assert spy.called is False
+
+
+def test_no_safety_cannot_opt_out_of_being_recorded(env, monkeypatch):
+    """`no_safety` skips the semantic-model pass and nothing else.
+
+    A caller able to turn off the audit guarantee by passing a flag is the hole this spec closes, so
+    the check sits outside that branch.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+    spy = _SpyExecutor()
+
+    envelope = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, "sales", executor=spy, no_safety=True
+    )
+
+    assert envelope.refusal.rule == guardrail.RULE_AUDIT_UNAVAILABLE
+    assert spy.called is False
+
+
+def test_the_subprocess_path_never_opens_the_warehouse(env, monkeypatch):
+    """The fork path, proved from the filesystem rather than from a spy.
+
+    `python -m execute_sql` runs the chokepoint in a child, where a monkeypatched spy cannot reach.
+    sqlite creates its database file on connect, so a warehouse file that still does not exist after
+    the call is proof the executor was never entered — the same claim as the in-process test, made
+    the only way it can be made across a process boundary.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+    assert not env.warehouse.exists(), "fixture invariant: the warehouse must not exist yet"
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "execute_sql", "--profile", PROFILE, "--area", "sales",
+         "--sql", "SELECT id FROM orders"],
+        capture_output=True, text=True, timeout=180, env={**os.environ},
+    )
+
+    refusal = json.loads(proc.stderr)["refusal"]
+    assert refusal["rule"] == guardrail.RULE_AUDIT_UNAVAILABLE
+    assert refusal["reason"] == "undetermined"
+    assert not env.warehouse.exists(), "the executor connected to the warehouse despite the refusal"
+
+
+# ---------------------------------------------------------------------------
+# 2. Local is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_local_still_answers_with_no_store_at_all(env, monkeypatch):
+    """No `AGAMI_DB_URL` is the local path, and it keeps best-effort recording.
+
+    The principles describe the served deployment; locally there is no store to reach and
+    `_record_query` writes jsonl. A read-only artifacts directory must not stop a laptop answering.
+    """
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    _seed_warehouse(env.warehouse)
+
+    envelope = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, "sales", executor=execute_sql.BUILTIN_EXECUTOR
+    )
+
+    assert envelope.status == "ok"
+
+
+def test_local_never_opens_a_store_to_ask(monkeypatch):
+    """The local no-op returns before touching `Store`, so the check costs a laptop nothing."""
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+
+    import store as store_module
+
+    def _boom(cls):
+        raise AssertionError("the local path opened a store to check availability")
+
+    monkeypatch.setattr(store_module.Store, "from_env", classmethod(_boom))
+    assert execute_sql._audit_store_reachable() is True
+
+
+# ---------------------------------------------------------------------------
+# 3. The refusal's shape
+# ---------------------------------------------------------------------------
+
+
+def test_a_healthy_store_is_reachable_and_the_call_proceeds(env):
+    """The positive control. Without it, every assertion above passes on a gate that always refuses."""
+    _seed_warehouse(env.warehouse)
+
+    assert execute_sql._audit_store_reachable() is True
+    envelope = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, "sales", executor=execute_sql.BUILTIN_EXECUTOR
+    )
+    assert envelope.status == "ok"
+
+
+def test_the_refusal_says_nothing_about_where_the_store_lives(env, monkeypatch):
+    """`Refusal.detail` and `remediation` are value-free — never a DSN, a host, a path or a scheme.
+
+    The rule the two `model_unavailable` branches already follow, for the same reason: a refusal is
+    the one outcome a caller can provoke on purpose, so it must not become a way to read the
+    deployment's configuration back out.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+
+    envelope = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, "sales", executor=_SpyExecutor()
+    )
+    text = f"{envelope.refusal.detail} {envelope.refusal.remediation}"
+
+    for leak in ("mysql", "not-a-supported-scheme", str(env.artifacts), env.app_db):
+        assert leak not in text
+    assert envelope.refusal.remediation.strip(), "a refusal the caller cannot act on is a dead end"
+
+
+def test_the_refusal_carries_the_before_the_model_receipt(env, monkeypatch):
+    """It is in `PRE_MODEL_RULES`, so its receipt says the model was never consulted.
+
+    The gate runs above the semantic-model pass, and the deployment's model resolves perfectly a
+    line later — so the generic "no model could be resolved" marker would be a different fact and an
+    untrue one. `PRE_MODEL_RULES`'s own docstring asks for this in the diff that adds the gate.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+
+    envelope = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, "sales", executor=_SpyExecutor()
+    )
+
+    assert guardrail.RULE_AUDIT_UNAVAILABLE in guardrail.PRE_MODEL_RULES
+    assert envelope.receipt.columns.undetermined == guardrail.RECEIPT_BEFORE_MODEL

--- a/tests/test_ace097_recording_mandatory.py
+++ b/tests/test_ace097_recording_mandatory.py
@@ -315,6 +315,35 @@ def test_the_audit_unavailable_refusal_itself_writes_no_row(env, monkeypatch):
     assert json.loads(body)["status"] == "refused"
 
 
+def test_the_tool_call_row_is_exempt_too_or_the_refusal_never_arrives(env, monkeypatch):
+    """The exemption has to cover BOTH writes, and this is the test that says why.
+
+    Exempting only the query row looks complete from the in-process path a unit test usually drives.
+    It is not: the HTTP transport writes a tool-call row in a `finally` for EVERY call, so the row
+    this exemption exists to avoid was written anyway, failed against the unreachable store, and
+    raised — replacing the clean fail-closed refusal with a transport error and losing the
+    remediation naming what the operator must restore. On the served surface, where they most need
+    it.
+
+    Found by driving a real server whose audit store died under it (testbed step 11b), not here.
+    This is that finding, brought back as a unit test.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+    envelope = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, "sales", executor=_SpyExecutor()
+    )
+    body = tools._emit(envelope, sql="SELECT id FROM orders", execution_ms=None, profile=PROFILE)
+
+    # The transport's own call, verbatim in shape: it hands over the serialized body and lets the
+    # recorder classify it. Must not raise, or the refusal above never reaches the caller.
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT id FROM orders"}, result_text=body,
+        execution_ms=1, actor=None,
+    )
+
+    assert json.loads(body)["refusal"]["rule"] == guardrail.RULE_AUDIT_UNAVAILABLE
+
+
 def test_every_other_refusal_still_records(env):
     """The exemption is exactly one rule wide, asserted rather than assumed.
 

--- a/tests/test_ace097_recording_mandatory.py
+++ b/tests/test_ace097_recording_mandatory.py
@@ -277,6 +277,42 @@ def test_a_healthy_store_is_reachable_and_the_call_proceeds(env):
     assert envelope.status == "ok"
 
 
+def test_the_cause_reaches_the_operator_even_though_the_caller_never_sees_it(env, monkeypatch, caplog):
+    """The refusal is one sentence for every cause, so the cause has to land in the server log.
+
+    Without this, the spec reintroduces its own defect somewhere new: a bad DSN scheme, an
+    unreachable host and a missing driver would all read as one opaque refusal, and the operator
+    told to "restore the audit database" would have nothing to work from. Same treatment
+    `_record_query` gives a swallowed write, and the same split ACE-039 draws — raw text is the
+    operator's, the classified sentence is the caller's.
+
+    It goes on `_RAW_LOG` rather than `_LOG`, which is not a detail:
+    `test_the_subprocess_path_never_opens_the_warehouse` caught the first version of this on `_LOG`,
+    where it fell through to `logging.lastResort`, landed on the child's stderr and made the
+    refusal unparseable. `main` silences `_RAW_LOG` for the child's lifetime.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+
+    with caplog.at_level("WARNING", logger="execute_sql.raw"):
+        assert execute_sql._audit_store_reachable() is False
+
+    warnings = [r for r in caplog.records if r.name == "execute_sql.raw"]
+    assert [r.levelname for r in warnings] == ["WARNING"]
+    assert warnings[0].exc_info is not None  # the cause, not just the fact
+
+
+def test_a_configured_but_empty_store_url_reads_as_unreachable(env, monkeypatch):
+    """`_hosted()` tests truthiness, `Store.from_env()` strips — so whitespace lands between them.
+
+    Not a defensive branch: a whitespace-only `AGAMI_DB_URL` reaches it, and on a security gate a
+    misconfiguration has to read as unreachable rather than as fine.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", "   ")
+
+    assert execute_sql._hosted() is True
+    assert execute_sql._audit_store_reachable() is False
+
+
 def test_the_refusal_says_nothing_about_where_the_store_lives(env, monkeypatch):
     """`Refusal.detail` and `remediation` are value-free — never a DSN, a host, a path or a scheme.
 

--- a/tests/test_ace097_recording_mandatory.py
+++ b/tests/test_ace097_recording_mandatory.py
@@ -296,6 +296,162 @@ def test_the_refusal_says_nothing_about_where_the_store_lives(env, monkeypatch):
     assert envelope.refusal.remediation.strip(), "a refusal the caller cannot act on is a dead end"
 
 
+def test_the_audit_unavailable_refusal_itself_writes_no_row(env, monkeypatch):
+    """The exemption, and the reason it is load-bearing rather than tidy.
+
+    This refusal means the store could not be opened. Writing a row to say so is the same write
+    failing a second time — and on the served path a failing write now RAISES, so without the
+    exemption the clean fail-closed refusal would arrive at the caller as an unhandled exception
+    from the serializer. `_emit` returning normally here is the whole assertion.
+    """
+    monkeypatch.setenv("AGAMI_DB_URL", BROKEN_DB_URL)
+    envelope = execute_sql.execute_guarded(
+        "SELECT id FROM orders", PROFILE, "sales", executor=_SpyExecutor()
+    )
+    assert envelope.refusal.rule == guardrail.RULE_AUDIT_UNAVAILABLE
+
+    body = tools._emit(envelope, sql="SELECT id FROM orders", execution_ms=None, profile=PROFILE)
+
+    assert json.loads(body)["status"] == "refused"
+
+
+def test_every_other_refusal_still_records(env):
+    """The exemption is exactly one rule wide, asserted rather than assumed.
+
+    An exemption keyed on "it is a refusal" would have quietly stopped recording the outcomes
+    principle 7 most wants kept, and this file would still be green.
+    """
+    _seed_warehouse(env.warehouse)
+
+    envelope = execute_sql.execute_guarded(
+        "DROP TABLE orders", PROFILE, "sales", executor=execute_sql.BUILTIN_EXECUTOR
+    )
+    assert envelope.refusal.rule == guardrail.RULE_READ_ONLY
+
+    tools._emit(envelope, sql="DROP TABLE orders", execution_ms=None, profile=PROFILE)
+
+    store = Store.connect(env.app_db)
+    try:
+        rows = store.query("SELECT id, status, rule FROM query_executions")
+    finally:
+        store.close()
+    assert [(r["status"], r["rule"]) for r in rows] == [("refused", guardrail.RULE_READ_ONLY)]
+
+
+# ---------------------------------------------------------------------------
+# 4. The two swallows on the tool-call path
+# ---------------------------------------------------------------------------
+
+
+def _jsonrpc_result(text: str) -> dict:
+    """The `result` object out of a JSON-RPC reply, whether it arrived plain or SSE-framed.
+
+    The streamable-HTTP transport may negotiate either, and which one it picks is not this test's
+    subject — so the frame is stripped here rather than asserted on.
+    """
+    payload = text.strip()
+    if payload.startswith("event:") or payload.startswith("data:"):
+        payload = next(
+            line[len("data:"):].strip()
+            for line in payload.splitlines()
+            if line.startswith("data:")
+        )
+    return json.loads(payload)["result"]
+
+
+def _break_the_tool_call_sink(monkeypatch) -> None:
+    import model_store
+
+    def _boom(self, record):
+        raise RuntimeError("the tool_calls table is unreachable")
+
+    monkeypatch.setattr(model_store.DbActivitySink, "record_tool_call", _boom)
+
+
+def test_the_recorder_no_longer_swallows_its_own_failure(env, monkeypatch):
+    """The first of the two masking swallows: `_record_tool_call`'s `except Exception: pass`.
+
+    Asserted on behaviour rather than by grepping for a bare `except`. A grep would have passed
+    before this spec started — there is no bare `except:` anywhere in the package, and never was.
+    Both swallows were `except Exception:`, which a grep for the bare form does not see.
+    """
+    _break_the_tool_call_sink(monkeypatch)
+
+    with pytest.raises(RuntimeError):
+        tools.record_tool_call(
+            name="execute_sql", arguments={"sql": "SELECT 1"}, result_text=None,
+            execution_ms=1, actor=None,
+        )
+
+
+def test_the_transport_no_longer_swallows_it_either(env, monkeypatch):
+    """The second: the `except Exception: pass` around the call, in the HTTP transport's `finally`.
+
+    The two are why neither had been closed. Removing this one alone changes nothing, because
+    `_record_tool_call` swallowed internally and never raised anything for it to catch; removing
+    that one alone changes nothing, because this caught what it then raised. Each made the other
+    unobservable. So this drives the real transport with the sink broken and asserts the failure
+    reaches the wire — which is only true once BOTH are gone.
+    """
+    import mcp_http
+    from oauth_server import issue_jwt
+    from starlette.testclient import TestClient
+
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://your-host.example.com")
+    monkeypatch.setenv("AGAMI_SIGNING_SECRET", "x" * 40)
+    _seed_warehouse(env.warehouse)
+    _break_the_tool_call_sink(monkeypatch)
+
+    headers = {
+        "Authorization": f"Bearer {issue_jwt('jordan@example.com')}",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    with TestClient(mcp_http.create_app(), raise_server_exceptions=False) as client:
+        init = client.post("/mcp", headers=headers, json={
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                       "clientInfo": {"name": "t", "version": "1"}}})
+        session = init.headers.get("mcp-session-id")
+        headers2 = {**headers, **({"mcp-session-id": session} if session else {})}
+        client.post("/mcp", headers=headers2,
+                    json={"jsonrpc": "2.0", "method": "notifications/initialized"})
+        reply = client.post("/mcp", headers=headers2, json={
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "execute_sql", "arguments": {
+                "sql": "SELECT id FROM orders", "datasource": PROFILE}}})
+
+    result = _jsonrpc_result(reply.text)
+
+    # `isError` is read as a parsed boolean, not by scanning the body for "error". The substring is
+    # present either way — `"isError":false` contains it — so a text search passes whether or not
+    # the swallow is back, which is the one thing this test exists to tell apart. Caught by
+    # restoring the swallow and watching this test stay green.
+    assert result["isError"] is True, (
+        "the tool call returned an answer with its audit row lost — a swallow is back"
+    )
+    assert "unreachable" in result["content"][0]["text"]
+
+
+def test_locally_the_tool_call_recorder_is_still_best_effort(env, monkeypatch, caplog):
+    """The local half of the same split, so the swallow's removal does not reach a laptop."""
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+
+    def _boom(path, record):
+        raise OSError("the log directory is read-only")
+
+    monkeypatch.setattr(tools, "_append_jsonl", _boom)
+
+    with caplog.at_level("WARNING", logger="tools"):
+        tools.record_tool_call(
+            name="execute_sql", arguments={"sql": "SELECT 1"}, result_text=None,
+            execution_ms=1, actor=None,
+        )  # must NOT raise
+
+    assert [r.levelname for r in caplog.records if r.name == "tools"] == ["WARNING"]
+
+
 def test_the_refusal_carries_the_before_the_model_receipt(env, monkeypatch):
     """It is in `PRE_MODEL_RULES`, so its receipt says the model was never consulted.
 

--- a/tests/test_db_activity_sink.py
+++ b/tests/test_db_activity_sink.py
@@ -70,24 +70,57 @@ def test_record_query_writes_one_row(tmp_path, monkeypatch):
     ]
 
 
-def test_record_query_is_best_effort_on_db_error(tmp_path, monkeypatch, caplog):
-    # AGAMI_DB_URL points at a DB with NO migrations applied, so the INSERT into query_executions
-    # fails. _record_query must swallow it — a logging failure can't break a successful query — but
-    # it must SAY so: a permanently broken sink and a working one have to be distinguishable.
+_A_RECORD = {
+    "id": "0a1b2c3d4e5f60718293a4b5c6d7e8f9",
+    "ts": "2026-06-25T00:00:00Z",
+    "profile": "main",
+    "question": "q",
+    "sql": "SELECT 1",
+    "row_count": 1,
+    "source": "mcp_server",
+    "status": "ok",
+}
+
+
+def test_record_query_raises_on_a_db_error_when_a_store_is_configured(tmp_path, monkeypatch):
+    """Served: the write is part of the call, so its failure is the call's failure (ACE-097).
+
+    This test asserted the opposite until ACE-097 — that a broken sink is swallowed and warned
+    about, because "a logging failure can't break a successful query". That was right while the row
+    was a convenience. Principle 7 makes it load-bearing: an answer delivered with no record of the
+    statement that produced it is precisely what the principle forbids, and the operator reading a
+    warning hours later does not help the caller who already acted on the answer. The inversion is
+    deliberate and is recorded in the spec's `## Decisions`.
+
+    AGAMI_DB_URL points at a database with NO migrations applied, so the INSERT fails while the
+    store opens perfectly — the residual `execute_guarded`'s pre-execution reachability check cannot
+    cover, and therefore the case worth pinning here.
+    """
     url = "sqlite://" + str(tmp_path / "empty.db")
     Store.connect(url).close()  # create the file; no tables
     monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    with pytest.raises(Exception):
+        tools._record_query(dict(_A_RECORD))
+
+
+def test_record_query_is_best_effort_with_no_store_configured(tmp_path, monkeypatch, caplog):
+    """Local keeps the old contract, unchanged, and still says so.
+
+    `governance-principles.md` scopes the principles to the served deployment. Here there is no
+    store, the sink is a jsonl file, and an unwritable artifacts directory must not stop a laptop
+    answering. Best-effort still never means silent: a sink broken for a month must not look
+    identical to a working one.
+    """
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+
+    def _boom(path, record):
+        raise OSError("the log directory is read-only")
+
+    monkeypatch.setattr(tools, "_append_jsonl", _boom)
+
     with caplog.at_level("WARNING", logger="tools"):
-        tools._record_query(
-            {  # must NOT raise
-                "id": "0a1b2c3d4e5f60718293a4b5c6d7e8f9",
-                "ts": "2026-06-25T00:00:00Z",
-                "profile": "main",
-                "question": "q",
-                "sql": "SELECT 1",
-                "row_count": 1,
-                "source": "mcp_server",
-                "status": "ok",
-            }
-        )
+        tools._record_query(dict(_A_RECORD))  # must NOT raise
+
     assert [r.levelname for r in caplog.records] == ["WARNING"]


### PR DESCRIPTION
Spec: ACE-097

## Summary

Principle 7 says every call is recorded, executed or refused. It was not true, and could not be made true by tidying the `except` blocks: **the audit write runs at the tool edge, after the statement**. Closing the swallows alone could only turn a lost record into an exception on SQL that already reached the customer's database.

So this adds the half that runs before execution, and closes the swallows behind it.

On a **served** deployment (one with `AGAMI_DB_URL` / `APP_DATABASE_URL`), the audit store is opened before the statement runs. If it cannot be opened the call is refused and the statement never reaches the warehouse. If the store was reachable then and the write fails afterwards, the call fails rather than returning an answer whose statement left no trace. **Local is untouched** — no store to reach, jsonl sink, warning-and-continue, so a read-only artifacts directory cannot stop a laptop answering.

## Changes

- **`RULE_AUDIT_UNAVAILABLE`**, pinned to the existing `undetermined` reason. `RefusalReason` stays closed at three: this is a deployment-state rule, the sibling of `model_unavailable`, not of the scope gates. Added to `PRE_MODEL_RULES` (its docstring asks for that in the diff that adds a gate above the model pass) and to the contract's rule list.
- **`execute_sql._audit_store_reachable()`** beside `_hosted()`. `Store.connect` opens eagerly, so constructing one is a real reachability probe, and it is the identical call `_record_query` will make. Local returns `True` without opening anything.
- **The gate runs first in `execute_guarded`**, above `check_read_only` and outside `no_safety`. First because principle 7 records refusals too, so gating only execution would leave those unrecorded. Outside `no_safety` because a caller must not be able to opt out of being recorded with a flag.
- **`_record_query` and `_record_tool_call` raise on the served path**; the HTTP transport's `except Exception: pass` around the recorder goes. Those two masked each other exactly, which is why neither had ever been closed.
- **`audit_unavailable` is exempt from recording**, on both write paths. A row saying the row could not be written is the same write failing twice.
- `_audit_is_load_bearing()` reads `execute_sql._hosted()` so the gate and the write cannot disagree about what a served deployment is.

## Verification

`uv run dev.py check` green: 2712 passed, 4 skipped, 9 xfailed; ruff, format and gitleaks clean.

**Asserted on behaviour, not by grep.** A grep-clean assertion would have passed before any of this started: there is no bare `except:` in the package and never was — both swallows were `except Exception:`. Each was restored in turn and the corresponding test confirmed failing, as was the anti-circularity exemption.

**Smoke-tested against a real Postgres 16.12** (testbed step 11b, added in the same pass), on all three routes:

| Check | Result |
|---|---|
| A row per call, three vectors x `ok`/`refused`/`failed` | 6 rows on the two MCP routes; CLI writes none (it is not the tool edge), stdio writes no `tool_calls` row (`mcp_harness` never calls the recorder) |
| Store unreachable, statement must not run | warehouse `xact_commit` delta **0**; the healthy control moves it by 2 |
| `audit_unavailable` writes no row | `count(*) WHERE rule='audit_unavailable'` = **0** |
| http, store lost under a running server | `refused` / `audit_unavailable` |
| Local, unwritable log destination | answers, warehouse delta 2 |

**Two defects the smoke test and the review found, which the unit tests had missed:**

1. The exemption covered only the query row. On http the transport writes a `tool_calls` row in a `finally` for *every* call, so the row the exemption exists to avoid was written anyway, failed, and raised — replacing the clean refusal with a transport error and losing the remediation naming what the operator must restore. Fixed in `ca60113`, brought back as a unit test.
2. The reachability probe swallowed its cause with nothing logged, which is the same silence this spec exists to remove. The first fix put the warning on `_LOG`, where it fell through to `logging.lastResort` onto the child's stderr and made the refusal unparseable on the fork path; the suite caught it. It is on `_RAW_LOG`, which `main` silences for the child's lifetime. Re-verified against a real fork: one stderr line, parses whole.

## Behaviour changes a reviewer should weigh

- **This is an availability change on served deployments**, deliberately: a briefly unreachable audit database now produces refusals rather than unrecorded answers. Bounded twice — local is exempt, and the connection is read-only (ACE-036), so a call failed after execution changed nothing and re-running costs a round trip.
- **One extra store connect per served call.** Measured against the alternatives in the plan: a cached health flag is stale in the direction that matters, and anything cheaper does not establish reachability. Comparable to the per-request open `_model_version` already does; pooling the pair belongs to ACE-028.
- **Four existing tests moved, none weakened.** Three inverted their assertion and each keeps its original claim as a local-path test of its own (`test_a_sink_whose_write_raises_...`, `test_a_store_that_cannot_even_be_opened_...`, `test_record_query_is_best_effort_on_db_error`). The fourth, `test_ace051_fail_closed.py::test_hosted_refusal_stderr_is_a_single_clean_json_object`, gave its child an unreachable app DB, which is now both "no model source" and "no audit store"; it gets a reachable but empty one so its own subject is reachable again. Recorded in the spec's `## Decisions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
