### PR TITLE
ACE-098: what the record holds, and the test that it is enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ below corresponds to one such version.
 
 ### Changed
 
+- **The audit row now says what the decision was made against, and what you were told (ACE-098).**
+  A row recorded the verdict — `ok` / `refused` / `failed`, and for a refusal which rule under which
+  reason — but nothing about the basis for it, so nobody could take a row and check the decision
+  again. Three columns close that: `detail` (the refusal's own sentence, which is where "which bound
+  fired and what it was set to" lives, since the statement timeout and the row bound share one rule),
+  `receipt` (everything the trust receipt reported, including its `undetermined` markers), and
+  `model_version` as a column you can filter on.
+
+  A test now takes those rows and **re-derives each refusal with no database connection at all**,
+  matching what was recorded. That is the check that tells whether the fields are sufficient rather
+  than merely present. The two runtime bounds are exempt and stay exempt: whether a statement
+  outruns its budget is a property of the run, not of the SQL, so it is not reproducible offline by
+  anyone.
+
+  Also, the **tool-call log now reads the verdict rather than re-reading the answer**. It used to
+  parse the response body to work out whether a call failed and why, which made the audit trail
+  depend on the wire format; it now takes the classified outcome directly.
+
 - **A self-hosted server that cannot record a query no longer runs it (ACE-097).** Recording was
   best-effort in three places, and two of them were silent, so a deployment could execute SQL
   against your database and keep no record of having done so with nothing anywhere saying the

--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -213,6 +213,18 @@ class QueryExecutionRecord(_Contract):
     # crosses). Bounded by the writer — `tools.AUDIT_ERROR_DETAIL_MAX_CHARS`.
     error_detail: str | None = None
     org_id: str = "local"  # the tenant this ran for; defaults to the single-tenant org
+    # The three that make the row re-derivable (ACE-098, principle 7). `detail` is the refusal's own
+    # sentence — NULL on every non-refusal row, because only a refusal has one — and it is where
+    # "which bound fired, and what it was set to" lives, since the statement timeout and the result
+    # bound share one rule id. `receipt` is the `Receipt` as JSON, all five sections including their
+    # `undetermined` markers: a section nobody checked has to keep saying so in the record too.
+    # Bounded by the writer (`tools.AUDIT_DETAIL_MAX_CHARS`) like `sql` and `error_detail`.
+    detail: str | None = None
+    receipt: str | None = None
+    # Duplicated inside `receipt` on purpose: a replay must be able to SELECT on the version, and a
+    # value inside a JSON blob is not portably filterable across SQLite and Postgres. NULL means
+    # either a pre-migration row or a call whose receipt could not pin a version at all.
+    model_version: str | None = None
 
 
 class ToolCallRecord(_Contract):

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1288,6 +1288,33 @@ _max_rows_override: ContextVar[int | None] = ContextVar("_max_rows_override", de
 # eventually serializes.
 _last_error_detail: ContextVar[str | None] = ContextVar("_last_error_detail", default=None)
 
+# The classified outcome of THIS call, for the tool-call recorder (ACE-098). `tools.record_tool_call`
+# derived `success` / `error_kind` by `json.loads`-ing the serialized body and reading
+# `refusal["rule"]` out of it — so the tool_calls row's account of WHY a call failed depended on our
+# own wire shape holding still, which is exactly what principle 7's re-derivation bar cannot rest on.
+#
+# It has to travel out-of-band because the tool handler returns a `str`: by the time the transport
+# runs its `finally`, the Envelope is gone and a serialized body is all there is. Same mechanism and
+# same reasoning as `_last_error_detail` directly above, including the clear-on-entry — a verdict
+# left behind by an earlier call must never label this one — and the same reason it is a ContextVar
+# rather than a module global: the in-process path runs tool handlers on worker threads.
+#
+# **Read by the TRANSPORT, out of a context it owns.** That is not a detail — a ContextVar set
+# inside `async_offload.run_blocking`'s worker thread is invisible to the caller and to every other
+# worker, because anyio hands the thread a COPY of the context. Verified rather than assumed: a var
+# set in one `run_blocking` reads back `None` both in the request task and in a second
+# `run_blocking`. So `mcp_http` runs the handler inside its own `contextvars.copy_context()` and
+# reads the result out of that object afterwards. A plain "set here, read there" would silently
+# record nothing on the one surface that records tool calls at all.
+#
+# `(status, rule, row_count)`, not the whole Envelope: the transport needs to say whether the call
+# succeeded, which gate stopped it, and how many rows came back. Putting a contract object in here
+# invites somebody to serialize it from the transport instead of from the one place that owns the
+# wire shape.
+_last_outcome: ContextVar[tuple[str, str | None, int | None] | None] = ContextVar(
+    "_last_outcome", default=None
+)
+
 # The semantic model `_model_safety` resolved for THIS call, so the receipt describes the model the
 # gates actually consulted rather than one re-resolved a moment later — and so the hosted path loads
 # it ONCE per query rather than twice (`_resolve_guard_model` is a full DB or disk load and is not
@@ -2253,6 +2280,10 @@ def execute_guarded(
     # be attributed to this one. The recorder reads it unconditionally; a stale value would put the
     # wrong error text on a row that succeeded.
     _last_error_detail.set(None)
+    # Same reason again: a verdict left behind by an earlier call in this context must never label
+    # this one. The recorder falls back to parsing the body when this is None, so a stale value is
+    # strictly worse than no value — it would be believed.
+    _last_outcome.set(None)
     # Same reason, same load-bearing half: a model resolved for an earlier call in this context must
     # never be the one this call's receipt describes.
     _guard_model.set(None)

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import contextvars
 import time
 from collections.abc import Callable
 from contextvars import ContextVar
@@ -51,6 +52,8 @@ from tools import (
     _current_org_ctx,
     bootstrap_paths,
     record_tool_call,
+    reset_typed_outcome,
+    typed_outcome_overrides,
     resolved_org_id,
     server_version,
     set_injected_executor,
@@ -424,6 +427,12 @@ def build_server(
         started = time.monotonic()
         result_text = None
         raised = False
+        handler_ctx = contextvars.copy_context()
+        # Cleared inside the context we own, before the handler can run. `copy_context()`
+        # copies whatever is current, so a verdict published by an earlier call would be
+        # inherited here and read back as THIS tool's outcome — and a tool that never
+        # reaches `execute_guarded` has nothing else to clear it.
+        handler_ctx.run(reset_typed_outcome)
         try:
             # Run the tool handler OFF the event loop. The heavy handlers block for the whole query —
             # execute_sql runs it under the executor's own bounds (the per-statement budget, plus the
@@ -432,7 +441,13 @@ def build_server(
             # off-loaded the KDF/OIDC/audit calls but left the handler on the loop).
             # `run_blocking` (anyio.to_thread) copies the request context into the worker thread, so
             # the org-scoped model cache (ACE-045, read via `_current_org_ctx`) stays tenant-correct.
-            result_text = await run_blocking(meta["handler"], arguments or {})
+            # Run the handler inside a context THIS frame owns, so the classified outcome it
+            # publishes can be read back afterwards (ACE-098). `run_blocking` hands the worker a
+            # copy of the current context, and a `ContextVar.set` inside a copy is invisible here —
+            # verified, not assumed. Giving the handler a `Context` object we hold is what makes the
+            # verdict readable at the audit write below, instead of it having to `json.loads` the
+            # body this call is about to return.
+            result_text = await run_blocking(handler_ctx.run, meta["handler"], arguments or {})
             return [mt.TextContent(type="text", text=result_text)]
         except Exception:
             raised = True
@@ -461,6 +476,10 @@ def build_server(
                 execution_ms=int((time.monotonic() - started) * 1000),
                 actor=_actor_ctx.get(),
                 raised=raised,
+                # The classified outcome, when the handler produced one (ACE-098). Empty for every
+                # tool that does not speak the Envelope, which means "derive it the way you always
+                # have" — so those tools keep the body parse and nothing about them changes.
+                **typed_outcome_overrides(handler_ctx),
             )
 
     return server

--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -18,9 +18,9 @@ reliably auto-detected behind a proxy/LB.
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import logging
 import os
-import contextvars
 import time
 from collections.abc import Callable
 from contextvars import ContextVar
@@ -53,10 +53,10 @@ from tools import (
     bootstrap_paths,
     record_tool_call,
     reset_typed_outcome,
-    typed_outcome_overrides,
     resolved_org_id,
     server_version,
     set_injected_executor,
+    typed_outcome_overrides,
 )
 
 _log = logging.getLogger(__name__)

--- a/packages/agami-core/src/migrations/core/017_query_executions_receipt.sql
+++ b/packages/agami-core/src/migrations/core/017_query_executions_receipt.sql
@@ -1,0 +1,53 @@
+-- Make the audit row enough to reproduce the judgement without the database (ACE-098, principle 7).
+-- 014 gave the row a verdict — which of `ok` / `refused` / `failed`, and for a refusal which rule
+-- under which reason. That says WHAT was decided. It does not say what the decision was made
+-- against, nor what the caller was told, so nobody could take a row and re-derive it. Three columns
+-- close that:
+--
+--   detail         The refusal's own sentence. Principle 9 carves the two RUNTIME bounds out of the
+--                  re-derivation bar and says their record "states that a bound fired, which one,
+--                  and what it was set to". The row could not say which one or what it was set to:
+--                  the statement timeout and the result bound share ONE rule id
+--                  (`resource_limit`, deliberately — ACE-087 keeps one rule with one emit site) and
+--                  `reason` + `rule` were the whole of the row. `Refusal.detail` already holds the
+--                  distinction and the configured number, and was simply never written down.
+--   receipt        Everything principle 6 reported, verbatim, as the `Receipt` JSON — all five
+--                  sections including their `undetermined` markers. 7c requires it, and the marker
+--                  is the half that matters: a section that was never checked has to keep saying so
+--                  in the record, or the audit trail turns "nobody looked" into "nothing wrong" all
+--                  over again.
+--   model_version  The version the judgement was made against.
+--
+-- MODEL_VERSION IS DELIBERATELY STORED TWICE. It is inside the receipt JSON as well, and that is
+-- not redundancy to be cleaned up: a replay has to be able to SELECT on the version — find every
+-- row judged against a model, or detect that a re-derivation ran against a different one — and a
+-- value buried in a JSON blob cannot be filtered or joined on portably across SQLite and Postgres.
+-- The column is the queryable copy; the receipt stays the verbatim record of what the caller saw,
+-- and decomposing it into columns would make it something other than that.
+--
+-- COLUMNS, NOT A SECOND TABLE — 014's argument, unchanged. All three are 1:1 with the execution and
+-- `Envelope.audit_id` IS `query_executions.id`, so a side table would be a join that can only ever
+-- match one row, keyed on an id that already lives here.
+--
+-- NULLABLE, all three, and NULL is a claim rather than a gap. `detail` is NULL on every non-refusal
+-- row because only a refusal has one. `receipt` and `model_version` are NULL on rows written before
+-- this migration ran, which is the same claim 014 made about `status`: written before the contract
+-- existed. A back-fill would be inventing history. `model_version` is additionally NULL where the
+-- receipt itself could not pin one — a deployment with no resolvable model — and that is a fact
+-- about the call worth keeping rather than a hole to fill.
+--
+-- BOUNDED BY THE WRITER, like `sql` (015) and `error_detail` (016) before it. `detail` is authored
+-- by us and value-free by the `Refusal` contract, but it echoes identifiers the caller sent, so the
+-- same argument applies: a statement must not become a way to grow the store
+-- (`tools.AUDIT_DETAIL_MAX_CHARS`). `receipt` is bounded upstream instead — `runtime._RECEIPT_MAX_REFS`
+-- caps the per-section reference count before the receipt is ever built, so the JSON has a ceiling
+-- by construction rather than by truncation, which matters because a truncated JSON blob does not
+-- parse and would be worse than no receipt at all.
+--
+-- Forward-only and portable (runs on SQLite + Postgres unchanged) — same shape as 016. No
+-- `IF NOT EXISTS`: SQLite's ALTER TABLE does not accept it, and re-run safety comes from the
+-- runner's `schema_migrations` ledger, which skips an applied file.
+
+ALTER TABLE query_executions ADD COLUMN detail TEXT;
+ALTER TABLE query_executions ADD COLUMN receipt TEXT;
+ALTER TABLE query_executions ADD COLUMN model_version TEXT;

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -407,8 +407,9 @@ class DbActivitySink:
         # which made the id unreferenceable the moment it existed.
         self._store.execute(
             "INSERT INTO query_executions (id, ts, org_id, datasource, question, sql, row_count, "
-            "source, status, reason, rule, sql_truncated, error_detail) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "source, status, reason, rule, sql_truncated, error_detail, detail, receipt, "
+            "model_version) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 record.id,
                 record.ts,
@@ -427,6 +428,12 @@ class DbActivitySink:
                 # The raw driver error, operator-only. NULL on the forked surface, where the
                 # chokepoint holding it and this recorder are different processes (ACE-039).
                 getattr(record, "error_detail", None),
+                # The three that make the row re-derivable (ACE-098). `getattr` with a default like
+                # the two above, so a caller still on the older record shape writes NULLs rather
+                # than raising — the same tolerance `error_detail` and `sql_truncated` already have.
+                getattr(record, "detail", None),
+                getattr(record, "receipt", None),
+                getattr(record, "model_version", None),
             ),
         )
         self._store.commit()

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1436,6 +1436,17 @@ def _emit(
     body["audit_id"] = env.audit_id
 
     _record_execution(env, sql=sql, profile=profile, args=args, row_count=row_count)
+    # Publish the TYPED outcome for the tool-call recorder (ACE-098). It runs later, in the
+    # transport's `finally`, where the Envelope no longer exists and only this serialized string
+    # does — so without this the tool_calls row's account of why a call failed is a `json.loads` of
+    # our own output. Set here rather than in `execute_guarded` because the tool edge is what
+    # decides the final status: the fork path rebuilds the Envelope on the parent side, and the
+    # chokepoint that ran in the child cannot reach this context at all.
+    from execute_sql import _last_outcome
+
+    _last_outcome.set(
+        (env.status, env.refusal.rule if env.refusal is not None else None, row_count)
+    )
     return json.dumps(body, indent=2, default=str)
 
 
@@ -1889,6 +1900,56 @@ def _record_query(rec: dict[str, Any]) -> None:
         # Local: no SQL, no question, no org — the record's own fields are the caller's data, and
         # this line goes to the server log. The exception and the stack say where the write broke.
         _LOG.warning("query-execution audit write failed; the answer is unaffected", exc_info=True)
+
+
+def reset_typed_outcome() -> None:
+    """Clear the published outcome. Run by the transport INSIDE the context it hands the handler.
+
+    Load-bearing, and a test found it: `copy_context()` copies whatever is current, so a verdict
+    published by an earlier `execute_sql` call in this context would be inherited by the next tool's
+    context and read back as that tool's outcome. A tool that never reaches `execute_guarded` — every
+    model-backed one — has nothing to clear it, so a raising `list_datasources` was recorded with the
+    previous query's refusal rule instead of `exception`.
+
+    `execute_guarded` clears it too, on entry, for the calls that do reach it. Both are needed: that
+    one covers a second query in one context, this one covers a different tool after a query.
+    """
+    from execute_sql import _last_outcome
+
+    _last_outcome.set(None)
+
+
+def typed_outcome_overrides(ctx: Any) -> dict[str, Any]:
+    """The `record_tool_call` overrides for a call whose Envelope classified itself (ACE-098).
+
+    The transport runs the tool handler inside a `contextvars.Context` it owns and passes it here.
+    That indirection is load-bearing: a ContextVar set inside `run_blocking`'s worker is invisible
+    to the caller, because anyio gives the thread a copy — so reading the var directly at the
+    recorder would read `None` on the one surface that records tool calls at all.
+
+    Returns `{}` for every other tool. The model-backed tools do not speak the Envelope (they return
+    the older `{"error": {kind, remediation}}` body) and never reach `_emit`, so there is nothing
+    typed to read and the body parse stays their path. `{}` means "derive it the way you always
+    have", which is exactly what `record_tool_call`'s override seam already documents.
+
+    The three come back as a group because that seam forces them to: stating any one replaces all
+    three, so returning a partial dict would silently blank the other two.
+    """
+    from execute_sql import _last_outcome
+
+    outcome = ctx.get(_last_outcome)
+    if outcome is None:
+        return {}
+    status, rule, row_count = outcome
+    success = status == "ok"
+    return {
+        "success": success,
+        # The rule the gate chose, straight off the `Refusal` — strictly more informative than the
+        # status alone, and no longer a `json.loads` of our own output. `status` is the fallback for
+        # a `failed`, which has a kind rather than a rule.
+        "error_kind": None if success else (rule or status),
+        "row_count": row_count,
+    }
 
 
 def record_tool_call(

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1454,6 +1454,15 @@ AUDIT_SQL_MAX_CHARS = 8_000
 # couple of thousand characters is the whole of what is worth keeping.
 AUDIT_ERROR_DETAIL_MAX_CHARS = 2_000
 
+# The refusal's own sentence, bounded on 015's argument (ACE-098). `Refusal.detail` is authored by
+# us and value-free by contract, so it is nothing like the unbounded driver text above — but it
+# ECHOES identifiers the caller sent, and an echo is caller-controlled length. 1,000 characters is
+# several times the longest detail any gate writes, so this bites only on something that has already
+# gone wrong. `receipt` needs no bound here: `runtime._RECEIPT_MAX_REFS` caps every section before
+# the receipt is built, so its JSON has a ceiling by construction — and truncating JSON would leave
+# a blob that does not parse, which is worse than the row having no receipt at all.
+AUDIT_DETAIL_MAX_CHARS = 1_000
+
 
 def _bounded_audit_sql(sql: str) -> tuple[str, bool]:
     """The statement as it will be stored, plus whether it had to be cut.
@@ -1464,6 +1473,17 @@ def _bounded_audit_sql(sql: str) -> tuple[str, bool]:
     if len(sql) <= AUDIT_SQL_MAX_CHARS:
         return sql, False
     return sql[:AUDIT_SQL_MAX_CHARS], True
+
+
+def _bounded_audit_detail(detail: str) -> str:
+    """The refusal's detail as it will be stored (ACE-098).
+
+    No companion truncation flag, unlike `sql`. The flag exists there because a cut statement reads
+    as the whole one and a reviewer would re-run something that does not reproduce the decision. A
+    detail is prose we authored, not something anyone re-runs, and it is bounded well above what any
+    gate writes — so the flag would be a column that is false on every row ever written.
+    """
+    return detail[:AUDIT_DETAIL_MAX_CHARS]
 
 
 def _record_execution(
@@ -1527,6 +1547,23 @@ def _record_execution(
             "status": env.status,
             "reason": refusal.reason if refusal is not None else None,
             "rule": refusal.rule if refusal is not None else None,
+            # The three that make the row re-derivable (ACE-098). All read off the Envelope this
+            # function already holds, for the same reason `reason` and `rule` are: the typed object
+            # is right here, and re-deriving any of them from the serialized body would make the
+            # record's account depend on a wire shape rather than on the decision.
+            #
+            # `detail` is where "which bound fired, and what it was set to" lives. The statement
+            # timeout and the result bound share ONE rule id by design, so `rule` alone cannot tell
+            # them apart and principle 9's carve-out claims the record does.
+            "detail": _bounded_audit_detail(refusal.detail) if refusal is not None else None,
+            # The whole receipt, verbatim, including every section's `undetermined` marker — the
+            # half that matters, since a section nobody checked has to keep saying so in the record
+            # too. `_emit` serializes the same `asdict` for the caller, so the row and the answer
+            # cannot disagree about what was reported.
+            "receipt": json.dumps(asdict(env.receipt), default=str),
+            # Lifted OUT of the receipt into its own column so a replay can SELECT on it. Inside the
+            # JSON as well, deliberately: see migration 017.
+            "model_version": env.receipt.model_version,
         }
     )
 

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1288,6 +1288,33 @@ _max_rows_override: ContextVar[int | None] = ContextVar("_max_rows_override", de
 # eventually serializes.
 _last_error_detail: ContextVar[str | None] = ContextVar("_last_error_detail", default=None)
 
+# The classified outcome of THIS call, for the tool-call recorder (ACE-098). `tools.record_tool_call`
+# derived `success` / `error_kind` by `json.loads`-ing the serialized body and reading
+# `refusal["rule"]` out of it — so the tool_calls row's account of WHY a call failed depended on our
+# own wire shape holding still, which is exactly what principle 7's re-derivation bar cannot rest on.
+#
+# It has to travel out-of-band because the tool handler returns a `str`: by the time the transport
+# runs its `finally`, the Envelope is gone and a serialized body is all there is. Same mechanism and
+# same reasoning as `_last_error_detail` directly above, including the clear-on-entry — a verdict
+# left behind by an earlier call must never label this one — and the same reason it is a ContextVar
+# rather than a module global: the in-process path runs tool handlers on worker threads.
+#
+# **Read by the TRANSPORT, out of a context it owns.** That is not a detail — a ContextVar set
+# inside `async_offload.run_blocking`'s worker thread is invisible to the caller and to every other
+# worker, because anyio hands the thread a COPY of the context. Verified rather than assumed: a var
+# set in one `run_blocking` reads back `None` both in the request task and in a second
+# `run_blocking`. So `mcp_http` runs the handler inside its own `contextvars.copy_context()` and
+# reads the result out of that object afterwards. A plain "set here, read there" would silently
+# record nothing on the one surface that records tool calls at all.
+#
+# `(status, rule, row_count)`, not the whole Envelope: the transport needs to say whether the call
+# succeeded, which gate stopped it, and how many rows came back. Putting a contract object in here
+# invites somebody to serialize it from the transport instead of from the one place that owns the
+# wire shape.
+_last_outcome: ContextVar[tuple[str, str | None, int | None] | None] = ContextVar(
+    "_last_outcome", default=None
+)
+
 # The semantic model `_model_safety` resolved for THIS call, so the receipt describes the model the
 # gates actually consulted rather than one re-resolved a moment later — and so the hosted path loads
 # it ONCE per query rather than twice (`_resolve_guard_model` is a full DB or disk load and is not
@@ -2253,6 +2280,10 @@ def execute_guarded(
     # be attributed to this one. The recorder reads it unconditionally; a stale value would put the
     # wrong error text on a row that succeeded.
     _last_error_detail.set(None)
+    # Same reason again: a verdict left behind by an earlier call in this context must never label
+    # this one. The recorder falls back to parsing the body when this is None, so a stale value is
+    # strictly worse than no value — it would be believed.
+    _last_outcome.set(None)
     # Same reason, same load-bearing half: a model resolved for an earlier call in this context must
     # never be the one this call's receipt describes.
     _guard_model.set(None)

--- a/tests/test_ace038_timeout.py
+++ b/tests/test_ace038_timeout.py
@@ -210,7 +210,14 @@ def test_the_budget_has_exactly_one_configuration_surface():
     # the safety pass already resolved ACROSS to the receipt builder a few lines later, inside one
     # call. Nothing reads it to compute a bound, and it is cleared at the entry to every call, so it
     # cannot outlive the call that set it — let alone reach a child.
-    context_vars -= {"_last_error_detail", "_guard_model"}
+    #
+    # `_last_outcome` (ACE-098) is the third, and it is the same kind as the first: an OUTPUT
+    # carrier. It holds the classified verdict of a call that has already finished, so the transport
+    # can record why it failed without re-parsing the body it is about to return. Written after the
+    # budget is resolved and spent, never read to compute a bound, and cleared at the entry to every
+    # call. It also cannot cross the fork, which is the hazard here — and does not need to: the
+    # parent sets it from the Envelope it rebuilds on its own side.
+    context_vars -= {"_last_error_detail", "_guard_model", "_last_outcome"}
     assert context_vars == {"_max_rows_override"}, (
         "a second, higher-precedence configuration surface for the budget cannot cross the fork; "
         f"found {sorted(context_vars)}"

--- a/tests/test_ace098_completeness.py
+++ b/tests/test_ace098_completeness.py
@@ -1,0 +1,338 @@
+"""The record is enough to reproduce the judgement without the database (ACE-098, principle 7).
+
+This is Wave 5's done-bar, and it is the only check that can tell whether the recorded fields are
+**sufficient** rather than merely present. A field list nobody has re-derived from is a guess about
+what sufficiency requires.
+
+**How the re-derivation works, and why it needs no new code.** The obvious reading — a second
+function that redoes the gate battery — would be a second place that decides, against the
+one-chokepoint invariant and free to drift from the real one. It is not needed. A refusal never
+reaches the executor, so `execute_guarded` can be re-run exactly as it ships with an executor that
+raises if called: no database is involved, by construction rather than by mocking. What comes back
+is the same verdict the row recorded, or the record was not sufficient.
+
+**What is exempt, and it is one rule.** Principle 9 carves out the two RUNTIME bounds — the
+statement timeout (ACE-038) and the result bound (ACE-087) — because they are determined at
+runtime rather than from the SQL and the model: the same statement executes at 29s and refuses at
+31s. Both emit ONE rule id, `resource_limit`, and ACE-087 keeps it that way deliberately (one rule,
+one emit site). So the exempt set has one member, and this file asserts the set rather than
+accepting whatever the harness happens to skip — the carve-out cannot widen by accident.
+
+**Synthetic only.** Every statement, model and record here is fabricated. The record's contents are
+customer data in a real deployment, and this repo is public.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import execute_sql  # noqa: E402
+import guardrail  # noqa: E402
+import tools  # noqa: E402
+from store import Store  # noqa: E402
+
+PROFILE = "acme"
+
+# The one rule the completeness bar does not apply to. Asserted as a SET below, not consulted as a
+# convenience: an exemption the harness merely honours can grow silently, and the whole value of
+# principle 9's carve-out is that it is bounded.
+EXEMPT_RULES = frozenset({guardrail.RULE_RESOURCE_LIMIT})
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    tools.set_injected_executor(None)
+    yield
+    tools.set_injected_executor(None)
+
+
+def _write_model(root: Path) -> None:
+    """A two-table model: `orders` is declared, `secrets` is not.
+
+    `secrets` is what makes a 4b vector possible — a statement reaching a table the model does not
+    expose — without inventing a table the warehouse also lacks, which would produce `failed`.
+    """
+    import yaml
+
+    (root / "subject_areas" / "sales" / "tables").mkdir(parents=True)
+    (root / "datasource.yaml").write_text(
+        yaml.safe_dump(
+            {"datasource": "Shop", "version": 1, "subject_areas": ["subject_areas/sales"]}
+        )
+    )
+    (root / "subject_areas" / "sales" / "subject_area.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "sales",
+                "tables": [{"storage_connection": "c", "schema": "public", "table": "orders"}],
+            }
+        )
+    )
+    (root / "subject_areas" / "sales" / "tables" / "orders.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "orders",
+                "schema": "public",
+                "storage_connection": "c",
+                "grain": ["id"],
+                "description": "orders",
+                "columns": [
+                    {"name": "id", "type": "integer", "primary_key": True},
+                    {"name": "status", "type": "string"},
+                    # Declared here and deliberately ABSENT from the warehouse below. That is how a
+                    # statement gets past every gate and is then rejected by the database — the `failed`
+                    # branch, reached for real rather than by stubbing the executor.
+                    {"name": "amount", "type": "integer"},
+                ],
+            }
+        )
+    )
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    app_db = "sqlite://" + str(tmp_path / "app.db")
+    store = Store.connect(app_db)
+    store.run_migrations()
+    store.close()
+
+    artifacts = tmp_path / "artifacts"
+    _write_model(artifacts / PROFILE)
+
+    warehouse = tmp_path / "warehouse.db"
+    con = sqlite3.connect(warehouse)
+    con.execute("CREATE TABLE orders (id INTEGER, status TEXT)")
+    con.executemany("INSERT INTO orders VALUES (?, ?)", [(1, "paid"), (2, "open")])
+    con.execute("CREATE TABLE secrets (id INTEGER)")
+    con.commit()
+    con.close()
+
+    monkeypatch.setenv("AGAMI_DB_URL", app_db)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(artifacts))
+    monkeypatch.setenv("DATASOURCE_URL__ACME", f"sqlite:///{warehouse}")
+    monkeypatch.delenv("AGAMI_ORG_ID", raising=False)
+    return SimpleNamespace(app_db=app_db, artifacts=artifacts, warehouse=warehouse)
+
+
+class _NeverExecutes:
+    """The database, absent by construction.
+
+    Not a mock of one: it is the assertion. A re-derivation that needed the warehouse would call
+    this and fail the test on the call itself, which is the only way to prove the record alone was
+    enough rather than the fixture quietly helping.
+    """
+
+    def execute(self, sql, creds, *, profile=None, **kwargs):
+        raise AssertionError("re-derivation reached the database; the record was not sufficient")
+
+
+# The corpus. One vector per REFUSAL REASON — the three principle 4 admits — plus an executed call
+# and a database failure, because 7's "whether it executed or was refused" covers both and a corpus
+# of refusals alone would not notice a receipt that only ever ships on one status.
+CORPUS = [
+    ("4a unsafe", "DELETE FROM orders", "refused", "unsafe"),
+    ("4b out_of_scope", "SELECT id FROM secrets", "refused", "out_of_scope"),
+    ("4c undetermined", "SELECT * FROM orders", "refused", "undetermined"),
+    ("executed", "SELECT id, status FROM orders", "ok", None),
+    ("database failed", "SELECT amount FROM orders", "failed", None),
+]
+
+
+def _record_one(sql: str) -> dict:
+    """Run one statement through the real chokepoint and the real serializer, as a caller would."""
+    envelope = execute_sql.execute_guarded(
+        sql, PROFILE, "sales", executor=execute_sql.BUILTIN_EXECUTOR
+    )
+    body = tools._emit(envelope, sql=sql, execution_ms=None, profile=PROFILE)
+    return {"envelope": envelope, "body": json.loads(body)}
+
+
+def _rows(url: str) -> list[dict]:
+    store = Store.connect(url)
+    try:
+        return store.query(
+            "SELECT id, sql, status, reason, rule, detail, receipt, model_version "
+            "FROM query_executions ORDER BY ts"
+        )
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# The completeness bar
+# ---------------------------------------------------------------------------
+
+
+def test_the_corpus_spans_every_refusal_reason():
+    """The bar is over EVERY reason, so a corpus that quietly lost one would pass on less."""
+    covered = {reason for _, _, status, reason in CORPUS if status == "refused"}
+    assert covered == set(guardrail._REASONS)
+
+
+def test_every_vector_produces_the_status_the_corpus_claims(env):
+    """The corpus declares an expected status per vector; nothing else checks it holds.
+
+    Worth its own test because the failure is silent in the direction that matters. A vector that
+    quietly started refusing — a model fixture typo is enough, and one cost an hour here — would
+    still leave the completeness assertion green while the corpus no longer spanned what it says it
+    spans. The `ok` and `failed` rows in particular exist to prove the receipt survives on a status
+    other than `refused`.
+    """
+    for label, sql, expected_status, expected_reason in CORPUS:
+        envelope = _record_one(sql)["envelope"]
+        assert envelope.status == expected_status, (
+            f"{label}: {envelope.refusal or envelope.failure}"
+        )
+        if expected_reason is not None:
+            assert envelope.refusal.reason == expected_reason, label
+
+
+def test_the_exempt_set_is_exactly_one_rule():
+    """Asserted, not accepted. An exemption a harness merely honours can grow without a diff.
+
+    It is one rule and not two because the statement timeout and the result bound share
+    `resource_limit` — ACE-087 keeps one rule with one emit site, so the only thing separating them
+    is the refusal's wording, and reading THAT is what this spec removes.
+    """
+    assert EXEMPT_RULES == {guardrail.RULE_RESOURCE_LIMIT}
+    assert EXEMPT_RULES < set(guardrail.REASON_FOR_RULE)
+
+
+def test_every_recorded_verdict_re_derives_from_the_record_alone(env):
+    """The done-bar. Write the corpus, read the rows back, re-derive each with no database.
+
+    The rows are the ONLY input to the second half: the statement comes off the row, not from the
+    corpus, so a field the record failed to keep cannot be silently supplied by the test.
+    """
+    for _, sql, _, _ in CORPUS:
+        _record_one(sql)
+
+    rows = _rows(env.app_db)
+    assert len(rows) == len(CORPUS)
+
+    re_derived = 0
+    for row in rows:
+        if row["rule"] in EXEMPT_RULES:
+            continue
+        if row["status"] != "refused":
+            continue  # only a refusal carries a verdict to re-derive; the ok/failed rows are below
+        envelope = execute_sql.execute_guarded(
+            row["sql"], PROFILE, "sales", executor=_NeverExecutes()
+        )
+        assert envelope.status == "refused", row["sql"]
+        assert envelope.refusal.reason == row["reason"], row["sql"]
+        assert envelope.refusal.rule == row["rule"], row["sql"]
+        assert envelope.refusal.detail == row["detail"], row["sql"]
+        re_derived += 1
+
+    assert re_derived == 3, "every refusal reason must have been re-derived, not skipped"
+
+
+def test_the_record_carries_the_receipt_for_an_executed_call_and_a_refused_one(env):
+    """7c: everything principle 6 reported is in the record, `undetermined` markers included.
+
+    The marker is the half worth pinning. A section nobody checked has to keep saying so in the
+    record too, or the audit trail turns "nobody looked" back into "nothing wrong" one layer down
+    from where ACE-088 fixed it.
+    """
+    _record_one("SELECT id, status FROM orders")  # ok
+    _record_one("DELETE FROM orders")  # refused
+
+    for row in _rows(env.app_db):
+        receipt = json.loads(row["receipt"])
+        assert set(receipt) == {"model_version", *guardrail.Receipt.SECTIONS}
+        markers = [receipt[s]["undetermined"] for s in guardrail.Receipt.SECTIONS]
+        assert any(m for m in markers), (
+            f"{row['status']} row carries no undetermined marker at all — the state that says "
+            "'nobody looked' has to survive into the record"
+        )
+
+
+def test_the_model_version_is_a_selectable_column(env):
+    """SC-4. It rides inside the receipt JSON too, and that copy cannot be filtered on portably."""
+    _record_one("SELECT id, status FROM orders")
+    version = _rows(env.app_db)[0]["model_version"]
+
+    store = Store.connect(env.app_db)
+    try:
+        assert (
+            store.query(
+                "SELECT count(*) AS n FROM query_executions WHERE model_version IS ?", (version,)
+            )[0]["n"]
+            == 1
+        )
+        # A replay against a DIFFERENT version is detectable rather than silently wrong.
+        assert (
+            store.query(
+                "SELECT count(*) AS n FROM query_executions WHERE model_version IS ?", ("other",)
+            )[0]["n"]
+            == 0
+        )
+    finally:
+        store.close()
+
+
+def test_the_recorded_statement_is_the_executed_statement_byte_for_byte(env):
+    """Wave 2 made these the same value, which turns this from a field to populate into an assertion.
+
+    Compared on the bytes rather than after any normalization: the whole point of ACE-093 is that
+    nothing between the caller and the driver alters the statement, and a comparison that trimmed or
+    re-cased would not notice if something started to.
+    """
+    sql = "SELECT id, status  FROM  orders"  # irregular spacing on purpose
+    result = _record_one(sql)
+
+    assert result["envelope"].status == "ok"
+    assert _rows(env.app_db)[0]["sql"].encode() == sql.encode()
+    assert result["body"]["sql"].encode() == sql.encode()
+
+
+def test_the_detail_names_which_bound_fired_and_what_it_was_set_to(env, monkeypatch):
+    """Principle 9's carve-out claims the record states "which one, and what it was set to".
+
+    Before ACE-098 it could not: both runtime bounds share `resource_limit` and the row held only
+    `reason` and `rule`. `detail` is where the distinction and the number already lived.
+    """
+    monkeypatch.setenv("AGAMI_SQL_TIMEOUT_S", "7")
+    refusal = execute_sql._resource_limit_refusal(execute_sql._ResourceLimit())
+    tools._emit(
+        execute_sql._envelope("refused", refusal=refusal, receipt=guardrail.Receipt()),
+        sql="SELECT 1",
+        execution_ms=None,
+        profile=PROFILE,
+    )
+
+    row = _rows(env.app_db)[0]
+    assert row["rule"] == guardrail.RULE_RESOURCE_LIMIT
+    assert "7" in row["detail"], "the configured bound is not in the record"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="the result bound is ACE-087, in flight and not on main; its refusal cannot be "
+    "constructed here yet. Owned by ACE-087 — delete this marker in the diff that lands it.",
+)
+def test_the_detail_tells_the_result_bound_apart_from_the_timeout(env):
+    """The other half of the carve-out, and the reason `detail` is recorded rather than a new rule.
+
+    ACE-087 gives `_resource_limit_refusal` a `None` arm for the transfer bound and keeps ONE rule
+    id, so the record distinguishes them by this field or not at all.
+    """
+    refusal = execute_sql._resource_limit_refusal(None)
+    assert "row" in refusal.detail.lower()

--- a/tests/test_ace098_completeness.py
+++ b/tests/test_ace098_completeness.py
@@ -265,27 +265,44 @@ def test_the_record_carries_the_receipt_for_an_executed_call_and_a_refused_one(e
 
 
 def test_the_model_version_is_a_selectable_column(env):
-    """SC-4. It rides inside the receipt JSON too, and that copy cannot be filtered on portably."""
-    _record_one("SELECT id, status FROM orders")
-    version = _rows(env.app_db)[0]["model_version"]
+    """SC-4. It rides inside the receipt JSON too, and that copy cannot be filtered on portably.
+
+    The version is written EXPLICITLY here rather than taken from whatever the fixture happens to
+    resolve. A disk-only deployment pins no version at all — verified against a real Postgres, where
+    every row came back with `model_version` NULL — so a test that read the fixture's own value
+    would have compared NULL to NULL and passed while proving nothing about a version that exists.
+    """
+    receipt = guardrail.Receipt(model_version="v-2026-08-03")
+    tools._emit(
+        execute_sql._envelope(
+            "refused",
+            refusal=guardrail.refuse(guardrail.RULE_READ_ONLY, detail="d", remediation="r"),
+            receipt=receipt,
+        ),
+        sql="DELETE FROM orders",
+        execution_ms=None,
+        profile=PROFILE,
+    )
+
+    row = _rows(env.app_db)[0]
+    assert row["model_version"] == "v-2026-08-03"
+    assert json.loads(row["receipt"])["model_version"] == "v-2026-08-03", (
+        "the column and the receipt must agree; they are two copies of one fact"
+    )
 
     store = Store.connect(env.app_db)
     try:
-        assert (
-            store.query(
-                "SELECT count(*) AS n FROM query_executions WHERE model_version IS ?", (version,)
-            )[0]["n"]
-            == 1
+        hit = store.query(
+            "SELECT count(*) AS n FROM query_executions WHERE model_version = ?",
+            ("v-2026-08-03",),
         )
         # A replay against a DIFFERENT version is detectable rather than silently wrong.
-        assert (
-            store.query(
-                "SELECT count(*) AS n FROM query_executions WHERE model_version IS ?", ("other",)
-            )[0]["n"]
-            == 0
+        miss = store.query(
+            "SELECT count(*) AS n FROM query_executions WHERE model_version = ?", ("v-other",)
         )
     finally:
         store.close()
+    assert (hit[0]["n"], miss[0]["n"]) == (1, 0)
 
 
 def test_the_recorded_statement_is_the_executed_statement_byte_for_byte(env):


### PR DESCRIPTION
Spec: ACE-098

**Stacked on #189 (ACE-097).** Base is that branch, not `main` — this needs its `audit_unavailable` rule and recording exemption. Retarget to `main` once #189 merges.

## Summary

ACE-097 guarantees a record exists. This makes it sufficient.

Principle 7 sets a bar no field list can be checked against by inspection: *the record is enough to reproduce the judgement without the database.* A row recorded the verdict but nothing about the basis for it, so nobody could take one and check the decision again. Three columns close that, and a harness then proves the fields are **sufficient** rather than merely present — a field list nobody has re-derived from is a guess about what sufficiency requires.

## Changes

- **Migration 017**: `detail`, `receipt`, `model_version` on `query_executions`, all nullable, all populated off the Envelope `_record_execution` already holds.
  - `detail` is where *"which bound fired, and what it was set to"* lives. Principle 9's carve-out claims the record says that; it could not, because the statement timeout and the result bound share one rule id by design and `reason` + `rule` were the whole row.
  - `receipt` is the whole `Receipt` as JSON, `undetermined` markers included. The marker is the half that matters: a section nobody checked has to keep saying so in the record, or the trail turns "nobody looked" back into "nothing wrong" one layer down from where ACE-088 fixed it.
  - `model_version` is **deliberately stored twice** — in its own column and inside the receipt JSON. SC-4 needs a *selectable* version, and a value in a blob is not portably filterable across SQLite and Postgres; the receipt has to stay the verbatim record of what the caller saw.
- **The tool-call row reads the verdict, not the body.** `_emit` publishes the classified `(status, rule, row_count)`, and the transport passes it through `record_tool_call`'s existing override seam — built for exactly this and previously with no caller.
- **The completeness harness** (`tests/test_ace098_completeness.py`) and its corpus.

## Verification

`uv run dev.py check`: **2722 passed**, 4 skipped, 10 xfailed. `ruff check` and gitleaks clean.

**The re-derivation adds no new decision path, deliberately.** A second function that redoes the gate battery would be a second place that decides — against the one-chokepoint invariant and free to drift. A refusal never reaches the executor, so `execute_guarded` is re-run exactly as it ships with an executor that raises if called: no database by construction rather than by mocking, and **the statement comes off the row**, so a field the record failed to keep cannot be quietly supplied by the test.

Smoke-tested against Postgres 16.12 on all three routes, with migration 017 applied to a fresh app DB: six rows, every one carrying a receipt, refusals carrying `detail`.

**Three defects the tests and the smoke run found, each fixed in its own commit:**

1. **The plan's mechanism was wrong.** A ContextVar set inside `run_blocking`'s worker is invisible to the caller and to every other worker — anyio hands the thread a copy. Verified directly rather than reasoned about: a var set in one `run_blocking` reads back `None` both in the request task and in a second one. Since the transport records tool calls from a separate `run_blocking`, the planned set-here-read-there would have recorded nothing on the only surface that records them. The transport now runs the handler in a `Context` it owns.
2. **A cross-call mislabeling**, caught by `test_a_raising_tool_is_still_logged_as_an_error`: `copy_context()` copies whatever is current, so a verdict published by an earlier query was inherited by the next tool's context and read back as that tool's outcome — a raising `list_datasources` recorded the previous query's refusal rule instead of `exception`. Tools that never reach `execute_guarded` have nothing to clear it, so the transport clears it in the context it owns.
3. **The `model_version` assertion tested nothing.** Against a real Postgres every row came back NULL, because a disk-only deployment pins no version — so the test was comparing NULL to NULL. It now writes an explicit version and exercises both a filter hit and a miss.

A fourth was caught by the corpus guard: a model-fixture typo (`type: text`, not a valid column type) made three vectors refuse for `model_unavailable` while the completeness assertion stayed green. The local path hides it, since a model that fails to load is a silent no-op there. `test_every_vector_produces_the_status_the_corpus_claims` exists so that cannot recur.

## For the reviewer

- **The exempt set is one rule, asserted rather than honoured.** `{RULE_RESOURCE_LIMIT}` — one, not two, because the timeout and the result bound share it and telling them apart would mean reading the refusal's wording, which is exactly what this change removes.
- **One strict xfail**, owned by ACE-087: the result-bound half of the detail assertion cannot be constructed until that lands. Delete the marker in the diff that ships it.
- **Scope of the claim.** The harness proves the *fields* are sufficient on a synthetic corpus that carries its own model. It does not prove a production record is replayable: `model_deploy.deploy_one` is clear-then-insert, so a redeploy overwrites the model a row was judged against. Making principle 7 literally true needs model retention, which is a separate spec and is stated as out of scope.
- **Pre-existing, not introduced here.** `ruff format` also wants changes in `dev.py`, `agami_paths.py`, `deploy_preflight.py` and two ACE-039 test files. None are touched by this branch and all are byte-identical to `main`. Reformatting them inside a high-lane security PR would be unrelated churn; worth its own commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
