### PR TITLE
ACE-037: refuse a FROM/JOIN source the scope walk cannot read

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1876,9 +1876,8 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
     except Exception:
         # The model package (pydantic) isn't importable, so the guards can't run at all. On the
         # hosted served path that is the same "can't guarantee safety" condition as a missing model
-        # — fail closed. Locally it stays a no-op (a bare install legitimately has no model). (The
-        # sqlglot-unavailable / unparseable-SQL degrade-to-allow is a distinct fail-open owned by
-        # ACE-037, not closed here.)
+        # — fail closed. Locally it stays a no-op (a bare install legitimately has no model). The
+        # two siblings of this branch are below: an unresolvable model, and an absent SQL parser.
         if _hosted():
             # `remediation` is authored here rather than carried across: this branch had no
             # `suggestion` at all, and the contract makes an unactionable refusal a construction
@@ -1913,6 +1912,24 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
         # The non-hosted twin again: locally a not-yet-built model is expected, so no refusal.
         return sql, None  # local: no model yet -> no-op (unchanged)
 
+    # No parser, no guard — the third member of the family above, and the last of them to be closed.
+    # Every gate below opens with `if not _HAVE_SQLGLOT: return None`, so a hosted server whose
+    # sqlglot import failed resolves a model, reports itself guarded, and then runs the statement
+    # with table scope, column scope, the star ban and the readability gate all silently inert. It is
+    # the same "cannot guarantee safety" condition as the two branches above and takes the same rule:
+    # a deployment-state fact that says nothing about the statement, so no re-emission fixes it.
+    #
+    # The local twin stays a no-op for the third time, and for the same reason — a bare install
+    # legitimately has no sqlglot, and refusing there would break every local user to close a hole
+    # that only exists on a served path.
+    if _hosted() and not getattr(RT, "_HAVE_SQLGLOT", True):
+        return sql, refuse(
+            RULE_MODEL_UNAVAILABLE,
+            detail="the SQL parser is not installed, so no guard could read the statement; "
+                   "refusing to run unguarded on the hosted server",
+            remediation="Install the semantic-model dependencies on the server and retry.",
+        )
+
     # Build the shared guard context ONCE — parse the SQL + build each model index a single
     # time — and thread it through the battery below, instead of every guard re-parsing and
     # rebuilding its index (audit P2 / ACE-045). Behaviour-preserving: a guard given `ctx`
@@ -1936,6 +1953,18 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
         unreadable = check_readable(sql, org, ctx=ctx)
         if unreadable is not None:
             return sql, unreadable
+
+    # Scopability gate — the readable statement that still cannot be checked. It runs between the
+    # readability gate and the scope gates because that is exactly the gap it fills: the gate above
+    # asks whether we could read the statement, the gates below ask what the statement reaches, and
+    # a table function is readable while reaching something neither one can name. Table scope skips
+    # an empty-name table so that a CTE reference passes, and a table function arrives as precisely
+    # that node, so it went through both. Same `getattr` reason as the gate above.
+    check_scopable = getattr(RT, "check_scopable", None)
+    if check_scopable is not None:
+        unscopable = check_scopable(sql, org, ctx=ctx)
+        if unscopable is not None:
+            return sql, unscopable
 
     # Table-scope guard — a query may only reference tables the semantic model
     # declares; any other table in the connected database is refused. Runs FIRST

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -416,14 +416,20 @@ def check_scopable(sql: str, org: Datasource,
     a table function arrives as. The gate cannot be taught the difference without breaking the case
     it exists for, which is why this is a separate slice rather than a condition bolted onto it.
 
-    Refuses four source shapes, each anywhere in the tree so every set-operation arm and nested
-    subquery is covered by the same walk:
+    Refuses four shapes, each looked for anywhere in the tree so that every set-operation arm and
+    nested subquery is covered by the same walk:
 
     * a table function or `ROWS FROM` — an `exp.Table` carrying a function rather than a name.
-    * a `LATERAL` source, in both the Postgres `LATERAL (...)` and Hive `LATERAL VIEW` spellings.
-    * `VALUES`, `UNNEST`, or any other FROM/JOIN source that is neither an `exp.Table` nor a derived
+    * a `LATERAL`, in both the Postgres `LATERAL (...)` and Hive `LATERAL VIEW` spellings.
+    * a `VALUES` list, which is not always a FROM/JOIN source: as a set-operation arm it hangs off
+      the `Union` instead, contributing rows while the source walk below cannot see it.
+    * `UNNEST`, or any other FROM/JOIN source that is neither an `exp.Table` nor a derived
       `exp.Subquery` — including one reached through a comma-join, whose extra sources some sqlglot
       versions hang off `From.expressions` rather than normalizing into a `Join`.
+
+    The first three are whole-tree `find`s rather than source-walk cases on purpose: each has at
+    least one spelling that is not a FROM/JOIN source, so a walk that only visited sources would
+    miss it while it still shaped the result.
 
     Reuses `ctx.tree` and never parses a second time: a gate that re-parsed could disagree with the
     tree every other gate judged, which is the divergence this whole family exists to prevent.
@@ -455,6 +461,18 @@ def check_scopable(sql: str, org: Datasource,
         return _unscopable(
             "a FROM/JOIN source is a LATERAL rather than a named table, so there is nothing to "
             "check against the declared surface"
+        )
+    # `VALUES` is swept whole-tree for the same reason, and the reason is not symmetry.
+    # A parenthesized `VALUES` used as a set-operation ARM — `SELECT id FROM orders UNION ALL
+    # (VALUES (1))` — is not a FROM/JOIN source at all: it hangs off the `Union` beside the select,
+    # so the source walk below never reaches it while it contributes rows to the result exactly as
+    # an arm reading a table would. Found by review, and it executed against a real engine with all
+    # three gates silent. A read-only SELECT over declared tables carries no `Values` node —
+    # `IN (1, 2, 3)` is an `exp.In` over expressions, not this — so the sweep costs no false refusal.
+    if tree.find(exp.Values) is not None:
+        return _unscopable(
+            "the query builds rows from a VALUES list rather than reading a named table, so there "
+            "is nothing to check against the declared surface"
         )
     # Every remaining non-`Table`, non-derived-subquery source. `From.expressions` carries the extra
     # sources of a comma-join on the sqlglot versions that do not normalize them into a `Join`, so a

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -374,6 +374,103 @@ def check_readable(
     return None
 
 
+# A statement whose sources the scope walk cannot reason about. The remediation names the shape that
+# would scope and never the declared names, for the same reason every other refusal does not: a
+# refusal that lists the alternatives is a schema-listing endpoint reachable by one wrong query.
+_DECLARED_SOURCE_REMEDIATION = (
+    "Query declared tables directly — replace the table function, VALUES, UNNEST or LATERAL source "
+    "with a plain FROM/JOIN on a declared table, or add the source to the model if it should be "
+    "queryable."
+)
+
+
+def _unscopable(detail: str) -> "guardrail.Refusal":
+    return guardrail.refuse(
+        guardrail.RULE_UNSCOPABLE,
+        detail=detail,
+        remediation=_DECLARED_SOURCE_REMEDIATION,
+    )
+
+
+def check_scopable(sql: str, org: Datasource,
+                   ctx: "GuardContext | None" = None) -> "guardrail.Refusal | None":
+    """Refuse a statement that parses perfectly and still presents a source the scope walk cannot
+    reason about.
+
+    **The boundary, stated: this is a 4c gate**, and it is the second half of a split the contract
+    makes on purpose. `unparseable` is a statement sqlglot cannot read at all and belongs to
+    `check_readable` above; `unscopable` is one that reads fine and offers the scope walk nothing to
+    accept or reject. Collapsing them would make the remediation a guess — "re-emit the query" is
+    useless advice to someone whose query parsed.
+
+    **Why the gate above does not already cover this.** `check_readable`'s backstop refuses a
+    statement that resolves to NO named table, which is the right shape for a quoting style nobody
+    has mapped. It is not the right shape here, twice over: a table function parses to an
+    `exp.Table` with an EMPTY name, so the backstop's `find(exp.Table) is None` sees a table and
+    passes; and one declared table leading a comma-join is enough to satisfy it while every source
+    after the comma goes unexamined. Measured on this tree, six such statements reached the database
+    with every gate silent.
+
+    **Why the scope gates do not catch it either.** `check_table_scope` skips an empty-name table by
+    design — that is how it lets a CTE reference through — so the same node it must ignore is the one
+    a table function arrives as. The gate cannot be taught the difference without breaking the case
+    it exists for, which is why this is a separate slice rather than a condition bolted onto it.
+
+    Refuses four source shapes, each anywhere in the tree so every set-operation arm and nested
+    subquery is covered by the same walk:
+
+    * a table function or `ROWS FROM` — an `exp.Table` carrying a function rather than a name.
+    * a `LATERAL` source, in both the Postgres `LATERAL (...)` and Hive `LATERAL VIEW` spellings.
+    * `VALUES`, `UNNEST`, or any other FROM/JOIN source that is neither an `exp.Table` nor a derived
+      `exp.Subquery` — including one reached through a comma-join, whose extra sources some sqlglot
+      versions hang off `From.expressions` rather than normalizing into a `Join`.
+
+    Reuses `ctx.tree` and never parses a second time: a gate that re-parsed could disagree with the
+    tree every other gate judged, which is the divergence this whole family exists to prevent.
+
+    Inert when the model declares no tables, matching `check_table_scope` — a deployment with no
+    declared surface is not scoping anything. Returns `None` when satisfied.
+    """
+    if not _HAVE_SQLGLOT:
+        return None
+    if not (ctx.model_table_index if ctx is not None else _model_table_index(org)):
+        return None
+    tree = ctx.tree if ctx is not None else _parse_sql(sql, _dialect_of(org)[0])
+    # An unparseable statement and a non-SELECT are both somebody else's refusal — `check_readable`
+    # above and the read-only guard respectively. Passing here says nothing about them.
+    if tree is None or tree.find(exp.Select) is None:
+        return None
+    # A table function and `ROWS FROM` parse to an `exp.Table` whose name is empty, the function
+    # sitting in `.this`. Checked first because it is the shape the two gates above each look
+    # straight through.
+    for tbl in tree.find_all(exp.Table):
+        if not tbl.name:
+            return _unscopable(
+                "a FROM/JOIN source is a table function rather than a named table, so there is "
+                "nothing to check against the declared surface"
+            )
+    # sqlglot attaches a LATERAL under the From/Join for Postgres' `LATERAL (...)` and as a Select
+    # property for Hive's `LATERAL VIEW`, so sweep the whole tree rather than the sources alone.
+    if tree.find(exp.Lateral) is not None:
+        return _unscopable(
+            "a FROM/JOIN source is a LATERAL rather than a named table, so there is nothing to "
+            "check against the declared surface"
+        )
+    # Every remaining non-`Table`, non-derived-subquery source. `From.expressions` carries the extra
+    # sources of a comma-join on the sqlglot versions that do not normalize them into a `Join`, so a
+    # declared table written first cannot shield what follows it.
+    for node in tree.find_all(exp.From, exp.Join):
+        for src in [node.this, *(node.args.get("expressions") or [])]:
+            if src is not None and not isinstance(src, (exp.Table, exp.Subquery)):
+                # The node's class name describes the SQL construct the caller wrote, not a value
+                # from it or a name from the model — value-free in the sense the contract means.
+                return _unscopable(
+                    f"a FROM/JOIN source is a {type(src).__name__.upper()} rather than a named "
+                    "table, so there is nothing to check against the declared surface"
+                )
+    return None
+
+
 def statement_shape(ctx: "GuardContext | None") -> "str | None":
     """`"aggregate"` when the statement groups, `"listing"` otherwise, `None` when there is no
     tree to read (sqlglot absent, or the SQL did not parse).

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1876,9 +1876,8 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
     except Exception:
         # The model package (pydantic) isn't importable, so the guards can't run at all. On the
         # hosted served path that is the same "can't guarantee safety" condition as a missing model
-        # — fail closed. Locally it stays a no-op (a bare install legitimately has no model). (The
-        # sqlglot-unavailable / unparseable-SQL degrade-to-allow is a distinct fail-open owned by
-        # ACE-037, not closed here.)
+        # — fail closed. Locally it stays a no-op (a bare install legitimately has no model). The
+        # two siblings of this branch are below: an unresolvable model, and an absent SQL parser.
         if _hosted():
             # `remediation` is authored here rather than carried across: this branch had no
             # `suggestion` at all, and the contract makes an unactionable refusal a construction
@@ -1913,6 +1912,24 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
         # The non-hosted twin again: locally a not-yet-built model is expected, so no refusal.
         return sql, None  # local: no model yet -> no-op (unchanged)
 
+    # No parser, no guard — the third member of the family above, and the last of them to be closed.
+    # Every gate below opens with `if not _HAVE_SQLGLOT: return None`, so a hosted server whose
+    # sqlglot import failed resolves a model, reports itself guarded, and then runs the statement
+    # with table scope, column scope, the star ban and the readability gate all silently inert. It is
+    # the same "cannot guarantee safety" condition as the two branches above and takes the same rule:
+    # a deployment-state fact that says nothing about the statement, so no re-emission fixes it.
+    #
+    # The local twin stays a no-op for the third time, and for the same reason — a bare install
+    # legitimately has no sqlglot, and refusing there would break every local user to close a hole
+    # that only exists on a served path.
+    if _hosted() and not getattr(RT, "_HAVE_SQLGLOT", True):
+        return sql, refuse(
+            RULE_MODEL_UNAVAILABLE,
+            detail="the SQL parser is not installed, so no guard could read the statement; "
+                   "refusing to run unguarded on the hosted server",
+            remediation="Install the semantic-model dependencies on the server and retry.",
+        )
+
     # Build the shared guard context ONCE — parse the SQL + build each model index a single
     # time — and thread it through the battery below, instead of every guard re-parsing and
     # rebuilding its index (audit P2 / ACE-045). Behaviour-preserving: a guard given `ctx`
@@ -1936,6 +1953,18 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
         unreadable = check_readable(sql, org, ctx=ctx)
         if unreadable is not None:
             return sql, unreadable
+
+    # Scopability gate — the readable statement that still cannot be checked. It runs between the
+    # readability gate and the scope gates because that is exactly the gap it fills: the gate above
+    # asks whether we could read the statement, the gates below ask what the statement reaches, and
+    # a table function is readable while reaching something neither one can name. Table scope skips
+    # an empty-name table so that a CTE reference passes, and a table function arrives as precisely
+    # that node, so it went through both. Same `getattr` reason as the gate above.
+    check_scopable = getattr(RT, "check_scopable", None)
+    if check_scopable is not None:
+        unscopable = check_scopable(sql, org, ctx=ctx)
+        if unscopable is not None:
+            return sql, unscopable
 
     # Table-scope guard — a query may only reference tables the semantic model
     # declares; any other table in the connected database is refused. Runs FIRST

--- a/tests/test_ace051_fail_closed.py
+++ b/tests/test_ace051_fail_closed.py
@@ -340,6 +340,7 @@ _UNSCOPABLE_CORPUS = [
     "SELECT o.id FROM orders o, (VALUES (1),(2)) AS v(x)",              # shielded by a declared table
     "SELECT o.id FROM orders o, generate_series(1,10) AS t(g)",         # ditto, table function
     "SELECT id FROM orders UNION SELECT g FROM generate_series(1,3) AS t(g)",  # hidden in an arm
+    "SELECT id FROM orders UNION ALL (VALUES (1))",                     # an arm that is not a source
 ]
 
 

--- a/tests/test_ace051_fail_closed.py
+++ b/tests/test_ace051_fail_closed.py
@@ -288,6 +288,109 @@ def test_hosted_fail_closed_when_model_package_unimportable(tmp_path, monkeypatc
     _silent(capsys)
 
 
+# ── ACE-037: the third member of the family — no parser, and the scopability gate ──
+
+def test_hosted_fail_closed_when_the_sql_parser_is_unavailable(tmp_path, monkeypatch, capsys):
+    """Every gate opens with `if not _HAVE_SQLGLOT: return None`, so without sqlglot a served
+    deployment resolves a model, reports itself guarded, and runs the statement with table scope,
+    column scope, the star ban and the readability gate all silently inert.
+
+    The sibling of the two branches above and pinned to the same rule: a deployment-state fact that
+    says nothing about the statement, so no re-emission fixes it. The model here resolves fine —
+    that is the point, since a missing model would refuse for the other reason and the assertion
+    would pass while measuring nothing.
+    """
+    from semantic_model import runtime as RT
+
+    url = "sqlite://" + str(tmp_path / "seeded.db")
+    _seed_db(url)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_disk"))
+    monkeypatch.setattr(RT, "_HAVE_SQLGLOT", False)
+
+    sql, verdict = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
+    assert _refusal(verdict).rule == guardrail.RULE_MODEL_UNAVAILABLE
+    assert verdict.reason == "undetermined"
+    assert sql == "SELECT id FROM orders"  # refused, and never rewritten on the way out
+    _silent(capsys)
+
+
+def test_local_missing_sql_parser_is_noop(tmp_path, monkeypatch):
+    """The local twin, for the third time and for the same reason: a bare install legitimately has
+    no sqlglot, and refusing there would break every local user to close a hole that only exists on
+    a served path."""
+    from semantic_model import runtime as RT
+
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "art"))
+    _write_disk(tmp_path / "art" / "acme")
+    monkeypatch.setattr(RT, "_HAVE_SQLGLOT", False)
+
+    sql, verdict = execute_sql._model_safety("SELECT id FROM orders", "acme", None)
+    assert verdict is None and sql == "SELECT id FROM orders"
+
+
+_UNSCOPABLE_CORPUS = [
+    "SELECT g FROM generate_series(1, 10) AS t(g)",                     # table function
+    "SELECT a FROM ROWS FROM (generate_series(1,3)) AS t(a)",           # ROWS FROM
+    "SELECT x FROM (VALUES (1), (2)) AS v(x)",                          # VALUES source
+    "SELECT x FROM UNNEST(ARRAY[1,2]) AS t(x)",                         # UNNEST source
+    "SELECT o.id FROM orders o, LATERAL (SELECT 1 AS a) l",             # LATERAL source
+    "SELECT o.id FROM orders o, (VALUES (1),(2)) AS v(x)",              # shielded by a declared table
+    "SELECT o.id FROM orders o, generate_series(1,10) AS t(g)",         # ditto, table function
+    "SELECT id FROM orders UNION SELECT g FROM generate_series(1,3) AS t(g)",  # hidden in an arm
+]
+
+
+@pytest.mark.parametrize("sql", _UNSCOPABLE_CORPUS)
+def test_the_unscopable_corpus_is_refused_at_the_chokepoint(tmp_path, monkeypatch, capsys, sql):
+    """The gate is wired, not merely written.
+
+    `test_scopable_gate.py` calls the gate directly; this asserts each construct is refused where it
+    matters — the one pass every surface goes through. Six of these eight reached the database
+    before this gate existed, with the readability gate and both scope gates silent, so a unit test
+    alone would have proved a function nobody called.
+    """
+    url = "sqlite://" + str(tmp_path / "seeded.db")
+    _seed_db(url)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_disk"))
+
+    out_sql, verdict = execute_sql._model_safety(sql, "acme", None)
+    refusal = _refusal(verdict)
+    assert refusal.rule == guardrail.RULE_UNSCOPABLE
+    assert refusal.reason == "undetermined"
+    assert out_sql == sql  # refused, never rewritten
+    _silent(capsys)
+
+
+def test_the_scopability_gate_runs_after_readability_and_before_table_scope(tmp_path, monkeypatch,
+                                                                            capsys):
+    """Ordering, asserted by the verdicts three statements get rather than by reading the source.
+
+    An unreadable statement must still be `unparseable` (the gate above owns it), an undeclared
+    table must still be `table_scope` (the gate below owns it), and only the readable-but-unscopable
+    one is this gate's. A gate inserted in the wrong place returns the right refusal for the wrong
+    statement, which no single-case test would catch.
+    """
+    url = "sqlite://" + str(tmp_path / "seeded.db")
+    _seed_db(url)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "no_disk"))
+
+    _, unreadable = execute_sql._model_safety("SELECT FROM WHERE ((", "acme", None)
+    assert _refusal(unreadable).rule == guardrail.RULE_UNPARSEABLE
+
+    _, unscopable = execute_sql._model_safety(
+        "SELECT o.id FROM orders o, generate_series(1,3) AS t(g)", "acme", None)
+    assert _refusal(unscopable).rule == guardrail.RULE_UNSCOPABLE
+
+    _, out_of_scope = execute_sql._model_safety("SELECT id FROM secret", "acme", None)
+    assert _refusal(out_of_scope).rule == guardrail.RULE_TABLE_SCOPE
+    _silent(capsys)
+
+
 def test_db_model_resolves_under_the_requests_org(tmp_path, monkeypatch, capsys):
     """The guard must look up the model under the REQUEST's org, not the 'local' sentinel.
 

--- a/tests/test_scopable_gate.py
+++ b/tests/test_scopable_gate.py
@@ -1,0 +1,210 @@
+"""The scopability gate: a statement that parses perfectly and still cannot be checked is refused.
+
+**This is the other half of a split the contract makes deliberately.** `unparseable` is a statement
+sqlglot cannot read at all and belongs to `check_readable`; `unscopable` is one that reads fine and
+offers the scope walk nothing to accept or reject — a table function, `ROWS FROM`, `VALUES`,
+`UNNEST`, `LATERAL`. Collapsing them into one rule would make the remediation a guess, because
+"re-emit the query" is useless advice to someone whose query parsed.
+
+**Why neither existing gate catches these, which is the whole reason this file exists.** ACE-079's
+readability backstop refuses a statement resolving to NO named table. A table function does not have
+that shape: sqlglot parses it to an `exp.Table` whose *name* is empty, with the function in `.this`,
+so `find(exp.Table) is None` sees a table and passes. `check_table_scope` then skips the very same
+node — `if not name ... continue` is how it lets a CTE reference through — so the node no gate can
+name is the node both gates decline to judge. And one declared table leading a comma-join satisfies
+the backstop while every source after the comma goes unexamined.
+
+Measured before this gate existed: of the eight constructs below, six reached the database with
+`check_readable`, `check_table_scope` and `check_column_scope` all silent. The two that did refuse
+did so incidentally, via the zero-named-table backstop, which is a backstop rather than a diagnosis.
+
+**Every assertion names the rule and the reason.** A suite asserting only "something refused" would
+have read green while the wrong gate fired for the wrong reason — the failure mode
+`test_parse_fidelity_gaps.py` was written to prevent, kept here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import guardrail  # noqa: E402
+from semantic_model import models as m  # noqa: E402
+from semantic_model import runtime as rt  # noqa: E402
+
+
+def _scope_org(engine: str = "PostgreSQL"):
+    """orders(id, amount) + customers(id, name), on a declared engine.
+
+    The engine is declared because the readability gate refuses a datasource that names none, and a
+    statement refused there would never reach this gate — the assertions below would then be pinning
+    ACE-079's refusal while reading as though they pinned this one.
+    """
+    def _t(name, cols):
+        return m.Table(name=name, schema="public", storage_connection="c", grain=["id"],
+                       description=name,
+                       columns=[m.Column(name=c, type="integer") for c in cols])
+    return m.Datasource(
+        datasource="Shop",
+        storage_connections=[m.StorageConnection(name="c", storage_type=engine)],
+        subject_areas=[m.SubjectArea(name="sales",
+                                     tables_defined=[_t("orders", ["id", "amount"]),
+                                                     _t("customers", ["id", "name"])])])
+
+
+def _assert_unscopable(refusal) -> None:
+    """The refusal is 4c, carries the contract's rule, and names a fix without listing the model.
+
+    `reason` is asserted against the enum's own mapping rather than a literal, so a future edit that
+    re-pinned the rule to `unsafe` or `out_of_scope` fails here rather than passing a hard-coded
+    string that was copied from the same edit.
+    """
+    assert refusal is not None
+    assert refusal.rule == guardrail.RULE_UNSCOPABLE
+    assert refusal.reason == "undetermined"
+    assert refusal.reason == guardrail.REASON_FOR_RULE[guardrail.RULE_UNSCOPABLE]
+    assert refusal.remediation
+    # Echo, never enumerate: a refusal that lists the declared tables is a schema-listing endpoint
+    # reachable by one deliberately-wrong query.
+    assert "orders" not in refusal.detail and "customers" not in refusal.detail
+    assert "orders" not in refusal.remediation and "customers" not in refusal.remediation
+
+
+# ===========================================================================
+# The refuse-class
+# ===========================================================================
+
+UNSCOPABLE = [
+    pytest.param("SELECT g FROM generate_series(1, 10) AS t(g)", id="table-function"),
+    pytest.param("SELECT a FROM ROWS FROM (generate_series(1,3)) AS t(a)", id="rows-from"),
+    pytest.param("SELECT x FROM (VALUES (1), (2)) AS v(x)", id="values"),
+    pytest.param("SELECT x FROM UNNEST(ARRAY[1,2]) AS t(x)", id="unnest"),
+    pytest.param("SELECT o.id FROM orders o, LATERAL (SELECT 1 AS a) l", id="lateral"),
+    pytest.param("SELECT x FROM orders LATERAL VIEW explode(arr) t AS x", id="hive-lateral-view"),
+]
+
+
+@pytest.mark.parametrize("sql", UNSCOPABLE)
+def test_an_unscopable_source_is_refused(sql):
+    _assert_unscopable(rt.check_scopable(sql, _scope_org()))
+
+
+@pytest.mark.parametrize("sql", [
+    pytest.param("SELECT o.id FROM orders o, (VALUES (1),(2)) AS v(x)", id="values"),
+    pytest.param("SELECT o.id FROM orders o, UNNEST(ARRAY[1,2]) AS u(x)", id="unnest"),
+    pytest.param("SELECT o.id FROM orders o, generate_series(1,10) AS t(g)", id="table-function"),
+])
+def test_a_declared_table_does_not_shield_a_later_comma_join_source(sql):
+    """The leading source is `orders`, which is declared, and that is the point.
+
+    This is where the readability backstop stops helping: the statement resolves to a named table,
+    so `find(exp.Table) is None` is false and it passes. Whether the extra sources of a comma-join
+    normalize into a `Join` or hang off `From.expressions` varies by sqlglot version, so the walk
+    reads both and neither shape can hide a source behind a valid one.
+    """
+    _assert_unscopable(rt.check_scopable(sql, _scope_org()))
+
+
+def test_an_unscopable_source_in_a_set_operation_arm_is_refused():
+    """A table function hidden in the second `UNION` arm, behind a first arm that is entirely
+    declared. The walk is whole-tree rather than per-select for exactly this: a gate that judged
+    only the outermost select would return the right verdict for the wrong half of the statement."""
+    sql = "SELECT id FROM orders UNION SELECT g FROM generate_series(1,3) AS t(g)"
+    _assert_unscopable(rt.check_scopable(sql, _scope_org()))
+
+
+def test_an_unscopable_source_nested_in_a_subquery_is_refused():
+    """A derived subquery is a legal source, so the gate descends into one rather than accepting it
+    on sight — otherwise wrapping any construct in parentheses would be the bypass."""
+    sql = "SELECT s.g FROM (SELECT g FROM generate_series(1,3) AS t(g)) s"
+    _assert_unscopable(rt.check_scopable(sql, _scope_org()))
+
+
+# ===========================================================================
+# The allow-list — the gate is silent on everything the scope walk CAN read
+#
+# A fail-closed gate is only worth having if it does not refuse valid SQL, and this half is the
+# expensive half to get wrong: a false refusal here is a broken query on every deployment.
+# ===========================================================================
+
+@pytest.mark.parametrize("sql", [
+    pytest.param("SELECT id FROM orders", id="plain"),
+    pytest.param("SELECT o.id FROM orders o JOIN customers c ON c.id = o.id", id="join"),
+    pytest.param("SELECT o.id FROM orders o, customers c", id="comma-join"),
+    pytest.param("WITH t AS (SELECT id FROM orders) SELECT id FROM t", id="cte"),
+    pytest.param("SELECT x FROM (SELECT id AS x FROM orders) s", id="derived-subquery"),
+    pytest.param("SELECT x FROM (SELECT id AS x FROM (SELECT id FROM orders) i) s", id="nested"),
+    pytest.param("SELECT id FROM orders UNION SELECT id FROM customers", id="set-operation"),
+    pytest.param("SELECT 1", id="no-from"),
+    pytest.param("SELECT id FROM orders WHERE id IN (SELECT id FROM customers)", id="in-subquery"),
+])
+def test_a_scopable_statement_is_allowed(sql):
+    assert rt.check_scopable(sql, _scope_org()) is None
+
+
+def test_an_undeclared_table_is_not_this_gate_s_refusal():
+    """`secret` is undeclared, and that is a 4b reach for table scope to name — not a 4c
+    cannot-determine. A gate that refused here would be taking the other gate's verdict and
+    reporting the wrong reason for it, which is what the reason split exists to prevent."""
+    assert rt.check_scopable("SELECT id FROM secret", _scope_org()) is None
+    assert rt.check_table_scope("SELECT id FROM secret", _scope_org()) is not None
+
+
+def test_the_gate_is_inert_when_the_model_declares_no_tables():
+    """A deployment with no declared surface is not scoping anything, so there is nothing to be
+    unable to scope against. Matches `check_table_scope`'s empty-model no-op rather than inventing
+    a second posture for the same situation."""
+    org = m.Datasource(datasource="Shop",
+                       storage_connections=[m.StorageConnection(name="c",
+                                                                storage_type="PostgreSQL")],
+                       subject_areas=[])
+    assert rt.check_scopable("SELECT g FROM generate_series(1,3) AS t(g)", org) is None
+
+
+# ===========================================================================
+# Structural properties
+# ===========================================================================
+
+@pytest.mark.parametrize("sql", [p.values[0] for p in UNSCOPABLE] + [
+    "SELECT id FROM orders",
+    "WITH t AS (SELECT id FROM orders) SELECT id FROM t",
+])
+def test_the_shared_context_and_standalone_paths_agree(sql):
+    """Reusing `ctx.tree` must not change the verdict. A gate that re-parsed could disagree with the
+    tree every other gate judged, which is the divergence this whole family exists to prevent."""
+    org = _scope_org()
+    ctx = rt.build_guard_context(sql, org)
+    standalone, shared = rt.check_scopable(sql, org), rt.check_scopable(sql, org, ctx=ctx)
+    assert (standalone is None) == (shared is None)
+    if standalone is not None:
+        assert (standalone.rule, standalone.detail) == (shared.rule, shared.detail)
+
+
+def test_no_environment_variable_can_open_the_gate(monkeypatch):
+    """Principle 4 admits no waiver, and the earlier design of this gate shipped one:
+    `AGAMI_SQL_UNSCOPABLE_POSTURE=warn` logged and executed the statement anyway. It is asserted
+    absent rather than merely deleted, because a fail-open reintroduced behind an env var is exactly
+    the change that reads as an operational knob in review.
+    """
+    for name in ("AGAMI_SQL_UNSCOPABLE_POSTURE", "AGAMI_UNSCOPABLE_POSTURE",
+                 "AGAMI_SQL_SCOPABLE_POSTURE"):
+        for value in ("warn", "off", "disable", "0", "allow", "ignore"):
+            monkeypatch.setenv(name, value)
+            _assert_unscopable(
+                rt.check_scopable("SELECT g FROM generate_series(1,3) AS t(g)", _scope_org()))
+
+
+def test_the_rule_is_pinned_to_a_reason_the_contract_admits():
+    """The refusal vocabulary is closed at three. Asserted against the enum rather than by grep, so
+    a fourth reason cannot be introduced by this gate without failing here."""
+    assert guardrail.REASON_FOR_RULE[guardrail.RULE_UNSCOPABLE] == "undetermined"
+    assert guardrail.REASON_FOR_RULE[guardrail.RULE_UNSCOPABLE] in {
+        "unsafe", "out_of_scope", "undetermined"}

--- a/tests/test_scopable_gate.py
+++ b/tests/test_scopable_gate.py
@@ -86,14 +86,60 @@ UNSCOPABLE = [
     pytest.param("SELECT g FROM generate_series(1, 10) AS t(g)", id="table-function"),
     pytest.param("SELECT a FROM ROWS FROM (generate_series(1,3)) AS t(a)", id="rows-from"),
     pytest.param("SELECT x FROM (VALUES (1), (2)) AS v(x)", id="values"),
+    pytest.param("SELECT x FROM ((VALUES (1), (2))) AS v(x)", id="values-wrapped-in-a-subquery"),
     pytest.param("SELECT x FROM UNNEST(ARRAY[1,2]) AS t(x)", id="unnest"),
     pytest.param("SELECT o.id FROM orders o, LATERAL (SELECT 1 AS a) l", id="lateral"),
-    pytest.param("SELECT x FROM orders LATERAL VIEW explode(arr) t AS x", id="hive-lateral-view"),
 ]
 
 
 @pytest.mark.parametrize("sql", UNSCOPABLE)
 def test_an_unscopable_source_is_refused(sql):
+    _assert_unscopable(rt.check_scopable(sql, _scope_org()))
+
+
+def test_the_hive_lateral_view_spelling_is_refused_on_a_hive_family_engine():
+    """`LATERAL VIEW` is Hive's spelling, so it is asserted on Databricks rather than on the
+    PostgreSQL default.
+
+    Both dialects happen to parse it today, so this passed either way — but on PostgreSQL it was
+    passing because sqlglot is lenient about a construct that engine does not have, not because the
+    guard read the statement in its own grammar. A vector whose premise is an accident tells you
+    nothing the day the accident stops. It also exercises the half of the LATERAL sweep the Postgres
+    spelling does not: sqlglot hangs `LATERAL VIEW` off the Select rather than under a From/Join.
+    """
+    sql = "SELECT x FROM orders LATERAL VIEW explode(arr) t AS x"
+    _assert_unscopable(rt.check_scopable(sql, _scope_org("Databricks")))
+
+
+def test_a_values_arm_of_a_set_operation_is_refused():
+    """Found by review on this PR, and it executed against a real Postgres with all three gates
+    silent — `check_scopable`, `check_readable` and `check_table_scope` each returned `None`.
+
+    A parenthesized `VALUES` used as a set-operation arm is **not a FROM/JOIN source**: sqlglot
+    hangs it off the `Union` beside the select, so a walk over `From`/`Join` sources never reaches
+    it — while it contributes rows to the result exactly as an arm reading a table would. This is
+    why `VALUES` is a whole-tree sweep rather than a case in the source walk.
+    """
+    _assert_unscopable(rt.check_scopable("SELECT id FROM orders UNION ALL (VALUES (1))",
+                                         _scope_org()))
+
+
+@pytest.mark.parametrize("sql", [
+    pytest.param("SELECT o.id FROM orders o JOIN (VALUES (1),(2)) AS v(x) ON true", id="join"),
+    pytest.param("SELECT o.id FROM orders o CROSS JOIN (VALUES (1)) AS v(x)", id="cross-join"),
+    pytest.param("SELECT o.id FROM orders o WHERE o.id IN (SELECT x FROM (VALUES (1)) AS v(x))",
+                 id="in-subquery"),
+    pytest.param("SELECT o.id FROM orders o JOIN (SELECT * FROM (VALUES (1)) AS v(x)) s ON true",
+                 id="nested-in-a-derived-table"),
+    pytest.param("WITH v AS (SELECT * FROM (VALUES (1)) AS t(x)) SELECT o.id FROM orders o "
+                 "JOIN v ON true", id="cte-body"),
+    pytest.param("SELECT o.id FROM orders o JOIN UNNEST(ARRAY[1,2]) AS u(x) ON true",
+                 id="unnest-join"),
+])
+def test_every_placement_of_a_row_building_source_is_refused(sql):
+    """One declared table plus a row-building source, in each place SQL lets you put one. The gate
+    must not depend on which of them sqlglot chose to represent as a `Subquery` wrapper, which
+    varies by shape and by version."""
     _assert_unscopable(rt.check_scopable(sql, _scope_org()))
 
 


### PR DESCRIPTION
Rebuilt against `main` after ACE-079 (#194). The `agami-governance-branch` build (PR #112, orphaned on a non-mergeable base) was read for mechanism only — nothing was merged, rebased or cherry-picked from it.

## Triage — ACE-079 took most of this spec

`tests/test_parse_fidelity_gaps.py` carried two strict-xfail vectors naming ACE-037. **They already pass on main and carry no markers** (`14 passed` at `3f10a49`; `4 passed, 9 xfailed` at `5c2411d`). Under the `snowflake` dialect sqlglot parses `payload:cust.ssn` correctly and keeps the FROM, so the silent truncation was a dialect artifact, not a fail-closed gap. That file's own docstring now says so: *"Nothing here now depends on the unscopable-statement work."* **No xfail markers were removed by this PR — there were none left to remove.**

Also struck from the spec as ACE-079's: `unparseable`, the undeclared-engine refusal, the zero-named-table backstop, and every `error_level="ignore"` call site. Checked and found *adjacent, not overlapping*: `PreFlightResult.unchecked` (ACE-094) reports an undetermined analysis and never gates execution, and has no reader at all on the served path; ACE-097's chokepoint is the audit store and decides before any parse.

## What survived, measured

A table function parses to an `exp.Table` whose **name is empty**, the function in `.this`. ACE-079's backstop refuses a statement resolving to *no named table*, so it sees a table and passes. `check_table_scope` then skips the same node — `if not name ... continue` is how a CTE reference gets through. The one node no gate can name is the node both gates decline to judge, and one declared table leading a comma-join shields everything after it.

On `main` @ `3f10a49`, through `check_readable` → `check_table_scope` → `check_column_scope`:

| construct | before | after |
|---|---|---|
| `FROM generate_series(1,10) AS t(g)` | **executes** | `unscopable` |
| `FROM ROWS FROM (generate_series(1,3)) AS t(a)` | **executes** | `unscopable` |
| `FROM orders o, LATERAL (SELECT 1 AS a) l` | **executes** | `unscopable` |
| `FROM orders o, (VALUES (1),(2)) AS v(x)` | **executes** | `unscopable` |
| `FROM orders o, generate_series(1,10) AS t(g)` | **executes** | `unscopable` |
| `... UNION SELECT g FROM generate_series(1,3) AS t(g)` | **executes** | `unscopable` |
| `FROM (VALUES (1),(2)) AS v(x)` | refused (backstop) | `unscopable` |
| `FROM UNNEST(ARRAY[1,2]) AS t(x)` | refused (backstop) | `unscopable` |

Six of eight reached the database with every gate silent.

## The change

`runtime.py::check_scopable` — a 4c gate refusing `unscopable` / `undetermined`. Nothing about these statements is dangerous and nothing is out of scope; there is simply nothing to check. One whole-tree walk, so a comma-join, a derived subquery and every set-operation arm are covered by construction, and `From.expressions` is read alongside `.this` so the comma-join shape varying by sqlglot version does not open a hole. Reuses `ctx.tree` — a gate that re-parsed could disagree with the tree every other gate judged.

Wired in `_model_safety` between the readability gate and the scope gates, which is the gap it fills. **The scope gates are untouched:** their empty-name skip is load-bearing for CTE references and cannot be taught this distinction without breaking the case it exists for. **ACE-079's backstop stays where it is** — two producers of one rule is deliberate, since its clause is independent of the dialect map and fails closed for a quoting style nobody has mapped.

Also closes the third fail-open in that function's family: every gate opens with `if not _HAVE_SQLGLOT: return None`, so a hosted server whose sqlglot import failed resolved a model, reported itself guarded, and ran the statement with all gates inert. Same rule as its two siblings. The local path stays a no-op — a bare install legitimately has no parser.

No posture flag. The abandoned branch shipped `AGAMI_SQL_UNSCOPABLE_POSTURE=warn`, which logged and executed anyway; it is asserted absent over plausible spellings, not merely deleted.

## Verification

- `uv run dev.py check` → **3351 passed, 9 skipped**, ruff + gitleaks + vendored-mirror drift clean. `sync-lib` run (`execute_sql.py` is vendored; `runtime.py` is not).
- The reason is asserted **against the enum** — `REASON_FOR_RULE[RULE_UNSCOPABLE] == "undetermined"` — not by grep.
- **No false refusal:** plain selects, joins, comma-joins, CTEs, derived and nested subqueries, `IN` subqueries, set operations and `SELECT 1` all pass. ACE-079's whole suite stays green.
- Ordering asserted by verdict: unreadable → `unparseable`, unscopable → `unscopable`, undeclared table → `table_scope`.
- The corpus is asserted **at the chokepoint** through `_model_safety`, not only against the function.

## Notes

- ACE-071's `depends_on: ACE-037` still holds — `_model_safety`'s import branch names ACE-037 in its own comment on main, and its local twin still returns the statement untouched. ACE-040 also still depends on this.
- `tests/safety/**` and `tests/e2e/**` untouched (corpus agent); `assemble_receipt`'s body untouched (ACE-058/059/060).
- Could not verify the spec's claim that the differential corpus is "folded into ACE-040" — ACE-040 is still `in-review`, so the corpus lives here in `tests/test_scopable_gate.py` and at the chokepoint in `test_ace051_fail_closed.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)