### PR TITLE
ACE-071: the executor that already says "undetermined" refuses, instead of executing anyway

### DIFF
--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1777,6 +1777,23 @@ def _engine_mismatch(profile: str, creds: dict) -> "Refusal | None":
     )
 
 
+def _disk_model_root(profile: str) -> Path | None:
+    """The on-disk model root for `profile`, or None when no model is declared there.
+
+    Stdlib-only and free of any `semantic_model` import, deliberately: the fail-closed branch in
+    `_model_safety` that calls this runs on the interpreter where that package is absent, and
+    `_resolve_guard_model` below — the other caller — is unreachable there, since its own first
+    statement imports `semantic_model.loader`.
+
+    One definition rather than two copies of the same expression, because the two callers must agree
+    about whether a model exists. If they drifted apart, the package-less path would refuse where the
+    supported path would not have enforced (a false positive that breaks a working install) or stay
+    silent where it would have (the hole ACE-071 closes).
+    """
+    root = Path(os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")) / profile
+    return root if (root / "datasource.yaml").exists() else None
+
+
 def _resolve_guard_model(profile: str):
     """Resolve the semantic model for the safety pass, mirroring `tools._load_org` (ACE-051): from
     the DB when one is configured (hosted — the `/artifacts` disk mount may be absent), else the
@@ -1816,8 +1833,8 @@ def _resolve_guard_model(profile: str):
         except Exception:
             pass  # DB unreachable/misconfigured -> fall through to disk
 
-    root = Path(os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")) / profile
-    if (root / "datasource.yaml").exists():
+    root = _disk_model_root(profile)
+    if root is not None:
         try:
             return L.load_datasource(root)
         except Exception:
@@ -1862,9 +1879,11 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
 
     Returns ``(sql_to_run, verdict)``. ``verdict`` is ``None`` to continue or a ``Refusal`` from
     whichever gate chose it — there is no third thing, so every refusal names its own rule. Inert
-    (returns the SQL unchanged) when the
-    model package isn't importable, or — on the LOCAL path only — when there is no model yet. On the
-    HOSTED path a model that can't be resolved fails closed (refuses), never runs unguarded (ACE-051).
+    (returns the SQL unchanged) only when no model is DECLARED for the profile: a local install with
+    nothing built yet has no declared surface, so no gate has anything to enforce. Every other
+    "cannot guarantee safety" state refuses — on the HOSTED path when the model cannot be resolved or
+    the package/parser is missing (ACE-051), and on the LOCAL path when the guards cannot be imported
+    while a model does exist on disk (ACE-071).
 
     Every branch writes NOTHING: it hands the contract object back and ``execute_guarded`` puts it
     in the Envelope, so the in-process caller sees the same rule the forked one does. The fan/chasm
@@ -1889,9 +1908,33 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
                        "hosted server",
                 remediation="Install the semantic-model dependencies on the server and retry.",
             )
-        # The non-hosted twin: a bare local install legitimately has no model package, so this is a
-        # silent no-op rather than a refusal. Not a branch to convert — there is nothing to refuse.
-        return sql, None  # local: model package not available -> no-op
+        # The local twin, in two halves (ACE-071). This path is the VENDORED slice — the one
+        # `python3 -m execute_sql` resolves, which ships no `runtime.py` — so table scope, the star
+        # ban and column scope cannot run here at all. `_receipt_for` already concedes exactly that,
+        # returning `undetermined_receipt(RECEIPT_NO_RUNTIME)`, and principle 4c makes undetermined a
+        # refusal. The gap was never missing information: we published the conclusion and then
+        # executed anyway.
+        #
+        # So: refuse when a model is DECLARED for this profile, because the user has a declared
+        # surface and believes it is being enforced, and 4b reach is exactly what is unchecked here.
+        # `_hosted()` is deliberately not consulted — both interpreters in question are local, and
+        # what separates them is which one can import the guards, not where they run.
+        if _disk_model_root(profile) is not None:
+            # Value-free, like its hosted siblings: it names no resolved path, no profile directory,
+            # no DSN. The remediation names the supported invocation, which is the whole actionable
+            # content — the model is fine, the interpreter is the problem.
+            return sql, refuse(
+                RULE_MODEL_UNAVAILABLE,
+                detail="the semantic-model package is not importable on this interpreter, so table "
+                       "and column scope could not run against the model declared for this profile",
+                remediation="Run this through the interpreter that has the semantic-model package "
+                            "installed (the project virtualenv), then retry.",
+            )
+        # And stay inert with no model on disk. A bare install between `pip install` and its first
+        # `agami-connect` has no declared surface, so there is nothing 4b could be exceeded against
+        # and nothing 4c could be undetermined about. Refusing here would break every user in that
+        # window to close a hole that is not open.
+        return sql, None  # local: no model declared -> no-op
 
     org = _resolve_guard_model(profile)
     # Published for the receipt builder before any gate can refuse, so a refusal's receipt is built

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1892,7 +1892,7 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
     """
     try:
         from semantic_model import runtime as RT
-    except Exception:
+    except Exception as exc:
         # The model package (pydantic) isn't importable, so the guards can't run at all. On the
         # hosted served path that is the same "can't guarantee safety" condition as a missing model
         # — fail closed. Locally it stays a no-op (a bare install legitimately has no model). The
@@ -1920,16 +1920,32 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
         # `_hosted()` is deliberately not consulted — both interpreters in question are local, and
         # what separates them is which one can import the guards, not where they run.
         if _disk_model_root(profile) is not None:
-            # Value-free, like its hosted siblings: it names no resolved path, no profile directory,
-            # no DSN. The remediation names the supported invocation, which is the whole actionable
-            # content — the model is fine, the interpreter is the problem.
-            return sql, refuse(
-                RULE_MODEL_UNAVAILABLE,
-                detail="the semantic-model package is not importable on this interpreter, so table "
-                       "and column scope could not run against the model declared for this profile",
-                remediation="Run this through the interpreter that has the semantic-model package "
-                            "installed (the project virtualenv), then retry.",
-            )
+            # Absent and broken are two different facts, and `_receipt_for` below already refuses to
+            # report them as one — it answers `RECEIPT_NO_RUNTIME` to an ImportError and
+            # `RECEIPT_BUILD_FAILED`, logged, to anything else. This arm catches `Exception`, so the
+            # refusal has to make the same distinction or it states the wrong one with confidence:
+            # a package that IS installed and raised while importing itself would be reported as
+            # missing, sending the user to swap interpreters when the interpreter is not the problem
+            # and leaving the real traceback unlogged.
+            #
+            # Both cases still refuse. Which of them it is changes what we can honestly say, not
+            # whether the guards ran — they did not, either way.
+            if isinstance(exc, ImportError):
+                # Value-free, like its hosted siblings: no resolved path, no profile directory, no
+                # DSN. The remediation names the supported invocation, which is the whole actionable
+                # content — the model is fine, the interpreter is.
+                detail = ("the semantic-model package is not importable on this interpreter, so "
+                          "table and column scope could not run against the model declared for this "
+                          "profile")
+                remediation = ("Run this through the interpreter that has the semantic-model "
+                               "package installed (the project virtualenv), then retry.")
+            else:
+                _LOG.error("the semantic-model runtime failed to import", exc_info=True)
+                detail = ("the semantic-model package failed to load, so table and column scope "
+                          "could not run against the model declared for this profile")
+                remediation = ("Check the server log for the import error, repair the "
+                               "semantic-model installation, then retry.")
+            return sql, refuse(RULE_MODEL_UNAVAILABLE, detail=detail, remediation=remediation)
         # And stay inert with no model on disk. A bare install between `pip install` and its first
         # `agami-connect` has no declared surface, so there is nothing 4b could be exceeded against
         # and nothing 4c could be undetermined about. Refusing here would break every user in that

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -1919,7 +1919,20 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
         # surface and believes it is being enforced, and 4b reach is exactly what is unchecked here.
         # `_hosted()` is deliberately not consulted — both interpreters in question are local, and
         # what separates them is which one can import the guards, not where they run.
-        if _disk_model_root(profile) is not None:
+        try:
+            declared = _disk_model_root(profile) is not None
+        except OSError:
+            # `Path.exists()` re-raises a non-ignorable OSError rather than answering False —
+            # EACCES on a TCC-protected folder, EPERM on a locked volume, ESTALE on NFS. Left to
+            # propagate it would escape this except arm entirely (an exception raised inside one is
+            # not caught by its own try), surface as `failed`/`other` with no remediation, and put
+            # the resolved artifacts path on stderr in a traceback.
+            #
+            # So treat "cannot tell" as declared. That is the fail-closed direction: the fail-open
+            # one is answering None, which returns the statement unchecked on a machine where we
+            # could not even read whether there was a model to check it against.
+            declared = True
+        if declared:
             # Absent and broken are two different facts, and `_receipt_for` below already refuses to
             # report them as one — it answers `RECEIPT_NO_RUNTIME` to an ImportError and
             # `RECEIPT_BUILD_FAILED`, logged, to anything else. This arm catches `Exception`, so the
@@ -1943,8 +1956,13 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
                 _LOG.error("the semantic-model runtime failed to import", exc_info=True)
                 detail = ("the semantic-model package failed to load, so table and column scope "
                           "could not run against the model declared for this profile")
-                remediation = ("Check the server log for the import error, repair the "
-                               "semantic-model installation, then retry.")
+                # Not "check the server log": `_hosted()` returned above, so this arm is local by
+                # construction and there is no server. The CLI child silences `_LOG` because its
+                # stderr is the refusal wire, so the traceback reaches a log only for an in-process
+                # caller that configured one. What is always true, and is the actionable half, is
+                # that the installation on this interpreter is broken rather than absent.
+                remediation = ("Reinstall the semantic-model package and its dependencies on this "
+                               "interpreter, then retry.")
             return sql, refuse(RULE_MODEL_UNAVAILABLE, detail=detail, remediation=remediation)
         # And stay inert with no model on disk. A bare install between `pip install` and its first
         # `agami-connect` has no declared surface, so there is nothing 4b could be exceeded against
@@ -2621,6 +2639,17 @@ def main() -> int:
     # recorder were not in one process.
     _RAW_LOG.addHandler(logging.NullHandler())
     _RAW_LOG.propagate = False
+
+    # `_LOG` is silenced for the same reason and it is not a lesser one. This module never configures
+    # logging, so an unsilenced `_LOG.error(..., exc_info=True)` also falls through to
+    # `logging.lastResort` and onto stderr — where a traceback, absolute paths and all, both breaks
+    # the single-JSON-object contract `_write_refusal` owns and rides back into the caller's answer
+    # via the parent's stderr relay. Two call sites reach it on a refusing path: the broken-package
+    # arm of `_model_safety` and `_receipt_for`'s build-failure arm. Neither can write here, because
+    # on this entry point stderr IS the wire. An in-process caller that configures logging still gets
+    # both records; the CLI child drops them, exactly as it drops raw driver detail above.
+    _LOG.addHandler(logging.NullHandler())
+    _LOG.propagate = False
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1777,6 +1777,23 @@ def _engine_mismatch(profile: str, creds: dict) -> "Refusal | None":
     )
 
 
+def _disk_model_root(profile: str) -> Path | None:
+    """The on-disk model root for `profile`, or None when no model is declared there.
+
+    Stdlib-only and free of any `semantic_model` import, deliberately: the fail-closed branch in
+    `_model_safety` that calls this runs on the interpreter where that package is absent, and
+    `_resolve_guard_model` below — the other caller — is unreachable there, since its own first
+    statement imports `semantic_model.loader`.
+
+    One definition rather than two copies of the same expression, because the two callers must agree
+    about whether a model exists. If they drifted apart, the package-less path would refuse where the
+    supported path would not have enforced (a false positive that breaks a working install) or stay
+    silent where it would have (the hole ACE-071 closes).
+    """
+    root = Path(os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")) / profile
+    return root if (root / "datasource.yaml").exists() else None
+
+
 def _resolve_guard_model(profile: str):
     """Resolve the semantic model for the safety pass, mirroring `tools._load_org` (ACE-051): from
     the DB when one is configured (hosted — the `/artifacts` disk mount may be absent), else the
@@ -1816,8 +1833,8 @@ def _resolve_guard_model(profile: str):
         except Exception:
             pass  # DB unreachable/misconfigured -> fall through to disk
 
-    root = Path(os.environ.get("AGAMI_ARTIFACTS_DIR") or (Path.home() / "agami-artifacts")) / profile
-    if (root / "datasource.yaml").exists():
+    root = _disk_model_root(profile)
+    if root is not None:
         try:
             return L.load_datasource(root)
         except Exception:
@@ -1862,9 +1879,11 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
 
     Returns ``(sql_to_run, verdict)``. ``verdict`` is ``None`` to continue or a ``Refusal`` from
     whichever gate chose it — there is no third thing, so every refusal names its own rule. Inert
-    (returns the SQL unchanged) when the
-    model package isn't importable, or — on the LOCAL path only — when there is no model yet. On the
-    HOSTED path a model that can't be resolved fails closed (refuses), never runs unguarded (ACE-051).
+    (returns the SQL unchanged) only when no model is DECLARED for the profile: a local install with
+    nothing built yet has no declared surface, so no gate has anything to enforce. Every other
+    "cannot guarantee safety" state refuses — on the HOSTED path when the model cannot be resolved or
+    the package/parser is missing (ACE-051), and on the LOCAL path when the guards cannot be imported
+    while a model does exist on disk (ACE-071).
 
     Every branch writes NOTHING: it hands the contract object back and ``execute_guarded`` puts it
     in the Envelope, so the in-process caller sees the same rule the forked one does. The fan/chasm
@@ -1889,9 +1908,33 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
                        "hosted server",
                 remediation="Install the semantic-model dependencies on the server and retry.",
             )
-        # The non-hosted twin: a bare local install legitimately has no model package, so this is a
-        # silent no-op rather than a refusal. Not a branch to convert — there is nothing to refuse.
-        return sql, None  # local: model package not available -> no-op
+        # The local twin, in two halves (ACE-071). This path is the VENDORED slice — the one
+        # `python3 -m execute_sql` resolves, which ships no `runtime.py` — so table scope, the star
+        # ban and column scope cannot run here at all. `_receipt_for` already concedes exactly that,
+        # returning `undetermined_receipt(RECEIPT_NO_RUNTIME)`, and principle 4c makes undetermined a
+        # refusal. The gap was never missing information: we published the conclusion and then
+        # executed anyway.
+        #
+        # So: refuse when a model is DECLARED for this profile, because the user has a declared
+        # surface and believes it is being enforced, and 4b reach is exactly what is unchecked here.
+        # `_hosted()` is deliberately not consulted — both interpreters in question are local, and
+        # what separates them is which one can import the guards, not where they run.
+        if _disk_model_root(profile) is not None:
+            # Value-free, like its hosted siblings: it names no resolved path, no profile directory,
+            # no DSN. The remediation names the supported invocation, which is the whole actionable
+            # content — the model is fine, the interpreter is the problem.
+            return sql, refuse(
+                RULE_MODEL_UNAVAILABLE,
+                detail="the semantic-model package is not importable on this interpreter, so table "
+                       "and column scope could not run against the model declared for this profile",
+                remediation="Run this through the interpreter that has the semantic-model package "
+                            "installed (the project virtualenv), then retry.",
+            )
+        # And stay inert with no model on disk. A bare install between `pip install` and its first
+        # `agami-connect` has no declared surface, so there is nothing 4b could be exceeded against
+        # and nothing 4c could be undetermined about. Refusing here would break every user in that
+        # window to close a hole that is not open.
+        return sql, None  # local: no model declared -> no-op
 
     org = _resolve_guard_model(profile)
     # Published for the receipt builder before any gate can refuse, so a refusal's receipt is built

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1892,7 +1892,7 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
     """
     try:
         from semantic_model import runtime as RT
-    except Exception:
+    except Exception as exc:
         # The model package (pydantic) isn't importable, so the guards can't run at all. On the
         # hosted served path that is the same "can't guarantee safety" condition as a missing model
         # — fail closed. Locally it stays a no-op (a bare install legitimately has no model). The
@@ -1920,16 +1920,32 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
         # `_hosted()` is deliberately not consulted — both interpreters in question are local, and
         # what separates them is which one can import the guards, not where they run.
         if _disk_model_root(profile) is not None:
-            # Value-free, like its hosted siblings: it names no resolved path, no profile directory,
-            # no DSN. The remediation names the supported invocation, which is the whole actionable
-            # content — the model is fine, the interpreter is the problem.
-            return sql, refuse(
-                RULE_MODEL_UNAVAILABLE,
-                detail="the semantic-model package is not importable on this interpreter, so table "
-                       "and column scope could not run against the model declared for this profile",
-                remediation="Run this through the interpreter that has the semantic-model package "
-                            "installed (the project virtualenv), then retry.",
-            )
+            # Absent and broken are two different facts, and `_receipt_for` below already refuses to
+            # report them as one — it answers `RECEIPT_NO_RUNTIME` to an ImportError and
+            # `RECEIPT_BUILD_FAILED`, logged, to anything else. This arm catches `Exception`, so the
+            # refusal has to make the same distinction or it states the wrong one with confidence:
+            # a package that IS installed and raised while importing itself would be reported as
+            # missing, sending the user to swap interpreters when the interpreter is not the problem
+            # and leaving the real traceback unlogged.
+            #
+            # Both cases still refuse. Which of them it is changes what we can honestly say, not
+            # whether the guards ran — they did not, either way.
+            if isinstance(exc, ImportError):
+                # Value-free, like its hosted siblings: no resolved path, no profile directory, no
+                # DSN. The remediation names the supported invocation, which is the whole actionable
+                # content — the model is fine, the interpreter is.
+                detail = ("the semantic-model package is not importable on this interpreter, so "
+                          "table and column scope could not run against the model declared for this "
+                          "profile")
+                remediation = ("Run this through the interpreter that has the semantic-model "
+                               "package installed (the project virtualenv), then retry.")
+            else:
+                _LOG.error("the semantic-model runtime failed to import", exc_info=True)
+                detail = ("the semantic-model package failed to load, so table and column scope "
+                          "could not run against the model declared for this profile")
+                remediation = ("Check the server log for the import error, repair the "
+                               "semantic-model installation, then retry.")
+            return sql, refuse(RULE_MODEL_UNAVAILABLE, detail=detail, remediation=remediation)
         # And stay inert with no model on disk. A bare install between `pip install` and its first
         # `agami-connect` has no declared surface, so there is nothing 4b could be exceeded against
         # and nothing 4c could be undetermined about. Refusing here would break every user in that

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -1919,7 +1919,20 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
         # surface and believes it is being enforced, and 4b reach is exactly what is unchecked here.
         # `_hosted()` is deliberately not consulted — both interpreters in question are local, and
         # what separates them is which one can import the guards, not where they run.
-        if _disk_model_root(profile) is not None:
+        try:
+            declared = _disk_model_root(profile) is not None
+        except OSError:
+            # `Path.exists()` re-raises a non-ignorable OSError rather than answering False —
+            # EACCES on a TCC-protected folder, EPERM on a locked volume, ESTALE on NFS. Left to
+            # propagate it would escape this except arm entirely (an exception raised inside one is
+            # not caught by its own try), surface as `failed`/`other` with no remediation, and put
+            # the resolved artifacts path on stderr in a traceback.
+            #
+            # So treat "cannot tell" as declared. That is the fail-closed direction: the fail-open
+            # one is answering None, which returns the statement unchecked on a machine where we
+            # could not even read whether there was a model to check it against.
+            declared = True
+        if declared:
             # Absent and broken are two different facts, and `_receipt_for` below already refuses to
             # report them as one — it answers `RECEIPT_NO_RUNTIME` to an ImportError and
             # `RECEIPT_BUILD_FAILED`, logged, to anything else. This arm catches `Exception`, so the
@@ -1943,8 +1956,13 @@ def _model_safety(sql: str, profile: str, area: str | None) -> tuple[str, Refusa
                 _LOG.error("the semantic-model runtime failed to import", exc_info=True)
                 detail = ("the semantic-model package failed to load, so table and column scope "
                           "could not run against the model declared for this profile")
-                remediation = ("Check the server log for the import error, repair the "
-                               "semantic-model installation, then retry.")
+                # Not "check the server log": `_hosted()` returned above, so this arm is local by
+                # construction and there is no server. The CLI child silences `_LOG` because its
+                # stderr is the refusal wire, so the traceback reaches a log only for an in-process
+                # caller that configured one. What is always true, and is the actionable half, is
+                # that the installation on this interpreter is broken rather than absent.
+                remediation = ("Reinstall the semantic-model package and its dependencies on this "
+                               "interpreter, then retry.")
             return sql, refuse(RULE_MODEL_UNAVAILABLE, detail=detail, remediation=remediation)
         # And stay inert with no model on disk. A bare install between `pip install` and its first
         # `agami-connect` has no declared surface, so there is nothing 4b could be exceeded against
@@ -2621,6 +2639,17 @@ def main() -> int:
     # recorder were not in one process.
     _RAW_LOG.addHandler(logging.NullHandler())
     _RAW_LOG.propagate = False
+
+    # `_LOG` is silenced for the same reason and it is not a lesser one. This module never configures
+    # logging, so an unsilenced `_LOG.error(..., exc_info=True)` also falls through to
+    # `logging.lastResort` and onto stderr — where a traceback, absolute paths and all, both breaks
+    # the single-JSON-object contract `_write_refusal` owns and rides back into the caller's answer
+    # via the parent's stderr relay. Two call sites reach it on a refusing path: the broken-package
+    # arm of `_model_safety` and `_receipt_for`'s build-failure arm. Neither can write here, because
+    # on this entry point stderr IS the wire. An in-process caller that configures logging still gets
+    # both records; the CLI child drops them, exactly as it drops raw driver detail above.
+    _LOG.addHandler(logging.NullHandler())
+    _LOG.propagate = False
 
     if args.sql_file:
         sql = Path(os.path.expanduser(args.sql_file)).read_text()

--- a/tests/test_ace071_entry_point_parity.py
+++ b/tests/test_ace071_entry_point_parity.py
@@ -34,6 +34,7 @@ import pytest
 
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlglot")
+pytest.importorskip("yaml")  # `_write_model` builds the fixture model with it
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
@@ -333,3 +334,52 @@ def test_the_supported_interpreter_enforces_what_the_package_less_one_refuses(
     # the statement did rather than what the deployment could not do.
     assert _refusal(refused).rule == guardrail.RULE_TABLE_SCOPE
     _silent(capsys)
+
+
+def test_a_package_that_raises_is_not_reported_as_a_package_that_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Absent and broken are two different facts. `_receipt_for` already refuses to report them as
+    one — `RECEIPT_NO_RUNTIME` for an ImportError, `RECEIPT_BUILD_FAILED` (logged) for anything
+    else. The refusal this spec adds sits under an `except Exception`, so it has to draw the same
+    line: an installed package that raised while importing itself must not be described as missing,
+    which would send the user to swap interpreters when the interpreter is not the problem, and
+    would leave the real traceback unlogged.
+
+    Both cases still refuse. Which one it is changes what we can honestly say, not whether the
+    guards ran."""
+    import builtins
+    import logging
+
+    real_import = builtins.__import__
+
+    def boom(name, _globals=None, _locals=None, fromlist=(), level=0):  # type: ignore[no-untyped-def]
+        if name == "semantic_model" and fromlist and "runtime" in fromlist:
+            raise RuntimeError("forced: the package is installed and raised while importing")
+        return real_import(name, _globals, _locals, fromlist, level)
+
+    artifacts = tmp_path / "art"
+    _write_model(artifacts / PROFILE)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(artifacts))
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    monkeypatch.setattr(builtins, "__import__", boom)
+
+    with caplog.at_level(logging.ERROR):
+        _, verdict = execute_sql._model_safety(IN_SCOPE_SQL, PROFILE, None)
+
+    refusal = _refusal(verdict)
+    # Still fail-closed, and still the same rule: the guards did not run either way.
+    assert refusal.rule == guardrail.RULE_MODEL_UNAVAILABLE
+    assert refusal.reason == guardrail.REASON_FOR_RULE[guardrail.RULE_MODEL_UNAVAILABLE]
+    # But it does not claim the package is missing, and it does not send the user to another
+    # interpreter — that advice is inert when the package is installed and broken.
+    assert "not importable" not in refusal.detail
+    assert "virtualenv" not in refusal.remediation
+    # And the real failure is not swallowed: the traceback reaches the log.
+    assert any(r.levelno >= logging.ERROR for r in caplog.records), caplog.text
+
+    # Still value-free — the same bar the ImportError arm clears.
+    text = json.dumps({"reason": refusal.reason, "rule": refusal.rule,
+                       "detail": refusal.detail, "remediation": refusal.remediation})
+    assert str(tmp_path) not in text

--- a/tests/test_ace071_entry_point_parity.py
+++ b/tests/test_ace071_entry_point_parity.py
@@ -383,3 +383,92 @@ def test_a_package_that_raises_is_not_reported_as_a_package_that_is_absent(
     text = json.dumps({"reason": refusal.reason, "rule": refusal.rule,
                        "detail": refusal.detail, "remediation": refusal.remediation})
     assert str(tmp_path) not in text
+
+
+# A broken vendored slice, built by shadowing the runtime module the real one does not ship. Writing
+# `semantic_model/runtime.py` into a COPY of the vendored dir is the only way to reach the
+# broken-package arm through the CLI: the arm is chosen by what the import raises, and a child
+# process cannot be monkeypatched.
+_BROKEN_RUNTIME = "raise RuntimeError('forced: installed and raising while importing')\n"
+
+
+def _broken_slice(root: Path) -> Path:
+    """A copy of the vendored slice whose `semantic_model.runtime` raises a non-ImportError."""
+    import shutil
+
+    lib = root / "brokenlib"
+    shutil.copytree(VENDORED_LIB, lib, ignore=shutil.ignore_patterns("__pycache__"))
+    (lib / "semantic_model" / "runtime.py").write_text(_BROKEN_RUNTIME)
+    return lib
+
+
+def test_the_broken_package_refusal_survives_the_wire_it_travels(tmp_path: Path) -> None:
+    """The refusal is only worth adding if the caller can still read it.
+
+    On this entry point stderr IS the wire: `_write_refusal` puts one JSON object there and several
+    callers, plus the fail-closed suite, parse the WHOLE stream as that object. A traceback printed
+    alongside it does not merely add noise, it destroys the refusal — and the parent relays the
+    child's stderr into `failure.message`, so the traceback's absolute paths would arrive in the
+    caller's answer, which is the ACE-039 leak class through a different logger.
+
+    The broken-package arm logs, so it is the arm that can break this. It only stayed readable
+    because `main` silences `_LOG` as well as `_RAW_LOG`.
+    """
+    _require_a_package_less_interpreter()
+    artifacts = tmp_path / "art"
+    _write_model(artifacts / PROFILE)
+    lib = _broken_slice(tmp_path)
+
+    proc = subprocess.run([*_NOPKG, "-m", "execute_sql", "--profile", PROFILE, "--sql", IN_SCOPE_SQL],
+                          env=_child_env(artifacts, pythonpath=str(lib)),
+                          capture_output=True, text=True)
+
+    assert proc.returncode == 1, proc.stderr
+    assert proc.stdout == ""  # no partial CSV alongside a refusal
+    assert proc.stderr.count("\n") == 1, proc.stderr  # one line, so no traceback rode along
+    payload = json.loads(proc.stderr)  # parses WHOLE -> a single object
+    assert set(payload) == {"refusal"}
+    refusal = guardrail.Refusal(**payload["refusal"])
+    assert refusal.rule == guardrail.RULE_MODEL_UNAVAILABLE
+    # And it is the broken-package wording, not the absent-package one.
+    assert "not importable" not in refusal.detail
+    # Nothing about where anything lives reached the caller — the traceback would have carried the
+    # slice's and the artifacts' absolute paths.
+    assert str(tmp_path) not in proc.stderr
+
+
+def test_a_probe_that_cannot_read_the_disk_refuses_rather_than_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`Path.exists()` answers False only for a path that is absent. For one it may not read at all
+    — EACCES under macOS TCC, EPERM on a locked volume, ESTALE on NFS — it raises, and this probe
+    runs INSIDE an `except` arm, where a raise escapes the enclosing `try` entirely.
+
+    Unhandled, that surfaces as `failed`/`other` with no remediation and a traceback carrying the
+    resolved artifacts path. Handled the wrong way — answering None — it is worse than either: the
+    statement runs unchecked on a machine where we could not read whether there was a model to
+    check it against. So doubt counts as declared, and the caller gets the refusal.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_runtime(name, _globals=None, _locals=None, fromlist=(), level=0):  # type: ignore[no-untyped-def]
+        if name == "semantic_model" and fromlist and "runtime" in fromlist:
+            raise ImportError("forced: semantic_model.runtime unavailable")
+        return real_import(name, _globals, _locals, fromlist, level)
+
+    def unreadable(_self: Path) -> bool:
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path / "art"))
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+    monkeypatch.setattr(builtins, "__import__", no_runtime)
+    monkeypatch.setattr(Path, "exists", unreadable)
+
+    _, verdict = execute_sql._model_safety(IN_SCOPE_SQL, PROFILE, None)
+
+    refusal = _refusal(verdict)  # a refusal, not an escaped PermissionError
+    assert refusal.rule == guardrail.RULE_MODEL_UNAVAILABLE
+    _silent(capsys)

--- a/tests/test_ace071_entry_point_parity.py
+++ b/tests/test_ace071_entry_point_parity.py
@@ -1,0 +1,335 @@
+"""ACE-071 — a statement whose reach cannot be determined is refused on the entry point that cannot
+determine it, and the two entry points agree about everything else.
+
+`python3 -m execute_sql` is the invocation the plugin README documents, and it resolves the vendored
+stdlib-only slice, which ships `semantic_model/__init__.py` and `units.py` and no runtime at all.
+Table scope, the `SELECT *` ban and column scope therefore cannot run there. `_receipt_for` already
+conceded exactly that, returning `undetermined_receipt(RECEIPT_NO_RUNTIME)` — so the executor
+published "I could not determine what this statement reaches" and then executed it anyway. Principle
+4c makes undetermined a refusal, so that path now refuses whenever a model is DECLARED for the
+profile, and stays inert only when none is (a bare install before its first `agami-connect` has no
+declared surface, so nothing about it is undetermined).
+
+This file is the entry-point parity test: the same statement against the same on-disk model, run
+from the supported virtualenv interpreter (in process) and from the package-less one (a child
+started with `-S`, which disables site.py so the installed package is invisible). The two must agree
+that a write is refused and that neither ever runs a statement it has not checked. Where they
+legitimately differ is which of those two things happens: the supported interpreter ENFORCES the
+scope gates, and the package-less one REFUSES because it cannot.
+
+The `-S` device is the one `tests/test_ace088_receipt_placement.py` uses to pin the degraded
+receipt, and the layout it depends on is pinned by `tests/test_plugin_lib_resolution.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import execute_sql  # noqa: E402
+import guardrail  # noqa: E402
+
+VENDORED_LIB = REPO_ROOT / "plugins" / "agami" / "lib"
+
+# One profile and one statement for the whole file, so "the same statement against the same on-disk
+# model" is a property of the file rather than something each test has to restate.
+PROFILE = "acme"
+IN_SCOPE_SQL = "SELECT id FROM orders"
+OUT_OF_SCOPE_SQL = "SELECT id FROM invoices"
+WRITE_SQL = "DROP TABLE orders"
+
+# `-S` disables site.py, so the installed agami-core is invisible and only the vendored `lib/` slice
+# is importable — the state a marketplace user's plain `python3` is in.
+_NOPKG = [sys.executable, "-S"]
+
+# Reports BOTH what the safety pass RETURNS and what the chokepoint's Envelope CARRIES, because
+# those are the two questions this file asks of the package-less interpreter and one process start
+# answers both. It carries its own executor stub rather than importing the module-level one below:
+# a child that cannot see the installed package cannot see this test module either.
+_CHILD_PROBE = """
+import json
+import sys
+
+sys.path.insert(0, sys.argv[1])
+
+import execute_sql
+
+
+class _NeverRuns:
+    def execute(self, vetted_sql, creds, *, profile):
+        raise AssertionError("the executor must not be reached on a statement that was refused")
+
+
+sql, verdict = execute_sql._model_safety(sys.argv[2], sys.argv[3], None)
+envelope = execute_sql.execute_guarded(sys.argv[2], sys.argv[3], None, executor=_NeverRuns())
+print(json.dumps({
+    "safety": {
+        "refused": verdict is not None,
+        "sql_unchanged": sql == sys.argv[2],
+        "reason": getattr(verdict, "reason", None),
+        "rule": getattr(verdict, "rule", None),
+        "detail": getattr(verdict, "detail", None),
+        "remediation": getattr(verdict, "remediation", None),
+    },
+    "envelope": {
+        "status": envelope.status,
+        "reason": getattr(envelope.refusal, "reason", None),
+        "rule": getattr(envelope.refusal, "rule", None),
+        "receipt_undetermined": envelope.receipt.tables.undetermined,
+    },
+}))
+"""
+
+
+class _NeverRuns:
+    """An executor that fails the test if the chokepoint ever reaches it.
+
+    Every statement this file sends is refused above the executor, so being called at all is the
+    defect under test rather than an incidental setup detail.
+    """
+
+    def execute(self, vetted_sql: str, creds: dict[str, str], *, profile: str) -> None:
+        raise AssertionError("the executor must not be reached on a statement that was refused")
+
+
+def _silent(capsys: pytest.CaptureFixture[str]) -> None:
+    """Assert the in-process branch wrote nothing.
+
+    A gate returns its `Refusal`; the ONE writer is `main`. Anything on stderr from here would be a
+    diagnostic that precedes the refusal on the wire — exactly what makes the stream unparseable to
+    the parent that reads it.
+    """
+    captured = capsys.readouterr()
+    assert captured.err == "", captured.err
+    assert captured.out == "", captured.out
+
+
+def _refusal(verdict: Any) -> guardrail.Refusal:
+    """The verdict, asserted to be a real contract `Refusal` rather than a bare sentinel."""
+    assert isinstance(verdict, guardrail.Refusal), verdict
+    return verdict
+
+
+def _write_model(root: Path) -> None:
+    """Write a loadable two-table model for `AcmeCorp` at `root`.
+
+    A real, parseable model rather than a stub file, even though the branch under test only asks
+    whether `datasource.yaml` EXISTS (it refuses before `_resolve_guard_model` is ever reached, and
+    an empty file fires it just as well). The supported interpreter has to LOAD this same directory
+    to enforce the scope gates against it, and the parity claim is about one on-disk model seen by
+    two interpreters — a model only one of them could read would be two models.
+    """
+    import yaml
+
+    (root / "subject_areas" / "sales" / "tables").mkdir(parents=True)
+    (root / "datasource.yaml").write_text(
+        yaml.safe_dump({"datasource": "AcmeCorp", "version": 1,
+                        "storage_connections": [{"name": "c", "storage_type": "PostgreSQL"}],
+                        "subject_areas": ["subject_areas/sales"]})
+    )
+    (root / "subject_areas" / "sales" / "subject_area.yaml").write_text(
+        yaml.safe_dump({"name": "sales", "tables": [
+            {"storage_connection": "c", "schema": "public", "table": "orders"},
+            {"storage_connection": "c", "schema": "public", "table": "customers"}]})
+    )
+    for table in ("orders", "customers"):
+        (root / "subject_areas" / "sales" / "tables" / f"{table}.yaml").write_text(
+            yaml.safe_dump({"name": table, "schema": "public", "storage_connection": "c",
+                            "grain": ["id"], "description": table,
+                            "columns": [{"name": "id", "type": "integer", "primary_key": True}]})
+        )
+
+
+def _child_env(artifacts_dir: Path, *, pythonpath: str = "") -> dict[str, str]:
+    """The environment every child in this file runs with.
+
+    `AGAMI_ARTIFACTS_DIR` is set EXPLICITLY rather than inherited. `_disk_model_root` falls back to
+    `~/agami-artifacts`, so leaving it unset would make the answer depend on the developer's home
+    directory instead of on the fixture, in both directions: a developer with a real `acme` profile
+    would see the refusal fire in the test that asserts inertness.
+
+    Both database URLs are removed so `_hosted()` is false and the branch reached is the LOCAL one.
+    The hosted twin of this refusal is ACE-051's and is pinned there.
+
+    `PYTHONPATH` is emptied by default so an inherited entry cannot put the installed package back.
+    """
+    env = {**os.environ, "PYTHONPATH": pythonpath, "AGAMI_ARTIFACTS_DIR": str(artifacts_dir)}
+    env.pop("AGAMI_DB_URL", None)
+    env.pop("APP_DATABASE_URL", None)
+    return env
+
+
+def _require_a_package_less_interpreter() -> None:
+    """Skip unless `-S` really does hide the installed package on this machine.
+
+    If the probe SUCCEEDS, the child can import agami-core after all, and every assertion below
+    would be measuring the supported interpreter under a package-less name — passing for the wrong
+    reason, which on a fail-closed property is worse than not running. It probes with an empty
+    `PYTHONPATH` rather than the vendored dir because what it confirms is that the INSTALLED package
+    is hidden, which is independent of where the vendored slice sits.
+    """
+    hidden = subprocess.run([*_NOPKG, "-c", "import agami_paths"],
+                            env={**os.environ, "PYTHONPATH": ""}, capture_output=True)
+    if hidden.returncode == 0:
+        pytest.skip("cannot simulate a package-less interpreter here (-S does not hide agami-core)")
+
+
+def _package_less(artifacts_dir: Path, sql: str) -> dict[str, Any]:
+    """Run `_CHILD_PROBE` on a package-less interpreter and return its parsed report.
+
+    The vendored dir arrives as `argv[1]` and the probe puts it on `sys.path` itself, which keeps
+    `PYTHONPATH` empty and therefore keeps the skip guard above measuring the same thing this run
+    relies on.
+    """
+    _require_a_package_less_interpreter()
+    proc = subprocess.run([*_NOPKG, "-c", _CHILD_PROBE, str(VENDORED_LIB), sql, PROFILE],
+                          env=_child_env(artifacts_dir), capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _package_less_cli(artifacts_dir: Path, sql: str) -> subprocess.CompletedProcess[str]:
+    """Run the documented `python3 -m execute_sql` on a package-less interpreter.
+
+    `PYTHONPATH` carries the vendored dir here, unlike everywhere else in this file: `-m` has no
+    `argv[1]` for the probe to insert, so the slice has to be importable before the interpreter
+    starts. `-S` still hides the installed package, which is the part that makes this package-less.
+    """
+    _require_a_package_less_interpreter()
+    return subprocess.run([*_NOPKG, "-m", "execute_sql", "--profile", PROFILE, "--sql", sql],
+                          env=_child_env(artifacts_dir, pythonpath=str(VENDORED_LIB)),
+                          capture_output=True, text=True)
+
+
+def test_the_documented_entry_point_refuses_when_a_model_is_declared(tmp_path: Path) -> None:
+    """A1 — the invocation the plugin README documents, on the interpreter it actually resolves,
+    with a model declared for the profile: it refuses rather than running a statement whose reach
+    nothing on that interpreter could check."""
+    artifacts = tmp_path / "art"
+    _write_model(artifacts / PROFILE)
+
+    proc = _package_less_cli(artifacts, IN_SCOPE_SQL)
+
+    assert proc.returncode == 1, proc.stderr
+    assert proc.stdout == "", proc.stdout  # nothing ran, so there is no result to emit
+    refusal = json.loads(proc.stderr)["refusal"]
+    assert refusal["rule"] == guardrail.RULE_MODEL_UNAVAILABLE
+    # The reason comes from the contract's own table rather than a literal, so a gate cannot pick
+    # its own and a change to the mapping is caught here rather than agreed with.
+    assert refusal["reason"] == guardrail.REASON_FOR_RULE[guardrail.RULE_MODEL_UNAVAILABLE]
+    # The whole actionable content: the model is fine and the interpreter is the problem, so the
+    # remediation has to name the invocation that works.
+    assert "interpreter" in refusal["remediation"]
+    assert "virtualenv" in refusal["remediation"]
+
+
+def test_the_refusal_names_no_path_it_probed(tmp_path: Path) -> None:
+    """A1 — value-free, like its hosted siblings. The branch resolves an artifacts directory to
+    decide whether a model is declared, and the refusal it returns must not carry that directory
+    back to the caller: a refusal is answered by an operator, and a resolved filesystem path is
+    disclosure rather than advice."""
+    artifacts = tmp_path / "art"
+    _write_model(artifacts / PROFILE)
+
+    proc = _package_less_cli(artifacts, IN_SCOPE_SQL)
+
+    assert proc.returncode == 1, proc.stderr
+    refusal = json.loads(proc.stderr)["refusal"]
+    # The WHOLE refusal, not just the detail, so the authored remediation is covered too.
+    text = json.dumps({key: refusal[key] for key in ("reason", "rule", "detail", "remediation")})
+    assert str(tmp_path) not in text
+
+
+def test_the_package_less_entry_point_stays_inert_with_no_model_on_disk(tmp_path: Path) -> None:
+    """A2 — the other half of the branch, unchanged. Between `pip install` and the first
+    `agami-connect` there is no declared surface, so there is nothing 4b could be exceeded against
+    and nothing 4c could be undetermined about. The pass hands the statement back untouched."""
+    empty = tmp_path / "art"
+    empty.mkdir()  # a real directory with no profile in it, so nothing is declared
+
+    safety = _package_less(empty, IN_SCOPE_SQL)["safety"]
+
+    assert safety["refused"] is False
+    assert safety["sql_unchanged"] is True
+
+
+def test_the_read_only_gate_holds_on_both_interpreters(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A4 — `sql_guard` is vendored and `execute_guarded` runs it ABOVE the semantic-model pass, so
+    a write is refused on the package-less interpreter with or without this spec's branch. Pinned
+    per path rather than assumed: the branch under test sits directly beneath this gate, and a
+    reordering that let a `DROP` reach it would be invisible to every other test in this file."""
+    artifacts = tmp_path / "art"
+    _write_model(artifacts / PROFILE)
+
+    package_less = _package_less(artifacts, WRITE_SQL)["envelope"]
+    assert package_less["status"] == "refused"
+    assert package_less["rule"] == guardrail.RULE_READ_ONLY
+    assert package_less["reason"] == guardrail.REASON_FOR_RULE[guardrail.RULE_READ_ONLY]
+
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(artifacts))
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+
+    supported = execute_sql.execute_guarded(WRITE_SQL, PROFILE, None, executor=_NeverRuns())
+    assert supported.status == "refused"
+    assert supported.refusal.rule == guardrail.RULE_READ_ONLY
+    assert supported.refusal.reason == guardrail.REASON_FOR_RULE[guardrail.RULE_READ_ONLY]
+    _silent(capsys)
+
+
+def test_the_refusal_and_the_receipt_agree(tmp_path: Path) -> None:
+    """A5 — the defect was the disagreement, not the gap. The receipt said the runtime was absent
+    and nothing could be established; the executor read that and ran the statement. Both halves are
+    asserted in one test on purpose, because either one alone is consistent with the defect."""
+    artifacts = tmp_path / "art"
+    _write_model(artifacts / PROFILE)
+
+    envelope = _package_less(artifacts, IN_SCOPE_SQL)["envelope"]
+
+    assert envelope["status"] == "refused"
+    assert envelope["rule"] == guardrail.RULE_MODEL_UNAVAILABLE
+    # `RULE_MODEL_UNAVAILABLE` is deliberately absent from `PRE_MODEL_RULES`, so this refusal keeps
+    # the receipt the builder actually produced rather than the "refused before any model" marker —
+    # which is what lets the two be compared at all.
+    assert envelope["receipt_undetermined"] == guardrail.RECEIPT_NO_RUNTIME
+
+
+def test_the_supported_interpreter_enforces_what_the_package_less_one_refuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A6 — the parity's other side. Same statement, same on-disk model, and here the guards import,
+    so the pass resolves the model and the scope gates run: the declared statement is allowed and an
+    undeclared table is refused by name of rule. That is what the package-less interpreter cannot
+    do, and therefore what it now refuses instead of skipping."""
+    artifacts = tmp_path / "art"
+    _write_model(artifacts / PROFILE)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(artifacts))
+    monkeypatch.delenv("AGAMI_DB_URL", raising=False)
+    monkeypatch.delenv("APP_DATABASE_URL", raising=False)
+
+    sql, allowed = execute_sql._model_safety(IN_SCOPE_SQL, PROFILE, None)
+    assert allowed is None  # the gates ran against the declared model and found nothing to refuse
+    assert sql == IN_SCOPE_SQL
+
+    _, refused = execute_sql._model_safety(OUT_OF_SCOPE_SQL, PROFILE, None)
+    # Table scope, not `model_unavailable`: the gates were reachable here, so the refusal names what
+    # the statement did rather than what the deployment could not do.
+    assert _refusal(refused).rule == guardrail.RULE_TABLE_SCOPE
+    _silent(capsys)

--- a/tests/test_ace071_single_composition.py
+++ b/tests/test_ace071_single_composition.py
@@ -70,7 +70,7 @@ def _call_sites(tree: ast.AST) -> list[tuple[str, int]]:
 
 def _composing_function() -> ast.FunctionDef:
     """The `_model_safety` definition in `execute_sql.py` — the one place the battery is assembled."""
-    module = ast.parse(COMPOSER.read_text(), filename=str(COMPOSER))
+    module = ast.parse(COMPOSER.read_text(encoding="utf-8"), filename=str(COMPOSER))
     for node in ast.walk(module):
         if isinstance(node, ast.FunctionDef) and node.name == COMPOSING_FUNCTION:
             return node
@@ -88,7 +88,7 @@ def test_the_guard_battery_is_called_only_from_the_one_composing_function() -> N
 
     for root in SCANNED_ROOTS:
         for path in sorted(root.rglob("*.py")):
-            sites = _call_sites(ast.parse(path.read_text(), filename=str(path)))
+            sites = _call_sites(ast.parse(path.read_text(encoding="utf-8"), filename=str(path)))
             expected = inside if path == COMPOSER else []
             assert sites == expected, f"{path.relative_to(REPO_ROOT)} calls a guard gate: {sites}"
 

--- a/tests/test_ace071_single_composition.py
+++ b/tests/test_ace071_single_composition.py
@@ -6,11 +6,16 @@ meaningful is that there is nowhere else for the battery to be assembled. A call
 gates through its own sequence is a second composition whether or not it happens to be correct
 today, and the next gate added to `_model_safety` would silently not be in it.
 
-So this is a structural test over the package source rather than a behavioural one: every call of
-every gate lives inside `_model_safety`, each appears exactly once, and they appear in the order the
-battery depends on. It reads `packages/agami-core/src/` alone; `plugins/agami/lib/execute_sql.py` is
-generated from it by `dev.py sync-lib` and held byte-identical by the drift gate, so a second scan
-would assert the drift gate rather than this property.
+So this is a structural test over the source rather than a behavioural one: every call of every gate
+lives inside `_model_safety`, each appears exactly once, and they appear in the order the battery
+depends on.
+
+It reads `packages/agami-core/src/` and `plugins/agami/scripts/`. The second is not the package and
+is not generated, but it is the importable plugin code on precisely the local path this spec is
+about, so a battery assembled there would be the same defect wearing a different directory. Nothing
+there calls a gate today; the point is to notice if that changes. `plugins/agami/lib/` is excluded
+because it is `dev.py sync-lib` output held byte-identical by the drift gate, so scanning it would
+assert the drift gate rather than this property.
 """
 
 from __future__ import annotations
@@ -20,6 +25,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+SCANNED_ROOTS = (PKG_SRC, REPO_ROOT / "plugins" / "agami" / "scripts")
 COMPOSER = PKG_SRC / "execute_sql.py"
 COMPOSING_FUNCTION = "_model_safety"
 
@@ -72,7 +78,7 @@ def _composing_function() -> ast.FunctionDef:
 
 
 def test_the_guard_battery_is_called_only_from_the_one_composing_function() -> None:
-    """No module in the package calls a gate outside `_model_safety`.
+    """No module in the package or the plugin scripts calls a gate outside `_model_safety`.
 
     A gate reached from anywhere else is a second battery: it can be assembled in the wrong order,
     miss a member, or run against a model the receipt was not built from, and none of those is
@@ -80,10 +86,11 @@ def test_the_guard_battery_is_called_only_from_the_one_composing_function() -> N
     """
     inside = _call_sites(_composing_function())
 
-    for path in sorted(PKG_SRC.rglob("*.py")):
-        sites = _call_sites(ast.parse(path.read_text(), filename=str(path)))
-        expected = inside if path == COMPOSER else []
-        assert sites == expected, f"{path.relative_to(REPO_ROOT)} calls a guard gate: {sites}"
+    for root in SCANNED_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            sites = _call_sites(ast.parse(path.read_text(), filename=str(path)))
+            expected = inside if path == COMPOSER else []
+            assert sites == expected, f"{path.relative_to(REPO_ROOT)} calls a guard gate: {sites}"
 
 
 def test_the_guard_battery_is_composed_once_in_a_fixed_order() -> None:

--- a/tests/test_ace071_single_composition.py
+++ b/tests/test_ace071_single_composition.py
@@ -1,0 +1,98 @@
+"""ACE-071 — the guard battery is composed in exactly one place, in one fixed order.
+
+The defect this spec closes was a second, silent composition: the package-less entry point ran no
+gates at all and said nothing about it. The fix is a refusal on that path, and what keeps the fix
+meaningful is that there is nowhere else for the battery to be assembled. A caller that reaches the
+gates through its own sequence is a second composition whether or not it happens to be correct
+today, and the next gate added to `_model_safety` would silently not be in it.
+
+So this is a structural test over the package source rather than a behavioural one: every call of
+every gate lives inside `_model_safety`, each appears exactly once, and they appear in the order the
+battery depends on. It reads `packages/agami-core/src/` alone; `plugins/agami/lib/execute_sql.py` is
+generated from it by `dev.py sync-lib` and held byte-identical by the drift gate, so a second scan
+would assert the drift gate rather than this property.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+COMPOSER = PKG_SRC / "execute_sql.py"
+COMPOSING_FUNCTION = "_model_safety"
+
+# The five gates, in the order `_model_safety` runs them. The order is load-bearing rather than
+# stylistic: the readability gate refuses a statement no gate below could parse, the scopability
+# gate catches the readable statement whose reach still cannot be named, and each scope gate below
+# degrades to ALLOW when it has nothing to read — so a battery run out of order reports clean on
+# exactly the statements the first two gates exist to stop.
+BATTERY = (
+    "check_readable",
+    "check_scopable",
+    "check_table_scope",
+    "check_no_select_star",
+    "check_column_scope",
+)
+
+
+def _call_sites(tree: ast.AST) -> list[tuple[str, int]]:
+    """Every call of a battery gate under `tree`, as (gate, line), in source order.
+
+    An AST walk rather than a text search, because the two families of gate read differently in
+    source and only one of them is greppable without false positives. The three scope gates are
+    called off the `RT` alias, so `RT.check_table_scope(` is distinctive; the other two are resolved
+    through `getattr(RT, ..., None)` and then called as bare names, and that bare name also appears
+    in `semantic_model/runtime.py` as its own `def` and in several prose comments. A `Call` node is
+    neither a definition nor English.
+
+    Both the attribute form and the bare form are collected for all five names, so importing a gate
+    directly and calling it somewhere else is caught as readily as reaching it through the alias.
+    """
+    sites: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr in BATTERY:
+            sites.append((func.attr, node.lineno))
+        elif isinstance(func, ast.Name) and func.id in BATTERY:
+            sites.append((func.id, node.lineno))
+    return sorted(sites, key=lambda site: site[1])
+
+
+def _composing_function() -> ast.FunctionDef:
+    """The `_model_safety` definition in `execute_sql.py` — the one place the battery is assembled."""
+    module = ast.parse(COMPOSER.read_text(), filename=str(COMPOSER))
+    for node in ast.walk(module):
+        if isinstance(node, ast.FunctionDef) and node.name == COMPOSING_FUNCTION:
+            return node
+    raise AssertionError(f"{COMPOSING_FUNCTION} is not defined in {COMPOSER}")
+
+
+def test_the_guard_battery_is_called_only_from_the_one_composing_function() -> None:
+    """No module in the package calls a gate outside `_model_safety`.
+
+    A gate reached from anywhere else is a second battery: it can be assembled in the wrong order,
+    miss a member, or run against a model the receipt was not built from, and none of those is
+    visible from the outcome of a single query.
+    """
+    inside = _call_sites(_composing_function())
+
+    for path in sorted(PKG_SRC.rglob("*.py")):
+        sites = _call_sites(ast.parse(path.read_text(), filename=str(path)))
+        expected = inside if path == COMPOSER else []
+        assert sites == expected, f"{path.relative_to(REPO_ROOT)} calls a guard gate: {sites}"
+
+
+def test_the_guard_battery_is_composed_once_in_a_fixed_order() -> None:
+    """Each gate is called exactly once inside `_model_safety`, and in the battery's own order.
+
+    One assertion covers both because both failures look the same from outside: a duplicated gate
+    and a reordered one each produce a sequence that is not `BATTERY`, and a dropped gate produces a
+    shorter one.
+    """
+    called = tuple(gate for gate, _ in _call_sites(_composing_function()))
+
+    assert called == BATTERY


### PR DESCRIPTION
Spec: ACE-071

## Summary

`python3 -m execute_sql`, the invocation the plugin README documents, resolves the **vendored**
stdlib-only slice. `plugins/agami/lib/semantic_model/` ships `__init__.py` and `units.py` and nothing
else, so `from semantic_model import runtime` raises, `_model_safety` took its `except` branch,
`_hosted()` was false, and it handed the statement back untouched. Table scope, the `SELECT *` ban
and column scope never ran.

That path already conceded as much. `_receipt_for` on the same interpreter returns
`undetermined_receipt(RECEIPT_NO_RUNTIME)`, pinned since ACE-088. So the executor published "I could
not determine what this statement reaches" and then executed it. Principle 4c makes undetermined a
refusal. The gap was never missing information; it was holding the conclusion and declining to act
on it.

## The hole, measured

Not a thought experiment. Run on the §9f testbed against real PostgreSQL 16.12, vendored slice, model
declared, `439ecd1` (the merge immediately before this branch) as the before column:

| Vector | Before (`439ecd1`) | After |
|---|---|---|
| `SELECT id FROM orders LIMIT 2` | **returned `1,2`** | `refused` / `model_unavailable` / `undetermined` |
| `SELECT id FROM orders` (unbounded) | reached the database, stopped only by `resource_limit` | `refused` / `model_unavailable` |
| `SELECT id FROM pg_shadow` (**undeclared**) | **reached the warehouse**; Postgres rejected it on a column error, table scope never ran | `refused` / `model_unavailable` |
| `INSERT INTO categories …` | `unsafe` / `read_only` | `unsafe` / `read_only` (unchanged) |
| same reads, **no** model declared | rows | rows (unchanged, inert) |

**Row 3 is the one to read.** An undeclared table reached the warehouse on the documented invocation,
with `check_table_scope` and `check_column_scope` silent because neither could be imported. Row 2 is
why it hid: unbounded, the **row cap** refused it, and a reader crediting that refusal would have
recorded the path as covered. That is the fourth time in that runbook a refusal from an unrelated
rule has stood in for a gate that was not firing.

Warehouse `xact_commit` moves by **0** across the refused call and by **2** across the same statement
on the venv path in the same window, so the statement never reaches the database rather than the
counter being dead.

## Changes

**`execute_sql.py::_disk_model_root`** (new, stdlib-only) — extracted from `_resolve_guard_model`'s
inline disk probe, now called by both. The new branch cannot call `_resolve_guard_model` itself: that
function's unguarded first statement is `from semantic_model import loader as L`, and the vendored
slice ships no `loader.py`. Sharing one definition is what keeps the two callers from drifting into
disagreeing about whether a model exists — a refusal firing where the supported path would not have
enforced is a false positive, and the reverse is this hole.

**`execute_sql.py::_model_safety`** — a fourth fail-closed branch, ACE-051's shape conditioned on the
model's presence rather than on `_hosted()`. Refuse `RULE_MODEL_UNAVAILABLE` when the guards cannot
be imported **and** a model is declared for the profile; stay inert when none is. A bare install
between `pip install` and its first `agami-connect` has no declared surface, so nothing 4b could be
exceeded against and nothing 4c could be undetermined about; refusing there would break every user in
that window to close a hole that is not open.

The refusal is value-free like its hosted siblings: no resolved path, no profile directory, no DSN.
`_hosted()` is deliberately not consulted — both interpreters in question are local, and what
separates them is which one can import the guards.

`uv run dev.py sync-lib` mirrors both into `plugins/agami/lib/execute_sql.py` (generated, byte-identical
under `_lib_drift`).

## Decisions

Four build-side questions were settled at grounding and are recorded in the spec's `## Decisions`:

1. **The disk probe is the one that already exists, not `agami_paths.profile_dir`.** The two resolve
   differently: `profile_dir` honours the `~/.config/agami/path` pointer, `_resolve_guard_model` does
   not. Naming `profile_dir` would have introduced a second path semantics and let the two
   interpreters disagree about whether a model exists.
2. **The branch stays inside `if not no_safety:`,** where ACE-051's three hosted `model_unavailable`
   siblings also sit. `--no-safety` remains an explicit local opt-out on a machine the user owns.
   Making it unbypassable is a separate decision, not a silent side effect of this slice.
3. **"Verified by grep" became a structural test.** Nothing pinned the single-composition invariant,
   so the criterion had no artifact and would have decayed into a review ritual.
4. **`RULE_MODEL_UNAVAILABLE` does not join `PRE_MODEL_RULES`,** despite that set's docstring reading
   as an instruction to add new pre-model gates. Adding it swaps the receipt from `RECEIPT_NO_RUNTIME`
   to `RECEIPT_BEFORE_MODEL`, contradicting the criterion that a path returning `RECEIPT_NO_RUNTIME`
   does not execute, and mutating hosted receipts pinned by ACE-088. ACE-051's three branches are
   absent from the set for the same reason.

## What review changed

Three review passes ran (correctness/tests, security, structural rubric). Four must-fixes landed as
commits 3 and 4 rather than being argued away, and two of them were bugs this branch introduced.

- **A broken package was reported as an absent one.** The arm this branch lives in catches
  `Exception`, not `ImportError`, so the refusal asserted an ImportError-only diagnosis for
  everything it could see. A `semantic_model.runtime` that IS installed and raises while importing
  itself was described as missing, with a remediation telling the user to swap interpreters. Before
  this branch that arm returned `(sql, None)` and asserted nothing, so the conflation was new here —
  and `_receipt_for` already refuses to conflate the same two facts, its comment reading *"Two
  different facts, and this spec exists to stop them being reported as one."*
- **The refusal did not survive its own wire.** `_LOG` was never silenced in `main()`, and this
  module configures no logging, so `_LOG.error(..., exc_info=True)` fell through to
  `logging.lastResort` onto stderr — 15 lines, `json.loads(stderr)` failing outright. On this entry
  point stderr **is** the wire, and the parent relays the child's stderr into `failure.message`, so
  the traceback's absolute paths rode back into the caller's answer. `_receipt_for`'s logger has the
  same problem and predates this branch; it became wire-corrupting only because there is now a
  refusal in front of it.
- **`_disk_model_root` was not total.** `Path.exists()` re-raises a non-ignorable `OSError` (EACCES
  under macOS TCC, EPERM on a locked volume, ESTALE on NFS), and the probe runs inside an `except`
  arm, where a raise escapes the enclosing `try`. It surfaced as `failed`/`other` with no
  remediation and 26 stderr lines ending in the resolved artifacts path. Doubt now counts as
  declared, which is the fail-closed direction.
- **The F9 contract row still described the pre-rescope slice** (a shared `runtime.vet_sql`
  composition, and dropping a `markdown` field that no longer exists). Rewritten in place.

The security pass's own summary: walking hosted/local × package importable/not × model on disk/not ×
`--no-safety`, **no cell admits a statement the pre-change code refused.**

## Verification

- `uv run dev.py check` → **3371 passed, 9 skipped**, ruff check + format, gitleaks, vendored-mirror
  drift all clean.
- **`tests/test_ace071_entry_point_parity.py`** (9 tests) — the package-less interpreter under the
  `-S` device: refuses with a model declared, stays inert without one, `read_only` still wins over the
  new branch, the refusal and the receipt agree (`status == "refused"` **and**
  `RECEIPT_NO_RUNTIME` in one assertion), the refusal names no path it probed, and the venv half of
  the parity. Asserted on **symbols**, never string literals.
- **`tests/test_ace071_single_composition.py`** (2 tests) — `ast`-based: the five gates are called
  from exactly one function in exactly one module, in a fixed order. Nothing pinned this before;
  a gate could be inserted or reordered and no test would catch it.
- **The subprocess tests ran, they did not skip** — confirmed in both the local interpreter and the
  `uvx --with-editable` environment `dev.py check` uses. A skipped run leaves these items unproven.
- **Not vacuous:** with the branch reverted, 3 of the 6 parity tests fail (`assert 'failed' ==
  'refused'`, and the CLI exiting 2 on a credentials error, i.e. the statement got past the guard and
  tried to connect). Swapping two gates fails the order test; adding a battery call to `tools.py`
  fails the single-site test.
- **No existing test was modified, weakened or deleted.** All 33 `test_ace*` files untouched.
- **Full testbed re-run** (§5 through §11b, real PostgreSQL 16.12, real least-privilege grants, both
  MCP transports): **no regression on the supported venv path.** The stop-the-line check — §11b's
  "the local path must be unaffected", with `AGAMI_DB_URL` unset, a model present and the log
  destination unwritable — returns the CSV with rc=0 and moves `xact_commit` by 2. The fail-closed
  rule did not leak onto the supported local path.

## Security sign-off — what the reviewer should confirm

High lane, so this needs an explicit sign-off. The two claims to check:

- **The bound.** `sql_guard` is itself vendored and runs above `_model_safety`, so read-only genuinely
  held on this path already. What was open is **4b reach** (a table or column the model does not
  declare) plus the 4c star, not a 4a write. The §9f before column bears this out: the `INSERT`
  vector refused `read_only` both before and after.
- **The inertness carve-out.** A modelless local install has no declared surface, so nothing 4b could
  be exceeded against and nothing 4c could be undetermined about. Refusing there would break every
  user between install and first `agami-connect`.

Three residuals, all stated rather than hidden:

1. **The new refusal fires only on the direct-CLI entry point, which writes no audit row.** Recording
   happens at the tool edge (`tools._emit`), which `python -m execute_sql` never reaches. F9's "every
   refusal recorded" holds on the MCP/hosted edge and does not here. The gap predates this change
   (ACE-097 scopes local recording as best-effort), but this is the first change to put a security
   decision entirely on that path.
2. **`--no-safety` still skips this gate.** Decision 2. The sharper form the security pass found: on
   the local plugin path the **model** composes the argv, so the opt-out is reachable by the same
   actor the gate constrains, and what keeps it unused is prose in `agami-query/SKILL.md` ("do
   **NOT** pass `--no-safety`"). That is the one place scope-gate enforcement rests on a prompt
   instruction rather than on the executor. Worth its own follow-up: either gate the flag behind an
   env var the skill cannot set, or record a `no_safety` marker on the audit row so a bypass is
   visible after the fact.
3. **The subprocess tests skip rather than fail where `-S` cannot hide an installed package.** They
   ran here (confirmed in both the local and the `uvx --with-editable` environments), but a skip is
   invisible in a green CI line, and a skipped run leaves the spec's behavioural surface unpinned.

## Notes

- **Follow-up defect, filed at `bugs/artifacts-pointer-is-invisible-to-the-guard.md`:**
  `_disk_model_root` resolves `AGAMI_ARTIFACTS_DIR or ~/agami-artifacts` and ignores the
  `~/.config/agami/path` pointer that `agami-connect` writes, while `agami_paths.artifacts_dir()`
  honours it. So on a pointer-configured install **this branch does not fire either**, and that user
  keeps executing unguarded on both interpreters. Pre-existing; fixing it changes the venv path,
  which criterion 3 forbids.
- **Same bug carries a second divergence, deliberately deferred:** the branch's probe asks whether
  `datasource.yaml` *exists* while the venv path enforces only when the model *resolves*, so a
  truncated file from an interrupted `agami-connect` refuses on one interpreter and runs unguarded on
  the other. One line to close, and it breaks no existing test, but it contradicts "and only a
  fourth" and changes the supported venv path. Both divergences are the same question — what counts
  as "a model is declared here" — and are better answered once, together.
- **ACE-040 coordination** (in-progress, same feature, same owner): no shared file and no `⚠` marker,
  but its safety corpus runs against the vendored surface and asserts it is inert there. This changes
  that state from inert to refusing. Whichever lands second updates its expectations.
- The testbed runbook gained **§9f** for this path and had §10's third-remediation sentence corrected
  (the vendored mirror reaches that bound only when no model is declared now).
- `--no-safety` still bypasses this branch, by decision 2. Residual exposure is stated there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
