### PR TITLE
ACE-083: report the aggregate a join actually multiplies, and the join that actually does it

### DIFF
--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -1697,7 +1697,22 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
     `ctx` supplies the shared cardinality/column indices (ACE-045); `tree` is always the
     caller's own SELECT (a set-op arm ≠ `ctx.tree`), so only the indices come from `ctx`."""
     rels = ctx.cardinality_index if ctx is not None else _cardinality_index(org)
-    tables_in_scope = _alias_map(tree)  # alias -> table
+    # Filtered to what THIS SELECT's own FROM/JOIN clauses bind, and derived once: every consumer
+    # below reads this one map. Asking for it twice with two flags would be the second tree walk
+    # ACE-099 exists to prevent, and would let the fan detector and the aggregation-semantics check
+    # disagree about which tables the statement is even reading.
+    tables_in_scope = _alias_map(tree, in_scope_only=True)  # alias -> table ("" when unbindable)
+    # A name the statement bound for itself stands where a table name would, and the map cannot
+    # tell the difference: `FROM oi` reads `oi` whether `oi` is a table or a WITH. Resolving it is
+    # what lets the fan detector see the join the statement actually takes, and the guard is the
+    # cheap half of the question, so a statement with no CTE in its FROM pays nothing for this.
+    if _cte_names(tree) & {_tkey(v) for v in tables_in_scope.values()}:
+        tidx = ctx.model_table_index if ctx is not None else _model_table_index(org)
+        tables_in_scope, cte_rels = _resolve_cte_scope(tree, tables_in_scope, tidx)
+        # A NEW list. `ctx.cardinality_index` is the model's own edges, shared across every guard
+        # in the battery and across every arm of a set operation; appending a statement-derived
+        # edge to it would leak this query's CTE into the next one's analysis.
+        rels = rels + cte_rels
     table_set = set(tables_in_scope.values())
 
     sites = _aggregate_sites(tree, tables_in_scope, scope, visible)
@@ -1825,6 +1840,185 @@ def _multiplication_status(site: "_AggSite", findings: list[Finding]) -> str:
     if any(f.risk in _MULTIPLYING_RISKS for f in findings):
         return MULTIPLIED
     return NOT_MULTIPLIED if site.resolved else UNDETERMINED
+
+
+# ---------------------------------------------------------------------------
+# What a CTE reference stands for
+#
+# The scope filter above is what makes these necessary. Once a reference written inside a CTE body
+# stops entering the outer query's map, `FROM oi` is all the outer query says, and `oi` is a name
+# the model never declared. Three answers are possible and the whole of the work here is telling
+# them apart: the CTE hands back the rows of a table unchanged, so the reference IS that table and
+# the model's own edges apply; the CTE changes the grain, so it is a source of its own whose
+# cardinality has to be derived from the grain it produces; or the analysis cannot read the body,
+# in which case the honest answer is that it could not tell.
+#
+# Fail-closed throughout. Every guard below returns None, `_resolve_cte_scope` turns a None into
+# the empty binding, and the empty binding makes every aggregate in that SELECT `undetermined`.
+# ---------------------------------------------------------------------------
+
+
+def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
+                             tidx: dict[str, tuple], seen: set[str]) -> Optional[str]:
+    """The declared table a CTE hands back ROW FOR ROW, or None when it is not that simple.
+
+    `WITH oi AS (SELECT * FROM order_items)` produces exactly the rows of `order_items`, so a join
+    to `oi` multiplies whatever a join to `order_items` would and the model's declared edge for
+    `order_items` describes it exactly. Returning the table name is what lets the fan detector name
+    the real join rather than the alias the statement invented for it.
+
+    Every guard is a way the body could produce a DIFFERENT number of rows than its source, and
+    each returns None rather than guessing:
+
+    * not an `exp.Select` — a UNION-bodied CTE, whose row count is the sum of its arms;
+    * already `seen` — the cycle guard, for a CTE that reads itself directly or through another;
+    * `GROUP BY`, `DISTINCT` — both collapse rows by definition;
+    * a `JOIN` — the join is the multiplication, one scope further in than the caller can see;
+    * an aggregate anywhere — `SELECT SUM(quantity) FROM order_items` is one row from many, and it
+      needs no `GROUP BY` to be so;
+    * no `FROM` — and this one is read with `body.find(exp.From)`, NEVER `body.args.get("from")`.
+      sqlglot keys that argument `"from_"`, so the `args` spelling is `None` on every SELECT ever
+      written and a resolver built on it silently answers None for every CTE, passing the corpus
+      and failing only the assertions that name the join. The guard is load-bearing on its own
+      terms too: `SELECT 1 AS x WHERE EXISTS (SELECT 1 FROM orders)` has no FROM and one
+      `exp.Table`, and without it the body would resolve to `orders`;
+    * more than one table, or none — a nested source, or a body that reads nothing nameable.
+
+    Recursive through a chain of grain-preserving CTEs, because one that reads another is still
+    handing back the same rows, and `seen` is what stops a cyclic WITH from recursing forever. A
+    source that is neither another CTE nor a table the model declares returns None: an undeclared
+    name is one the analysis can say nothing about.
+    """
+    body = bodies.get(key)
+    if not isinstance(body, exp.Select) or key in seen:
+        return None
+    seen.add(key)
+    if body.args.get("group") or body.args.get("distinct") or body.args.get("joins"):
+        return None
+    if body.find(exp.AggFunc) is not None:
+        return None
+    if body.find(exp.From) is None:
+        return None
+    tables = list(body.find_all(exp.Table))
+    if len(tables) != 1:
+        return None
+    name = _tkey(tables[0].name)
+    if name in bodies:
+        return _grain_preserving_source(name, bodies, tidx, seen)
+    return tables[0].name if name in tidx else None
+
+
+def _cte_edge(sel: "exp.Select", alias: str, cte_key: str, grain: list[str],
+              grains: dict[str, set[str]], scope_map: dict[str, str]) -> Optional[Relationship]:
+    """The join edge between a grain-CHANGING CTE and the table it is joined to, or None.
+
+    A CTE that groups is a source in its own right: `WITH oi AS (SELECT order_id, SUM(quantity)
+    FROM order_items GROUP BY order_id)` is one row per order, whatever `order_items` is per order.
+    Whether a join to it multiplies anything is decided by the same rule the model's own edges were
+    built with, so `infer_cardinality` is imported and applied rather than re-derived — two rules
+    about one edge is how a fan detector and a chasm detector start disagreeing about one join.
+
+    Grouped to the join key, the CTE is one row per joined row and nothing is multiplied. Grouped
+    finer than the join key — `GROUP BY order_id, product_id` joined on `order_id` alone — it is
+    many rows per joined row and the fan is real. That difference is the whole reason this returns
+    an edge instead of abstaining, and it is `infer_cardinality` that reads it off the grains.
+
+    Three ways to decline, each an honest `undetermined` rather than a guess:
+
+    * anything other than exactly ONE equality naming this alias. None means the join key is absent
+      (a comma join, or an edge written some way this does not read); more than one means a
+      composite key, whose cardinality is not the single-column rule's to state.
+    * the far side resolving to no table in scope.
+    * the far side's DECLARED GRAIN being empty. This guard sits BEFORE the call and that placement
+      is the point: `infer_cardinality` tests `bool(to_pk)`, so a table declared `grain: []` and a
+      table with no grain at all are indistinguishable to it and BOTH fall through to its
+      `many_to_one` default. Calling it anyway would put a cardinality on the receipt that no one
+      declared, which is worse than saying nothing.
+
+    The lazy import matches `cli.py`'s `from . import build as B` idiom, so `runtime.py`'s
+    module-load import closure — pinned by `tests/test_plugin_lib_resolution.py` — is untouched.
+    """
+    pairs: list[tuple["exp.Column", "exp.Column"]] = []
+    for on in _all_join_predicates(sel):
+        for conjunct in _and_conjuncts(on):
+            if not isinstance(conjunct, exp.EQ):
+                continue
+            left, right = conjunct.this, conjunct.expression
+            if not (isinstance(left, exp.Column) and isinstance(right, exp.Column)):
+                continue
+            if left.table == alias:
+                pairs.append((left, right))
+            elif right.table == alias:
+                pairs.append((right, left))
+    if len(pairs) != 1:
+        return None
+    near, far = pairs[0]
+    other = scope_map.get(far.table)
+    if not other or not grains.get(_tkey(other)):
+        return None
+
+    from .build import infer_cardinality
+    return Relationship(
+        from_table=cte_key, to_table=other,
+        from_column=near.name, to_column=far.name,
+        relationship=infer_cardinality(
+            _tkey(cte_key), _tkey(other), [near.name], [far.name],
+            {**grains, _tkey(cte_key): set(grain)},
+        ),
+    )
+
+
+def _resolve_cte_scope(sel: "exp.Select", scope_map: dict[str, str],
+                       tidx: dict[str, tuple]) -> tuple[dict[str, str], list[Relationship]]:
+    """The scope map with every CTE reference resolved, plus the edges that resolution derived.
+
+    One pass over the map the caller already built, never a second walk for the reference list. The
+    CTE BODIES are collected here because nothing else needs them: `_cte_body_scopes` answers which
+    CTE a reference sits IN, which is the opposite question.
+
+    Three outcomes per reference, and they are the three a caller can act on:
+
+    * a grain-preserving CTE rebinds to the table it hands back, and the model's declared edges then
+      describe the join with no new edge invented;
+    * a grain-changing CTE keeps its own name and contributes ONE derived edge, so the fan detector
+      sees it as the distinct source it is;
+    * anything else binds to the empty string, which `_aggregate_sites` reads as "this scope holds
+      something the analysis could not resolve" and reports `undetermined` for every aggregate in
+      the SELECT. That is the fail-closed branch and it is the common one: a CTE body with a join
+      in it, or a grain written as an expression rather than as columns, lands here.
+
+    The grain is the GROUP BY's columns and only those. A `GROUP BY date_trunc('month', created_at)`
+    groups by something with no column name to compare a join key against, so it is no grain this
+    can state and the reference falls to the empty binding.
+
+    Case is the reason the CTE's own written spelling is carried through rather than the folded key:
+    `_cte_names` and `_model_table_index` both fold, while `_alias_map` preserves what the statement
+    wrote, and the derived edge has to name the table the way `table_set` holds it or the detector
+    matches nothing. So `WITH OI AS (…) … JOIN OI` derives an edge named `OI`, and the grain lookup
+    that decides its cardinality folds on the way in.
+    """
+    bodies = {_tkey(cte.alias_or_name): cte.this
+              for cte in sel.find_all(exp.CTE) if cte.this is not None}
+    grains = {key: set(table.grain or []) for key, (table, _area) in tidx.items()}
+    resolved = dict(scope_map)
+    derived: list[Relationship] = []
+    for alias, written in scope_map.items():
+        key = _tkey(written)
+        if key not in bodies:
+            continue
+        source = _grain_preserving_source(key, bodies, tidx, set())
+        if source is not None:
+            resolved[alias] = source
+            continue
+        group = bodies[key].args.get("group")
+        keys = list(group.expressions) if group is not None else []
+        grain = [k.name for k in keys] if keys and all(isinstance(k, exp.Column) for k in keys) else []
+        edge = _cte_edge(sel, alias, written, grain, grains, resolved) if grain else None
+        if edge is None:
+            resolved[alias] = ""
+            continue
+        derived.append(edge)
+    return resolved, derived
 
 
 # ---------------------------------------------------------------------------
@@ -2987,7 +3181,7 @@ class TableRef(NamedTuple):
 
 
 class _RefSite(NamedTuple):
-    """One resolved `TableRef` beside the `exp.Table` node it was read from.
+    """One resolved `TableRef` beside the node it was read from.
 
     Internal, and the node stays here rather than on `TableRef` because `TableRef` is
     receipt-facing: its fields are rendered into tool output, and a parse-tree node is neither
@@ -2995,14 +3189,20 @@ class _RefSite(NamedTuple):
     `check_declared_filters` resolves a reference's own enclosing SELECT from it — and an analysis
     that re-walked `exp.Table` to find the node again would be walking the tree a second time to
     recover something the first walk had in hand.
+
+    `node` is an `exp.Table` on the default walk and may be an `exp.Subquery` / `exp.Lateral` /
+    `exp.Values` when `_reference_sites` is asked to bind derived sources, which is why the
+    annotation is the base class. TWO fields, and that is a contract: `tests/
+    test_ace043_set_operation_arms.py` unpacks a site positionally as `for ref, tbl in ...`.
     """
 
     ref: TableRef
-    node: "exp.Table"
+    node: "exp.Expression"
 
 
-def _reference_sites(node: "exp.Expression") -> list[_RefSite]:
-    """The one walk of `exp.Table`: every table REFERENCE, resolved to its scope, with its node.
+def _reference_sites(node: "exp.Expression", *,
+                     bind_derived: bool = False) -> list[_RefSite]:
+    """The one walk: every table REFERENCE, resolved to its scope, with the node it was read from.
 
     Deliberately not one entry per table, which is what keying by alias would give: a CTE reading
     `orders` and an outer `FROM orders` collapse into a single entry that way. The receipt needs
@@ -3029,15 +3229,65 @@ def _reference_sites(node: "exp.Expression") -> list[_RefSite]:
     The CTE name goes through `_echo_name` because it is CALLER-written text: a quoted identifier
     can hold any string at all, and this label lands in a receipt, which is tool output the calling
     model weights as server-authored.
+
+    `bind_derived` widens the SAME walk — never a second one — to the FROM/JOIN sources that bind a
+    name without naming a table: a derived table, a LATERAL, a VALUES list. Each yields a reference
+    whose `bare` is the empty string, which is the honest answer: the alias is in scope and resolves
+    to no model table. A caller that needs "everything this SELECT can see" has to know those
+    aliases exist, because a scope-filtered map that simply omitted them would leave the alias
+    looking unbound and let an unqualified column resolve as though the derived source were not
+    there. It defaults OFF so the receipt's roster and `check_declared_filters` see exactly the
+    reference list they saw before, and so that
+    `tests/test_ace043_set_operation_arms.py::test_no_reference_in_any_arm_of_a_set_operation_falls_through_to_subquery`
+    keeps counting the references it was written to count.
+
+    Two guards on that arm, both measured rather than defensive:
+
+    - The FROM/JOIN parent test is `check_column_scope`'s, reused rather than reinvented. A scalar
+      or `IN (...)` subquery is an `exp.Subquery` too and it binds no alias into the SELECT's scope.
+      It also excludes the inner `Subquery` of `LATERAL (SELECT 1) l`, whose parent is the
+      `Lateral`: the alias `l` belongs to the LATERAL and the wrapper inside it binds nothing.
+    - A `Subquery` wrapping a bare `exp.Table` is a PARENTHESIZED NAMED TABLE — `FROM (orders)`
+      parses to `Subquery(this=Table)` — and the `exp.Table` arm above has already bound it under
+      its real name. Binding it a second time would report a source the statement does not have.
+
+    An UNALIASED source that is anything else — `VALUES`, `LATERAL`, a derived `SELECT` — binds
+    under the empty key, and that is the point rather than an oversight. It introduces rows nothing
+    can name, and `FROM orders, (VALUES (1), (2))` doubles every order; reporting
+    `SUM(orders.total_amount)` clean over it is exactly the false receipt this spec exists to kill.
+    One falsy entry is all the scope-completeness conjunct in `_aggregate_sites` needs, so two
+    unaliased sources colliding on that one key costs nothing: the value is `""` either way.
+
+    The `exp.Lateral` and `exp.Values` arms look unreachable and are not. `check_scopable` (ACE-037)
+    refuses both source kinds at the `execute_guarded` chokepoint, so no GUARDED query reaches here
+    carrying one — but `cmd_preflight` and `cmd_prepare` in `cli.py` call `pre_flight_check`
+    directly with no gate battery at all, and on that surface both shapes reported a clean
+    `not_multiplied` over a source that can multiply rows. Deleting them as dead code would restore
+    exactly that.
     """
     cte_scopes = _cte_body_scopes(node)
     arm_suffixes = _arm_suffixes(node)
     output_ids = {id(sel) for sel in _output_selects(node)}
+    walk = (exp.Table, exp.Subquery, exp.Lateral, exp.Values) if bind_derived else (exp.Table,)
     sites: list[_RefSite] = []
-    for tbl in node.find_all(exp.Table):
-        written = ".".join(p for p in (tbl.catalog, tbl.db, tbl.name) if p)
-        scope = _scope_label(_enclosing_select(tbl), node, cte_scopes, arm_suffixes, output_ids)
-        sites.append(_RefSite(TableRef(written, tbl.name, tbl.alias or None, scope), tbl))
+    for ref_node in node.find_all(*walk):
+        # One scope determination for both arms, so a derived table nested inside a subquery is
+        # labelled `subquery` by the same three branches that label a table there, and is dropped
+        # by the same filter. `_scope_label` is that one composition, shared with the join walk.
+        scope = _scope_label(_enclosing_select(ref_node), node, cte_scopes, arm_suffixes,
+                             output_ids)
+        if isinstance(ref_node, exp.Table):
+            written = ".".join(p for p in (ref_node.catalog, ref_node.db, ref_node.name) if p)
+            sites.append(
+                _RefSite(TableRef(written, ref_node.name, ref_node.alias or None, scope), ref_node)
+            )
+            continue
+        if not isinstance(ref_node.parent, (exp.From, exp.Join)):
+            continue
+        if isinstance(ref_node, exp.Subquery) and isinstance(ref_node.this, exp.Table):
+            continue
+        sites.append(_RefSite(TableRef(ref_node.alias, "", ref_node.alias or None, scope),
+                              ref_node))
     return sites
 
 
@@ -3068,6 +3318,18 @@ def _scope_label(sel: "exp.Select | None", root: "exp.Expression",
     return "subquery"
 
 
+def _scope_family(scope: str) -> str:
+    """A `TableRef.scope` with its set-operation arm ordinal stripped: `"main#2"` -> `"main"`.
+
+    Split from the RIGHT, because the two things either side of a `#` are of different kinds. The
+    ordinal `_arm_suffixes` appends is ours and always last; the rest can hold a CTE name, which is
+    caller-written text. `_echo_name` already replaces a `#` in a caller's identifier with `?`
+    (measured: `_echo_name("a#b") == "a?b"`), so no CTE name can actually carry one today — the
+    right-side split is simply the form that stays correct without depending on that.
+    """
+    return scope.rsplit("#", 1)[0]
+
+
 def _table_references(node: "exp.Expression") -> list[TableRef]:
     """Every table REFERENCE in the statement, resolved to its query scope — the receipt's view.
 
@@ -3090,7 +3352,7 @@ def _table_references(node: "exp.Expression") -> list[TableRef]:
     return [site.ref for site in _reference_sites(node)]
 
 
-def _alias_map(node: "exp.Expression") -> dict[str, str]:
+def _alias_map(node: "exp.Expression", *, in_scope_only: bool = False) -> dict[str, str]:
     """alias (or table name) -> bare table name, derived from the one reference walk.
 
     Exactly what the former `_tables_in_scope` returned, and derived rather than walked a second
@@ -3103,8 +3365,31 @@ def _alias_map(node: "exp.Expression") -> dict[str, str]:
     Per NODE, never per tree: each caller passes the SELECT it is analyzing, so an arm of a UNION
     sees only its own tables. Flattening the whole tree into one map would let a table read by one
     arm decide the other arm's fan-trap and sensitive-projection results.
+
+    **`in_scope_only` is the map a caller may reason about JOINS from, and it is opt-in.** The
+    default keeps every reference whatever scope wrote it, which is what made the multiplication
+    report name a join only a CTE body takes and miss one the statement does take:
+    `WITH oi AS (SELECT … FROM order_items …) SELECT SUM(orders.total_amount) FROM orders JOIN oi …`
+    put `order_items` in the outer map, and `WITH o AS (SELECT * FROM orders) SELECT SUM(o.…) FROM o
+    JOIN order_items …` resolved `o` to `'o'` and found no join at all. Filtered to the `main`
+    family, the map holds what THIS query's FROM/JOIN clauses bind and nothing else.
+
+    Two things about that filter are deliberate. It tests `== "main"` rather than "not a CTE and not
+    a subquery", which is the same set today and stays right if a fourth scope family is ever added:
+    a scope we could not name must never read as the main query. And it turns on `bind_derived`,
+    which is not a second concern but the same one — dropping a CTE reference the outer query cannot
+    see while silently omitting the derived alias it CAN see would turn a genuinely inflated
+    statement into a clean one, since the outer scope would then look like a single table.
+
+    The default is a contract, and `tests/test_ace099_resolver_parity.py` is what holds it: three
+    other callers read this map, and two of them (`_projected_sensitive`, which REFUSES, and
+    `assemble_receipt`'s roster) would change what they disclose if the filter reached them.
     """
-    return {(r.alias or r.bare): r.bare for r in _table_references(node)}
+    if not in_scope_only:
+        return {(r.alias or r.bare): r.bare for r in _table_references(node)}
+    return {(r.alias or r.bare): r.bare
+            for r in (site.ref for site in _reference_sites(node, bind_derived=True))
+            if _scope_family(r.scope) == "main"}
 
 
 def _own_alias_map(sel: "exp.Select | None") -> dict[str, str]:
@@ -3516,6 +3801,16 @@ def _aggregate_sites(tree: "exp.Select", scope_map: dict[str, str], scope: str,
     that marker would claim the opposite. `visible` defaults to None for a caller that has no index
     to hand, which keeps the old behaviour rather than failing every site closed.
 
+    **An alias in `scope_map` that resolves to NOTHING settles every aggregate in this SELECT.** A
+    derived table, a LATERAL or a VALUES list binds a name and no model table, so the scope-filtered
+    map holds it as `""`. The aggregate's own columns may resolve perfectly well without it, and the
+    statement can still be inflated: the source behind that alias is free to produce many rows per
+    row of everything else and no declared cardinality says whether it does. That is a property of
+    the scope all of them are computed in rather than of any one of them, hence a conjunct on the
+    map rather than a test on the columns. `SELECT SUM(orders.total_amount) FROM orders JOIN
+    (SELECT order_id FROM order_items) d ON d.order_id = orders.id` is the shape, and clean is the
+    one thing it is not.
+
     The label comes from `node.sql()`. That is a FRAGMENT serialized for a receipt: it rebinds
     nothing, is handed to no driver, and the statement that executes is still the one received.
     ACE-093's byte-identity pin is about the executed statement and is untouched. It is the
@@ -3540,7 +3835,7 @@ def _aggregate_sites(tree: "exp.Select", scope_map: dict[str, str], scope: str,
             aggregate=_echo_expr(agg.sql()),
             scope=scope,
             sources=frozenset(t for t in value_tables if t),
-            resolved=bool(cols) and all(resolved) and (
+            resolved=bool(cols) and all(resolved) and all(scope_map.values()) and (
                 visible is None or all(_tkey(t) in visible for t in resolved)
             ),
         ))

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -79,6 +79,20 @@ from .models import (
 )
 from .sql_dialect import DialectUnresolved, engines_disagree, resolve_datasource_dialect
 
+
+def _exp_nodes(*names: str) -> tuple[type, ...]:
+    """The `sqlglot.expressions` classes among `names` that THIS sqlglot declares.
+
+    Resolved by name rather than by attribute because the package pins only `sqlglot>=20` and not
+    every node type below exists across that whole range: `exp.Nvl2` and `exp.DecodeCase` are
+    later additions. A class this version does not declare is a shape this version cannot parse, so
+    leaving it out of the tuple changes no answer; a bare `exp.Nvl2` in a module-level tuple would
+    instead make the whole module unimportable against a sqlglot that reads every statement here
+    perfectly well.
+    """
+    return tuple(t for t in (getattr(exp, name, None) for name in names) if isinstance(t, type))
+
+
 # A prober resolves a literal/value against the DB. Returns True if the value
 # exists in <table>.<column>. Injected so runtime stays DB-agnostic.
 Prober = Callable[[str, str, str], bool]
@@ -1892,6 +1906,33 @@ def _multiplication_status(site: "_AggSite", findings: list[Finding]) -> str:
 _MAX_CTE_CHAIN = 64
 
 
+# The `exp.Select` arguments a body may populate and still hand back its source's rows one for one.
+# **An ALLOWLIST, which is the correction**: the guard read `group`, `distinct` and `joins` and
+# accepted everything else, so an unanticipated argument landed on the clean side. `exp.Select`
+# also carries `laterals`, `connect`, `match` and `pivots`, and each of the four changes the row
+# count. Measured, all three parseable ones reported `not_multiplied` against a base that said
+# `undetermined`: `SELECT * FROM orders LATERAL VIEW EXPLODE(orders.status) t AS s`,
+# `SELECT * FROM orders UNPIVOT (v FOR k IN (total_amount, revenue))` and
+# `SELECT * FROM orders CONNECT BY PRIOR id = customer_id`, each as the body of a CTE the outer
+# statement then aggregates over. `limit`, `qualify`, `sample` and `with_` are the same hazard
+# class and are out for the same reason.
+#
+# Five members, and each earns its place. `expressions` is the projection, which renames and drops
+# columns and never rows. `from_` is required, and `from` is the pre-sqlglot-30 spelling of it —
+# read under one spelling only, every CTE silently answers None. `where` REMOVES rows, which is not
+# a grain change: a filtered many side is still the many side, and the model's declared edge still
+# describes the join exactly. `order` changes the sequence and not the count, and `limit` and
+# `offset` — the two arguments that turn an ordering into a truncation — are their own keys and are
+# both out.
+#
+# `order` earns it on a measurement rather than on the argument alone. Excluded, the analysis
+# answers `undetermined` for `WITH oi AS (SELECT * FROM order_items ORDER BY id)` joined into a fan,
+# which is not the fail-closed direction but a LOST FINDING: the fan is real, the resolver can see
+# it, and the receipt would decline to say so. Over-reporting is the safe way to be wrong; going
+# quiet about a trap this layer can prove is not.
+_GRAIN_PRESERVING_SELECT_ARGS = ("expressions", "from_", "from", "where", "order")
+
+
 def _visible_cte_bodies(sel: "exp.Expression") -> dict[str, "exp.Expression"]:
     """Folded CTE name -> body, for every WITH that BINDS for `sel`. Innermost binding wins.
 
@@ -1941,10 +1982,12 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
 
     * not an `exp.Select` — a UNION-bodied CTE, whose row count is the sum of its arms;
     * already `seen` — the cycle guard, for a CTE that reads itself directly or through another;
-    * `GROUP BY`, `DISTINCT` — both collapse rows by definition;
-    * a `JOIN` — the join is the multiplication, one scope further in than the caller can see;
-    * an aggregate anywhere — `SELECT SUM(quantity) FROM order_items` is one row from many, and it
-      needs no `GROUP BY` to be so;
+    * **any populated argument outside `_GRAIN_PRESERVING_SELECT_ARGS`.** This is the allowlist,
+      and it subsumes the `GROUP BY` / `DISTINCT` / `JOIN` tests it replaced — all three collapse or
+      multiply rows by definition, and so do the four the denylist never named. See the constant for
+      the three shapes measured reporting `not_multiplied` through the hole;
+    * an aggregate anywhere — `SELECT SUM(quantity) FROM order_items` is one row from many, it needs
+      no `GROUP BY` to be so, and no argument of `exp.Select` says it is happening;
     * the body's own `FROM` not naming a table directly. Read off `args`, under BOTH spellings —
       sqlglot 30 keys the argument `"from_"`, so a resolver built on `args.get("from")` alone
       silently answers None for every CTE, passing the corpus and failing only the assertions that
@@ -1955,6 +1998,11 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
       is the second half: `SELECT * FROM (SELECT DISTINCT order_id FROM order_items) g` hands back
       one row per DISTINCT order, not one row per order item, and reading through the wrapper named
       a join the statement does not take;
+    * that `exp.Table` carrying `pivots`. A PIVOT and an UNPIVOT both hang off the TABLE rather than
+      off the SELECT — `Table(this=Identifier, pivots=[Pivot])` — so an argument allowlist on the
+      body cannot see them and the `isinstance(frm.this, exp.Table)` test passes straight through
+      one. An UNPIVOT turns one row into one row per unpivoted column; a PIVOT escaped only by
+      accident, because it happens to contain an `exp.AggFunc` the guard below catches;
     * more than one table, or none — a nested source, or a body that reads nothing nameable. This
       count stays WHOLE-SUBTREE deliberately: `SELECT order_id FROM order_items WHERE order_id IN
       (SELECT id FROM orders)` is caught only because the IN subquery's table is counted, and its
@@ -1974,12 +2022,15 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
     if not isinstance(body, exp.Select) or key in seen or depth > _MAX_CTE_CHAIN:
         return None
     seen.add(key)
-    if body.args.get("group") or body.args.get("distinct") or body.args.get("joins"):
+    if any(value and arg not in _GRAIN_PRESERVING_SELECT_ARGS
+           for arg, value in body.args.items()):
         return None
     if body.find(exp.AggFunc) is not None:
         return None
     frm = body.args.get("from_") or body.args.get("from")
     if not isinstance(frm, exp.From) or not isinstance(frm.this, exp.Table):
+        return None
+    if frm.this.args.get("pivots"):
         return None
     if len(list(body.find_all(exp.Table))) != 1:
         return None
@@ -3347,6 +3398,19 @@ class _RefSite(NamedTuple):
     node: "exp.Expression"
 
 
+# The row-multiplying sources that are NOT a FROM's or a JOIN's `this`, and so are reached by no
+# walk of those two clauses. `exp.Lateral` (from `Select.args["laterals"]`, the `LATERAL VIEW`
+# spelling), `exp.Connect` (`CONNECT BY`), `exp.MatchRecognize` (`MATCH_RECOGNIZE`) and `exp.Pivot`
+# (`PIVOT` / `UNPIVOT`, which rides the `exp.Table` rather than the `exp.Select`). Each binds the
+# empty string, which is the honest answer and the one `_aggregate_sites` reads as "this scope holds
+# something the analysis could not resolve".
+#
+# Resolved by name for the reason `_exp_nodes` gives, and empty when there is no parser at all.
+_ROW_MULTIPLYING_SOURCES: tuple[type, ...] = (
+    _exp_nodes("Lateral", "Connect", "MatchRecognize", "Pivot") if _HAVE_SQLGLOT else ()
+)
+
+
 def _reference_sites(node: "exp.Expression", *,
                      bind_derived: bool = False) -> list[_RefSite]:
     """The one walk: every table REFERENCE, resolved to its scope, with the node it was read from.
@@ -3397,6 +3461,17 @@ def _reference_sites(node: "exp.Expression", *,
     surface for a statement whose rows an unnest can multiply. A source kind nobody anticipated has
     to default to `undetermined`, and only binding by exclusion gives that.
 
+    **`_ROW_MULTIPLYING_SOURCES` is what makes that claim true rather than only stated.** Four
+    constructs multiply a SELECT's rows without ever being a FROM's or a JOIN's `this`, so walking
+    From/Join alone reached none of them: `laterals`, `connect` and `match` are SIBLINGS of `from_`
+    on `exp.Select`, and `pivots` rides the `exp.Table` itself under its real name. Each was
+    measured reporting a clean `not_multiplied` on the ungated `cmd_preflight` / `cmd_prepare`
+    surface — `FROM orders LATERAL VIEW EXPLODE(orders.status) t AS tag`,
+    `FROM orders o UNPIVOT (v FOR k IN (total_amount, revenue))` and
+    `FROM orders CONNECT BY PRIOR id = customer_id`. They are walked by their own node types here,
+    and a node already bound as a FROM/JOIN source is not bound twice: `LATERAL (SELECT 1) l` is an
+    `exp.Lateral` the Join arm reaches first, and one source reported twice is one source too many.
+
     Two guards, both measured rather than defensive:
 
     - Taking each clause's own bound source is `check_column_scope`'s FROM/JOIN parent test read
@@ -3425,11 +3500,17 @@ def _reference_sites(node: "exp.Expression", *,
     cte_scopes = _cte_body_scopes(node)
     arm_suffixes = _arm_suffixes(node)
     output_ids = {id(sel) for sel in _output_selects(node)}
-    walk = (exp.Table, exp.From, exp.Join) if bind_derived else (exp.Table,)
+    walk = ((exp.Table, exp.From, exp.Join, *_ROW_MULTIPLYING_SOURCES)
+            if bind_derived else (exp.Table,))
+    # Node identity, so a source reachable two ways is bound once. An `exp.Lateral` in a JOIN is
+    # both that JOIN's `this` and a member of the walk above.
+    bound: set[int] = set()
     sites: list[_RefSite] = []
     for found in node.find_all(*walk):
         if isinstance(found, exp.Table):
             ref_node: "exp.Expression" = found
+        elif isinstance(found, _ROW_MULTIPLYING_SOURCES):
+            ref_node = found
         else:
             # What this FROM/JOIN clause binds. An `exp.Table` source was already bound by the arm
             # above under its real name, and so was the table inside a parenthesized `FROM (orders)`;
@@ -3450,7 +3531,15 @@ def _reference_sites(node: "exp.Expression", *,
             sites.append(
                 _RefSite(TableRef(written, ref_node.name, ref_node.alias or None, scope), ref_node)
             )
+            # A PIVOT or an UNPIVOT on this table is NOT bound here. It rides the `exp.Table` under
+            # the table's own name, and both facts have to reach the map: the rows really do come
+            # from `orders`, so the model's declared edges apply, and there really are more of them
+            # than `orders` has. The table binds the first; the `exp.Pivot` in the walk binds the
+            # second, under its own alias when it wrote one and under the empty key when it did not.
             continue
+        if id(ref_node) in bound:
+            continue
+        bound.add(id(ref_node))
         sites.append(_RefSite(
             TableRef(ref_node.alias, "", ref_node.alias or None, scope), ref_node))
     return sites
@@ -4020,6 +4109,166 @@ def _aggregate_sites(tree: "exp.Select", scope_map: dict[str, str], scope: str,
     return sites
 
 
+# The node types `_value_operands` understands, in the three readings it has, plus a fail-closed
+# default for everything else. **They are an ALLOWLIST, and inverting that polarity is the whole of
+# this correction.** They were a denylist: four node types were named as putting an operand
+# somewhere that is not the value, and every other node unioned all of its children. An
+# unanticipated shape therefore landed on the UNSAFE side, because contributing a choice's INPUTS
+# as though they were its result is exactly what clears a fan the number really does move. Four
+# shapes of ordinary analytics SQL were measured doing that against `orders JOIN order_items`, each
+# reporting `not_multiplied` where the pre-spec implementation reported `multiplied`:
+# `SUM(GREATEST(orders.total_amount, order_items.quantity))`, the same with `LEAST`,
+# `SUM(NVL2(order_items.quantity, orders.total_amount, 0))` and
+# `SUM(DECODE(order_items.product_id, 1, orders.total_amount, 0))` — Snowflake, Redshift and Oracle
+# spellings, not contrived ones. `ROUND`, `SUBSTRING`, `LEFT`, `LPAD`, `SPLIT_PART`, `REPEAT` and
+# `TRUNCATE` were measured on the same polarity and are contrived; the fix is the same for both.
+#
+# Enumerated this way round, a node nobody anticipated contributes NOTHING, an empty contribution
+# suppresses no edge, and the fan is reported. Over-reporting is a receipt that says more than it
+# had to; the other polarity is a receipt that says something false.
+if _HAVE_SQLGLOT:
+    # ALTERNATION: the result is ONE of the operands, so the value is at a table's grain only when
+    # every alternative is. `exp.Nvl2.arg_types` is `{this, true, false}`, byte-identical to
+    # `exp.If`'s, and `NVL2(a, b, c)` returns `b` or `c` exactly as `IF` does. `exp.Greatest` and
+    # `exp.Least` carry `exp.Coalesce`'s `this` + `expressions` layout and, like it, return one of
+    # their arguments rather than a function of all of them. `DECODE` parses to
+    # `exp.DecodeCase(expressions=[operand, search, result, …, default])`, which is a simple CASE
+    # with the commas moved. Every one of these was read off `arg_types` and off a parse, not
+    # assumed.
+    _ALTERNATION_NODES = _exp_nodes(
+        "Case", "If", "Nvl2", "Coalesce", "Greatest", "Least", "DecodeCase")
+    # The two that hold their arms under `true` and `false` rather than under `expressions`.
+    _TERNARY_NODES = _exp_nodes("If", "Nvl2")
+    # STRUCTURAL: the value is `this` and the rest of the node is neither predicate nor value.
+    # `exp.Order` holds `STRING_AGG(x ORDER BY y)`'s ordering arms on `expressions`; reordering a
+    # concatenation changes the string, but the fan is not what reordered it. `exp.Nullif`'s
+    # `expression` is the value `this` is COMPARED against, and the result is `this` or NULL, which
+    # every aggregate skips rather than folds. `exp.GroupConcat`'s `separator` is punctuation.
+    _STRUCTURAL_NODES = _exp_nodes("Order", "Nullif", "GroupConcat")
+    # COMBINING: every operand is on the value path, so the sets UNION. This set is load-bearing
+    # for the spec's own criterion rather than a convenience: A7 pins
+    # `SUM(order_items.quantity * orders.total_amount)` to `not_multiplied`, which happens only if
+    # `exp.Mul` unions so that `order_items` reaches `value_sources` and suppresses that edge.
+    # `exp.Binary` is the arithmetic and the comparisons (`a > b` is a value built from both `a`
+    # and `b`, which is what `BOOL_OR(orders.total_amount > 0)` folds); `exp.Unary` is `exp.Paren`
+    # and `exp.Neg`. The aggregate classes are here because `_value_sources` is called ON the
+    # aggregate node, so a `SUM` that combined nothing would empty every value path in the
+    # statement. They are enumerated one by one rather than as `exp.AggFunc`, because an aggregate
+    # CAN mix a selector with its value — `ARG_MAX(a, b)` returns `a` at the row maximizing `b` —
+    # and the base class would put that selector on the value path. The membership is derived from
+    # what the suite actually exercises, measured by tracing every node type that reached the old
+    # generic branch across the whole test run.
+    _COMBINING_NODES = _exp_nodes(
+        "Binary", "Unary", "Cast", "Distinct",
+        "Sum", "Count", "Avg", "Min", "Max", "LogicalOr", "LogicalAnd",
+    )
+else:  # pragma: no cover - nothing in this section runs without a parser
+    _ALTERNATION_NODES = _TERNARY_NODES = _STRUCTURAL_NODES = _COMBINING_NODES = ()
+
+
+# What `_value_operands` says about a node, and what `_value_sources` does with the operands beside
+# it. `_VALUE_UNKNOWN` is the fail-closed default and carries no operands at all.
+_VALUE_COLUMN = "column"
+_VALUE_INTERSECT = "intersect"
+_VALUE_UNION = "union"
+_VALUE_UNKNOWN = "unknown"
+
+
+def _value_operands(node: "exp.Expression") -> tuple[str, list["exp.Expression"]]:
+    """How to read one node's value, and which of its operands that reading is over.
+
+    Split out of `_value_sources` so that the classification and the traversal are two things: the
+    traversal is a stack and says nothing about SQL, and this says everything about SQL and walks
+    nothing. Every operand it returns is a node the tree already holds, never a new one, which is
+    what lets the caller key its results by `id()`.
+
+    The alternation arms are the operands that can BE the result, and never the ones that decide
+    WHICH:
+
+    - `exp.Case`. `ifs[].this` is the branch predicate and `Case.this` is the simple-CASE operand
+      compared against them, so both are inputs to the choice. The arms are `ifs[].true` and
+      `default`. An ABSENT `default` is not an arm: the implicit result is NULL, which every
+      aggregate skips rather than folds, so counting it would report a fan on
+      `SUM(CASE WHEN orders.flag THEN order_items.quantity END)`, whose value is at item grain on
+      every row that contributes one. An explicit `ELSE NULL` IS counted, contributes no table and
+      so clears no edge: the same shape read the other way, in the fail-closed direction.
+    - `exp.If` and `exp.Nvl2`. `IF` / `IIF` / `IFF` parse to `exp.If`, NOT to `exp.Case`, on every
+      dialect this layer speaks, and `NVL2` to a node with the identical three arguments. Without a
+      case of their own the combining branch would take the CONDITION's columns as value columns,
+      which is the polarity that manufactures a false clean, and sqlglot RENDERS both as
+      `CASE WHEN … END` — so two spellings would produce a byte-identical receipt label carrying
+      opposite statuses.
+    - `exp.Coalesce` (`IFNULL` and `NVL` parse to it too), `exp.Greatest` and `exp.Least`. Each
+      returns one of its arguments, so each is at a table's grain only if every argument is.
+    - `exp.DecodeCase`. `expressions` is `[operand, search, result, …]` with an optional trailing
+      default, so the arms are the RESULT slots plus that default. The operand and the searches are
+      the comparison, which is the choice and not the result. Fewer than three expressions is not a
+      DECODE this can read, and falls to the fail-closed default rather than guessing which slot is
+      which.
+
+    `exp.Filter` needs no reading of its own and never will: `SUM(x) FILTER (WHERE y)` parses to
+    `Filter(this=Sum, expression=Where)`, so the predicate is structurally OUTSIDE the aggregate and
+    `find_all(exp.AggFunc)` hands the bare `Sum` to `_value_sources` rather than the wrapper.
+
+    `node.args` is iterated by hand rather than through `iter_expressions()`: two lines that cannot
+    drift, against a package that pins only `sqlglot>=20`.
+    """
+    if isinstance(node, exp.Column):
+        return _VALUE_COLUMN, []
+    if isinstance(node, exp.Case):
+        arms = [branch.args.get("true") for branch in node.args.get("ifs") or []]
+        arms.append(node.args.get("default"))
+        return _VALUE_INTERSECT, _present(arms)
+    if isinstance(node, _ALTERNATION_NODES):
+        if isinstance(node, exp.DecodeCase):
+            return _VALUE_INTERSECT, _decode_arms(node)
+        if isinstance(node, _TERNARY_NODES):
+            return _VALUE_INTERSECT, _present([node.args.get("true"), node.args.get("false")])
+        # `exp.Coalesce`, `exp.Greatest`, `exp.Least`: one leading argument plus the rest.
+        return _VALUE_INTERSECT, _present([node.this, *(node.args.get("expressions") or [])])
+    if isinstance(node, _STRUCTURAL_NODES):
+        return _VALUE_UNION, _present([node.this])
+    if isinstance(node, _COMBINING_NODES):
+        return _VALUE_UNION, _present(
+            [child for arg in node.args.values()
+             for child in (arg if isinstance(arg, list) else [arg])]
+        )
+    return _VALUE_UNKNOWN, []
+
+
+def _present(operands: list) -> list["exp.Expression"]:
+    """The operands that are actually expression nodes, in the order given.
+
+    An absent argument is `None` in `args` and a `sqlglot` argument can also hold a bare string or
+    a bool (`Greatest.ignore_nulls`, `Cast.safe`). Neither is a value path, and neither is
+    something the traversal can key by `id()` and expect to still be alive.
+    """
+    return [operand for operand in operands if isinstance(operand, exp.Expression)]
+
+
+def _decode_arms(node: "exp.Expression") -> list["exp.Expression"]:
+    """The result slots of a `DECODE`, plus its trailing default when it wrote one.
+
+    `DECODE(e, s1, r1, s2, r2, d)` parses to `expressions=[e, s1, r1, s2, r2, d]`: one operand,
+    then `(search, result)` pairs, then an optional default in the odd position left over. Walked
+    rather than sliced, because the two arities read differently and a slice that is right for one
+    is silently wrong for the other.
+    """
+    args = _present(list(node.args.get("expressions") or []))
+    if len(args) < 3:
+        return []
+    arms: list["exp.Expression"] = []
+    index = 1
+    while index < len(args):
+        if index + 1 < len(args):
+            arms.append(args[index + 1])  # the RESULT of this (search, result) pair
+            index += 2
+        else:
+            arms.append(args[index])  # the trailing default
+            index += 1
+    return arms
+
+
 def _value_sources(node: "exp.Expression", scope_map: dict[str, str]) -> frozenset[str]:
     """The tables an expression's value is at the grain of on EVERY path through it.
 
@@ -4037,7 +4286,7 @@ def _value_sources(node: "exp.Expression", scope_map: dict[str, str]) -> frozens
     one-side amount on the rows where the flag is set, and the join duplicates those rows and sums
     the amount once per duplicate. Reading the union of the branches would put `order_items` on the
     value path and clear a number the fan really does move, so an alternation INTERSECTS its
-    branches and everything else UNIONS its children. Those two compose correctly at depth without
+    branches and a combining node UNIONS its operands. Those two compose correctly at depth without
     enumerating paths: table sets under union and intersection are a distributive lattice, so
     `(A∩B) ∪ (C∩D)` is exactly the intersection over the four paths of `CASE… * CASE…`.
 
@@ -4046,70 +4295,54 @@ def _value_sources(node: "exp.Expression", scope_map: dict[str, str]) -> frozens
     END` is at `orders` grain on both branches; an intersection taken over COLUMNS would find nothing
     in common and report the opposite.
 
-    The nodes that put an operand somewhere that is not the value, each measured rather than assumed:
+    **A node `_value_operands` does not recognize contributes NOTHING**, and that direction is the
+    correction rather than an omission. An empty contribution suppresses no edge, so the fan is
+    reported; the union-everything default it replaced contributed a choice's own inputs and cleared
+    real edges. See `_COMBINING_NODES` for the four ordinary-SQL shapes that were measured doing it.
 
-    - `exp.Case`. `ifs[].this` is the branch predicate and `Case.this` is the simple-CASE operand
-      compared against them, so both are inputs to the choice and not to the result. The branches
-      are `ifs[].true` and `default`. An ABSENT `default` is not a branch: the implicit result is
-      NULL, which every aggregate skips rather than folds, so counting it would report a fan on
-      `SUM(CASE WHEN orders.flag THEN order_items.quantity END)`, whose value is at item grain on
-      every row that contributes one. An explicit `ELSE NULL` is counted, contributes no table and
-      so clears no edge — the same shape read the other way, in the fail-closed direction.
-    - `exp.If`. `IF` / `IIF` / `IFF` parse to this, NOT to `exp.Case`, on every dialect this layer
-      speaks. Without a case of its own the generic branch would take the CONDITION's columns as
-      value columns, which is the polarity that manufactures a false clean, and sqlglot RENDERS an
-      `exp.If` as `CASE WHEN … END` — so the two spellings produce a byte-identical receipt label
-      with opposite statuses.
-    - `exp.Nullif`. `args["expression"]` is the value the first argument is COMPARED against, not a
-      value the result is built from.
-    - `exp.GroupConcat`. `args["separator"]` is punctuation between the folded values.
-    - `exp.Coalesce`. `IFNULL` and `NVL` parse to it too. It is an alternation like `exp.Case`, and
-      the same reasoning applies: its value is at a table's grain only if every alternative is.
-    - `exp.Order`. `STRING_AGG(x ORDER BY y)` parses to `GroupConcat(this=Order(this=x,
-      expressions=[Ordered(y)]))`, so the ordering arms hang off `expressions` and are neither
-      predicate nor value: reordering a concatenation changes the string but the fan is not what
-      reordered it, and `y` is not a value the aggregate folds.
+    **ITERATIVE, over an explicit stack**, for the reason `_and_conjuncts` is: sqlglot builds
+    `a + 1 + 1 + …` LEFT-DEEP, so the tree is as deep as the expression is wide and one Python frame
+    per term is a ceiling a caller can reach. Measured: `SELECT SUM(orders.total_amount + 1 + …)`
+    with 989 terms is 4,052 characters against `sql_guard._MAX_SQL_CHARS` of 50,000 and raised
+    `RecursionError` out of the recursive version. `execute_sql._receipt_for` catches bare
+    `Exception` and returns `RECEIPT_BUILD_FAILED`, so the statement still ran and returned rows
+    while the caller silently lost the receipt; on the ungated `cmd_preflight` / `cmd_prepare`
+    surface it propagated as a traceback. That is caller-chosen input turning off the trust layer
+    without turning off the answer, which is the one shape this module already legislated against
+    twice — `_and_conjuncts` is iterative for it and `_MAX_CTE_CHAIN` exists for it. A stack has no
+    such ceiling, so there is no bound here to exhaust and no "value path unknown" to plumb.
 
-    Everything else unions its children, and THE POLARITY OF THAT DEFAULT DEPENDS ON THE NODE. For a
-    node that only combines values it is honest: a node type nobody thought about contributes its
-    columns rather than silently dropping them. For a node that mixes a PREDICATE or a SEPARATOR
-    with its values it is inverted and dangerous — contributing the predicate's columns is what
-    manufactures a false clean, because a many-side column on the value path is what clears the fan.
-    Any node mixing predicate and value operands is that hazard class and needs a case here;
-    `exp.Case`, `exp.If`, `exp.Nullif` and `exp.GroupConcat` are the members this layer has met.
-    `exp.Distinct` is safely generic: it holds its argument under `args["expressions"]` and combines
-    nothing. So is `exp.Filter`: `SUM(x) FILTER (WHERE y)` parses to `Filter(this=Sum,
-    expression=Where)`, so the predicate is structurally OUTSIDE the aggregate and
-    `find_all(exp.AggFunc)` never hands it here at all.
-
-    `node.args` is iterated by hand rather than through `iter_expressions()`. Four lines that cannot
-    drift, against a package that pins only `sqlglot>=20`.
+    Post-order over that stack: a node is pushed once to expand and once to fold, and the fold reads
+    its operands' answers out of `computed`. Keying by `id()` is safe because every operand
+    `_value_operands` returns is a node the caller's tree already holds, so none of them can be
+    collected and have its id reused while this runs.
     """
     if not isinstance(node, exp.Expression):
         return frozenset()
-    if isinstance(node, exp.Column):
-        table = _resolve_col_table(node, scope_map)
-        return frozenset([table]) if table else frozenset()
-    alternatives: Optional[list["exp.Expression"]] = None
-    if isinstance(node, exp.Case):
-        alternatives = [branch.args.get("true") for branch in node.args.get("ifs") or []]
-        alternatives.append(node.args.get("default"))
-    elif isinstance(node, exp.If):
-        alternatives = [node.args.get("true"), node.args.get("false")]
-    elif isinstance(node, exp.Coalesce):
-        alternatives = [node.this, *(node.args.get("expressions") or [])]
-    if alternatives is not None:
-        present = [alt for alt in alternatives if alt is not None]
-        if not present:
-            return frozenset()
-        return frozenset.intersection(*(_value_sources(alt, scope_map) for alt in present))
-    if isinstance(node, (exp.Order, exp.Nullif, exp.GroupConcat)):
-        return _value_sources(node.this, scope_map)
-    tables: set[str] = set()
-    for arg in node.args.values():
-        for child in (arg if isinstance(arg, list) else [arg]):
-            tables |= _value_sources(child, scope_map)
-    return frozenset(tables)
+    computed: dict[int, frozenset[str]] = {}
+    stack: list[tuple["exp.Expression", bool]] = [(node, False)]
+    while stack:
+        current, folding = stack.pop()
+        reading, operands = _value_operands(current)
+        if reading == _VALUE_COLUMN:
+            table = _resolve_col_table(current, scope_map)
+            computed[id(current)] = frozenset([table]) if table else frozenset()
+            continue
+        if reading == _VALUE_UNKNOWN or not operands:
+            # No operands is the empty alternation (`CASE` with no arm this counts) and the empty
+            # combination alike, and both are the same answer: nothing on the value path.
+            computed[id(current)] = frozenset()
+            continue
+        if not folding:
+            stack.append((current, True))
+            stack.extend((operand, False) for operand in operands)
+            continue
+        parts = [computed.get(id(operand), frozenset()) for operand in operands]
+        computed[id(current)] = (
+            frozenset.intersection(*parts) if reading == _VALUE_INTERSECT
+            else frozenset().union(*parts)
+        )
+    return computed.get(id(node), frozenset())
 
 
 def _select_aggregates(sel: "exp.Select") -> list["exp.AggFunc"]:

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -1903,6 +1903,10 @@ def _multiplication_status(site: "_AggSite", findings: list[Finding]) -> str:
 # reading the one before, which is not a cycle and so is not what `seen` catches. Sixty-four is far
 # past any chain a person writes and far short of the interpreter's own limit, and hitting it
 # returns None into the fail-closed branch — `undetermined`, not a lost receipt.
+#
+# Compared with `>=` and not with `>`. `depth` is 0 on the first hop, so `depth > _MAX_CTE_CHAIN`
+# admitted sixty-FIVE of them for a constant that says sixty-four, and a bound that does not admit
+# the number it is written as is a bound nobody can reason about from the constant alone.
 _MAX_CTE_CHAIN = 64
 
 
@@ -2007,7 +2011,7 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
       count stays WHOLE-SUBTREE deliberately: `SELECT order_id FROM order_items WHERE order_id IN
       (SELECT id FROM orders)` is caught only because the IN subquery's table is counted, and its
       row count is not `order_items`'s.
-    * more than `_MAX_CTE_CHAIN` hops. `seen` catches a CYCLE and a linear chain is not one: 990
+    * `_MAX_CTE_CHAIN` hops or more. `seen` catches a CYCLE and a linear chain is not one: 990
       CTEs each reading the one before fit inside `_MAX_SQL_CHARS` and raised `RecursionError`,
       which `_receipt_for` catches as a build failure — so the statement still ran and returned
       rows while the caller silently lost the receipt. Caller-chosen input that turns off the trust
@@ -2019,7 +2023,7 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
     name is one the analysis can say nothing about.
     """
     body = bodies.get(key)
-    if not isinstance(body, exp.Select) or key in seen or depth > _MAX_CTE_CHAIN:
+    if not isinstance(body, exp.Select) or key in seen or depth >= _MAX_CTE_CHAIN:
         return None
     seen.add(key)
     if any(value and arg not in _GRAIN_PRESERVING_SELECT_ARGS
@@ -2040,8 +2044,40 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
     return frm.this.name if name in tidx else None
 
 
+def _projection_sources(body: "exp.Expression") -> dict[str, str]:
+    """Folded OUTPUT name -> folded input column, over the projections that are ONE plain column.
+
+    The two names `_cte_edge` compares come from opposite sides of the CTE. `_group_by_grain` reads
+    what the body groups BY, which are the body's INPUT columns, and the join key is the name the
+    outer statement writes, which is the body's OUTPUT column. A CTE that renames its grain column
+    makes those two differ: `WITH x AS (SELECT id AS order_id FROM customers GROUP BY id)` joined on
+    `x.order_id` compared `order_id` against a grain of `{id}`, found no cover, and reported a fan on
+    a CTE that really is one row per key. Safe direction, and still a false positive on legitimate
+    SQL, so this is what closes the gap between the two spellings of one column.
+
+    Only a bare column and an alias over one resolve. `SELECT id + 1 AS k` has no input column that
+    `k` stands for, `SELECT *` names nothing, and two projections sharing an output name are
+    ambiguous. Each of those is left OUT, so the comparison falls back to the written name and the
+    fan is reported: unresolvable stays over-reporting, never under.
+    """
+    sources: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    for projection in (getattr(body, "expressions", None) or []):
+        inner = projection.this if isinstance(projection, exp.Alias) else projection
+        if not isinstance(inner, exp.Column):
+            continue
+        output = _tkey(projection.alias_or_name)
+        if output in sources and sources[output] != _tkey(inner.name):
+            ambiguous.add(output)
+        sources[output] = _tkey(inner.name)
+    for name in ambiguous:
+        sources.pop(name, None)
+    return sources
+
+
 def _cte_edge(conjuncts: list["exp.Expression"], alias: str, cte_key: str, grain: list[str],
-              grains: dict[str, set[str]], scope_map: dict[str, str]) -> Optional[Relationship]:
+              grains: dict[str, set[str]], scope_map: dict[str, str],
+              outputs: dict[str, str]) -> Optional[Relationship]:
     """The join edge between a grain-CHANGING CTE and the table it is joined to, or None.
 
     A CTE that groups is a source in its own right: `WITH oi AS (SELECT order_id, SUM(quantity)
@@ -2103,12 +2139,17 @@ def _cte_edge(conjuncts: list["exp.Expression"], alias: str, cte_key: str, grain
     # folded here — the module's own convention, stated on `check_column_scope` as "matching is
     # case-insensitive", and the one this comparison was missing. The `Relationship` keeps the
     # WRITTEN spellings, because that is what the receipt echoes back to the caller.
+    #
+    # The NEAR key is additionally resolved through the body's projections, because the grain it is
+    # about to be compared against is written in the body's own input names. See
+    # `_projection_sources`; a key that does not resolve is compared as written, which over-reports.
+    near_key = outputs.get(_tkey(near.name), _tkey(near.name))
     from .build import infer_cardinality
     return Relationship(
         from_table=cte_key, to_table=other,
         from_column=near.name, to_column=far.name,
         relationship=infer_cardinality(
-            _tkey(cte_key), _tkey(other), [_tkey(near.name)], [_tkey(far.name)],
+            _tkey(cte_key), _tkey(other), [near_key], [_tkey(far.name)],
             {**grains, _tkey(cte_key): set(grain)},
         ),
     )
@@ -2174,7 +2215,15 @@ def _resolve_cte_scope(sel: "exp.Select", bodies: dict[str, "exp.Expression"],
               for key, (table, _area) in tidx.items()}
     conjuncts = [c for on in _all_join_predicates(sel) for c in _and_conjuncts(on)]
     resolved = dict(scope_map)
-    derived: list[Relationship] = []
+    # PASS ONE settles every grain-preserving rebinding, and nothing else. `_cte_edge` resolves the
+    # FAR side of an edge through this map, and one pass read it while still mutating it: whichever
+    # alias the statement wrote FIRST was resolved against a map the other alias had not reached
+    # yet. Measured on one statement with two CTEs, one grain-preserving and one grouped —
+    # `FROM p JOIN g ON g.order_id = p.id` gave `multiplied` naming the derived edge, and
+    # `FROM g JOIN p ON g.order_id = p.id` gave `undetermined`. Both are the safe direction and
+    # neither is the rule this module states about itself, which is that a receipt has to read the
+    # same way twice for the same SQL.
+    pending: list[tuple[str, str]] = []
     for alias, written in scope_map.items():
         key = _tkey(written)
         if key not in bodies:
@@ -2182,13 +2231,22 @@ def _resolve_cte_scope(sel: "exp.Select", bodies: dict[str, "exp.Expression"],
         source = _grain_preserving_source(key, bodies, tidx, set())
         if source is not None:
             resolved[alias] = source
-            continue
-        grain = _group_by_grain(bodies[key])
-        edge = _cte_edge(conjuncts, alias, written, grain, grains, resolved) if grain else None
+        else:
+            pending.append((alias, written))
+    # PASS TWO derives the edges, every one of them against the SAME settled map. A snapshot rather
+    # than `resolved` itself, so that one grain-changing CTE failing to derive an edge — which binds
+    # it to the empty string below — cannot change what a later one resolves its far side to.
+    settled = dict(resolved)
+    derived: list[Relationship] = []
+    for alias, written in pending:
+        body = bodies[_tkey(written)]
+        grain = _group_by_grain(body)
+        edge = _cte_edge(conjuncts, alias, written, grain, grains, settled,
+                         _projection_sources(body)) if grain else None
         if edge is None:
             resolved[alias] = ""
-            continue
-        derived.append(edge)
+        else:
+            derived.append(edge)
     return resolved, derived
 
 

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -1687,7 +1687,7 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
                       ctx: "GuardContext | None" = None,
                       *, scope: str = "main",
                       visible: Optional[set[str]] = None,
-                      tidx: Optional[dict[str, tuple]] = None) -> list[AggregateReport]:
+                      tidx: dict[str, tuple]) -> list[AggregateReport]:
     """Fan/chasm + aggregation-semantics analysis of a SINGLE SELECT, read entirely off the tree.
     A top-level SELECT and a set-operation arm are analyzed identically; there is no longer a
     rewrite for one to be eligible for, and no statement text for either to carry.
@@ -1699,9 +1699,9 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
 
     `ctx` supplies the shared cardinality/column indices (ACE-045); `tree` is always the
     caller's own SELECT (a set-op arm ≠ `ctx.tree`), so only the indices come from `ctx`. `tidx` is
-    the same model table index under a second name, for the `assemble_receipt` path that has no
-    `ctx` and has already built one: without it, a statement whose arms read a CTE rebuilt the whole
-    model's index once per arm."""
+    REQUIRED and comes from `_aggregate_reports`, which resolves it once per statement from `ctx` or
+    from the caller: rebuilt here it walked every table in the model once per set-operation arm, on
+    the `assemble_receipt` path that has no `ctx` and has already built one."""
     rels = ctx.cardinality_index if ctx is not None else _cardinality_index(org)
     # Filtered to what THIS SELECT's own FROM/JOIN clauses bind, and derived once: every consumer
     # below reads this one map. Asking for it twice with two flags would be the second tree walk
@@ -1729,8 +1729,6 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
     # CTE anywhere spent 5.4 of their 5.5 seconds proving there was nothing to resolve.
     bodies = _visible_cte_bodies(tree)
     if bodies.keys() & {_tkey(v) for v in tables_in_scope.values()}:
-        if tidx is None:
-            tidx = ctx.model_table_index if ctx is not None else _model_table_index(org)
         tables_in_scope, cte_rels = _resolve_cte_scope(tree, bodies, tables_in_scope, tidx)
         # A NEW list. `ctx.cardinality_index` is the model's own edges, shared across every guard
         # in the battery and across every arm of a set operation; appending a statement-derived

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -1706,7 +1706,13 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
     # tell the difference: `FROM oi` reads `oi` whether `oi` is a table or a WITH. Resolving it is
     # what lets the fan detector see the join the statement actually takes, and the guard is the
     # cheap half of the question, so a statement with no CTE in its FROM pays nothing for this.
-    if _cte_names(tree) & {_tkey(v) for v in tables_in_scope.values()}:
+    #
+    # The CTE names come off the ROOT and the alias map does NOT, and the asymmetry is the point.
+    # A WITH binds its name for every arm below it, so an arm reading `oi` reads a name declared
+    # above it — `_aggregate_reports` computes `visible` on the root for exactly this reason. Which
+    # TABLES an arm reads is the opposite kind of question and stays strictly per-arm, because one
+    # arm's tables deciding another arm's fan is the defect ACE-099 and ACE-043 exist to prevent.
+    if _cte_names(tree.root()) & {_tkey(v) for v in tables_in_scope.values()}:
         tidx = ctx.model_table_index if ctx is not None else _model_table_index(org)
         tables_in_scope, cte_rels = _resolve_cte_scope(tree, tables_in_scope, tidx)
         # A NEW list. `ctx.cardinality_index` is the model's own edges, shared across every guard
@@ -1908,7 +1914,7 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
     return tables[0].name if name in tidx else None
 
 
-def _cte_edge(sel: "exp.Select", alias: str, cte_key: str, grain: list[str],
+def _cte_edge(conjuncts: list["exp.Expression"], alias: str, cte_key: str, grain: list[str],
               grains: dict[str, set[str]], scope_map: dict[str, str]) -> Optional[Relationship]:
     """The join edge between a grain-CHANGING CTE and the table it is joined to, or None.
 
@@ -1922,6 +1928,10 @@ def _cte_edge(sel: "exp.Select", alias: str, cte_key: str, grain: list[str],
     finer than the join key — `GROUP BY order_id, product_id` joined on `order_id` alone — it is
     many rows per joined row and the fan is real. That difference is the whole reason this returns
     an edge instead of abstaining, and it is `infer_cardinality` that reads it off the grains.
+
+    `conjuncts` is every join predicate of the enclosing SELECT, already flattened over AND by the
+    caller. It is passed in rather than derived because it is the same list for every alias in one
+    SELECT, and deriving it here would re-walk the joins once per grain-changing CTE.
 
     Three ways to decline, each an honest `undetermined` rather than a guess:
 
@@ -1939,17 +1949,16 @@ def _cte_edge(sel: "exp.Select", alias: str, cte_key: str, grain: list[str],
     module-load import closure — pinned by `tests/test_plugin_lib_resolution.py` — is untouched.
     """
     pairs: list[tuple["exp.Column", "exp.Column"]] = []
-    for on in _all_join_predicates(sel):
-        for conjunct in _and_conjuncts(on):
-            if not isinstance(conjunct, exp.EQ):
-                continue
-            left, right = conjunct.this, conjunct.expression
-            if not (isinstance(left, exp.Column) and isinstance(right, exp.Column)):
-                continue
-            if left.table == alias:
-                pairs.append((left, right))
-            elif right.table == alias:
-                pairs.append((right, left))
+    for conjunct in conjuncts:
+        if not isinstance(conjunct, exp.EQ):
+            continue
+        left, right = conjunct.this, conjunct.expression
+        if not (isinstance(left, exp.Column) and isinstance(right, exp.Column)):
+            continue
+        if left.table == alias:
+            pairs.append((left, right))
+        elif right.table == alias:
+            pairs.append((right, left))
     if len(pairs) != 1:
         return None
     near, far = pairs[0]
@@ -1976,6 +1985,14 @@ def _resolve_cte_scope(sel: "exp.Select", scope_map: dict[str, str],
     CTE BODIES are collected here because nothing else needs them: `_cte_body_scopes` answers which
     CTE a reference sits IN, which is the opposite question.
 
+    They come off `sel.root()`, and the JOIN PREDICATES do not. A WITH sits above a set operation
+    and binds its name for every arm, so an arm that reads `oi` is reading a name declared outside
+    itself and looking for it inside the arm finds nothing — measured: a UNION arm joining a
+    grain-preserving CTE reported `not_multiplied` over a fan, on both the resolvable and the
+    unreadable shape. `_aggregate_reports` reads `_cte_names` off the root for exactly this reason.
+    The join predicates stay the arm's own, because which rows an arm joins is a fact about that
+    arm, and folding two arms' joins together is the defect ACE-099 and ACE-043 exist to prevent.
+
     Three outcomes per reference, and they are the three a caller can act on:
 
     * a grain-preserving CTE rebinds to the table it hands back, and the model's declared edges then
@@ -1998,8 +2015,9 @@ def _resolve_cte_scope(sel: "exp.Select", scope_map: dict[str, str],
     that decides its cardinality folds on the way in.
     """
     bodies = {_tkey(cte.alias_or_name): cte.this
-              for cte in sel.find_all(exp.CTE) if cte.this is not None}
+              for cte in sel.root().find_all(exp.CTE) if cte.this is not None}
     grains = {key: set(table.grain or []) for key, (table, _area) in tidx.items()}
+    conjuncts = [c for on in _all_join_predicates(sel) for c in _and_conjuncts(on)]
     resolved = dict(scope_map)
     derived: list[Relationship] = []
     for alias, written in scope_map.items():
@@ -2013,7 +2031,7 @@ def _resolve_cte_scope(sel: "exp.Select", scope_map: dict[str, str],
         group = bodies[key].args.get("group")
         keys = list(group.expressions) if group is not None else []
         grain = [k.name for k in keys] if keys and all(isinstance(k, exp.Column) for k in keys) else []
-        edge = _cte_edge(sel, alias, written, grain, grains, resolved) if grain else None
+        edge = _cte_edge(conjuncts, alias, written, grain, grains, resolved) if grain else None
         if edge is None:
             resolved[alias] = ""
             continue

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -813,7 +813,10 @@ class Finding:
     disclosure naming an alternative presumes an intent principle 6 forbids us to presume.
     """
 
-    risk: str  # "fan_trap" | "chasm_trap" | "bad_aggregation" | "semi_additive"
+    # "fan_trap" | "fan_out_invariant" | "chasm_trap" | "bad_aggregation" | "semi_additive".
+    # `fan_out_invariant` is the fan its aggregate is immune to: the rows really were multiplied and
+    # the number is the same either way, so it belongs beside `fan_trap` and not instead of it.
+    risk: str
     reason: str
     triggering_joins: list[str] = field(default_factory=list)
     # WHICH aggregate this is about, as the parser read it. Without it a finding names the measure
@@ -1667,10 +1670,15 @@ def _aggregate_reports(tree, org: Datasource,
     return reports
 
 
-# The two risks that are statements about the ROWS an aggregate was computed from, and therefore
-# the two that decide `status`. `bad_aggregation` and `semi_additive` are about the aggregate's own
+# The risks that are statements about the ROWS an aggregate was computed from, and therefore the
+# ones that decide `status`. `bad_aggregation` and `semi_additive` are about the aggregate's own
 # meaning and leave the multiplication question exactly where they found it.
-_MULTIPLYING_RISKS = ("fan_trap", "chasm_trap")
+#
+# `fan_out_invariant` is in here, and that is the whole of what ACE-083 changed about `status`. The
+# rows behind a `MAX` over the one side of a fan ARE multiplied; what is false about calling it a
+# trap is the word trap, not the multiplication. Leaving it out would make the item say
+# `not_multiplied`, which is a positive claim that the rows were not duplicated, and they were.
+_MULTIPLYING_RISKS = ("fan_trap", "chasm_trap", "fan_out_invariant")
 
 
 def _preflight_select(tree: "exp.Select", org: Datasource,
@@ -1742,15 +1750,28 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
             }
             measure = _echo_name(measure_table)
             many = [_echo_name(mt) for mt in sorted(many_tables)]
-            reason = (
-                f"fan trap: aggregating {measure!r} (one side) across a join to "
-                f"{many} (many side)."
-            )
+            # Two sentences about ONE fan, picked per aggregate. The edge is the same edge and the
+            # duplication is the same duplication; what differs is whether the number moved with it.
+            # The second states that and stops there — it names no fix, because under principle 6c
+            # this layer does not hold the question and a sentence telling the caller to act on a
+            # value that did not change would be a verdict on a statement that is fine.
+            reason_for = {
+                "fan_trap": (
+                    f"fan trap: aggregating {measure!r} (one side) across a join to "
+                    f"{many} (many side)."
+                ),
+                "fan_out_invariant": (
+                    f"fan out: the join from {measure!r} (one side) to {many} (many side) "
+                    f"multiplies the rows this aggregate reads; its value is unchanged by that "
+                    f"duplication."
+                ),
+            }
             joins = [f"{measure} (1) <- {mt} (N)" for mt in many]
             for i, site in enumerate(sites):
                 if measure_table in site.sources:
+                    risk = "fan_out_invariant" if _is_fan_immune(site.node) else "fan_trap"
                     attached[i].append(Finding(
-                        "fan_trap", reason=reason,
+                        risk, reason=reason_for[risk],
                         triggering_joins=list(joins), aggregate=site.aggregate,
                     ))
 
@@ -2069,17 +2090,24 @@ def _undetermined_sections(reason: str) -> dict[str, dict[str, Any]]:
 
 
 def _is_fan_immune(agg: "exp.AggFunc") -> bool:
-    """Aggregates a fan-out cannot change the value of: MIN, MAX, COUNT(DISTINCT).
+    """Aggregates a row duplication cannot move: MIN, MAX, the boolean folds, anything DISTINCT.
 
-    Duplicating a row does not move a minimum, a maximum, or a count of distinct values, so the
-    detector counting these as fan-out risks is a false positive it currently makes. Fixing the
-    DETECTION is not this spec's; reporting that the detector does it, and only when this statement
-    contains one, is."""
-    if isinstance(agg, (exp.Min, exp.Max)):
+    Duplicating a row does not move a minimum, a maximum, a fold over booleans, or an aggregate
+    computed over the distinct values it was handed. The fan is still real for all of them, which is
+    why this decides the WORD the finding uses and not whether there is one.
+
+    A predicate over node TYPE, never over the written function name. ACE-079 reads every statement
+    in the engine's own dialect, so the same fold is `BOOL_OR` in Postgres and `LOGICAL_OR` on the
+    way back out and any name allowlist is wrong the first time a dialect spells it differently;
+    sqlglot has already resolved both to `exp.LogicalOr` by the time this runs.
+
+    Both DISTINCT spellings, and the first is the one that carries every dialect measured on sqlglot
+    30.15: `SUM(DISTINCT x)` parses to `exp.Sum(this=exp.Distinct(...))` with `args["distinct"]`
+    left at `None`, so testing the arg alone would see no DISTINCT at all. The arg test stays for
+    the older sqlglot the package's `>=20` floor still admits."""
+    if isinstance(agg, (exp.Min, exp.Max, exp.LogicalOr, exp.LogicalAnd)):
         return True
-    return isinstance(agg, exp.Count) and (
-        isinstance(agg.this, exp.Distinct) or bool(agg.args.get("distinct"))
-    )
+    return isinstance(agg.this, exp.Distinct) or bool(agg.args.get("distinct"))
 
 
 def _within(node: "exp.Expression", kinds: tuple) -> bool:
@@ -2128,8 +2156,12 @@ def _aggregates_marker(tree, reports: list[AggregateReport],
          if in_filter_or_sort else ""),
         ("An aggregate inside a CTE or a subquery is not reported: only the SELECT lists that "
          "reach the output are read." if in_nested_scope else ""),
-        ("MIN, MAX and COUNT(DISTINCT) are counted as fan-out risks although a fan-out cannot "
-         "change what they return." if any(_is_fan_immune(a) for a in output) else ""),
+        # The fan-immune clause stood here. It described a gap in the DETECTOR — that MIN, MAX and
+        # COUNT(DISTINCT) were counted as fan-out risks although a fan-out cannot change what they
+        # return — and ACE-083 closed that gap: those aggregates now carry `fan_out_invariant`,
+        # which says the same thing on the item itself where the reader is already looking. A marker
+        # sentence about a shortcoming the detector no longer has is a false statement about this
+        # statement, and the section's null state is the claim it would cost.
         (f"{dropped} further aggregate(s) are not listed." if dropped else ""),
     ) if clause) or None
 

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -1624,7 +1624,8 @@ def pre_flight_check(sql: str, org: Datasource,
 
 def _aggregate_reports(tree, org: Datasource,
                        ctx: "GuardContext | None" = None,
-                       *, visible: Optional[set[str]] = None) -> list[AggregateReport]:
+                       *, visible: Optional[set[str]] = None,
+                       tidx: Optional[dict[str, tuple]] = None) -> list[AggregateReport]:
     """The analysis half, on an already-parsed tree: one report per aggregate the statement outputs.
 
     This was `_collect_findings`, which returned the flat finding list this is now a projection of.
@@ -1657,15 +1658,16 @@ def _aggregate_reports(tree, org: Datasource,
     # A caller that already holds both halves passes them in: `assemble_receipt` builds this exact
     # index and this exact CTE set for its `tables` section, and `_model_table_index` walks every
     # table in the model, which is not work to repeat on a path that runs for every executed query.
-    if visible is None:
-        tidx = ctx.model_table_index if ctx is not None else _model_table_index(org)
-        visible = set(tidx) - _cte_names(tree)
+    # The index goes DOWN as well, because `_preflight_select` needs it too and rebuilt it per arm.
+    if visible is None or tidx is None:
+        tidx = tidx or (ctx.model_table_index if ctx is not None else _model_table_index(org))
+        visible = set(tidx) - _cte_names(tree) if visible is None else visible
     reports: list[AggregateReport] = []
     for arm in _output_select_arms(tree):
         for sel in arm:
             reports.extend(_preflight_select(
                 sel, org, ctx=ctx,
-                scope="main" + suffixes.get(id(sel), ""), visible=visible,
+                scope="main" + suffixes.get(id(sel), ""), visible=visible, tidx=tidx,
             ))
     return reports
 
@@ -1684,7 +1686,8 @@ _MULTIPLYING_RISKS = ("fan_trap", "chasm_trap", "fan_out_invariant")
 def _preflight_select(tree: "exp.Select", org: Datasource,
                       ctx: "GuardContext | None" = None,
                       *, scope: str = "main",
-                      visible: Optional[set[str]] = None) -> list[AggregateReport]:
+                      visible: Optional[set[str]] = None,
+                      tidx: Optional[dict[str, tuple]] = None) -> list[AggregateReport]:
     """Fan/chasm + aggregation-semantics analysis of a SINGLE SELECT, read entirely off the tree.
     A top-level SELECT and a set-operation arm are analyzed identically; there is no longer a
     rewrite for one to be eligible for, and no statement text for either to carry.
@@ -1695,7 +1698,10 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
     standing free beside a statement that computes three other numbers it did not.
 
     `ctx` supplies the shared cardinality/column indices (ACE-045); `tree` is always the
-    caller's own SELECT (a set-op arm ≠ `ctx.tree`), so only the indices come from `ctx`."""
+    caller's own SELECT (a set-op arm ≠ `ctx.tree`), so only the indices come from `ctx`. `tidx` is
+    the same model table index under a second name, for the `assemble_receipt` path that has no
+    `ctx` and has already built one: without it, a statement whose arms read a CTE rebuilt the whole
+    model's index once per arm."""
     rels = ctx.cardinality_index if ctx is not None else _cardinality_index(org)
     # Filtered to what THIS SELECT's own FROM/JOIN clauses bind, and derived once: every consumer
     # below reads this one map. Asking for it twice with two flags would be the second tree walk
@@ -1704,17 +1710,28 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
     tables_in_scope = _alias_map(tree, in_scope_only=True)  # alias -> table ("" when unbindable)
     # A name the statement bound for itself stands where a table name would, and the map cannot
     # tell the difference: `FROM oi` reads `oi` whether `oi` is a table or a WITH. Resolving it is
-    # what lets the fan detector see the join the statement actually takes, and the guard is the
-    # cheap half of the question, so a statement with no CTE in its FROM pays nothing for this.
+    # what lets the fan detector see the join the statement actually takes.
     #
-    # The CTE names come off the ROOT and the alias map does NOT, and the asymmetry is the point.
-    # A WITH binds its name for every arm below it, so an arm reading `oi` reads a name declared
-    # above it — `_aggregate_reports` computes `visible` on the root for exactly this reason. Which
-    # TABLES an arm reads is the opposite kind of question and stays strictly per-arm, because one
-    # arm's tables deciding another arm's fan is the defect ACE-099 and ACE-043 exist to prevent.
-    if _cte_names(tree.root()) & {_tkey(v) for v in tables_in_scope.values()}:
-        tidx = ctx.model_table_index if ctx is not None else _model_table_index(org)
-        tables_in_scope, cte_rels = _resolve_cte_scope(tree, tables_in_scope, tidx)
+    # The bindings come off this SELECT's LEXICAL ANCESTORS and the alias map does not, and the
+    # asymmetry is the point. A WITH binds its name for every arm below it, so an arm reading `oi`
+    # reads a name declared above it — `_aggregate_reports` computes `visible` on the root for
+    # exactly this reason. Which TABLES an arm reads is the opposite kind of question and stays
+    # strictly per-arm, because one arm's tables deciding another arm's fan is the defect ACE-099
+    # and ACE-043 exist to prevent.
+    #
+    # ANCESTORS rather than the root, because the root holds CTEs that do not bind here. Read off
+    # `root().find_all(exp.CTE)` and keyed by folded name, a same-named CTE in a SIBLING arm won by
+    # being written last, so swapping two arms of a UNION changed the answer for both; and a WITH
+    # nested inside a `WHERE … IN (…)` subquery rebound a real outer table out from under the
+    # statement. Both produced a receipt calling an inflated number sound. The ancestor walk is also
+    # what makes the guard cheap: `_cte_names(tree.root())` was the unconditional left operand of an
+    # `&` and walked the WHOLE tree once per set-operation arm, so 471 arms of a statement with no
+    # CTE anywhere spent 5.4 of their 5.5 seconds proving there was nothing to resolve.
+    bodies = _visible_cte_bodies(tree)
+    if bodies.keys() & {_tkey(v) for v in tables_in_scope.values()}:
+        if tidx is None:
+            tidx = ctx.model_table_index if ctx is not None else _model_table_index(org)
+        tables_in_scope, cte_rels = _resolve_cte_scope(tree, bodies, tables_in_scope, tidx)
         # A NEW list. `ctx.cardinality_index` is the model's own edges, shared across every guard
         # in the battery and across every arm of a set operation; appending a statement-derived
         # edge to it would leak this query's CTE into the next one's analysis.
@@ -1869,8 +1886,51 @@ def _multiplication_status(site: "_AggSite", findings: list[Finding]) -> str:
 # ---------------------------------------------------------------------------
 
 
+# How many grain-preserving hops the resolver will follow before it declines to answer. A bound on
+# the caller's SQL rather than on the model: `_MAX_SQL_CHARS` admits a chain of ~990 CTEs each
+# reading the one before, which is not a cycle and so is not what `seen` catches. Sixty-four is far
+# past any chain a person writes and far short of the interpreter's own limit, and hitting it
+# returns None into the fail-closed branch — `undetermined`, not a lost receipt.
+_MAX_CTE_CHAIN = 64
+
+
+def _visible_cte_bodies(sel: "exp.Expression") -> dict[str, "exp.Expression"]:
+    """Folded CTE name -> body, for every WITH that BINDS for `sel`. Innermost binding wins.
+
+    Lexical scope, walked up the parent chain, which is what "a WITH binds its name for every arm
+    below it" actually means. `sel.root().find_all(exp.CTE)` is the wrong set in both directions:
+    it collects CTEs from scopes that do not bind here, and being a flat dict keyed by folded name
+    it resolves a collision by whichever one the walk reached last. Two shapes measured, both of
+    them receipts calling an inflated number sound:
+
+    * two arms of a `UNION ALL` each declaring their OWN `WITH x AS (…)` over different tables. The
+      second arm's body won for both arms, so SWAPPING THE ARMS CHANGED THE ANSWER;
+    * `… WHERE orders.id IN (WITH order_items AS (SELECT id FROM customers) SELECT …)`, where a CTE
+      that binds only inside the subquery rebound the outer statement's real `order_items` table.
+
+    `setdefault` on the way UP is the innermost-wins rule: the nearest enclosing WITH is reached
+    first and keeps the name, and an outer WITH of the same name is shadowed exactly as SQL says.
+
+    **sqlglot 30 keys the argument `with_`**, the same rename that makes `args.get("from")` `None`
+    on every SELECT ever written. Read under one spelling only, this returns the empty dict for
+    every statement and every CTE reference silently falls to the fail-closed binding, which passes
+    a corpus that only forbids false cleans while quietly answering nothing at all.
+    """
+    bodies: dict[str, "exp.Expression"] = {}
+    node: Optional["exp.Expression"] = sel
+    while node is not None:
+        with_clause = node.args.get("with_") or node.args.get("with")
+        if isinstance(with_clause, exp.With):
+            for cte in with_clause.expressions:
+                if isinstance(cte, exp.CTE) and cte.this is not None:
+                    bodies.setdefault(_tkey(cte.alias_or_name), cte.this)
+        node = node.parent
+    return bodies
+
+
 def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
-                             tidx: dict[str, tuple], seen: set[str]) -> Optional[str]:
+                             tidx: dict[str, tuple], seen: set[str],
+                             depth: int = 0) -> Optional[str]:
     """The declared table a CTE hands back ROW FOR ROW, or None when it is not that simple.
 
     `WITH oi AS (SELECT * FROM order_items)` produces exactly the rows of `order_items`, so a join
@@ -1887,13 +1947,25 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
     * a `JOIN` — the join is the multiplication, one scope further in than the caller can see;
     * an aggregate anywhere — `SELECT SUM(quantity) FROM order_items` is one row from many, and it
       needs no `GROUP BY` to be so;
-    * no `FROM` — and this one is read with `body.find(exp.From)`, NEVER `body.args.get("from")`.
-      sqlglot keys that argument `"from_"`, so the `args` spelling is `None` on every SELECT ever
-      written and a resolver built on it silently answers None for every CTE, passing the corpus
-      and failing only the assertions that name the join. The guard is load-bearing on its own
-      terms too: `SELECT 1 AS x WHERE EXISTS (SELECT 1 FROM orders)` has no FROM and one
-      `exp.Table`, and without it the body would resolve to `orders`;
-    * more than one table, or none — a nested source, or a body that reads nothing nameable.
+    * the body's own `FROM` not naming a table directly. Read off `args`, under BOTH spellings —
+      sqlglot 30 keys the argument `"from_"`, so a resolver built on `args.get("from")` alone
+      silently answers None for every CTE, passing the corpus and failing only the assertions that
+      name the join. `body.find(exp.From)` is what it must not be: `find` is RECURSIVE, so it
+      reaches a FROM one scope further in and the guard stops testing what it says it tests. The
+      docstring's own example proved it — `SELECT 1 AS x WHERE EXISTS (SELECT 1 FROM orders)` has
+      no FROM of its own and resolved to `orders` anyway. Requiring `frm.this` to be an `exp.Table`
+      is the second half: `SELECT * FROM (SELECT DISTINCT order_id FROM order_items) g` hands back
+      one row per DISTINCT order, not one row per order item, and reading through the wrapper named
+      a join the statement does not take;
+    * more than one table, or none — a nested source, or a body that reads nothing nameable. This
+      count stays WHOLE-SUBTREE deliberately: `SELECT order_id FROM order_items WHERE order_id IN
+      (SELECT id FROM orders)` is caught only because the IN subquery's table is counted, and its
+      row count is not `order_items`'s.
+    * more than `_MAX_CTE_CHAIN` hops. `seen` catches a CYCLE and a linear chain is not one: 990
+      CTEs each reading the one before fit inside `_MAX_SQL_CHARS` and raised `RecursionError`,
+      which `_receipt_for` catches as a build failure — so the statement still ran and returned
+      rows while the caller silently lost the receipt. Caller-chosen input that turns off the trust
+      layer without turning off the answer is the one shape a bound has to exist for.
 
     Recursive through a chain of grain-preserving CTEs, because one that reads another is still
     handing back the same rows, and `seen` is what stops a cyclic WITH from recursing forever. A
@@ -1901,22 +1973,22 @@ def _grain_preserving_source(key: str, bodies: dict[str, "exp.Expression"],
     name is one the analysis can say nothing about.
     """
     body = bodies.get(key)
-    if not isinstance(body, exp.Select) or key in seen:
+    if not isinstance(body, exp.Select) or key in seen or depth > _MAX_CTE_CHAIN:
         return None
     seen.add(key)
     if body.args.get("group") or body.args.get("distinct") or body.args.get("joins"):
         return None
     if body.find(exp.AggFunc) is not None:
         return None
-    if body.find(exp.From) is None:
+    frm = body.args.get("from_") or body.args.get("from")
+    if not isinstance(frm, exp.From) or not isinstance(frm.this, exp.Table):
         return None
-    tables = list(body.find_all(exp.Table))
-    if len(tables) != 1:
+    if len(list(body.find_all(exp.Table))) != 1:
         return None
-    name = _tkey(tables[0].name)
+    name = _tkey(frm.this.name)
     if name in bodies:
-        return _grain_preserving_source(name, bodies, tidx, seen)
-    return tables[0].name if name in tidx else None
+        return _grain_preserving_source(name, bodies, tidx, seen, depth + 1)
+    return frm.this.name if name in tidx else None
 
 
 def _cte_edge(conjuncts: list["exp.Expression"], alias: str, cte_key: str, grain: list[str],
@@ -1950,8 +2022,14 @@ def _cte_edge(conjuncts: list["exp.Expression"], alias: str, cte_key: str, grain
       `many_to_one` default. Calling it anyway would put a cardinality on the receipt that no one
       declared, which is worse than saying nothing.
 
-    The lazy import matches `cli.py`'s `from . import build as B` idiom, so `runtime.py`'s
-    module-load import closure — pinned by `tests/test_plugin_lib_resolution.py` — is untouched.
+    The import of `build` is LAZY because `build.py` imports `yaml` at module scope while the
+    package declares `dependencies = []` and lists PyYAML only in the `model` extra. `execute_sql.py`
+    imports `semantic_model.runtime` inside a function for exactly that reason, so a base install
+    reaches this module and would meet a `ModuleNotFoundError` at import time rather than at the one
+    call site that needs YAML. It matches `cli.py`'s `from . import build as B` idiom.
+    (This previously cited `tests/test_plugin_lib_resolution.py` as pinning the closure. That test
+    is about the four PLUGIN SCRIPTS and names `runtime.py` nowhere; the decision is right and the
+    reason given for it was not.)
     """
     pairs: list[tuple["exp.Column", "exp.Column"]] = []
     for conjunct in conjuncts:
@@ -1971,32 +2049,40 @@ def _cte_edge(conjuncts: list["exp.Expression"], alias: str, cte_key: str, grain
     if not other or not grains.get(_tkey(other)):
         return None
 
+    # Every name that reaches `infer_cardinality` is folded, on BOTH sides of every comparison it
+    # makes. `grains` was folded by the caller, `grain` by `_group_by_grain`, and the join keys are
+    # folded here — the module's own convention, stated on `check_column_scope` as "matching is
+    # case-insensitive", and the one this comparison was missing. The `Relationship` keeps the
+    # WRITTEN spellings, because that is what the receipt echoes back to the caller.
     from .build import infer_cardinality
     return Relationship(
         from_table=cte_key, to_table=other,
         from_column=near.name, to_column=far.name,
         relationship=infer_cardinality(
-            _tkey(cte_key), _tkey(other), [near.name], [far.name],
+            _tkey(cte_key), _tkey(other), [_tkey(near.name)], [_tkey(far.name)],
             {**grains, _tkey(cte_key): set(grain)},
         ),
     )
 
 
-def _resolve_cte_scope(sel: "exp.Select", scope_map: dict[str, str],
+def _resolve_cte_scope(sel: "exp.Select", bodies: dict[str, "exp.Expression"],
+                       scope_map: dict[str, str],
                        tidx: dict[str, tuple]) -> tuple[dict[str, str], list[Relationship]]:
     """The scope map with every CTE reference resolved, plus the edges that resolution derived.
 
     One pass over the map the caller already built, never a second walk for the reference list. The
-    CTE BODIES are collected here because nothing else needs them: `_cte_body_scopes` answers which
-    CTE a reference sits IN, which is the opposite question.
+    CTE BODIES are passed in because the caller has already used them as its own guard, and they
+    are `_visible_cte_bodies`' answer rather than `_cte_body_scopes`', which answers which CTE a
+    reference sits IN — the opposite question.
 
-    They come off `sel.root()`, and the JOIN PREDICATES do not. A WITH sits above a set operation
-    and binds its name for every arm, so an arm that reads `oi` is reading a name declared outside
-    itself and looking for it inside the arm finds nothing — measured: a UNION arm joining a
-    grain-preserving CTE reported `not_multiplied` over a fan, on both the resolvable and the
-    unreadable shape. `_aggregate_reports` reads `_cte_names` off the root for exactly this reason.
-    The join predicates stay the arm's own, because which rows an arm joins is a fact about that
-    arm, and folding two arms' joins together is the defect ACE-099 and ACE-043 exist to prevent.
+    Those bodies come from `sel`'s LEXICAL ANCESTORS, and the JOIN PREDICATES do not. A WITH sits
+    above a set operation and binds its name for every arm, so an arm that reads `oi` is reading a
+    name declared outside itself and looking for it inside the arm finds nothing — measured: a
+    UNION arm joining a grain-preserving CTE reported `not_multiplied` over a fan, on both the
+    resolvable and the unreadable shape. `_aggregate_reports` reads `_cte_names` off the root for
+    exactly this reason. The join predicates stay the arm's own, because which rows an arm joins is
+    a fact about that arm, and folding two arms' joins together is the defect ACE-099 and ACE-043
+    exist to prevent.
 
     Three outcomes per reference, and they are the three a caller can act on:
 
@@ -2009,9 +2095,20 @@ def _resolve_cte_scope(sel: "exp.Select", scope_map: dict[str, str],
       the SELECT. That is the fail-closed branch and it is the common one: a CTE body with a join
       in it, or a grain written as an expression rather than as columns, lands here.
 
-    The grain is the GROUP BY's columns and only those. A `GROUP BY date_trunc('month', created_at)`
-    groups by something with no column name to compare a join key against, so it is no grain this
-    can state and the reference falls to the empty binding.
+    The grain is the GROUP BY's plain COLUMNS and only those, and three ways of not being that are
+    each an empty grain rather than a guess:
+
+    * `GROUP BY date_trunc('month', created_at)` groups by something with no column name to compare
+      a join key against, so it is no grain this can state;
+    * `ROLLUP`, `CUBE`, `GROUPING SETS`, `WITH TOTALS` and `GROUP BY ALL` hang off their OWN args of
+      `exp.Group`, so reading `expressions` alone saw `GROUP BY order_id, ROLLUP(product_id)` as a
+      grain of `{order_id}` — one row per order — when the rollup adds a subtotal row per order and
+      the join to it fans. Pure `CUBE` and `GROUPING SETS` left `expressions` empty and so failed
+      closed by accident; this makes all five deliberate;
+    * two grain columns that differ only in their qualifier. `[k.name for k in keys]` strips it, so
+      `GROUP BY orders.id, order_items.id` collapsed to a one-element grain, matched the join key
+      exactly, and declared the CTE unique on a key it is not unique on. The bare names have to be
+      INJECTIVE for the list to mean what the comparison below reads it as.
 
     Case is the reason the CTE's own written spelling is carried through rather than the folded key:
     `_cte_names` and `_model_table_index` both fold, while `_alias_map` preserves what the statement
@@ -2019,9 +2116,13 @@ def _resolve_cte_scope(sel: "exp.Select", scope_map: dict[str, str],
     matches nothing. So `WITH OI AS (…) … JOIN OI` derives an edge named `OI`, and the grain lookup
     that decides its cardinality folds on the way in.
     """
-    bodies = {_tkey(cte.alias_or_name): cte.this
-              for cte in sel.root().find_all(exp.CTE) if cte.this is not None}
-    grains = {key: set(table.grain or []) for key, (table, _area) in tidx.items()}
+    # Folded, because `Table.grain` comes from a catalog and the join keys come from the caller's
+    # SQL — Snowflake and Oracle hand back `ID` where the query writes `id`. Unfolded on either
+    # side, a declared `grain=["ID"]` matches no join key, `infer_cardinality` reads the CTE as
+    # non-unique and invents a fan the statement does not have. It also walks straight through the
+    # empty-grain guard above, since a case-mismatched grain is a non-empty one.
+    grains = {key: {_tkey(col) for col in table.grain or []}
+              for key, (table, _area) in tidx.items()}
     conjuncts = [c for on in _all_join_predicates(sel) for c in _and_conjuncts(on)]
     resolved = dict(scope_map)
     derived: list[Relationship] = []
@@ -2033,15 +2134,37 @@ def _resolve_cte_scope(sel: "exp.Select", scope_map: dict[str, str],
         if source is not None:
             resolved[alias] = source
             continue
-        group = bodies[key].args.get("group")
-        keys = list(group.expressions) if group is not None else []
-        grain = [k.name for k in keys] if keys and all(isinstance(k, exp.Column) for k in keys) else []
+        grain = _group_by_grain(bodies[key])
         edge = _cte_edge(conjuncts, alias, written, grain, grains, resolved) if grain else None
         if edge is None:
             resolved[alias] = ""
             continue
         derived.append(edge)
     return resolved, derived
+
+
+# The `exp.Group` arguments that hold a grouping the plain `expressions` list does not describe. Any
+# one of them present means the CTE emits rows at a grain no column list states, so there is no
+# grain to compare a join key against and the reference falls to the fail-closed binding.
+_NON_COLUMN_GROUPINGS = ("rollup", "cube", "grouping_sets", "totals", "all")
+
+
+def _group_by_grain(body: "exp.Expression") -> list[str]:
+    """The folded columns a CTE body groups by, or the empty list when that is not statable.
+
+    Empty means "no grain this can state", which `_resolve_cte_scope` turns into `undetermined`.
+    Every way of being empty is a way the body's row grain is not the list of columns it wrote:
+    no `GROUP BY` at all, a grouping construct beside the column list, an expression rather than a
+    column, or two columns whose bare names collide once the qualifier is stripped.
+    """
+    group = body.args.get("group") if isinstance(body, exp.Expression) else None
+    if group is None or any(group.args.get(arg) for arg in _NON_COLUMN_GROUPINGS):
+        return []
+    keys = list(group.expressions)
+    if not keys or not all(isinstance(k, exp.Column) for k in keys):
+        return []
+    names = [_tkey(k.name) for k in keys]
+    return names if len(set(names)) == len(names) else []
 
 
 # ---------------------------------------------------------------------------
@@ -2899,9 +3022,12 @@ def assemble_receipt(
     # listed: a truncated list under a silent marker is a positive claim of completeness. The cap
     # counts AGGREGATES now rather than findings, because that is what the items are; the count is
     # of the caller's own expressions either way, so stating it discloses nothing.
-    # `visible` is handed in rather than rebuilt: both halves are already in hand here, and
-    # `_model_table_index` walks the whole model.
-    reports = _aggregate_reports(tree, org, ctx=None, visible=visible)
+    # `visible` and the index behind it are handed in rather than rebuilt: both halves are already
+    # in hand here, `_model_table_index` walks the whole model, and this path has no `ctx` to read a
+    # shared one from — so without the second argument the analysis rebuilt it once per output arm.
+    # `visible` is the one the joins section above already computed off this same `tidx` and these
+    # same `cte_names`; recomputing it here would be the same set under a second spelling.
+    reports = _aggregate_reports(tree, org, ctx=None, visible=visible, tidx=tidx)
     dropped_aggregates = max(0, len(reports) - _RECEIPT_MAX_REFS)
     aggregate_items: list[dict[str, Any]] = [
         r.as_dict() for r in reports[:_RECEIPT_MAX_REFS]
@@ -3264,12 +3390,22 @@ def _reference_sites(node: "exp.Expression", *,
     `tests/test_ace043_set_operation_arms.py::test_no_reference_in_any_arm_of_a_set_operation_falls_through_to_subquery`
     keeps counting the references it was written to count.
 
-    Two guards on that arm, both measured rather than defensive:
+    It is a DENYLIST: every FROM/JOIN source that is not an `exp.Table` binds. Reached by walking
+    the `exp.From` and `exp.Join` nodes and taking what each one binds, so the question asked is
+    "what does this clause put in scope" rather than "is this one of the three node types someone
+    listed". An allowlist of `Subquery`, `Lateral` and `Values` left `UNNEST(…) AS t` — an
+    `exp.Unnest`, a fourth type — out of the map entirely, and a source absent from the map is a
+    source the analysis reads as not being there: measured `not_multiplied` on the `sm prepare`
+    surface for a statement whose rows an unnest can multiply. A source kind nobody anticipated has
+    to default to `undetermined`, and only binding by exclusion gives that.
 
-    - The FROM/JOIN parent test is `check_column_scope`'s, reused rather than reinvented. A scalar
-      or `IN (...)` subquery is an `exp.Subquery` too and it binds no alias into the SELECT's scope.
-      It also excludes the inner `Subquery` of `LATERAL (SELECT 1) l`, whose parent is the
-      `Lateral`: the alias `l` belongs to the LATERAL and the wrapper inside it binds nothing.
+    Two guards, both measured rather than defensive:
+
+    - Taking each clause's own bound source is `check_column_scope`'s FROM/JOIN parent test read
+      from the other end. A scalar or `IN (...)` subquery is an `exp.Subquery` too and it binds no
+      alias into the SELECT's scope, so it is never a From/Join's `this`. Nor is the inner
+      `Subquery` of `LATERAL (SELECT 1) l`, whose parent is the `Lateral`: the alias `l` belongs to
+      the LATERAL and the wrapper inside it binds nothing.
     - A `Subquery` wrapping a bare `exp.Table` is a PARENTHESIZED NAMED TABLE — `FROM (orders)`
       parses to `Subquery(this=Table)` — and the `exp.Table` arm above has already bound it under
       its real name. Binding it a second time would report a source the statement does not have.
@@ -3281,19 +3417,31 @@ def _reference_sites(node: "exp.Expression", *,
     One falsy entry is all the scope-completeness conjunct in `_aggregate_sites` needs, so two
     unaliased sources colliding on that one key costs nothing: the value is `""` either way.
 
-    The `exp.Lateral` and `exp.Values` arms look unreachable and are not. `check_scopable` (ACE-037)
-    refuses both source kinds at the `execute_guarded` chokepoint, so no GUARDED query reaches here
-    carrying one — but `cmd_preflight` and `cmd_prepare` in `cli.py` call `pre_flight_check`
-    directly with no gate battery at all, and on that surface both shapes reported a clean
-    `not_multiplied` over a source that can multiply rows. Deleting them as dead code would restore
-    exactly that.
+    The derived arm looks unreachable and is not. `check_scopable` (ACE-037) refuses a `VALUES`,
+    `LATERAL`, `UNNEST` or table-function source at the `execute_guarded` chokepoint, so no GUARDED
+    query reaches here carrying one — but `cmd_preflight` and `cmd_prepare` in `cli.py` call
+    `pre_flight_check` directly with no gate battery at all, and on that surface every one of those
+    shapes reported a clean `not_multiplied` over a source that can multiply rows. Deleting it as
+    dead code would restore exactly that.
     """
     cte_scopes = _cte_body_scopes(node)
     arm_suffixes = _arm_suffixes(node)
     output_ids = {id(sel) for sel in _output_selects(node)}
-    walk = (exp.Table, exp.Subquery, exp.Lateral, exp.Values) if bind_derived else (exp.Table,)
+    walk = (exp.Table, exp.From, exp.Join) if bind_derived else (exp.Table,)
     sites: list[_RefSite] = []
-    for ref_node in node.find_all(*walk):
+    for found in node.find_all(*walk):
+        if isinstance(found, exp.Table):
+            ref_node: "exp.Expression" = found
+        else:
+            # What this FROM/JOIN clause binds. An `exp.Table` source was already bound by the arm
+            # above under its real name, and so was the table inside a parenthesized `FROM (orders)`;
+            # binding either again would report a source the statement does not have.
+            source = found.this
+            if not isinstance(source, exp.Expression) or isinstance(source, exp.Table):
+                continue
+            if isinstance(source, exp.Subquery) and isinstance(source.this, exp.Table):
+                continue
+            ref_node = source
         # One scope determination for both arms, so a derived table nested inside a subquery is
         # labelled `subquery` by the same three branches that label a table there, and is dropped
         # by the same filter. `_scope_label` is that one composition, shared with the join walk.
@@ -3305,12 +3453,8 @@ def _reference_sites(node: "exp.Expression", *,
                 _RefSite(TableRef(written, ref_node.name, ref_node.alias or None, scope), ref_node)
             )
             continue
-        if not isinstance(ref_node.parent, (exp.From, exp.Join)):
-            continue
-        if isinstance(ref_node, exp.Subquery) and isinstance(ref_node.this, exp.Table):
-            continue
-        sites.append(_RefSite(TableRef(ref_node.alias, "", ref_node.alias or None, scope),
-                              ref_node))
+        sites.append(_RefSite(
+            TableRef(ref_node.alias, "", ref_node.alias or None, scope), ref_node))
     return sites
 
 

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -1770,35 +1770,40 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
                 for r in fan_rels
             }
             measure = _echo_name(measure_table)
-            many = [_echo_name(mt) for mt in sorted(many_tables)]
-            # Two sentences about ONE fan, picked per aggregate. The edge is the same edge and the
-            # duplication is the same duplication; what differs is whether the number moved with it.
-            # The second states that and stops there — it names no fix, because under principle 6c
-            # this layer does not hold the question and a sentence telling the caller to act on a
-            # value that did not change would be a verdict on a statement that is fine.
-            reason_for = {
-                "fan_trap": (
+            for i, site in enumerate(sites):
+                if measure_table not in site.sources:
+                    continue
+                # PER EDGE, and that is what this loop is for. A many-side column on the value path
+                # means the value is already one row per row of THAT many side, so THAT edge's
+                # duplication is the grain the value was defined at and multiplies nothing. Every
+                # other edge in `many_tables` still does. Suppressing the whole finding because one
+                # edge is the value's grain is how `SUM(customers.id * tickets.id)` over two fans
+                # off `customers` came to report clean: the tickets join is its grain, the orders
+                # join duplicates it, and only one of those is a reason to say nothing.
+                inflating = [mt for mt in sorted(many_tables) if mt not in site.value_sources]
+                if not inflating:
+                    continue
+                many = [_echo_name(mt) for mt in inflating]
+                # Two sentences about ONE fan, picked per aggregate. The edge is the same edge and
+                # the duplication is the same duplication; what differs is whether the number moved
+                # with it. The second states that and stops there — it names no fix, because under
+                # principle 6c this layer does not hold the question and a sentence telling the
+                # caller to act on a value that did not change would be a verdict on a fine
+                # statement.
+                risk = "fan_out_invariant" if _is_fan_immune(site.node) else "fan_trap"
+                reason = (
                     f"fan trap: aggregating {measure!r} (one side) across a join to "
                     f"{many} (many side)."
-                ),
-                "fan_out_invariant": (
+                ) if risk == "fan_trap" else (
                     f"fan out: the join from {measure!r} (one side) to {many} (many side) "
                     f"multiplies the rows this aggregate reads; its value is unchanged by that "
                     f"duplication."
-                ),
-            }
-            joins = [f"{measure} (1) <- {mt} (N)" for mt in many]
-            for i, site in enumerate(sites):
-                # A many-side column ON THE VALUE PATH means the value is already one row per
-                # many-side row, so this edge's duplication IS its grain and multiplies nothing.
-                # Scoped per fan edge deliberately: `many_tables` is the many side of THIS edge, and
-                # a many-side column belonging to some other edge must not suppress this one.
-                if measure_table in site.sources and not (site.sources & many_tables):
-                    risk = "fan_out_invariant" if _is_fan_immune(site.node) else "fan_trap"
-                    attached[i].append(Finding(
-                        risk, reason=reason_for[risk],
-                        triggering_joins=list(joins), aggregate=site.aggregate,
-                    ))
+                )
+                attached[i].append(Finding(
+                    risk, reason=reason,
+                    triggering_joins=[f"{measure} (1) <- {mt} (N)" for mt in many],
+                    aggregate=site.aggregate,
+                ))
 
     # The SEMANTIC checks the fan/chasm detector is blind to: aggregation-class violations and
     # semi-additive rollups over time. These need NO join, so cardinality analysis cannot see them.
@@ -3784,9 +3789,16 @@ class _AggSite(NamedTuple):
     node: "exp.AggFunc"
     aggregate: str  # the receipt's label for it, already bounded
     scope: str  # "main", or "main#<n>" inside a set operation
-    # The model tables this aggregate reads, as far as the scope map could resolve them. This is
-    # what the fan and chasm detectors consume, in aggregate across the sites.
+    # The model tables this aggregate reads, over EVERY column inside it, as far as the scope map
+    # could resolve them. This is what the fan and chasm detectors consume, in aggregate across the
+    # sites, and what `resolved` is computed from.
     sources: frozenset[str]
+    # The tables the aggregate's VALUE is built from, per `_value_sources`. Narrower than `sources`
+    # and used in exactly one place: deciding whether a particular fan edge's duplication is the
+    # grain the value was already at. It answers a different question from `sources`, and the two
+    # were briefly one field — which is what made a one-side column sitting in a CASE predicate
+    # look like a reason to report nothing at all about a fan that really did inflate the number.
+    value_sources: frozenset[str]
     # Whether the sources above are the WHOLE story. False when a column inside the aggregate could
     # not be attributed to a table, and false when there is no column at all — see `_aggregate_sites`
     # for why the second case is the one that matters.
@@ -3837,22 +3849,28 @@ def _aggregate_sites(tree: "exp.Select", scope_map: dict[str, str], scope: str,
     """
     sites: list[_AggSite] = []
     for agg in _select_aggregates(tree):
-        # TWO column walks over one aggregate, and the split is the point. `sources` is what the
-        # fan and chasm detectors attribute the multiplication by, so it takes only the columns the
-        # VALUE is computed from — a many-side column in a CASE predicate or an ORDER BY arm does
-        # not put the value at the many side's grain. `resolved` is a different question, "did the
-        # analysis understand everything this aggregate reads", and that one wants every column:
-        # narrowing it to the value path would turn `COUNT(CASE WHEN i.quantity > 0 THEN 1 END)`
-        # from a clean answer into `undetermined`, because a value path of one literal is
-        # indistinguishable from no columns at all to the `bool(...)` test below.
-        value_tables = [_resolve_col_table(col, scope_map) for col in _value_columns(agg)]
+        # TWO column walks over one aggregate, answering two different questions, and keeping them
+        # apart is the point. `sources` is WHICH TABLES THIS AGGREGATE READS, over every column
+        # inside it, and three consumers ask that: the fan loop's "is the measure table one this
+        # aggregate reads", the chasm rule's `agg_sources`, and `resolved`. `value_sources` is the
+        # narrower "which tables is the value BUILT from", and exactly one consumer asks it — the
+        # fan loop's per-edge suppression, where a many-side column on the value path means that
+        # edge's duplication is the grain the value was already defined at.
+        #
+        # Narrowing `sources` itself to the value path is what manufactured a clean receipt.
+        # `SUM(CASE WHEN orders.status = 'shipped' THEN 1 ELSE 0 END)` has NO column on its value
+        # path, so the aggregate stopped reading `orders` at all, the fan loop never reached it, and
+        # a total the join really does inflate reported `not_multiplied`. The chasm blast radius was
+        # wider still: `agg_sources` is the union over sites, so one wrapped aggregate emptied the
+        # set for every OTHER aggregate in the statement, including ones the CASE never touched.
         cols = list(agg.find_all(exp.Column))
         resolved = [_resolve_col_table(col, scope_map) for col in cols]
         sites.append(_AggSite(
             node=agg,
             aggregate=_echo_expr(agg.sql()),
             scope=scope,
-            sources=frozenset(t for t in value_tables if t),
+            sources=frozenset(t for t in resolved if t),
+            value_sources=_value_sources(agg, scope_map),
             resolved=bool(cols) and all(resolved) and all(scope_map.values()) and (
                 visible is None or all(_tkey(t) in visible for t in resolved)
             ),
@@ -3860,53 +3878,96 @@ def _aggregate_sites(tree: "exp.Select", scope_map: dict[str, str], scope: str,
     return sites
 
 
-def _value_columns(node: "exp.Expression") -> list["exp.Column"]:
-    """Every column on an expression's VALUE path: the ones whose values the result is built from.
+def _value_sources(node: "exp.Expression", scope_map: dict[str, str]) -> frozenset[str]:
+    """The tables an expression's value is at the grain of on EVERY path through it.
 
-    The complement is the columns that only decide WHICH rows or in WHAT ORDER, and the difference
-    is what a fan means for the number. `SUM(order_items.quantity * orders.total_amount)` is one
-    product per order item, so the duplication the join performs is the grain the value was already
-    at and multiplies nothing; `SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount
-    END)` sums a one-side amount once per item, so the same duplication really does inflate it. A
-    walk that took every column inside the aggregate cannot tell those apart — it sees
-    `order_items` in both — which is why attribution is by POSITION and never by presence.
+    This is the one question the per-edge fan suppression asks, and both halves of it are load
+    bearing. VALUE, because a column that only decides WHICH rows or in WHAT ORDER says nothing
+    about the grain of the number: `SUM(order_items.quantity * orders.total_amount)` is one product
+    per order item, so the duplication the join performs is the grain the value was already at and
+    multiplies nothing, while `SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount
+    END)` sums a one-side amount once per item and the same duplication really does inflate it. A
+    walk that took every column inside the aggregate sees `order_items` in both and cannot tell them
+    apart, which is why attribution is by POSITION and never by presence.
 
-    Two node types put a column somewhere that is not the value, and each gets a case:
+    EVERY PATH, because an alternation is only at a table's grain if all of its alternatives are.
+    `SUM(CASE WHEN orders.flag THEN orders.total_amount ELSE order_items.quantity END)` takes a
+    one-side amount on the rows where the flag is set, and the join duplicates those rows and sums
+    the amount once per duplicate. Reading the union of the branches would put `order_items` on the
+    value path and clear a number the fan really does move, so an alternation INTERSECTS its
+    branches and everything else UNIONS its children. Those two compose correctly at depth without
+    enumerating paths: table sets under union and intersection are a distributive lattice, so
+    `(A∩B) ∪ (C∩D)` is exactly the intersection over the four paths of `CASE… * CASE…`.
+
+    Resolution to tables happens HERE rather than in the caller for the same reason. Two different
+    columns of one table are one grain, and `CASE WHEN p THEN orders.total_amount ELSE orders.revenue
+    END` is at `orders` grain on both branches; an intersection taken over COLUMNS would find nothing
+    in common and report the opposite.
+
+    The nodes that put an operand somewhere that is not the value, each measured rather than assumed:
 
     - `exp.Case`. `ifs[].this` is the branch predicate and `Case.this` is the simple-CASE operand
-      compared against them, so both are inputs to the choice rather than to the result. The value
-      is `ifs[].true` and `default`.
+      compared against them, so both are inputs to the choice and not to the result. The branches
+      are `ifs[].true` and `default`. An ABSENT `default` is not a branch: the implicit result is
+      NULL, which every aggregate skips rather than folds, so counting it would report a fan on
+      `SUM(CASE WHEN orders.flag THEN order_items.quantity END)`, whose value is at item grain on
+      every row that contributes one. An explicit `ELSE NULL` is counted, contributes no table and
+      so clears no edge — the same shape read the other way, in the fail-closed direction.
+    - `exp.If`. `IF` / `IIF` / `IFF` parse to this, NOT to `exp.Case`, on every dialect this layer
+      speaks. Without a case of its own the generic branch would take the CONDITION's columns as
+      value columns, which is the polarity that manufactures a false clean, and sqlglot RENDERS an
+      `exp.If` as `CASE WHEN … END` — so the two spellings produce a byte-identical receipt label
+      with opposite statuses.
+    - `exp.Nullif`. `args["expression"]` is the value the first argument is COMPARED against, not a
+      value the result is built from.
+    - `exp.GroupConcat`. `args["separator"]` is punctuation between the folded values.
+    - `exp.Coalesce`. `IFNULL` and `NVL` parse to it too. It is an alternation like `exp.Case`, and
+      the same reasoning applies: its value is at a table's grain only if every alternative is.
     - `exp.Order`. `STRING_AGG(x ORDER BY y)` parses to `GroupConcat(this=Order(this=x,
       expressions=[Ordered(y)]))`, so the ordering arms hang off `expressions` and are neither
       predicate nor value: reordering a concatenation changes the string but the fan is not what
       reordered it, and `y` is not a value the aggregate folds.
 
-    Everything else recurses over `node.args` unchanged, which is what keeps this honest by default:
-    a node type nobody thought about contributes its columns rather than silently dropping them, and
-    dropping is the direction that manufactures a false clean. `exp.Distinct` needs no case for
-    exactly that reason — it holds its argument under `args["expressions"]` and the generic branch
-    already reaches it. Neither does `exp.Filter`: `SUM(x) FILTER (WHERE y)` parses to
-    `Filter(this=Sum, expression=Where)`, so the predicate is structurally OUTSIDE the aggregate and
+    Everything else unions its children, and THE POLARITY OF THAT DEFAULT DEPENDS ON THE NODE. For a
+    node that only combines values it is honest: a node type nobody thought about contributes its
+    columns rather than silently dropping them. For a node that mixes a PREDICATE or a SEPARATOR
+    with its values it is inverted and dangerous — contributing the predicate's columns is what
+    manufactures a false clean, because a many-side column on the value path is what clears the fan.
+    Any node mixing predicate and value operands is that hazard class and needs a case here;
+    `exp.Case`, `exp.If`, `exp.Nullif` and `exp.GroupConcat` are the members this layer has met.
+    `exp.Distinct` is safely generic: it holds its argument under `args["expressions"]` and combines
+    nothing. So is `exp.Filter`: `SUM(x) FILTER (WHERE y)` parses to `Filter(this=Sum,
+    expression=Where)`, so the predicate is structurally OUTSIDE the aggregate and
     `find_all(exp.AggFunc)` never hands it here at all.
 
     `node.args` is iterated by hand rather than through `iter_expressions()`. Four lines that cannot
     drift, against a package that pins only `sqlglot>=20`.
     """
     if not isinstance(node, exp.Expression):
-        return []
+        return frozenset()
     if isinstance(node, exp.Column):
-        return [node]
+        table = _resolve_col_table(node, scope_map)
+        return frozenset([table]) if table else frozenset()
+    alternatives: Optional[list["exp.Expression"]] = None
     if isinstance(node, exp.Case):
-        cols = [c for branch in node.args.get("ifs") or []
-                for c in _value_columns(branch.args.get("true"))]
-        return cols + _value_columns(node.args.get("default"))
-    if isinstance(node, exp.Order):
-        return _value_columns(node.this)
-    cols = []
+        alternatives = [branch.args.get("true") for branch in node.args.get("ifs") or []]
+        alternatives.append(node.args.get("default"))
+    elif isinstance(node, exp.If):
+        alternatives = [node.args.get("true"), node.args.get("false")]
+    elif isinstance(node, exp.Coalesce):
+        alternatives = [node.this, *(node.args.get("expressions") or [])]
+    if alternatives is not None:
+        present = [alt for alt in alternatives if alt is not None]
+        if not present:
+            return frozenset()
+        return frozenset.intersection(*(_value_sources(alt, scope_map) for alt in present))
+    if isinstance(node, (exp.Order, exp.Nullif, exp.GroupConcat)):
+        return _value_sources(node.this, scope_map)
+    tables: set[str] = set()
     for arg in node.args.values():
         for child in (arg if isinstance(arg, list) else [arg]):
-            cols.extend(_value_columns(child))
-    return cols
+            tables |= _value_sources(child, scope_map)
+    return frozenset(tables)
 
 
 def _select_aggregates(sel: "exp.Select") -> list["exp.AggFunc"]:

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -4197,6 +4197,12 @@ if _HAVE_SQLGLOT:
         "Case", "If", "Nvl2", "Coalesce", "Greatest", "Least", "DecodeCase")
     # The two that hold their arms under `true` and `false` rather than under `expressions`.
     _TERNARY_NODES = _exp_nodes("If", "Nvl2")
+    # `DECODE`'s own shape, resolved by name for the same reason the tuple above is. A bare
+    # `exp.DecodeCase` in the dispatch below would defeat `_exp_nodes` entirely: the attribute is
+    # read when the line RUNS, so on a sqlglot that predates the class every `COALESCE`, `IF`,
+    # `GREATEST` and `LEAST` in the dispatch raises `AttributeError` instead of being attributed,
+    # and the receipt fails to build for a statement that version parses perfectly well.
+    _DECODE_NODES = _exp_nodes("DecodeCase")
     # STRUCTURAL: the value is `this` and the rest of the node is neither predicate nor value.
     # `exp.Order` holds `STRING_AGG(x ORDER BY y)`'s ordering arms on `expressions`; reordering a
     # concatenation changes the string, but the fan is not what reordered it. `exp.Nullif`'s
@@ -4222,6 +4228,7 @@ if _HAVE_SQLGLOT:
     )
 else:  # pragma: no cover - nothing in this section runs without a parser
     _ALTERNATION_NODES = _TERNARY_NODES = _STRUCTURAL_NODES = _COMBINING_NODES = ()
+    _DECODE_NODES = ()
 
 
 # What `_value_operands` says about a node, and what `_value_sources` does with the operands beside
@@ -4278,7 +4285,7 @@ def _value_operands(node: "exp.Expression") -> tuple[str, list["exp.Expression"]
         arms.append(node.args.get("default"))
         return _VALUE_INTERSECT, _present(arms)
     if isinstance(node, _ALTERNATION_NODES):
-        if isinstance(node, exp.DecodeCase):
+        if isinstance(node, _DECODE_NODES):
             return _VALUE_INTERSECT, _decode_arms(node)
         if isinstance(node, _TERNARY_NODES):
             return _VALUE_INTERSECT, _present([node.args.get("true"), node.args.get("false")])

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -1768,7 +1768,11 @@ def _preflight_select(tree: "exp.Select", org: Datasource,
             }
             joins = [f"{measure} (1) <- {mt} (N)" for mt in many]
             for i, site in enumerate(sites):
-                if measure_table in site.sources:
+                # A many-side column ON THE VALUE PATH means the value is already one row per
+                # many-side row, so this edge's duplication IS its grain and multiplies nothing.
+                # Scoped per fan edge deliberately: `many_tables` is the many side of THIS edge, and
+                # a many-side column belonging to some other edge must not suppress this one.
+                if measure_table in site.sources and not (site.sources & many_tables):
                     risk = "fan_out_invariant" if _is_fan_immune(site.node) else "fan_trap"
                     attached[i].append(Finding(
                         risk, reason=reason_for[risk],
@@ -3520,18 +3524,76 @@ def _aggregate_sites(tree: "exp.Select", scope_map: dict[str, str], scope: str,
     """
     sites: list[_AggSite] = []
     for agg in _select_aggregates(tree):
+        # TWO column walks over one aggregate, and the split is the point. `sources` is what the
+        # fan and chasm detectors attribute the multiplication by, so it takes only the columns the
+        # VALUE is computed from — a many-side column in a CASE predicate or an ORDER BY arm does
+        # not put the value at the many side's grain. `resolved` is a different question, "did the
+        # analysis understand everything this aggregate reads", and that one wants every column:
+        # narrowing it to the value path would turn `COUNT(CASE WHEN i.quantity > 0 THEN 1 END)`
+        # from a clean answer into `undetermined`, because a value path of one literal is
+        # indistinguishable from no columns at all to the `bool(...)` test below.
+        value_tables = [_resolve_col_table(col, scope_map) for col in _value_columns(agg)]
         cols = list(agg.find_all(exp.Column))
         resolved = [_resolve_col_table(col, scope_map) for col in cols]
         sites.append(_AggSite(
             node=agg,
             aggregate=_echo_expr(agg.sql()),
             scope=scope,
-            sources=frozenset(t for t in resolved if t),
+            sources=frozenset(t for t in value_tables if t),
             resolved=bool(cols) and all(resolved) and (
                 visible is None or all(_tkey(t) in visible for t in resolved)
             ),
         ))
     return sites
+
+
+def _value_columns(node: "exp.Expression") -> list["exp.Column"]:
+    """Every column on an expression's VALUE path: the ones whose values the result is built from.
+
+    The complement is the columns that only decide WHICH rows or in WHAT ORDER, and the difference
+    is what a fan means for the number. `SUM(order_items.quantity * orders.total_amount)` is one
+    product per order item, so the duplication the join performs is the grain the value was already
+    at and multiplies nothing; `SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount
+    END)` sums a one-side amount once per item, so the same duplication really does inflate it. A
+    walk that took every column inside the aggregate cannot tell those apart — it sees
+    `order_items` in both — which is why attribution is by POSITION and never by presence.
+
+    Two node types put a column somewhere that is not the value, and each gets a case:
+
+    - `exp.Case`. `ifs[].this` is the branch predicate and `Case.this` is the simple-CASE operand
+      compared against them, so both are inputs to the choice rather than to the result. The value
+      is `ifs[].true` and `default`.
+    - `exp.Order`. `STRING_AGG(x ORDER BY y)` parses to `GroupConcat(this=Order(this=x,
+      expressions=[Ordered(y)]))`, so the ordering arms hang off `expressions` and are neither
+      predicate nor value: reordering a concatenation changes the string but the fan is not what
+      reordered it, and `y` is not a value the aggregate folds.
+
+    Everything else recurses over `node.args` unchanged, which is what keeps this honest by default:
+    a node type nobody thought about contributes its columns rather than silently dropping them, and
+    dropping is the direction that manufactures a false clean. `exp.Distinct` needs no case for
+    exactly that reason — it holds its argument under `args["expressions"]` and the generic branch
+    already reaches it. Neither does `exp.Filter`: `SUM(x) FILTER (WHERE y)` parses to
+    `Filter(this=Sum, expression=Where)`, so the predicate is structurally OUTSIDE the aggregate and
+    `find_all(exp.AggFunc)` never hands it here at all.
+
+    `node.args` is iterated by hand rather than through `iter_expressions()`. Four lines that cannot
+    drift, against a package that pins only `sqlglot>=20`.
+    """
+    if not isinstance(node, exp.Expression):
+        return []
+    if isinstance(node, exp.Column):
+        return [node]
+    if isinstance(node, exp.Case):
+        cols = [c for branch in node.args.get("ifs") or []
+                for c in _value_columns(branch.args.get("true"))]
+        return cols + _value_columns(node.args.get("default"))
+    if isinstance(node, exp.Order):
+        return _value_columns(node.this)
+    cols = []
+    for arg in node.args.values():
+        for child in (arg if isinstance(arg, list) else [arg]):
+            cols.extend(_value_columns(child))
+    return cols
 
 
 def _select_aggregates(sel: "exp.Select") -> list["exp.AggFunc"]:

--- a/plugins/agami/skills/agami-query/SKILL.md
+++ b/plugins/agami/skills/agami-query/SKILL.md
@@ -374,6 +374,7 @@ It returns JSON: `{sql, findings, units}`, and it **always exits 0**. The return
 `findings` is a list, usually empty. Each entry is `{risk, reason, triggering_joins}` and each one is a **fact about the statement**, not a verdict on it:
 
 - `fan_trap` / `chasm_trap` — a join multiplies the rows an aggregate is computed from. `triggering_joins` names which join does it.
+- `fan_out_invariant` — the same multiplication, on an aggregate it cannot move (`MIN`, `MAX`, a `DISTINCT` one, `BOOL_AND` / `BOOL_OR`). The rows were duplicated; the number is the same either way. `triggering_joins` names the join, exactly as above.
 - `bad_aggregation` — a `SUM` of a rate or an identifier, or an `AVG` of one.
 - `semi_additive` — a `SUM` of a balance across a time grain, which multiplies a stock.
 

--- a/tests/test_ace060_trap_free_aggregates.py
+++ b/tests/test_ace060_trap_free_aggregates.py
@@ -322,17 +322,24 @@ def test_the_division_of_labour_sentence_is_gone(org):
 
 @pytest.mark.parametrize("sql,phrase", [
     # Each residual clause fires only when THIS statement contains what it describes.
-    ("SELECT MIN(o.total) FROM orders o", "MIN, MAX and COUNT(DISTINCT)"),
-    ("SELECT COUNT(DISTINCT o.id) FROM orders o", "MIN, MAX and COUNT(DISTINCT)"),
     ("SELECT o.id FROM orders o GROUP BY o.id HAVING SUM(o.total) > 1", "HAVING or ORDER BY"),
     ("WITH x AS (SELECT SUM(o.total) t FROM orders o) SELECT x.t FROM x", "CTE or a subquery"),
     (COUNT_STAR, "could not be resolved"),
 ])
 def test_each_residual_clause_is_conditional_on_the_statement(org, sql, phrase):
-    """SC-6. The clauses ACE-083 will delete stay, but only where they are true of the statement.
+    """SC-6. Every surviving clause fires only where it is true of the statement.
 
     Fixed, they pin the marker non-null forever and the null state is unreachable. Conditional, a
     reader who gets one knows it is about the statement in front of them.
+
+    Two rows stood here and are gone, and that is a deliberate contract change made by ACE-083:
+    `SELECT MIN(o.total) FROM orders o` and `SELECT COUNT(DISTINCT o.id) FROM orders o`, both
+    keyed to the clause "MIN, MAX and COUNT(DISTINCT) are counted as fan-out risks…". That clause
+    described a gap in the detector, and the detector no longer has it — an aggregate a duplication
+    cannot move now carries `fan_out_invariant` on its own item. Keeping the sentence would make the
+    marker say the analysis has a shortcoming it does not.
+    `tests/test_ace083_trap_soundness.py::test_the_marker_stops_calling_an_invariant_aggregate_a_fan_out_risk`
+    pins the composition that replaced it, both the clause's absence and the four survivors.
     """
     assert phrase in (_section(org, sql)["undetermined"] or ""), _section(org, sql)
     # And it is absent from a statement that contains no such thing.

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -114,6 +114,12 @@ JOINED_CTE_BODY = (
 #    parenthesized table, and dropping this one with it would have been a false clean.
 UNALIASED_VALUES_FAN = "SELECT SUM(orders.total_amount) FROM orders, (VALUES (1), (2))"
 
+# 9. Members 6 and 1, wrapped in a set operation. A WITH sits ABOVE the arms and binds its name for
+#    all of them, so an arm looking for the CTE inside itself finds nothing and the laundered fan
+#    goes unseen — the same statement, one keyword further out, reading clean. Both arms are
+#    inflated so the corpus property stays unconditional over every item the statement produces.
+UNION_ARM_CTE_FAN = f"{CTE_LAUNDERED_FAN} UNION ALL {PLAIN_FAN}"
+
 # The corpus, named so the later slices can re-run it unchanged rather than restating it. Labels
 # are what a failure prints, so they name the disguise and not the SQL.
 INFLATED_SHAPES = [
@@ -125,6 +131,7 @@ INFLATED_SHAPES = [
     ("many side behind a CTE", CTE_LAUNDERED_FAN),
     ("join inside the CTE body", JOINED_CTE_BODY),
     ("rows from an unaliased VALUES list", UNALIASED_VALUES_FAN),
+    ("a laundered fan inside a set-operation arm", UNION_ARM_CTE_FAN),
 ]
 
 # A conditional count and a conditional sum over the many side. Both are honestly clean: one row
@@ -725,6 +732,39 @@ UNREADABLE_CTE_BODIES = [
     ("the grain is an expression with no column name to compare",
      "WITH oi AS (SELECT SUM(quantity) q FROM order_items GROUP BY order_id + 1) "
      "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.q = orders.id"),
+    ("the unreadable body is joined from inside a set-operation arm",
+     "WITH oi AS (SELECT i.order_id AS order_id FROM order_items i "
+     "JOIN orders o ON o.id = i.order_id) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id "
+     "UNION ALL SELECT SUM(orders.revenue) FROM orders JOIN oi ON oi.order_id = orders.id"),
+]
+
+# Every shape whose multiplication answer this spec decides, gathered for the one property that
+# holds across all of them. Not a new corpus: `INFLATED_SHAPES` is about the answer being wrong in
+# one direction, and this is about the answer being INTERNALLY consistent whatever it says.
+ALL_ANALYSED_SHAPES = INFLATED_SHAPES + UNREADABLE_CTE_BODIES + [
+    ("a value already at the many side's grain", VALUE_AT_MANY_GRAIN),
+    ("a conditional count over the many side", CONDITIONAL_COUNT),
+    ("a conditional sum over the many side", CONDITIONAL_SUM),
+    ("an aggregate a duplication cannot move", MIN_OVER_FAN),
+    ("a DISTINCT count over a fan", DISTINCT_COUNT_OVER_FAN),
+    ("a boolean fold over a fan", BOOL_OR_OVER_FAN),
+    ("COUNT(*) over a fan", COUNT_STAR_OVER_FAN),
+    ("a FILTER clause predicate", FILTERED_FAN),
+    ("three statuses and both risk labels at once", EVERY_STATUS_SQL),
+    ("a grain-changing CTE", GRAIN_CHANGING_CTE),
+    ("a grain-preserving CTE", GRAIN_PRESERVING_CTE),
+    ("a chain of grain-preserving CTEs", TRANSITIVE_CTE),
+    ("a CTE grain finer than the join key", CTE_GRAIN_BELOW_JOIN_KEY),
+    ("a CTE name spelled in another case", CASE_FOLDED_CTE),
+    ("a derived table with an unqualified measure", DERIVED_TABLE_UNQUALIFIED),
+    ("a parenthesized named table", PARENTHESIZED_TABLE),
+    ("a VALUES source", VALUES_SOURCE),
+    ("a LATERAL source", LATERAL_SOURCE),
+    ("a chasm over two independent measures",
+     "SELECT c.id, SUM(o.revenue), COUNT(t.id) FROM customers c "
+     "LEFT JOIN orders o ON o.customer_id = c.id "
+     "LEFT JOIN tickets t ON t.customer_id = c.id GROUP BY c.id"),
 ]
 
 
@@ -930,9 +970,14 @@ def test_a_cte_body_the_analysis_cannot_read_is_undetermined(label, sql):
     was multiplied, or that it was not, or that it could not tell — and every one of these is the
     third. What none of them may be is absent or clean: `not_multiplied` on any row here would be
     the receipt asserting a statement is sound on the strength of a body it could not read.
+
+    Asserted over the status SET rather than an exact list because the last row is a set operation
+    and produces one item per arm. Every item still has to be `undetermined` and every item still
+    has to name no join, so nothing is loosened for the single-select rows: one item whose status
+    must be `undetermined` is the same assertion either way.
     """
     reports = _reports(sql)
-    assert [a.status for a in reports] == [rt.UNDETERMINED], (label, reports)
+    assert {a.status for a in reports} == {rt.UNDETERMINED}, (label, reports)
     assert [j for a in reports for j in a.joins] == [], (label, reports)
 
 
@@ -1145,27 +1190,61 @@ def test_a_source_the_guarded_path_refuses_is_still_answered_honestly_on_the_pre
 @pytest.mark.parametrize("label,sql", [
     ("qualified", "SELECT SUM(facts.unit_price) FROM facts"),
     ("unqualified, one table in scope", "SELECT SUM(unit_price) FROM facts"),
+    ("unqualified, through a CTE",
+     "WITH c AS (SELECT unit_price FROM facts) SELECT SUM(unit_price) FROM c"),
+    ("qualified by a CTE alias — GAINED by the grain resolution",
+     "WITH c AS (SELECT unit_price FROM facts) SELECT SUM(c.unit_price) FROM c"),
+    ("qualified by a SELECT * CTE alias — GAINED by the grain resolution",
+     "WITH c AS (SELECT * FROM facts) SELECT SUM(c.unit_price) FROM c"),
 ])
 def test_an_aggregation_class_violation_still_fires_on_the_statement_that_makes_it(label, sql):
-    """`_check_aggregation_semantics` reads the same narrowed map, so its floor is pinned here.
+    """`_check_aggregation_semantics` reads the same map, so its floor is pinned here.
 
     It resolves the summed column's table through the scope map `_preflight_select` hands it, and
-    that map now holds only what this SELECT's own FROM/JOIN clauses bind. Two `bad_aggregation`
-    findings were measured to stop firing as a result, and both fired only by reading a table out of
-    a scope the outer statement cannot see: `SUM(unit_price) FROM (SELECT unit_price FROM facts) f`
-    and its CTE equivalent. That is ACE-099's rule applied consistently — a column in a CTE body is
-    not a reference of the outer statement — and it is recorded as a contract change rather than
-    hidden, since one of the two traded a lost finding for a killed false clean.
+    that map changed twice over: narrowed to what this SELECT's own FROM/JOIN clauses bind, then
+    widened again where a grain-preserving CTE resolves back to the table it hands through. The net
+    was measured against base `439ecd1` over eight spellings, and it is NOT the loss of two that an
+    earlier mid-build measurement recorded — that reading was taken before the grain resolution
+    landed and is superseded by this one.
 
-    What may not narrow is the case the check exists for: a statement that sums an `averageable`
-    column off a table it plainly reads. Both spellings are pinned, because they take different
-    paths through the resolver — the qualified one through the map, the unqualified one through the
-    single-in-scope-table fallback — and the fallback reads the map's VALUES, which is the half the
-    filter changed.
+    ONE finding is lost: `SUM(unit_price) FROM (SELECT unit_price FROM facts) f`, which fired only
+    by reading `facts` out of a derived body the outer statement cannot see. Its status moved from
+    `not_multiplied` to `undetermined` in the same change, so it trades a finding for a killed false
+    clean rather than simply going quiet.
+
+    TWO are gained, and both are the resolution working: `SUM(c.unit_price)` over a CTE resolves `c`
+    back to `facts`, where before it resolved to the undeclared name `c` and the check had nothing
+    to look up. Those are the last three rows here — pinned as gains rather than mentioned, because
+    a narrowing that quietly took them away again would otherwise look like the loss it is not.
+
+    Both plain spellings stay, and they take different paths through the resolver: the qualified one
+    through the map, the unqualified one through the single-in-scope-table fallback, which reads the
+    map's VALUES — the half the filter changed.
     """
     pf = rt.pre_flight_check(sql, _averageable_org())
     assert [f.risk for f in pf.findings] == ["bad_aggregation"], (label, pf.findings)
     assert "unit_price" in pf.findings[0].reason, (label, pf.findings[0].reason)
+
+
+def test_the_one_aggregation_class_finding_this_spec_gives_up_is_the_one_that_read_a_hidden_scope():
+    """The other side of the differential above, so the narrowing is bounded rather than open-ended.
+
+    This is the single `bad_aggregation` that base `439ecd1` reported and this spec does not. It
+    fired because `facts` leaked out of the derived table's body into the outer scope map, which is
+    precisely the leak S3 removes: a column inside a derived body is not a reference of the outer
+    statement, and the outer statement here reads one source, `f`, whose columns the analysis cannot
+    attribute to any declared table.
+
+    Asserted together with the status, because the two halves are one trade. Base called this
+    statement `not_multiplied` — a positive claim that a number computed over an unreadable derived
+    source is sound — and it now declines to answer. Losing a true finding is a real cost; losing it
+    alongside a false clean is the exchange this spec makes, and stating only one half of it would
+    misrepresent the change in either direction.
+    """
+    sql = "SELECT SUM(unit_price) FROM (SELECT unit_price FROM facts) f"
+    pf = rt.pre_flight_check(sql, _averageable_org())
+    assert [f.risk for f in pf.findings] == [], pf.findings
+    assert [a.status for a in pf.aggregates] == [rt.UNDETERMINED], pf.aggregates
 
 
 def test_the_chasm_still_reports_both_of_the_aggregates_it_inflates():
@@ -1184,3 +1263,138 @@ def test_the_chasm_still_reports_both_of_the_aggregates_it_inflates():
     assert [(a.aggregate, a.status) for a in reports] == [
         ("SUM(o.revenue)", rt.MULTIPLIED), ("COUNT(t.id)", rt.MULTIPLIED)], reports
     assert [f.risk for a in reports for f in a.findings] == ["chasm_trap", "chasm_trap"], reports
+
+
+# --- A25: an item that answers, names its evidence -------------------------
+
+
+def test_every_item_either_names_its_joins_or_declines_to_answer():
+    """A25. Whatever an item says, it says it consistently — over every shape this spec decides.
+
+    Two directions, and each is a way a receipt can be internally contradictory rather than merely
+    wrong. A `multiplied` item with an empty `joins` tells a reader their number was inflated and
+    gives them nothing to look at, which is a fact they cannot check and cannot act on. A
+    `not_multiplied` or `undetermined` item that names a join asserts the opposite of what its own
+    status says, and a reader has no way to know which half to believe.
+
+    An internal loop rather than a parametrize, deliberately: the property is about the whole set,
+    the set is assembled from constants defined for other tests, and a failure has to print the SQL
+    it came from or the label alone would not locate it. Collecting every offender before asserting
+    means one run reports all of them instead of stopping at the first.
+
+    `status` is checked against the three constants as well. The vocabulary is closed, and an item
+    carrying anything else is a fourth thing this layer is not allowed to say.
+    """
+    offenders: list[tuple[str, str, str, list[str]]] = []
+    for label, sql in ALL_ANALYSED_SHAPES:
+        for item in _reports(sql):
+            assert item.status in (rt.MULTIPLIED, rt.NOT_MULTIPLIED, rt.UNDETERMINED), (label, item)
+            names_joins = bool(item.joins)
+            if names_joins != (item.status == rt.MULTIPLIED):
+                offenders.append((label, item.aggregate, item.status, item.joins))
+    assert offenders == [], offenders
+
+
+# --- A20: the two surfaces report the same aggregates ----------------------
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("an invariant aggregate over a fan", MIN_OVER_FAN),
+    ("a value already at the many side's grain", VALUE_AT_MANY_GRAIN),
+    ("a grain-preserving CTE the analysis resolves", GRAIN_PRESERVING_CTE),
+    ("a grain-changing CTE whose edge is derived", GRAIN_CHANGING_CTE),
+    ("a derived table bound to nothing", DERIVED_TABLE_FAN),
+    ("three statuses and both risk labels at once", EVERY_STATUS_SQL),
+])
+def test_the_preflight_and_the_receipt_agree_about_the_aggregates(label, sql):
+    """A20. Both surfaces read one analysis, so the two renderings must be byte-equal.
+
+    `pre_flight_check` parses and analyses; `assemble_receipt` analyses a tree it already holds.
+    They are meant to be two doors onto one answer, and the way that stops being true is silent — a
+    caller reading a receipt and a caller reading a pre-flight result would simply disagree about
+    the same statement, with nothing failing anywhere.
+
+    ACE-060 already asserts this, and its file stays unedited — but its shapes all predate this
+    spec, so none of them exercises an invariance label, a value-path attribution, a resolved CTE or
+    an alias bound to nothing. These six do, one per mechanism this spec added, on `_sales_org` so
+    that no fixture ACE-060 depends on has to move.
+
+    The comparison is the serialized item list against `as_dict()`, not a status-by-status walk:
+    `joins`, `findings` and the aggregate's own label are all part of what the two surfaces have to
+    agree about, and a spot check of statuses would pass while a reason string differed.
+    """
+    org = _sales_org()
+    items = rt.assemble_receipt(org, sql)["aggregates"]["items"]
+    assert items == [a.as_dict() for a in rt.pre_flight_check(sql, org).aggregates], label
+
+
+# --- the invariance boundary, pinned where it is rather than where it could be ---
+
+
+def test_a_distinct_concatenation_with_an_ordering_arm_is_not_read_as_invariant():
+    """The boundary of `_is_fan_immune`, pinned in the direction it currently errs.
+
+    `STRING_AGG(DISTINCT x ORDER BY y)` parses to `GroupConcat(this=Order(this=Distinct(...)))`, so
+    `agg.this` is an `exp.Order` and not the `exp.Distinct` the predicate tests for, and
+    `args["distinct"]` is `None` as well. The same expression WITHOUT the ordering arm puts
+    `exp.Distinct` directly under the aggregate and reads as invariant, so one keyword moves the
+    answer.
+
+    A duplication genuinely cannot move a DISTINCT concatenation, so the honest label here is
+    `fan_out_invariant` and what it gets is `fan_trap`. That is the SAFE direction — it names a
+    defect where there is none, rather than telling a reader a number is unaffected when it is —
+    and it is not worth widening the predicate for, because the widening is where this split gets
+    dangerous. It is pinned so the boundary cannot move without someone deciding to move it: a
+    change that made this read invariant is a change that needs its own argument.
+
+    The two parses are asserted alongside the report, since the whole behaviour rests on a fact
+    about sqlglot's tree rather than about this module.
+    """
+    ordered = parse_one(
+        f"SELECT STRING_AGG(DISTINCT orders.status, ',' ORDER BY orders.status) {FAN_JOIN}"
+    ).find(exp.AggFunc)
+    assert isinstance(ordered.this, exp.Order), ordered.this
+    assert ordered.args.get("distinct") is None, ordered.args
+    assert rt._is_fan_immune(ordered) is False, ordered
+
+    plain = parse_one(f"SELECT STRING_AGG(DISTINCT orders.status, ',') {FAN_JOIN}").find(exp.AggFunc)
+    assert isinstance(plain.this, exp.Distinct), plain.this
+    assert rt._is_fan_immune(plain) is True, plain
+
+    reports = _reports(
+        f"SELECT STRING_AGG(DISTINCT orders.status, ',' ORDER BY orders.status) {FAN_JOIN}"
+    )
+    assert [a.status for a in reports] == [rt.MULTIPLIED], reports
+    assert [f.risk for f in reports[0].findings] == ["fan_trap"], reports[0].findings
+
+
+# --- a WITH binds its name for every arm below it --------------------------
+
+
+def test_a_set_operation_arm_sees_the_cte_the_statement_bound_above_it():
+    """A WITH sits above the arms, so an arm that looks for it inside itself finds nothing.
+
+    Measured on this statement before the fix: `main#1` reported `not_multiplied` over a laundered
+    fan, because `_cte_names` was read off the ARM, the guard never fired, and `oi` stayed bound to
+    the undeclared name `oi`. The unreadable-body shape failed the same way and is a row in the
+    guard table above.
+
+    The fix is narrow on purpose and both halves are asserted here. CTE NAMES and BODIES come off
+    the root, because a WITH binds its name for every arm below it — the same reason
+    `_aggregate_reports` computes `visible` on the root. Which TABLES an arm reads does NOT: the
+    alias map stays strictly per-arm, so the second arm below, which reads only `orders`, is
+    honestly clean and is not dragged into the first arm's fan.
+
+    The scope labels are asserted too. They are what tells a reader which arm an item belongs to,
+    and reading CTE names off the root is exactly the kind of change that could have flattened two
+    arms into one scope without any status moving.
+    """
+    reports = _reports(UNION_ARM_CTE_FAN)
+    assert [(a.scope, a.status) for a in reports] == [
+        ("main#1", rt.MULTIPLIED), ("main#2", rt.MULTIPLIED)], reports
+    assert [a.joins for a in reports] == [[FAN_EDGE], [FAN_EDGE]], reports
+
+    # And an arm that reads no CTE keeps its own answer, which is what "per-arm" has to mean.
+    mixed = _reports(f"{CTE_LAUNDERED_FAN} UNION ALL SELECT SUM(orders.total_amount) FROM orders")
+    assert [(a.scope, a.status) for a in mixed] == [
+        ("main#1", rt.MULTIPLIED), ("main#2", rt.NOT_MULTIPLIED)], mixed

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -39,6 +39,15 @@ is correct and is half of S3 — but `CTE_LAUNDERED_FAN` reported `multiplied` a
 of that leak, and with the leak gone and no resolution for what `oi` stands for, a genuinely
 inflated statement read `not_multiplied`. The intermediate state fails the corpus's own criterion,
 so it is not a legal place to stop.
+
+The last battery in this file is the one two independent re-reviews arrived at from opposite ends,
+and it is one root cause rather than several. `_value_sources` and `_grain_preserving_source` were
+both DENYLISTS with an unsafe default: one enumerated the alternation node types and let every other
+node union its children, the other rejected three `exp.Select` arguments and accepted the rest, and
+in both an unanticipated shape landed on the side that CLEARS a finding. Seven statements were
+measured `not_multiplied` through those two holes — four of them ordinary Snowflake / Redshift /
+Oracle analytics SQL — and they are corpus members above rather than a corpus of their own, because
+the property they violate is the one this file already asserts.
 """
 
 from __future__ import annotations
@@ -252,6 +261,68 @@ NESTED_WITH_SHADOWING_A_REAL_TABLE = (
     "SELECT id FROM order_items)"
 )
 
+# 30-33. The alternation spelled as a FUNCTION rather than as a keyword, which is where the same
+#     defect class was found one node type over. `GREATEST` and `LEAST` carry `COALESCE`'s
+#     `this` + `expressions` layout; `NVL2`'s three arguments are byte-identical to `IF`'s; `DECODE`
+#     parses to a node of its own, `exp.DecodeCase`. Every one of them returns ONE of its arguments,
+#     so a rule that unioned their operands put a many-side column on the value path and cleared the
+#     fan. All four are ordinary Snowflake / Redshift / Oracle analytics SQL rather than contrived
+#     shapes, and all four were measured `not_multiplied` against a base that said `multiplied`.
+GREATEST_ALTERNATION_FAN = (
+    f"SELECT SUM(GREATEST(orders.total_amount, order_items.quantity)) {FAN_JOIN}"
+)
+LEAST_ALTERNATION_FAN = f"SELECT SUM(LEAST(orders.total_amount, order_items.quantity)) {FAN_JOIN}"
+NVL2_ALTERNATION_FAN = f"SELECT SUM(NVL2(order_items.quantity, orders.total_amount, 0)) {FAN_JOIN}"
+DECODE_ALTERNATION_FAN = (
+    f"SELECT SUM(DECODE(order_items.product_id, 1, orders.total_amount, 0)) {FAN_JOIN}"
+)
+
+# 34-36. A CTE body that multiplies its OWN rows with no JOIN, no GROUP BY and no DISTINCT in it.
+#     `laterals`, `connect` and `match` are arguments of `exp.Select` that the grain-preserving
+#     guard's three-name denylist never read, so each body resolved as though it handed back
+#     `orders` row for row and the outer aggregate reported `not_multiplied` — against a base that
+#     said `undetermined`, which is a false clean created by this branch. A LATERAL VIEW emits one
+#     row per exploded element, an UNPIVOT one row per unpivoted column, and a CONNECT BY one row
+#     per path through the hierarchy.
+LATERAL_VIEW_CTE = (
+    "WITH o AS (SELECT * FROM orders LATERAL VIEW EXPLODE(orders.status) t AS s) "
+    "SELECT SUM(o.total_amount) FROM o"
+)
+UNPIVOT_CTE = (
+    "WITH o AS (SELECT * FROM orders UNPIVOT (v FOR k IN (total_amount, revenue))) "
+    "SELECT SUM(o.total_amount) FROM o"
+)
+CONNECT_BY_CTE = (
+    "WITH o AS (SELECT * FROM orders CONNECT BY PRIOR id = customer_id) "
+    "SELECT SUM(o.total_amount) FROM o"
+)
+
+# The same three constructs written STRAIGHT INTO the statement rather than into a CTE body, plus
+# the PIVOT that escaped only by accident. `laterals`, `connect` and `match` are siblings of `from_`
+# on `exp.Select` and `pivots` rides the `exp.Table`, so a binding walk over `exp.From` and
+# `exp.Join` reached none of them and the alias map looked like a single table. These are corpus
+# members of the ungated `cmd_preflight` / `cmd_prepare` surface — see the test that runs them —
+# and the false clean on them is PRE-EXISTING rather than created here.
+LATERAL_VIEW_SOURCE = (
+    "SELECT SUM(orders.total_amount) FROM orders LATERAL VIEW EXPLODE(orders.status) t AS tag"
+)
+UNPIVOT_SOURCE = (
+    "SELECT SUM(o.total_amount) FROM orders o UNPIVOT (v FOR k IN (total_amount, revenue))"
+)
+CONNECT_BY_SOURCE = "SELECT SUM(orders.total_amount) FROM orders CONNECT BY PRIOR id = customer_id"
+PIVOT_SOURCE = (
+    "SELECT SUM(p.total_amount) FROM orders PIVOT (SUM(total_amount) FOR status IN ('a')) p"
+)
+# `MATCH_RECOGNIZE` does not parse on sqlglot's default grammar, so it cannot be driven through
+# `pre_flight_check` against `_sales_org`, which declares no dialect. It is asserted on the binding
+# walk directly, off a tree parsed with a dialect that does speak it.
+MATCH_RECOGNIZE_SOURCE = (
+    "SELECT SUM(orders.total_amount) FROM orders MATCH_RECOGNIZE ("
+    "PARTITION BY customer_id ORDER BY id MEASURES id AS m ONE ROW PER MATCH "
+    "PATTERN (a+) DEFINE a AS a.id > 0)"
+)
+
+
 # The corpus, named so the later slices can re-run it unchanged rather than restating it. Labels are
 # what a failure prints, so they name the disguise and not the SQL.
 #
@@ -309,6 +380,17 @@ INFLATED_SHAPES = [
      ["SUM(x.total_amount)"]),
     ("a WITH bound inside a WHERE subquery", NESTED_WITH_SHADOWING_A_REAL_TABLE,
      ["SUM(orders.total_amount)"]),
+    ("an alternation spelled GREATEST", GREATEST_ALTERNATION_FAN,
+     ["SUM(GREATEST(orders.total_amount, order_items.quantity))"]),
+    ("an alternation spelled LEAST", LEAST_ALTERNATION_FAN,
+     ["SUM(LEAST(orders.total_amount, order_items.quantity))"]),
+    ("an alternation spelled NVL2", NVL2_ALTERNATION_FAN,
+     ["SUM(NVL2(order_items.quantity, orders.total_amount, 0))"]),
+    ("an alternation spelled DECODE", DECODE_ALTERNATION_FAN,
+     ["SUM(DECODE(order_items.product_id, 1, orders.total_amount, 0))"]),
+    ("a CTE body that explodes a column", LATERAL_VIEW_CTE, ["SUM(o.total_amount)"]),
+    ("a CTE body that unpivots", UNPIVOT_CTE, ["SUM(o.total_amount)"]),
+    ("a CTE body that walks a hierarchy", CONNECT_BY_CTE, ["SUM(o.total_amount)"]),
 ]
 
 # A conditional count and a conditional sum over the many side. Both are honestly clean: one row
@@ -412,6 +494,38 @@ VALUE_SOURCE_CASES = [
      {"orders"}),
     ("COALESCE, an alternation spelled as a function",
      "SUM(COALESCE(orders.total_amount, order_items.quantity))",
+     set()),
+    # The branches added because the union default cleared four more real fans. Each of these
+    # returns ONE of its arguments and so intersects them, exactly as COALESCE above does.
+    ("GREATEST, which carries COALESCE's layout",
+     "SUM(GREATEST(orders.total_amount, order_items.quantity))",
+     set()),
+    ("LEAST, the same node shape the other way up",
+     "SUM(LEAST(orders.total_amount, order_items.quantity))",
+     set()),
+    ("NVL2, whose three arguments are IF's",
+     "SUM(NVL2(order_items.quantity, orders.total_amount, 0))",
+     set()),
+    ("DECODE, a simple CASE with the commas moved",
+     "SUM(DECODE(order_items.product_id, 1, orders.total_amount, 0))",
+     set()),
+    ("DECODE with no default arm, whose implicit result is NULL",
+     "SUM(DECODE(order_items.product_id, 1, orders.total_amount))",
+     {"orders"}),
+    ("DECODE with two search arms and no default",
+     "SUM(DECODE(order_items.product_id, 1, orders.total_amount, 2, orders.revenue))",
+     {"orders"}),
+    ("an alternation whose arms are two columns of one table",
+     "SUM(GREATEST(orders.total_amount, orders.revenue))",
+     {"orders"}),
+    # The fail-closed default, which is the polarity this round inverted. Neither of these is a node
+    # `_value_operands` enumerates, and neither contributes anything: an empty value path suppresses
+    # no edge, so the fan is reported.
+    ("a scalar function nobody enumerated",
+     "SUM(ROUND(orders.total_amount, order_items.quantity))",
+     set()),
+    ("a function sqlglot does not know at all",
+     "SUM(SOME_UDF(orders.total_amount))",
      set()),
 ]
 
@@ -847,6 +961,14 @@ def test_the_value_path_of_something_that_is_not_an_expression_is_empty():
     assert rt._value_sources(None, VALUE_SCOPE) == frozenset()
     assert rt._value_sources(True, VALUE_SCOPE) == frozenset()
     assert rt._value_sources(exp.Case(), VALUE_SCOPE) == frozenset()
+    # `DECODE` needs at least an operand, a search value and a result before any slot means
+    # anything, and sqlglot parses the two-argument spelling to `exp.Decode` — a charset decode,
+    # an entirely different function — so this arity is reachable only by construction. Answered
+    # anyway rather than guessed at, because the alternative is reading a SEARCH value as a result.
+    short_decode = exp.DecodeCase(
+        expressions=[exp.column("product_id", "order_items"), exp.column("total_amount", "orders")])
+    assert rt._decode_arms(short_decode) == []
+    assert rt._value_sources(short_decode, VALUE_SCOPE) == frozenset()
 
 
 # --- the direction the corpus reaches only through members 14-21 ------------
@@ -1162,6 +1284,10 @@ ALL_ANALYSED_SHAPES = [
     ("a LATERAL source", LATERAL_SOURCE),
     ("a chasm over two independent measures", CHASM_OVER_TWO_MEASURES),
     ("a chasm whose measures a duplication cannot move", CHASM_OVER_INVARIANT_MEASURES),
+    ("a LATERAL VIEW beside the FROM clause", LATERAL_VIEW_SOURCE),
+    ("an UNPIVOT on the table itself", UNPIVOT_SOURCE),
+    ("a CONNECT BY beside the FROM clause", CONNECT_BY_SOURCE),
+    ("a PIVOT on the table itself", PIVOT_SOURCE),
 ]
 
 
@@ -2205,3 +2331,238 @@ def test_the_root_cte_set_and_the_model_index_are_built_once_per_statement(monke
     assert len(reports) == 10, reports
     assert calls["cte_names"] == 1, calls
     assert calls["model_index"] == 1, calls
+
+
+# --- the same defect class, one node type over -----------------------------
+#
+# Two independent re-reviews found the same root cause in two functions: `_value_sources` and
+# `_grain_preserving_source` were both written as DENYLISTS with an unsafe default. One enumerated
+# the alternation node types and let everything else union its children; the other rejected three
+# `exp.Select` arguments and accepted the rest. In both, an unanticipated shape landed on the side
+# that CLEARS a finding, and in both the docstring named the hazard without the code enforcing it.
+# Both are now allowlists: what is understood is enumerated, and everything else fails closed.
+#
+# The batteries below are the per-finding regressions. The corpus above carries the seven shapes
+# they were found on, so the property that no known-inflated statement reads clean covers them too.
+
+
+@pytest.mark.parametrize("label,sql,aggregate", [
+    ("GREATEST", GREATEST_ALTERNATION_FAN,
+     "SUM(GREATEST(orders.total_amount, order_items.quantity))"),
+    ("LEAST", LEAST_ALTERNATION_FAN, "SUM(LEAST(orders.total_amount, order_items.quantity))"),
+    ("NVL2", NVL2_ALTERNATION_FAN, "SUM(NVL2(order_items.quantity, orders.total_amount, 0))"),
+    ("DECODE", DECODE_ALTERNATION_FAN,
+     "SUM(DECODE(order_items.product_id, 1, orders.total_amount, 0))"),
+])
+def test_an_alternation_spelled_as_a_function_still_names_the_edge_it_multiplies(
+    label, sql, aggregate,
+):
+    """A7, A8. Four ordinary-SQL shapes that reported `not_multiplied` over a real fan.
+
+    Each of these returns ONE of its arguments, so the value is at a table's grain only if every
+    argument is — the rule `exp.Case` and `exp.Coalesce` were already read by. Without a case of
+    their own they reached the generic branch, which unioned every operand, put `order_items` on the
+    value path, and suppressed the only edge there was. Measured against base `439ecd1`, all four
+    said `multiplied` there and `not_multiplied` here.
+
+    The corpus above asserts only that these are not reported clean, which `undetermined` satisfies
+    too. This asserts the answer, because `multiplied` naming the fan edge is what base gave and
+    what the statement deserves: a one-side amount summed once per order item is inflated, whichever
+    keyword the alternation was written with.
+    """
+    reports = _reports(sql)
+    assert [(a.aggregate, a.status) for a in reports] == [(aggregate, rt.MULTIPLIED)], (
+        label, reports)
+    assert reports[0].joins == [FAN_EDGE], (label, reports[0].joins)
+
+
+@pytest.mark.parametrize("label,expression", [
+    ("a scalar function with a many-side argument", "ROUND(orders.total_amount, 2)"),
+    ("a function sqlglot has no node for", "SOME_UDF(orders.total_amount)"),
+])
+def test_a_node_type_the_value_path_does_not_enumerate_contributes_nothing(label, expression):
+    """The inverted polarity, asserted on the classifier rather than only through an answer.
+
+    This is the correction the four shapes above are symptoms of. A node `_value_operands` does not
+    recognize used to UNION its children, so an unanticipated shape contributed its operands to the
+    value path — and a many-side operand on the value path is exactly what clears a fan. Enumerated
+    the other way round, it contributes nothing, an empty contribution suppresses no edge, and the
+    fan is reported.
+
+    Asserted through `_value_operands` because the two ways of contributing nothing are different
+    facts. `COUNT(*)` contributes nothing because there is no column in it; these contribute nothing
+    because this layer has never established what their operands mean. A test that only read the
+    empty set could not tell a fail-closed default from a lucky parse.
+    """
+    node = parse_one(f"SELECT {expression} FROM orders").expressions[0]
+    reading, operands = rt._value_operands(node)
+    assert (reading, operands) == (rt._VALUE_UNKNOWN, []), (label, reading, operands)
+    assert rt._value_sources(node, VALUE_SCOPE) == frozenset(), label
+
+
+def test_a_wide_expression_inside_the_character_cap_does_not_cost_the_receipt():
+    """The availability bound, and it is the same shape `_and_conjuncts` was made iterative for.
+
+    sqlglot builds `a + 1 + 1 + …` LEFT-DEEP, so the tree is as deep as the expression is wide and a
+    recursive value walk costs one Python frame per term. Measured: 989 terms is 4,052 characters
+    against `sql_guard._MAX_SQL_CHARS` of 50,000 and raised `RecursionError`, which
+    `execute_sql._receipt_for` catches under bare `Exception` and turns into `RECEIPT_BUILD_FAILED`
+    — the statement runs, returns rows, and the caller silently loses the trust layer. On
+    `cmd_preflight` and `cmd_prepare`, which have no such catch, it propagated as a traceback.
+
+    So the widest expression the CHARACTER cap admits is what this asserts, rather than some number
+    chosen to be comfortably inside it. 12,476 terms is 50,000 characters exactly; anything wider is
+    refused by `sql_guard` before this layer is asked, so there is no shape left for a depth bound
+    to have an opinion about. The status is asserted too: an analysis that survived by answering
+    `undetermined` would pass a test that only asked for no exception.
+    """
+    terms = 12_476
+    sql = f"SELECT SUM(orders.total_amount{' + 1' * terms}) {FAN_JOIN}"
+    assert len(sql) == 50_000, len(sql)
+
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], [a.status for a in reports]
+    assert reports[0].joins == [FAN_EDGE], reports[0].joins
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("a LATERAL VIEW", LATERAL_VIEW_CTE),
+    ("an UNPIVOT", UNPIVOT_CTE),
+    ("a CONNECT BY", CONNECT_BY_CTE),
+])
+def test_a_cte_body_that_multiplies_its_own_rows_is_not_the_table_it_reads(label, sql):
+    """The grain-preserving guard read three `exp.Select` arguments and accepted every other one.
+
+    None of these bodies has a JOIN, a GROUP BY or a DISTINCT in it, so all three passed the whole
+    denylist and resolved as though they handed `orders` back row for row. They do not: a LATERAL
+    VIEW emits one row per exploded element, an UNPIVOT one row per unpivoted column, and a CONNECT
+    BY one row per path through the hierarchy. Each was measured `not_multiplied` here against an
+    `undetermined` on base `439ecd1`, which makes all three false cleans this branch created.
+
+    The resolver is asserted as well as the status, because they are separable: a body that resolved
+    to `orders` and then failed to find a fan would report `not_multiplied` for a second reason, and
+    the fix has to be that the body is unreadable rather than that the fan is absent.
+    """
+    tree = _parse(sql)
+    bodies = rt._visible_cte_bodies(tree.find(exp.Select))
+    assert set(bodies) == {"o"}, (label, bodies)
+    assert rt._grain_preserving_source(
+        "o", bodies, rt._model_table_index(_sales_org()), set()) is None, label
+
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.UNDETERMINED], (label, reports)
+
+
+def test_the_grain_preserving_allowlist_is_the_arguments_that_keep_the_rows():
+    """The allowlist itself, so that widening it is a deliberate act and not a side effect.
+
+    `exp.Select` carries thirty-odd arguments and only five of them leave the source's row count
+    alone: the projection, the FROM under both of sqlglot's spellings for it, the WHERE, which
+    removes rows without changing what a row IS, and the ORDER BY, which changes their sequence.
+    Every other one either collapses rows (`group`, `distinct`), multiplies them (`joins`,
+    `laterals`, `connect`, `match`, `pivots`), or truncates them (`limit`, `offset`), and a guard
+    that named three of those and accepted the rest is how the three shapes above got through.
+
+    `order` is in and `limit` is out, which is the pair that says why the allowlist is arguments and
+    not intuitions: ORDER BY alone is a sequence, ORDER BY with LIMIT is a truncation, and the two
+    live under separate keys. Both are asserted through the analysis below, because leaving `order`
+    out costs a LOST FINDING rather than an over-report — the fan is real and the resolver can see
+    it, and a receipt going quiet about a trap it can prove is the failure this spec is against.
+
+    Asserted as a set rather than as a sequence: the order it is written in decides nothing, and a
+    tuple comparison would fail on a reordering that changes no answer.
+    """
+    assert set(rt._GRAIN_PRESERVING_SELECT_ARGS) == {
+        "expressions", "from_", "from", "where", "order"}
+    for hazard in ("group", "distinct", "joins", "laterals", "connect", "match", "pivots",
+                   "limit", "offset", "qualify", "with_"):
+        assert hazard not in rt._GRAIN_PRESERVING_SELECT_ARGS, hazard
+
+    ordered = ("WITH oi AS (SELECT * FROM order_items ORDER BY id) "
+               "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id")
+    assert [(a.status, a.joins) for a in _reports(ordered)] == [(rt.MULTIPLIED, [FAN_EDGE])]
+    truncated = ("WITH oi AS (SELECT * FROM order_items ORDER BY id LIMIT 10) "
+                 "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id")
+    assert [(a.status, a.joins) for a in _reports(truncated)] == [(rt.UNDETERMINED, [])]
+
+
+@pytest.mark.parametrize("label,sql,expected_map", [
+    ("a LATERAL VIEW", LATERAL_VIEW_SOURCE, {"orders": "orders", "t": ""}),
+    ("an UNPIVOT", UNPIVOT_SOURCE, {"o": "orders", "": ""}),
+    ("a CONNECT BY", CONNECT_BY_SOURCE, {"orders": "orders", "": ""}),
+    ("a PIVOT", PIVOT_SOURCE, {"orders": "orders", "p": ""}),
+])
+def test_a_row_multiplying_source_beside_the_from_clause_binds_nothing(label, sql, expected_map):
+    """`_reference_sites`' own docstring claims a denylist; these are what made the claim false.
+
+    It says every FROM/JOIN source that is not an `exp.Table` binds, and that a source kind nobody
+    anticipated has to default to `undetermined`. Four constructs are neither: `laterals`, `connect`
+    and `match` are SIBLINGS of `from_` on `exp.Select` rather than children of it, and `pivots`
+    rides the `exp.Table`, which the table arm has already bound under its real name. A walk over
+    `exp.From` and `exp.Join` reaches none of the four, so the scope map looked like a single clean
+    table and every aggregate in the statement read `not_multiplied`.
+
+    The false clean is PRE-EXISTING — base `439ecd1` answers `not_multiplied` on the first three as
+    well — and it lives on the ungated surface: `cmd_preflight` and `cmd_prepare` in
+    `semantic_model/cli.py` call `pre_flight_check` with no gate battery in front of it. `PIVOT`
+    escaped only by accident, because it happens to contain an `exp.AggFunc`, which is not a
+    property of PIVOT so much as of the example anyone writes.
+
+    Both halves are asserted. The map says the alias is in scope and resolves to no model table,
+    which is the honest answer; the status says what the analysis does with that. A binding that
+    dropped `orders` instead of adding the empty one would also give `undetermined`, and would have
+    lost the join the model declares.
+    """
+    assert rt._alias_map(_parse(sql).find(exp.Select), in_scope_only=True) == expected_map, label
+
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.UNDETERMINED], (label, reports)
+
+
+def test_a_match_recognize_binds_nothing_on_the_dialect_that_speaks_it():
+    """The fourth `exp.Select` argument, asserted off a tree rather than through a receipt.
+
+    `MATCH_RECOGNIZE` does not parse on sqlglot's default grammar and `_sales_org` declares no
+    dialect, so `pre_flight_check` against it answers "could not be parsed" and reaches none of this
+    layer. That is not a reason to leave the argument unbound: Snowflake, Oracle and Trino all speak
+    it, a model declaring any of them resolves that grammar, and one match per partition out of many
+    rows is a row count nothing else in the statement states.
+
+    The parse is asserted first so the test cannot silently start measuring a statement that no
+    longer contains a MATCH_RECOGNIZE at all.
+    """
+    tree = parse_one(MATCH_RECOGNIZE_SOURCE, read="snowflake")
+    select = tree.find(exp.Select)
+    assert select.args.get("match") is not None, select.args
+    assert rt._alias_map(select, in_scope_only=True) == {"orders": "orders", "": ""}
+
+
+def test_the_receipts_own_reference_roster_is_unchanged_by_the_row_multiplying_binding():
+    """ACE-099's contract: the DEFAULT walk is what the receipt and the refusal path read.
+
+    `bind_derived` is opt-in precisely because `_projected_sensitive` refuses on what it finds and
+    `assemble_receipt`'s roster discloses it. A row-multiplying source is not a table reference and
+    must not appear as one, whatever the scope map needs to know about it — a receipt listing an
+    empty-named table would be a disclosure of a source that has no name to disclose.
+    """
+    for label, sql in [("a LATERAL VIEW", LATERAL_VIEW_SOURCE), ("an UNPIVOT", UNPIVOT_SOURCE),
+                       ("a CONNECT BY", CONNECT_BY_SOURCE), ("a PIVOT", PIVOT_SOURCE)]:
+        refs = rt._table_references(_parse(sql))
+        assert [(r.bare, r.scope) for r in refs] == [("orders", "main")], (label, refs)
+
+
+def test_a_lateral_that_a_join_already_bound_is_not_bound_twice():
+    """One source, one binding, whichever of the two walks reaches it first.
+
+    `LATERAL (SELECT 1) l` is an `exp.Lateral` that is also a JOIN's `this`, so it is now reachable
+    both as the clause's bound source and as a member of the row-multiplying walk. Binding it twice
+    would put one source in the reference list twice, and a list is what the receipt's roster and
+    the arm-counting assertions in `test_ace043_set_operation_arms.py` read.
+
+    The ORDER is sqlglot's own traversal order and is asserted as written rather than sorted, for
+    the reason `_table_references` states: `_RECEIPT_MAX_REFS` truncates from the front of exactly
+    this order, so a reordering is a change in which references a capped receipt lists.
+    """
+    sql = "SELECT SUM(orders.total_amount) FROM orders, LATERAL (SELECT 1) l"
+    sites = rt._reference_sites(_parse(sql).find(exp.Select), bind_derived=True)
+    assert [(s.ref.bare, s.ref.alias) for s in sites] == [("", "l"), ("orders", None)], sites

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -1,0 +1,182 @@
+"""ACE-083 — the shapes a soundness fix may never report clean, pinned before any fix lands.
+
+ACE-083 makes the multiplication report say what a join actually multiplies. Three of its four
+corrections are LOOSENINGS: an aggregate a duplication cannot move stops being called a trap, a
+many-side column that is not on the value path stops attributing the fan, and a reference the
+statement cannot see stops entering the alias map. Each one narrows what gets reported, and the
+whole existing battery guards the other direction — every shipped assertion says "this IS reported"
+and not one of them says "this is still not reported clean".
+
+That asymmetry is the hazard. A loosening that goes one step too far turns a genuinely inflated
+number into `not_multiplied`, which is a positive claim on the receipt that the number is sound.
+Nothing on `main` fails when that happens. So the reverse corpus lands FIRST, in its own file,
+before a line of production code moves.
+
+Everything here passes on the base implementation. That is the point: these are not the tests for
+the new behaviour, they are the tests for the behaviour that must survive it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+# `rt` is imported FROM the fixture's module rather than beside it, and that is load-bearing.
+# `test_semantic_model_runtime` puts `plugins/agami/scripts` on `sys.path`, while the ACE-060 and
+# ACE-099 batteries put `packages/agami-core/src` there. Importing `semantic_model.runtime` down a
+# different path than the fixture came down yields a second module object with its own
+# `MULTIPLIED` / `NOT_MULTIPLIED` string objects and its own detector — so an assertion here could
+# compare a status produced by one copy against a constant defined by the other. One import.
+from test_semantic_model_runtime import _sales_org, rt  # noqa: E402
+
+# The one-to-many the whole corpus is built on: `orders` is the ONE side, `order_items` the MANY,
+# and the model declares that edge. Written once so "the same fan join in every member" is a fact
+# of the code rather than of the typing.
+FAN_JOIN = "FROM orders JOIN order_items ON order_items.order_id = orders.id"
+
+# 1. The plain fan. The shape every other member is a disguise of.
+PLAIN_FAN = f"SELECT SUM(orders.total_amount) {FAN_JOIN}"
+
+# 2. The measure wrapped in arithmetic. The value path is still a one-side column; scaling every
+#    duplicated row scales the inflated total.
+SCALED_FAN = f"SELECT SUM(orders.total_amount * 1.1) {FAN_JOIN}"
+
+# 3. The many-side column is the CASE predicate, not the value. A value-path rule that attributes
+#    the fan to `order_items` here would clear a total that is still summed once per item.
+CONDITIONED_FAN = (
+    f"SELECT SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount END) {FAN_JOIN}"
+)
+
+# 4. The many-side column is the ordering arm. Same trap as 3, on the branch that reads an
+#    `exp.Order` rather than an `exp.Case`, and the concatenation genuinely repeats each status.
+ORDERED_FAN = f"SELECT STRING_AGG(orders.status, ',' ORDER BY order_items.id) {FAN_JOIN}"
+
+# 5. The many side behind a derived table. `d` is an `exp.Subquery` and binds no table name of its
+#    own, so a scope filter that drops what it cannot bind drops `order_items` — and the fan with
+#    it. This is the member that measures the false clean the filter itself creates.
+DERIVED_TABLE_FAN = (
+    "SELECT SUM(orders.total_amount) FROM orders "
+    "JOIN (SELECT order_id FROM order_items) d ON d.order_id = orders.id"
+)
+
+# 6. The many side behind a CTE that changes nothing. `oi` is one grain-preserving hop from
+#    `order_items`, so the join still multiplies `orders` exactly as member 1 does.
+CTE_LAUNDERED_FAN = (
+    "WITH oi AS (SELECT * FROM order_items) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id"
+)
+
+# 7. The join is inside the CTE body, so the outer statement joins nothing and the rows behind
+#    `SUM(j.total_amount)` were multiplied where the walk does not look. Nothing about this one is
+#    determinable, which is a different answer from clean and must stay a different answer.
+JOINED_CTE_BODY = (
+    "WITH j AS (SELECT o.id AS id, o.total_amount AS total_amount FROM orders o "
+    "JOIN order_items i ON i.order_id = o.id) SELECT SUM(j.total_amount) FROM j"
+)
+
+# The corpus, named so the later slices can re-run it unchanged rather than restating it. Labels
+# are what a failure prints, so they name the disguise and not the SQL.
+INFLATED_SHAPES = [
+    ("plain fan", PLAIN_FAN),
+    ("measure scaled by a literal", SCALED_FAN),
+    ("many side in the CASE predicate", CONDITIONED_FAN),
+    ("many side in the ORDER BY arm", ORDERED_FAN),
+    ("many side behind a derived table", DERIVED_TABLE_FAN),
+    ("many side behind a CTE", CTE_LAUNDERED_FAN),
+    ("join inside the CTE body", JOINED_CTE_BODY),
+]
+
+# A conditional count and a conditional sum over the many side. Both are honestly clean: one row
+# per order item is exactly what they count, so the join multiplies nothing they read.
+CONDITIONAL_COUNT = f"SELECT COUNT(CASE WHEN order_items.quantity > 0 THEN 1 END) {FAN_JOIN}"
+CONDITIONAL_SUM = (
+    f"SELECT SUM(CASE WHEN order_items.quantity > 0 THEN 1 ELSE 0 END) {FAN_JOIN}"
+)
+
+FAN_EDGE = "orders (1) <- order_items (N)"
+
+
+def _reports(sql: str) -> list["rt.AggregateReport"]:
+    """Every aggregate report for `sql` against the sales model, with the analysis proved to run.
+
+    `unchecked` is asserted here rather than in each test because an empty aggregate list is also
+    what an unparseable statement returns, and a corpus that silently stopped parsing would pass
+    every "is not reported clean" assertion below by computing nothing at all.
+    """
+    pf = rt.pre_flight_check(sql, _sales_org())
+    assert pf.unchecked is None, pf.unchecked
+    assert pf.aggregates, sql
+    return pf.aggregates
+
+
+@pytest.mark.parametrize("label,sql", INFLATED_SHAPES)
+def test_no_known_inflated_shape_is_ever_reported_clean(label, sql):
+    """A17 — for every shape a join is known to inflate, no aggregate says `not_multiplied`.
+
+    The assertion is a PROPERTY over the whole corpus, not a per-case expected value, and that
+    choice is the test. Three of ACE-083's four corrections are loosenings; each one is correct in
+    a direction nothing had asserted, and the failure mode they share is the same one: a shape that
+    used to report `multiplied` quietly starts reporting `not_multiplied`. Pinning each member's
+    exact status would freeze answers this spec is deliberately changing (a member may legitimately
+    move between `multiplied` and `undetermined` as the scope and grain work lands) and would still
+    not say the one thing that must hold across all seven.
+
+    `multiplied` and `undetermined` are both acceptable answers here. What is not acceptable is the
+    positive claim that a number a join inflated is sound: `undetermined` declines to answer, and a
+    reader can act on that, while `not_multiplied` is a receipt asserting something false.
+    """
+    statuses = [(a.aggregate, a.status) for a in _reports(sql)]
+    assert all(s != rt.NOT_MULTIPLIED for _, s in statuses), (label, statuses)
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("the CASE predicate", CONDITIONED_FAN),
+    ("the ORDER BY arm", ORDERED_FAN),
+])
+def test_a_many_side_column_off_the_value_path_still_reports_the_multiplication(label, sql):
+    """A8, A9 — a many-side column that is not the value does not clear the aggregate.
+
+    These are the regression the value-path rule must not cause. That rule attributes the fan by
+    the columns the aggregate's VALUE is computed from, so that
+    `SUM(order_items.quantity * orders.total_amount)` — already at the many side's grain — stops
+    being called a fan trap. Both statements here put a many-side column inside the aggregate
+    without putting it on the value path: one is a filter on which rows contribute, the other is
+    the order the values are concatenated in. In both the summed and concatenated value is a
+    one-side column, once per order item, and the join multiplies it.
+
+    Asserted on `status` and `joins` rather than on the finding's `risk`, because the risk label is
+    exactly what a later slice splits: an aggregate a duplication cannot move keeps the
+    multiplication and loses the word trap. What may never move is that the report says the rows
+    were multiplied, and names the edge that did it.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], (label, reports)
+    assert reports[0].joins == [FAN_EDGE], (label, reports[0].joins)
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("COUNT over a conditional literal", CONDITIONAL_COUNT),
+    ("SUM over a conditional literal", CONDITIONAL_SUM),
+])
+def test_a_conditional_count_over_the_many_side_still_says_it_is_clean(label, sql):
+    """These two are honestly clean, and a value-path rule applied too widely would lose that.
+
+    Each counts order items, one row per item, which is precisely the grain the join produces. No
+    fan fires because the only table either reads is the many side, and `not_multiplied` is the
+    true answer.
+
+    They are pinned because they are the measured cost of one tempting simplification. The value
+    path also decides `sources`; if it were made to decide `resolved` as well, both of these would
+    flip to `undetermined`, because their value path is a bare literal and "no columns on the value
+    path" is indistinguishable from "no columns at all" to a `bool(cols)` test. That degradation
+    breaks no existing assertion and would surface only as two receipts that stopped answering a
+    question they used to answer correctly. This is what catches it.
+
+    Unreachable before this spec: `_sales_org` declared no tables, so ACE-060's `visible` set was
+    empty and no aggregate on this model could report `not_multiplied` at all.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.NOT_MULTIPLIED], (label, reports)
+    assert [f.risk for f in reports[0].findings] == [], (label, reports[0].findings)

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -12,10 +12,19 @@ number into `not_multiplied`, which is a positive claim on the receipt that the 
 Nothing on `main` fails when that happens. So the reverse corpus lands FIRST, in its own file,
 before a line of production code moves.
 
-The reverse corpus passes on the base implementation. That is the point: those are not the tests for
-the new behaviour, they are the tests for the behaviour that must survive it. The batteries below it
-are the per-slice tests of what each correction actually changed, and they land beside the corpus
+Almost every member of the reverse corpus passes on the base implementation, and that is the point:
+those are not the tests for the new behaviour, they are the tests for the behaviour that must
+survive it. Three members do fail on base — the unaliased `VALUES` list and the two set operations
+whose CTE is bound above the arms — and each of those was a false clean measured on base while this
+slice was being built, so they are corpus members and regression tests at once. The batteries below
+the corpus are the per-slice tests of what each correction actually changed, and they land beside it
 rather than in files of their own so that a loosening and the pins guarding it are read together.
+
+The corpus rows carry the ITEMS each statement is known to inflate rather than only the SQL, because
+the property asserted over every aggregate in a statement can only hold members every one of whose
+arms is inflated. That shut out the mixed statements — one sound number beside one unsound one —
+that most real multi-aggregate SQL is, and a rule that suppresses per STATEMENT rather than per ITEM
+is invisible until one of those is in the corpus.
 
 Slice 2 (S1) is here: an aggregate a duplication cannot move keeps the multiplication and loses the
 word trap, and the marker sentence that reported the detector's old shortcoming is deleted.
@@ -116,22 +125,190 @@ UNALIASED_VALUES_FAN = "SELECT SUM(orders.total_amount) FROM orders, (VALUES (1)
 
 # 9. Members 6 and 1, wrapped in a set operation. A WITH sits ABOVE the arms and binds its name for
 #    all of them, so an arm looking for the CTE inside itself finds nothing and the laundered fan
-#    goes unseen — the same statement, one keyword further out, reading clean. Both arms are
-#    inflated so the corpus property stays unconditional over every item the statement produces.
+#    goes unseen — the same statement, one keyword further out, reading clean.
 UNION_ARM_CTE_FAN = f"{CTE_LAUNDERED_FAN} UNION ALL {PLAIN_FAN}"
 
-# The corpus, named so the later slices can re-run it unchanged rather than restating it. Labels
-# are what a failure prints, so they name the disguise and not the SQL.
+# 10. The same set operation with ONE inflated arm and one honest one, which is what most real
+#     multi-aggregate SQL looks like. It could not be a member while the property ran over every
+#     item in the statement — that constraint is why member 9 had to be built out of two inflated
+#     arms — and it is the shape that says the laundered arm is found without the clean arm being
+#     dragged in with it.
+MIXED_SET_OPERATION = f"{CTE_LAUNDERED_FAN} UNION ALL SELECT SUM(orders.revenue) FROM orders"
+
+# 11, 12. The same fan spelled two ways nothing else here spells it. The edge comes off the model's
+#     declared relationship rather than off the JOIN keyword, so neither of these should differ from
+#     member 1 — and until now nothing said so, which is what makes a rule keyed on `exp.Join`
+#     cheap to write by accident.
+COMMA_JOIN_FAN = ("SELECT SUM(orders.total_amount) FROM orders, order_items "
+                  "WHERE order_items.order_id = orders.id")
+LEFT_JOIN_FAN = ("SELECT SUM(orders.total_amount) FROM orders "
+                 "LEFT JOIN order_items ON order_items.order_id = orders.id")
+
+# 13. Member 5 turned around: the derived table is on the ONE side and the many side is the plain
+#     declared table. `t` binds a name the `exp.Table` walk never sees, so the measure's own source
+#     is what goes unresolved here rather than the fanning one.
+DERIVED_TABLE_ON_THE_ONE_SIDE = ("SELECT SUM(t.total_amount) FROM (SELECT * FROM orders) t "
+                                 "JOIN order_items ON order_items.order_id = t.id")
+
+# 14-17. A ONE-side column off the value path. Members 3 and 4 move the MANY side around; these move
+#     the one side, and that is the only direction that can manufacture a clean answer — a value
+#     path narrowed until it holds no one-side column stops the aggregate reading the one side at
+#     all, so the fan loop never reaches it and a total the join really does inflate reports sound.
+#     Each was measured `not_multiplied` while the value path decided `sources`.
+ONE_SIDE_IN_A_CASE_PREDICATE = (
+    f"SELECT SUM(CASE WHEN orders.status = 'shipped' THEN 1 ELSE 0 END) {FAN_JOIN}"
+)
+ONE_SIDE_AS_A_SIMPLE_CASE_OPERAND = (
+    f"SELECT SUM(CASE orders.status WHEN 'shipped' THEN 1 ELSE 0 END) {FAN_JOIN}"
+)
+ONE_SIDE_IN_A_CONDITIONAL_COUNT = (
+    f"SELECT COUNT(CASE WHEN orders.status = 'shipped' THEN 1 END) {FAN_JOIN}"
+)
+BRANCHES_DISAGREEING_ABOUT_THE_GRAIN = (
+    f"SELECT SUM(CASE WHEN orders.flag THEN orders.total_amount "
+    f"ELSE order_items.quantity END) {FAN_JOIN}"
+)
+
+# 18-21. The same defect reached through a node that is not an `exp.Case`. Which sqlglot node type
+#     spells a conditional is exactly what the value-path rule is scoped by, and members 1-9 vary it
+#     not at all: `IF` is an `exp.If` that RENDERS back as a CASE, `NULLIF` and `COALESCE` are
+#     functions whose arguments are not all values, and a `GROUP_CONCAT` separator is punctuation.
+#     For a node that only combines values, contributing its columns by default is honest; for one
+#     that mixes a predicate with its values it contributes the predicate that clears the fan.
+IF_SPELLED_CONDITIONAL_FAN = (
+    f"SELECT SUM(IF(order_items.quantity > 0, orders.total_amount, 0)) {FAN_JOIN}"
+)
+NULLIF_COMPARAND_FAN = f"SELECT SUM(NULLIF(orders.total_amount, order_items.quantity)) {FAN_JOIN}"
+COALESCE_ALTERNATION_FAN = (
+    f"SELECT SUM(COALESCE(orders.total_amount, order_items.quantity)) {FAN_JOIN}"
+)
+SEPARATOR_OFF_THE_MANY_SIDE_FAN = (
+    f"SELECT STRING_AGG(orders.status, order_items.product_id) {FAN_JOIN}"
+)
+
+# Two fans off ONE dimension, the other thing members 1-9 never vary: how many many-sides a measure
+# table has. Every one of them is a single declared one-to-many, so a rule that suppresses per
+# STATEMENT and a rule that suppresses per EDGE are indistinguishable on all nine.
+TWO_FAN_JOIN = ("FROM customers JOIN orders ON orders.customer_id = customers.id "
+                "JOIN tickets ON tickets.customer_id = customers.id")
+
+# 22. The value is a product of `customers` and `tickets` columns, so the tickets join is the grain
+#     the value was defined at and multiplies nothing, while the orders join duplicates it. Exactly
+#     one of the two edges is a reason to say nothing, and suppressing the whole finding because one
+#     of them is the value's own grain reported this statement clean.
+TWO_FANS_ONE_ON_THE_VALUE_PATH = f"SELECT SUM(customers.id * tickets.id) {TWO_FAN_JOIN}"
+
+# 23. Two independent measures over one shared dimension, one of them wrapped in a CASE that puts
+#     its only column in the predicate. `agg_sources` is derived across every site in the SELECT, so
+#     a narrowing at one aggregate is not local: with two measures needed for a shared dimension to
+#     be a chasm at all, one wrapped aggregate took the finding away from the other one too.
+#     `SUM(tickets.id)` is not inside that CASE and never was.
+CHASM_WITH_ONE_WRAPPED_AGGREGATE = (
+    f"SELECT SUM(CASE WHEN orders.status = 'x' THEN 1 ELSE 0 END), SUM(tickets.id) {TWO_FAN_JOIN}"
+)
+
+# 24. Grouped FINER than the join key: one row per (order, product), joined on the order alone. The
+#     CTE is genuinely the many side of its own edge and the fan is real.
+CTE_GRAIN_BELOW_JOIN_KEY = (
+    "WITH oi AS (SELECT order_id, product_id, SUM(quantity) q FROM order_items "
+    "GROUP BY order_id, product_id) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id"
+)
+# 25. Member 6 one hop further out. Two grain-preserving CTEs in a chain are still the same rows, so
+#     the resolution has to be transitive or it answers correctly only at depth one.
+TRANSITIVE_CTE = (
+    "WITH a AS (SELECT * FROM order_items), b AS (SELECT * FROM a) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN b ON b.order_id = orders.id"
+)
+# 26. `_cte_names` and `_model_table_index` fold case; `_alias_map` preserves it. Every comparison
+#     the resolution makes therefore has to be explicit about which side it is on, and this is the
+#     shape that catches one that is not.
+CASE_FOLDED_CTE = (
+    "WITH OI AS (SELECT * FROM order_items) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN OI ON OI.order_id = orders.id"
+)
+
+# 27, 28. Two arms, each declaring its OWN `x` over a different table. Only the first arm joins, and
+#     only the first arm's `x` is the one side of that join. Written in both orders because the
+#     defect was order-dependent: read off the root, whichever arm's body the walk reached last won
+#     the folded name for both.
+SAME_NAME_PER_ARM = (
+    "(WITH x AS (SELECT * FROM orders) SELECT SUM(x.total_amount) FROM x "
+    "JOIN order_items oi ON oi.order_id = x.id) UNION ALL "
+    "(WITH x AS (SELECT * FROM order_items) SELECT SUM(x.quantity) FROM x)"
+)
+SAME_NAME_PER_ARM_SWAPPED = (
+    "(WITH x AS (SELECT * FROM order_items) SELECT SUM(x.quantity) FROM x) UNION ALL "
+    "(WITH x AS (SELECT * FROM orders) SELECT SUM(x.total_amount) FROM x "
+    "JOIN order_items oi ON oi.order_id = x.id)"
+)
+
+# 29. A `WITH` inside a `WHERE … IN (…)` subquery. It binds `order_items` for that subquery and for
+#     nothing else, and the outer statement's `order_items` is the real declared table it joins.
+NESTED_WITH_SHADOWING_A_REAL_TABLE = (
+    "SELECT SUM(orders.total_amount) FROM orders "
+    "JOIN order_items ON order_items.order_id = orders.id "
+    "WHERE orders.id IN (WITH order_items AS (SELECT id FROM customers) "
+    "SELECT id FROM order_items)"
+)
+
+# The corpus, named so the later slices can re-run it unchanged rather than restating it. Labels are
+# what a failure prints, so they name the disguise and not the SQL.
+#
+# The third field is the ITEMS the statement is known to inflate, by the label the receipt gives
+# them. The property used to run over every aggregate in the statement, which forced every member to
+# be inflated in all of its arms — member 9 is built out of two inflated arms for exactly that
+# reason — and so shut the corpus out of the mixed statements that are most of real multi-aggregate
+# SQL. Naming the items instead lets a member carry an honestly clean aggregate beside an inflated
+# one, and members 10, 23, 27 and 28 all do.
 INFLATED_SHAPES = [
-    ("plain fan", PLAIN_FAN),
-    ("measure scaled by a literal", SCALED_FAN),
-    ("many side in the CASE predicate", CONDITIONED_FAN),
-    ("many side in the ORDER BY arm", ORDERED_FAN),
-    ("many side behind a derived table", DERIVED_TABLE_FAN),
-    ("many side behind a CTE", CTE_LAUNDERED_FAN),
-    ("join inside the CTE body", JOINED_CTE_BODY),
-    ("rows from an unaliased VALUES list", UNALIASED_VALUES_FAN),
-    ("a laundered fan inside a set-operation arm", UNION_ARM_CTE_FAN),
+    ("plain fan", PLAIN_FAN, ["SUM(orders.total_amount)"]),
+    ("measure scaled by a literal", SCALED_FAN, ["SUM(orders.total_amount * 1.1)"]),
+    ("many side in the CASE predicate", CONDITIONED_FAN,
+     ["SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount END)"]),
+    ("many side in the ORDER BY arm", ORDERED_FAN,
+     ["GROUP_CONCAT(orders.status ORDER BY order_items.id, ',')"]),
+    ("many side behind a derived table", DERIVED_TABLE_FAN, ["SUM(orders.total_amount)"]),
+    ("many side behind a CTE", CTE_LAUNDERED_FAN, ["SUM(orders.total_amount)"]),
+    ("join inside the CTE body", JOINED_CTE_BODY, ["SUM(j.total_amount)"]),
+    ("rows from an unaliased VALUES list", UNALIASED_VALUES_FAN, ["SUM(orders.total_amount)"]),
+    ("a laundered fan inside a set-operation arm", UNION_ARM_CTE_FAN,
+     ["SUM(orders.total_amount)"]),
+    ("a laundered fan beside an honestly clean arm", MIXED_SET_OPERATION,
+     ["SUM(orders.total_amount)"]),
+    ("a comma-join fan", COMMA_JOIN_FAN, ["SUM(orders.total_amount)"]),
+    ("a LEFT JOIN fan", LEFT_JOIN_FAN, ["SUM(orders.total_amount)"]),
+    ("the one side behind a derived table", DERIVED_TABLE_ON_THE_ONE_SIDE,
+     ["SUM(t.total_amount)"]),
+    ("one side in a searched CASE predicate", ONE_SIDE_IN_A_CASE_PREDICATE,
+     ["SUM(CASE WHEN orders.status = 'shipped' THEN 1 ELSE 0 END)"]),
+    ("one side as a simple CASE operand", ONE_SIDE_AS_A_SIMPLE_CASE_OPERAND,
+     ["SUM(CASE orders.status WHEN 'shipped' THEN 1 ELSE 0 END)"]),
+    ("one side in a conditional COUNT", ONE_SIDE_IN_A_CONDITIONAL_COUNT,
+     ["COUNT(CASE WHEN orders.status = 'shipped' THEN 1 END)"]),
+    ("branches that disagree about the grain", BRANCHES_DISAGREEING_ABOUT_THE_GRAIN,
+     ["SUM(CASE WHEN orders.flag THEN orders.total_amount ELSE order_items.quantity END)"]),
+    ("the conditional spelled IF", IF_SPELLED_CONDITIONAL_FAN,
+     ["SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount ELSE 0 END)"]),
+    ("a NULLIF comparand off the many side", NULLIF_COMPARAND_FAN,
+     ["SUM(NULLIF(orders.total_amount, order_items.quantity))"]),
+    ("a COALESCE alternation", COALESCE_ALTERNATION_FAN,
+     ["SUM(COALESCE(orders.total_amount, order_items.quantity))"]),
+    ("a GROUP_CONCAT separator off the many side", SEPARATOR_OFF_THE_MANY_SIDE_FAN,
+     ["GROUP_CONCAT(orders.status, order_items.product_id)"]),
+    ("two fans, one of them the value's own grain", TWO_FANS_ONE_ON_THE_VALUE_PATH,
+     ["SUM(customers.id * tickets.id)"]),
+    ("a chasm pair with one wrapped aggregate", CHASM_WITH_ONE_WRAPPED_AGGREGATE,
+     ["SUM(CASE WHEN orders.status = 'x' THEN 1 ELSE 0 END)", "SUM(tickets.id)"]),
+    ("a CTE grain finer than the join key", CTE_GRAIN_BELOW_JOIN_KEY,
+     ["SUM(orders.total_amount)"]),
+    ("a chain of grain-preserving CTEs", TRANSITIVE_CTE, ["SUM(orders.total_amount)"]),
+    ("a CTE name spelled in another case", CASE_FOLDED_CTE, ["SUM(orders.total_amount)"]),
+    ("the same CTE name declared per arm", SAME_NAME_PER_ARM, ["SUM(x.total_amount)"]),
+    ("the same CTE name declared per arm, swapped", SAME_NAME_PER_ARM_SWAPPED,
+     ["SUM(x.total_amount)"]),
+    ("a WITH bound inside a WHERE subquery", NESTED_WITH_SHADOWING_A_REAL_TABLE,
+     ["SUM(orders.total_amount)"]),
 ]
 
 # A conditional count and a conditional sum over the many side. Both are honestly clean: one row
@@ -162,6 +339,19 @@ EVERY_STATUS_SQL = (
     "SELECT SUM(i.quantity * o.total_amount), SUM(o.total_amount), MIN(o.total_amount), COUNT(*) "
     "FROM orders o JOIN order_items i ON i.order_id = o.id"
 )
+# And what it actually reports, written out. Three tests consume `EVERY_STATUS_SQL` for the breadth
+# the comment above claims, and every one of them compares the analysis against itself: the
+# cross-process probe compares four children against the parent, the both-surfaces test compares
+# `assemble_receipt` against `pre_flight_check`, and the internal-consistency property asks only
+# that `joins` agrees with `status`. All three would still pass if all four aggregates degraded to
+# `undetermined` together, and the comment describing the statement would silently become false
+# while the tests resting on it went on passing. This is the one assertion that says what it is.
+EVERY_STATUS_ITEMS = [
+    ("SUM(i.quantity * o.total_amount)", rt.NOT_MULTIPLIED, []),
+    ("SUM(o.total_amount)", rt.MULTIPLIED, ["fan_trap"]),
+    ("MIN(o.total_amount)", rt.MULTIPLIED, ["fan_out_invariant"]),
+    ("COUNT(*)", rt.UNDETERMINED, []),
+]
 
 # The scope map every `_value_sources` case below is resolved through. Identity, because these
 # statements qualify their columns with the table's own name and the question under test is which
@@ -253,6 +443,14 @@ STRING_AGG_OVER_FAN = f"SELECT STRING_AGG(orders.status, ',') {FAN_JOIN}"
 # `undetermined` before any fan is considered.
 COUNT_STAR_OVER_FAN = f"SELECT COUNT(*) {FAN_JOIN}"
 
+# The same two properties over a CHASM rather than over a fan. A cross-product cannot move a minimum
+# or a distinct count either, and the split above does not reach here — see the test.
+CHASM_OVER_INVARIANT_MEASURES = (
+    "SELECT c.id, MIN(o.revenue), COUNT(DISTINCT t.id) FROM customers c "
+    "LEFT JOIN orders o ON o.customer_id = c.id "
+    "LEFT JOIN tickets t ON t.customer_id = c.id GROUP BY c.id"
+)
+
 # --- the marker, after the fan-immune clause is deleted --------------------
 #
 # Four statements, one per state `_aggregates_marker` can be in that this spec could have disturbed,
@@ -290,24 +488,37 @@ def _reports(sql: str) -> list["rt.AggregateReport"]:
     return pf.aggregates
 
 
-@pytest.mark.parametrize("label,sql", INFLATED_SHAPES)
-def test_no_known_inflated_shape_is_ever_reported_clean(label, sql):
-    """A17 — for every shape a join is known to inflate, no aggregate says `not_multiplied`.
+@pytest.mark.parametrize("label,sql,inflated", INFLATED_SHAPES)
+def test_no_known_inflated_shape_is_ever_reported_clean(label, sql, inflated):
+    """A17 — for every shape a join is known to inflate, the inflated items say so.
 
-    The assertion is a PROPERTY over the whole corpus, not a per-case expected value, and that
-    choice is the test. Three of ACE-083's four corrections are loosenings; each one is correct in
-    a direction nothing had asserted, and the failure mode they share is the same one: a shape that
-    used to report `multiplied` quietly starts reporting `not_multiplied`. Pinning each member's
-    exact status would freeze answers this spec is deliberately changing (a member may legitimately
-    move between `multiplied` and `undetermined` as the scope and grain work lands) and would still
-    not say the one thing that must hold across all seven.
+    The assertion is a PROPERTY over the corpus, not a per-case expected value, and that choice is
+    the test. Three of ACE-083's four corrections are loosenings; each one is correct in a direction
+    nothing had asserted, and the failure mode they share is the same one: a shape that used to
+    report `multiplied` quietly starts reporting `not_multiplied`. Pinning each member's exact
+    status would freeze answers this spec is deliberately changing (a member may legitimately move
+    between `multiplied` and `undetermined` as the scope and grain work lands) and would still not
+    say the one thing that must hold across all of them.
 
     `multiplied` and `undetermined` are both acceptable answers here. What is not acceptable is the
     positive claim that a number a join inflated is sound: `undetermined` declines to answer, and a
     reader can act on that, while `not_multiplied` is a receipt asserting something false.
+
+    The property runs over the NAMED items rather than over every aggregate in the statement, and
+    that is what lets a member be a mixed statement. Over-everything, a member could only be added
+    if all of its arms were inflated, so the corpus held nine disguises of one topology and not one
+    statement in which a sound number sits beside an unsound one — which is most real
+    multi-aggregate SQL, and is where a rule that suppresses per STATEMENT rather than per ITEM
+    hides. Naming the items costs one thing, an expected label per row, and the first assertion is
+    what pays for it: a label this file gets wrong selects nothing, and a row that asserts a
+    property over an empty selection is a row that asserts nothing at all.
     """
-    statuses = [(a.aggregate, a.status) for a in _reports(sql)]
-    assert all(s != rt.NOT_MULTIPLIED for _, s in statuses), (label, statuses)
+    reports = _reports(sql)
+    named = [a for a in reports if a.aggregate in inflated]
+    assert sorted({a.aggregate for a in named}) == sorted(set(inflated)), (
+        label, [a.aggregate for a in reports])
+    assert all(a.status != rt.NOT_MULTIPLIED for a in named), (
+        label, [(a.aggregate, a.status) for a in named])
 
 
 @pytest.mark.parametrize("label,sql", [
@@ -638,45 +849,25 @@ def test_the_value_path_of_something_that_is_not_an_expression_is_empty():
     assert rt._value_sources(exp.Case(), VALUE_SCOPE) == frozenset()
 
 
-# --- the direction the corpus above cannot reach ---------------------------
+# --- the direction the corpus reaches only through members 14-21 ------------
 #
-# Every member of `INFLATED_SHAPES` puts the MANY-side column somewhere unusual. Not one puts a
-# ONE-side column off the value path, and that is the only direction that can manufacture a clean:
-# a value path narrowed until it holds no one-side column stops the aggregate reading the one side
-# at all, so the fan loop never reaches it and a total the join really does inflate reports sound.
-# Each of these was measured `not_multiplied` while the value path decided `sources`, and
-# `multiplied` on the base the spec is written against.
+# The exact edge each of those members has to name. The corpus property says only that a named item
+# is not reported clean, which is what lets a member move between `multiplied` and `undetermined` as
+# the scope and grain work lands; these seven have no such freedom, because the whole reason they
+# are in the corpus is that a value path narrowed until it holds no one-side column reports them
+# sound. Each was measured `not_multiplied` while the value path decided `sources`, and `multiplied`
+# on the base the spec is written against.
 
 ONE_SIDE_OFF_THE_VALUE_PATH = [
-    ("a searched CASE testing a one-side column",
-     f"SELECT SUM(CASE WHEN orders.status = 'shipped' THEN 1 ELSE 0 END) {FAN_JOIN}"),
-    ("a simple CASE whose operand is a one-side column",
-     f"SELECT SUM(CASE orders.status WHEN 'shipped' THEN 1 ELSE 0 END) {FAN_JOIN}"),
-    ("a conditional COUNT over a one-side predicate",
-     f"SELECT COUNT(CASE WHEN orders.status = 'shipped' THEN 1 END) {FAN_JOIN}"),
-    ("branches that disagree about the grain",
-     f"SELECT SUM(CASE WHEN orders.flag THEN orders.total_amount "
-     f"ELSE order_items.quantity END) {FAN_JOIN}"),
-    ("IF, which sqlglot renders back as a CASE",
-     f"SELECT SUM(IF(order_items.quantity > 0, orders.total_amount, 0)) {FAN_JOIN}"),
-    ("NULLIF, whose second argument is a comparand",
-     f"SELECT SUM(NULLIF(orders.total_amount, order_items.quantity)) {FAN_JOIN}"),
-    ("a GROUP_CONCAT separator read off the many side",
-     f"SELECT STRING_AGG(orders.status, order_items.product_id) {FAN_JOIN}"),
+    ("a searched CASE testing a one-side column", ONE_SIDE_IN_A_CASE_PREDICATE),
+    ("a simple CASE whose operand is a one-side column", ONE_SIDE_AS_A_SIMPLE_CASE_OPERAND),
+    ("a conditional COUNT over a one-side predicate", ONE_SIDE_IN_A_CONDITIONAL_COUNT),
+    ("branches that disagree about the grain", BRANCHES_DISAGREEING_ABOUT_THE_GRAIN),
+    ("IF, which sqlglot renders back as a CASE", IF_SPELLED_CONDITIONAL_FAN),
+    ("NULLIF, whose second argument is a comparand", NULLIF_COMPARAND_FAN),
+    ("COALESCE, an alternation spelled as a function", COALESCE_ALTERNATION_FAN),
+    ("a GROUP_CONCAT separator read off the many side", SEPARATOR_OFF_THE_MANY_SIDE_FAN),
 ]
-
-# Two fans off ONE dimension. The value is a product of `customers` and `tickets` columns, so the
-# tickets join is the grain the value was defined at and multiplies nothing, while the orders join
-# duplicates it. Exactly one of the two edges is a reason to say nothing.
-TWO_FAN_JOIN = ("FROM customers JOIN orders ON orders.customer_id = customers.id "
-                "JOIN tickets ON tickets.customer_id = customers.id")
-TWO_FANS_ONE_ON_THE_VALUE_PATH = f"SELECT SUM(customers.id * tickets.id) {TWO_FAN_JOIN}"
-
-# Two independent measures over one shared dimension, one of them wrapped in a CASE that puts its
-# only column in the predicate. `SUM(tickets.id)` is untouched by that CASE.
-CHASM_WITH_ONE_WRAPPED_AGGREGATE = (
-    f"SELECT SUM(CASE WHEN orders.status = 'x' THEN 1 ELSE 0 END), SUM(tickets.id) {TWO_FAN_JOIN}"
-)
 
 
 @pytest.mark.parametrize("label,sql", ONE_SIDE_OFF_THE_VALUE_PATH)
@@ -729,15 +920,78 @@ def test_one_wrapped_aggregate_does_not_clear_the_chasm_for_the_others():
     assert all("chasm_trap" in [f.risk for f in a.findings] for a in reports), reports
 
 
-# --- A24: the same report in every process ---------------------------------
+def test_the_statement_that_carries_every_status_carries_the_ones_its_comment_claims():
+    """`EVERY_STATUS_SQL` is a premise three other tests rest on, so it is pinned as one.
 
+    It is described as "one statement carrying all three statuses and both risk labels", and three
+    tests use it for exactly that breadth. Not one of them can tell whether the breadth is still
+    there: each compares the analysis against another rendering of the same analysis, or against a
+    shape-agnostic invariant. A change that collapsed all four aggregates to `undetermined` would
+    leave every one of them green and leave the comment above the constant describing a statement
+    this file no longer produces.
+
+    The findings' risks are pinned beside the statuses because the claim is "both risk labels", and
+    `multiplied` is reachable through either. A `MIN` that started reporting `fan_trap` would keep
+    the status column identical and lose half of what this statement is here to cover.
+    """
+    assert [(a.aggregate, a.status, [f.risk for f in a.findings])
+            for a in _reports(EVERY_STATUS_SQL)] == EVERY_STATUS_ITEMS
+
+
+# --- A24: the same report in every process ---------------------------------
+#
+# The statements the probe runs, one per SET the analysis iterates. Iteration order is only
+# observable when there is more than one element to order, and `EVERY_STATUS_SQL` — which was the
+# whole of this test — has one fanning source and one many-side table, so every set it produces is
+# a singleton and its answer is the same whether the code sorts or not. Measured: with all three
+# `sorted()` calls in `_preflight_select` deleted, `EVERY_STATUS_SQL` is byte-identical across hash
+# seeds and the entire suite stays green.
+#
+# Each of the three below makes exactly one of those sets hold two elements, and each was measured
+# to produce two different receipts across the seeds below when its own `sorted()` is removed:
+#
+#   `agg_sources` in the chasm branch  -> the `srcs` list inside the reason, and `joins`
+#   `agg_sources` in the fan loop      -> the ORDER of two findings on one aggregate
+#   `many_tables` inside the fan loop  -> the order of two edges inside one finding
+#
+# Two aggregate sources over a shared dimension. `_shared_dimension` walks a set to pick the
+# dimension and the chasm reason interpolates the sources, so this is the shape that orders them.
+CHASM_OVER_TWO_MEASURES = (
+    "SELECT c.id, SUM(o.revenue), COUNT(t.id) FROM customers c "
+    "LEFT JOIN orders o ON o.customer_id = c.id "
+    "LEFT JOIN tickets t ON t.customer_id = c.id GROUP BY c.id"
+)
+# One measure on the one side of TWO fans off it. `many_tables` holds `orders` and `tickets`, and
+# both are named inside a single finding, so their order is the receipt's order.
+TWO_MANY_SIDES_OFF_ONE_MEASURE = f"SELECT SUM(customers.id) {TWO_FAN_JOIN}"
+# One aggregate reading two measure tables, each the one side of a fan the value path does not
+# suppress. `customers` fans out to `tickets` and `orders` fans out to `order_items`, so this
+# aggregate carries TWO findings and the fan loop's iteration over `agg_sources` orders them.
+TWO_MEASURE_TABLES_ONE_AGGREGATE = (
+    "SELECT SUM(orders.total_amount * customers.id) FROM customers "
+    "JOIN orders ON orders.customer_id = customers.id "
+    "JOIN tickets ON tickets.customer_id = customers.id "
+    "JOIN order_items ON order_items.order_id = orders.id"
+)
+
+DETERMINISM_SHAPES = [
+    ("three statuses and both risk labels", EVERY_STATUS_SQL),
+    ("two aggregate sources over one shared dimension", CHASM_OVER_TWO_MEASURES),
+    ("one measure with two many sides", TWO_MANY_SIDES_OFF_ONE_MEASURE),
+    ("one aggregate reading two measure tables", TWO_MEASURE_TABLES_ONE_AGGREGATE),
+]
+
+# Every statement in ONE child per seed rather than one child per statement: the property is about
+# the process, and a child that analysed all four under one seed is the same evidence at a quarter
+# of the process cost.
 _PROBE = """
 import json, sys
 sys.path.insert(0, sys.argv[1])
 from semantic_model import models as m
 from semantic_model import runtime as rt
 org = m.Datasource.model_validate_json(sys.argv[3])
-print(json.dumps([a.as_dict() for a in rt.pre_flight_check(sys.argv[2], org).aggregates]))
+print(json.dumps([[a.as_dict() for a in rt.pre_flight_check(sql, org).aggregates]
+                  for sql in json.loads(sys.argv[2])]))
 """
 
 
@@ -748,35 +1002,40 @@ def test_the_aggregate_report_is_the_same_in_every_process():
     invisible under a fixed seed: `sources` is a `frozenset` and `many_tables` is a `set`, the fan
     branch iterates a sorted copy of one of them and intersects the other, and `_shared_dimension`
     picks its dimension by walking a set. Any answer derived from one of those is stable within an
-    interpreter and free to differ in the next. Four seeds, four processes, one answer.
+    interpreter and free to differ in the next. Eight seeds, eight processes, one answer.
 
     The whole serialized item list is compared rather than the statuses alone, and it is NOT sorted:
     the aggregates are reported in the order the statement wrote them, so a re-ordered list is as
     much a difference as a flipped status and sorting here would hide exactly one of the two modes
     this exists to catch.
 
-    `EVERY_STATUS_SQL` carries all three statuses and both risk labels over a single fan, so one
-    comparison covers the value-path attribution that produced `not_multiplied`, the fan that
-    produced `multiplied`, and the unresolved read that produced `undetermined`.
+    `DETERMINISM_SHAPES` and not one statement, and that is the whole of what this test is. A set
+    with one element has one iteration order, so a statement that produces only singletons cannot
+    distinguish a `sorted()` from its absence — and `EVERY_STATUS_SQL`, which stood here alone,
+    produces nothing else. Each of the other three makes one of the three sets hold two elements;
+    the comment above them says which set each reaches and what moves when it is left unordered.
 
     The model crosses the process boundary as JSON rather than as a path, because this fixture is
     built in Python and has no profile on disk; `model_validate_json` of `model_dump_json` is the
     same object by construction, so the child analyses the model the parent declared.
     """
     payload = _sales_org().model_dump_json()
+    statements = json.dumps([sql for _, sql in DETERMINISM_SHAPES])
     seen = set()
-    for seed in ("0", "1", "42", "12345"):
+    for seed in ("0", "1", "2", "3", "7", "42", "1234", "12345"):
         proc = subprocess.run(
-            [sys.executable, "-c", _PROBE, str(PKG_SRC), EVERY_STATUS_SQL, payload],
+            [sys.executable, "-c", _PROBE, str(PKG_SRC), statements, payload],
             capture_output=True, text=True, env={**os.environ, "PYTHONHASHSEED": seed},
         )
         assert proc.returncode == 0, proc.stderr
         seen.add(proc.stdout.strip())
 
     assert len(seen) == 1, f"the aggregate report differed across hash seeds: {seen}"
-    # And it is the answer this process gets, so four children agreeing on something wrong would
+    # And it is the answer this process gets, so eight children agreeing on something wrong would
     # still fail rather than agree quietly.
-    assert json.loads(seen.pop()) == [a.as_dict() for a in _reports(EVERY_STATUS_SQL)]
+    assert json.loads(seen.pop()) == [
+        [a.as_dict() for a in _reports(sql)] for _, sql in DETERMINISM_SHAPES
+    ]
 
 
 # --- S3: what a SELECT can see, and what a CTE reference stands for ---------
@@ -799,26 +1058,9 @@ GRAIN_PRESERVING_CTE = (
     "WITH o AS (SELECT * FROM orders) SELECT SUM(o.total_amount) FROM o "
     "JOIN order_items ON order_items.order_id = o.id"
 )
-# The same laundering one hop further out. Two grain-preserving CTEs in a chain are still the same
-# rows, so the resolution has to be transitive or it answers correctly only at depth one.
-TRANSITIVE_CTE = (
-    "WITH a AS (SELECT * FROM order_items), b AS (SELECT * FROM a) "
-    "SELECT SUM(orders.total_amount) FROM orders JOIN b ON b.order_id = orders.id"
-)
-# Grouped FINER than the join key: one row per (order, product), joined on the order alone. The
-# CTE is genuinely the many side of its own edge and the fan is real.
-CTE_GRAIN_BELOW_JOIN_KEY = (
-    "WITH oi AS (SELECT order_id, product_id, SUM(quantity) q FROM order_items "
-    "GROUP BY order_id, product_id) "
-    "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id"
-)
-# `_cte_names` and `_model_table_index` fold case; `_alias_map` preserves it. Every comparison the
-# resolution makes therefore has to be explicit about which side it is on, and this is the shape
-# that catches one that is not.
-CASE_FOLDED_CTE = (
-    "WITH OI AS (SELECT * FROM order_items) "
-    "SELECT SUM(orders.total_amount) FROM orders JOIN OI ON OI.order_id = orders.id"
-)
+# The other three CTE shapes this section reasons about — `TRANSITIVE_CTE`,
+# `CTE_GRAIN_BELOW_JOIN_KEY` and `CASE_FOLDED_CTE` — are corpus members and are declared with the
+# corpus above, so that every statement the property runs over is defined in one place.
 
 # The derived-table shape, with its aggregate's column UNQUALIFIED. Two independent mechanisms
 # would each have to fail for this to read clean: without the derived binding the outer scope is
@@ -900,7 +1142,9 @@ UNREADABLE_CTE_BODIES = [
 # Every shape whose multiplication answer this spec decides, gathered for the one property that
 # holds across all of them. Not a new corpus: `INFLATED_SHAPES` is about the answer being wrong in
 # one direction, and this is about the answer being INTERNALLY consistent whatever it says.
-ALL_ANALYSED_SHAPES = INFLATED_SHAPES + UNREADABLE_CTE_BODIES + [
+ALL_ANALYSED_SHAPES = [
+    (label, sql) for label, sql, _inflated in INFLATED_SHAPES
+] + UNREADABLE_CTE_BODIES + [
     ("a value already at the many side's grain", VALUE_AT_MANY_GRAIN),
     ("a conditional count over the many side", CONDITIONAL_COUNT),
     ("a conditional sum over the many side", CONDITIONAL_SUM),
@@ -912,17 +1156,12 @@ ALL_ANALYSED_SHAPES = INFLATED_SHAPES + UNREADABLE_CTE_BODIES + [
     ("three statuses and both risk labels at once", EVERY_STATUS_SQL),
     ("a grain-changing CTE", GRAIN_CHANGING_CTE),
     ("a grain-preserving CTE", GRAIN_PRESERVING_CTE),
-    ("a chain of grain-preserving CTEs", TRANSITIVE_CTE),
-    ("a CTE grain finer than the join key", CTE_GRAIN_BELOW_JOIN_KEY),
-    ("a CTE name spelled in another case", CASE_FOLDED_CTE),
     ("a derived table with an unqualified measure", DERIVED_TABLE_UNQUALIFIED),
     ("a parenthesized named table", PARENTHESIZED_TABLE),
     ("a VALUES source", VALUES_SOURCE),
     ("a LATERAL source", LATERAL_SOURCE),
-    ("a chasm over two independent measures",
-     "SELECT c.id, SUM(o.revenue), COUNT(t.id) FROM customers c "
-     "LEFT JOIN orders o ON o.customer_id = c.id "
-     "LEFT JOIN tickets t ON t.customer_id = c.id GROUP BY c.id"),
+    ("a chasm over two independent measures", CHASM_OVER_TWO_MEASURES),
+    ("a chasm whose measures a duplication cannot move", CHASM_OVER_INVARIANT_MEASURES),
 ]
 
 
@@ -1027,7 +1266,26 @@ def test_a_grain_preserving_cte_resolves_through_another_one():
 
     The cycle guard makes this safe rather than unbounded: `seen` is what stops `a` reading `b`
     reading `a` from recursing forever, and it is exercised by its own row in the guard table below.
+
+    The resolved SCOPE MAP is what the assertion rests on, and the status and the edge alone cannot
+    stand in for it. Base `439ecd1` produces this exact status and this exact edge on this exact
+    statement — by LEAKING `order_items` out of the CTE body into `_alias_map`, which is the defect
+    S3 exists to remove. The two implementations are byte-identical at the receipt and opposite
+    underneath it, so a test that reads only the receipt passes on the code it was written to fail
+    on. `b` resolving to `order_items` is the fact that is new: one entry per name the outer FROM/
+    JOIN clauses bind, `b` bound to the table two grain-preserving hops away, and no `a` in the map
+    at all, because `a` is a name only the CTE body ever writes.
     """
+    tree = _parse(TRANSITIVE_CTE)
+    scope, derived = rt._resolve_cte_scope(
+        tree, rt._visible_cte_bodies(tree), rt._alias_map(tree, in_scope_only=True),
+        rt._model_table_index(_sales_org()))
+    assert scope == {"orders": "orders", "b": "order_items"}, scope
+    # No DERIVED edge: `b` IS `order_items`, so the model's own declared relationship is the one the
+    # fan is read off. A derived edge here would mean the resolution fell back to treating the CTE
+    # as an entity of its own, which is the answer A14's shape gets and not this one's.
+    assert derived == [], derived
+
     reports = _reports(TRANSITIVE_CTE)
     assert [a.status for a in reports] == [rt.MULTIPLIED], reports
     assert reports[0].joins == [FAN_EDGE], reports[0].joins
@@ -1177,7 +1435,20 @@ def test_a_cte_name_is_resolved_case_insensitively_but_reported_as_written():
 
     A comparison that folded on neither side would leave this reading clean, which is the direction
     that matters: `OI` is `order_items` under another spelling and the fan is real.
+
+    The map is asserted for the same reason A13's is: this status and this edge are byte-identical
+    to what base `439ecd1` produced, where `order_items` reached the outer map by leaking out of the
+    CTE body rather than by `OI` being resolved to it. `{"OI": "order_items"}` is the whole claim —
+    the key preserved exactly as the statement wrote it, the value the folded table it stands for —
+    and it is the only place the fold's two directions are both visible at once.
     """
+    tree = _parse(CASE_FOLDED_CTE)
+    scope, derived = rt._resolve_cte_scope(
+        tree, rt._visible_cte_bodies(tree), rt._alias_map(tree, in_scope_only=True),
+        rt._model_table_index(_sales_org()))
+    assert scope == {"orders": "orders", "OI": "order_items"}, scope
+    assert derived == [], derived
+
     reports = _reports(CASE_FOLDED_CTE)
     assert [a.status for a in reports] == [rt.MULTIPLIED], reports
     assert reports[0].joins == [FAN_EDGE], reports[0].joins
@@ -1424,10 +1695,7 @@ def test_the_chasm_still_reports_both_of_the_aggregates_it_inflates():
     another file. Both aggregates are inflated by the cross-product and both must say so — a chasm
     reported on one of the two numbers it ruins is a receipt that reads as half a fact.
     """
-    sql = ("SELECT c.id, SUM(o.revenue), COUNT(t.id) FROM customers c "
-           "LEFT JOIN orders o ON o.customer_id = c.id "
-           "LEFT JOIN tickets t ON t.customer_id = c.id GROUP BY c.id")
-    reports = _reports(sql)
+    reports = _reports(CHASM_OVER_TWO_MEASURES)
     assert [(a.aggregate, a.status) for a in reports] == [
         ("SUM(o.revenue)", rt.MULTIPLIED), ("COUNT(t.id)", rt.MULTIPLIED)], reports
     assert [f.risk for a in reports for f in a.findings] == ["chasm_trap", "chasm_trap"], reports
@@ -1466,15 +1734,20 @@ def test_every_item_either_names_its_joins_or_declines_to_answer():
 # --- A20: the two surfaces report the same aggregates ----------------------
 
 
-@pytest.mark.parametrize("label,sql", [
-    ("an invariant aggregate over a fan", MIN_OVER_FAN),
-    ("a value already at the many side's grain", VALUE_AT_MANY_GRAIN),
-    ("a grain-preserving CTE the analysis resolves", GRAIN_PRESERVING_CTE),
-    ("a grain-changing CTE whose edge is derived", GRAIN_CHANGING_CTE),
-    ("a derived table bound to nothing", DERIVED_TABLE_FAN),
-    ("three statuses and both risk labels at once", EVERY_STATUS_SQL),
+@pytest.mark.parametrize("label,sql,expected", [
+    ("an invariant aggregate over a fan", MIN_OVER_FAN,
+     [("MIN(orders.total_amount)", rt.MULTIPLIED, ["fan_out_invariant"])]),
+    ("a value already at the many side's grain", VALUE_AT_MANY_GRAIN,
+     [("SUM(order_items.quantity * orders.total_amount)", rt.NOT_MULTIPLIED, [])]),
+    ("a grain-preserving CTE the analysis resolves", GRAIN_PRESERVING_CTE,
+     [("SUM(o.total_amount)", rt.MULTIPLIED, ["fan_trap"])]),
+    ("a grain-changing CTE whose edge is derived", GRAIN_CHANGING_CTE,
+     [("SUM(orders.total_amount)", rt.NOT_MULTIPLIED, [])]),
+    ("a derived table bound to nothing", DERIVED_TABLE_FAN,
+     [("SUM(orders.total_amount)", rt.UNDETERMINED, [])]),
+    ("three statuses and both risk labels at once", EVERY_STATUS_SQL, EVERY_STATUS_ITEMS),
 ])
-def test_the_preflight_and_the_receipt_agree_about_the_aggregates(label, sql):
+def test_the_preflight_and_the_receipt_agree_about_the_aggregates(label, sql, expected):
     """A20. Both surfaces read one analysis, so the two renderings must be byte-equal.
 
     `pre_flight_check` parses and analyses; `assemble_receipt` analyses a tree it already holds.
@@ -1490,10 +1763,57 @@ def test_the_preflight_and_the_receipt_agree_about_the_aggregates(label, sql):
     The comparison is the serialized item list against `as_dict()`, not a status-by-status walk:
     `joins`, `findings` and the aggregate's own label are all part of what the two surfaces have to
     agree about, and a spot check of statuses would pass while a reason string differed.
+
+    And each row is ANCHORED, because equality between the two surfaces is `f(x) == f(x)` on its
+    own. Both entry points call `_aggregate_reports` on one tree and differ only in whether
+    `visible` is handed in — computed identically either way — and in the receipt's
+    `_RECEIPT_MAX_REFS` cap, which none of these six reaches. So the agreement half of this test
+    passes with the production change fully reverted, and it would pass just as well if every one of
+    these statements degraded to a single `undetermined` item. The expected list is what makes each
+    row say which mechanism it is here for. The cap, which is the one place the two surfaces really
+    do diverge, is the test below.
     """
     org = _sales_org()
     items = rt.assemble_receipt(org, sql)["aggregates"]["items"]
-    assert items == [a.as_dict() for a in rt.pre_flight_check(sql, org).aggregates], label
+    reports = rt.pre_flight_check(sql, org).aggregates
+    assert items == [a.as_dict() for a in reports], label
+    assert [(a.aggregate, a.status, [f.risk for f in a.findings]) for a in reports] == expected, (
+        label, reports)
+
+
+def test_the_receipt_bounds_the_item_list_the_preflight_returns_whole():
+    """A20's one real divergence: the receipt is capped and the pre-flight result is not.
+
+    Every other difference between the two entry points is arranged away — one analysis, one tree,
+    one `visible` set — and this one is deliberate. A receipt is tool output bounded at every
+    section, so `_RECEIPT_MAX_REFS` truncates the items and COUNTS what it dropped on the marker,
+    because a truncated list under a silent marker is a positive claim of completeness.
+    `PreFlightResult` is an in-process object with no such bound, and a caller reading it gets all
+    of them.
+
+    So the two surfaces agree UP TO the cap and not beyond it, and that is the contract this asserts
+    rather than a bug it reports. It matters because the agreement test above cannot see it: none of
+    its six shapes comes near 50 aggregates, so an equality that holds only below the cap and a
+    equality that holds everywhere are the same test there. A reader who takes A20 to mean the two
+    surfaces are interchangeable at any size is reading something no test said.
+
+    The real constant is used rather than a monkeypatched one. ACE-060's
+    `test_the_cap_counts_aggregates_and_says_so` already pins the counting behaviour at a patched
+    cap of 2; what is unpinned is what the OTHER surface does at the same statement, and patching
+    the constant would leave the shipped 50 uncovered on the only question this test is about.
+    """
+    org = _sales_org()
+    over = rt._RECEIPT_MAX_REFS + 5
+    sql = (f"SELECT {', '.join(f'SUM(orders.total_amount) AS a{i}' for i in range(over))} "
+           f"{FAN_JOIN}")
+    section = rt.assemble_receipt(org, sql)["aggregates"]
+    reports = rt.pre_flight_check(sql, org).aggregates
+
+    assert len(reports) == over, len(reports)
+    assert len(section["items"]) == rt._RECEIPT_MAX_REFS, len(section["items"])
+    assert section["items"] == [a.as_dict() for a in reports][:rt._RECEIPT_MAX_REFS]
+    # And the marker says how many it dropped, so the shorter list is not read as the whole list.
+    assert "5 further aggregate(s) are not listed." in section["undetermined"], section
 
 
 # --- the invariance boundary, pinned where it is rather than where it could be ---
@@ -1536,6 +1856,34 @@ def test_a_distinct_concatenation_with_an_ordering_arm_is_not_read_as_invariant(
     assert [f.risk for f in reports[0].findings] == ["fan_trap"], reports[0].findings
 
 
+def test_the_invariance_split_is_the_fan_branchs_alone_and_the_chasm_keeps_its_word():
+    """The other boundary: `fan_out_invariant` is a FAN label, and a chasm does not get one.
+
+    A cross-product cannot move a `MIN` or a `COUNT(DISTINCT)` any more than a fan-out can — the
+    property is about the aggregate, not about which join duplicated the rows — so on the reading
+    that produced the split, these two are as mislabelled as `MIN` over a fan was. They are not
+    relabelled, and that is deliberate rather than an oversight: the spec scopes S1 to the fan
+    branch, `_is_fan_immune` is called at one site inside the fan loop, and widening a risk
+    vocabulary is a contract change that needs its own argument.
+
+    It is asserted because nothing else would notice it move. `SKILL.md` documents both labels for a
+    reader, `chasm_trap` and `fan_out_invariant` are both in `_MULTIPLYING_RISKS` so `status` is
+    identical either way, and hoisting `_is_fan_immune` out of the fan loop into the shared path is
+    a one-line change that reads like a simplification. This is the assertion that makes it a
+    decision: the two aggregates here still say `chasm_trap`, and the word this file spent a slice
+    removing from the fan branch is not quietly added to a second one.
+
+    The statuses are pinned beside the risks. `chasm_trap` and `fan_out_invariant` are both
+    multiplying risks, so a swap between them is invisible in `status` — which is exactly why the
+    risk is what this asserts on.
+    """
+    reports = _reports(CHASM_OVER_INVARIANT_MEASURES)
+    assert [(a.aggregate, a.status) for a in reports] == [
+        ("MIN(o.revenue)", rt.MULTIPLIED), ("COUNT(DISTINCT t.id)", rt.MULTIPLIED)], reports
+    assert [f.risk for a in reports for f in a.findings] == ["chasm_trap", "chasm_trap"], reports
+    assert "fan_out_invariant" not in _every_risk(CHASM_OVER_INVARIANT_MEASURES), reports
+
+
 # --- a WITH binds its name for every arm below it --------------------------
 
 
@@ -1562,8 +1910,10 @@ def test_a_set_operation_arm_sees_the_cte_the_statement_bound_above_it():
         ("main#1", rt.MULTIPLIED), ("main#2", rt.MULTIPLIED)], reports
     assert [a.joins for a in reports] == [[FAN_EDGE], [FAN_EDGE]], reports
 
-    # And an arm that reads no CTE keeps its own answer, which is what "per-arm" has to mean.
-    mixed = _reports(f"{CTE_LAUNDERED_FAN} UNION ALL SELECT SUM(orders.total_amount) FROM orders")
+    # And an arm that reads no CTE keeps its own answer, which is what "per-arm" has to mean. The
+    # statement is `MIXED_SET_OPERATION`, a corpus member: the corpus asks that its laundered arm is
+    # never reported clean, and this asks that its honest arm still is.
+    mixed = _reports(MIXED_SET_OPERATION)
     assert [(a.scope, a.status) for a in mixed] == [
         ("main#1", rt.MULTIPLIED), ("main#2", rt.NOT_MULTIPLIED)], mixed
 
@@ -1573,30 +1923,9 @@ def test_a_set_operation_arm_sees_the_cte_the_statement_bound_above_it():
 # The other half of the same rule, and the one that was measured wrong. `sel.root().find_all(
 # exp.CTE)` collects every CTE in the statement, keyed by folded name with last-writer-wins, so a
 # CTE from a scope that does not bind for this SELECT could win the name. Both shapes below were
-# receipts calling an inflated number sound.
-
-# Two arms, each declaring its OWN `x` over a different table. Only the first arm joins, and only
-# the first arm's `x` is the one side of that join. Written in both orders because the defect was
-# order-dependent: whichever arm's body the root walk reached last won the name for both.
-SAME_NAME_PER_ARM = (
-    "(WITH x AS (SELECT * FROM orders) SELECT SUM(x.total_amount) FROM x "
-    "JOIN order_items oi ON oi.order_id = x.id) UNION ALL "
-    "(WITH x AS (SELECT * FROM order_items) SELECT SUM(x.quantity) FROM x)"
-)
-SAME_NAME_PER_ARM_SWAPPED = (
-    "(WITH x AS (SELECT * FROM order_items) SELECT SUM(x.quantity) FROM x) UNION ALL "
-    "(WITH x AS (SELECT * FROM orders) SELECT SUM(x.total_amount) FROM x "
-    "JOIN order_items oi ON oi.order_id = x.id)"
-)
-
-# A `WITH` inside a `WHERE … IN (…)` subquery. It binds `order_items` for that subquery and for
-# nothing else, and the outer statement's `order_items` is the real declared table it joins.
-NESTED_WITH_SHADOWING_A_REAL_TABLE = (
-    "SELECT SUM(orders.total_amount) FROM orders "
-    "JOIN order_items ON order_items.order_id = orders.id "
-    "WHERE orders.id IN (WITH order_items AS (SELECT id FROM customers) "
-    "SELECT id FROM order_items)"
-)
+# receipts calling an inflated number sound, so both are corpus members and both are declared with
+# the corpus: `SAME_NAME_PER_ARM`, `SAME_NAME_PER_ARM_SWAPPED` and
+# `NESTED_WITH_SHADOWING_A_REAL_TABLE`.
 
 
 def test_a_cte_declared_in_a_sibling_arm_does_not_bind_for_this_one():

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -163,34 +163,66 @@ EVERY_STATUS_SQL = (
     "FROM orders o JOIN order_items i ON i.order_id = o.id"
 )
 
-# Every branch of `_value_columns`, exercised on the function directly. `expected` is a LIST and not
-# a set: the walk's order decides the order of nothing the receipt renders today, but `sources` is
-# built from it and a list says what was measured rather than what happened to be enough.
-VALUE_COLUMN_CASES = [
-    ("a bare column", "orders.total_amount", ["orders.total_amount"]),
+# The scope map every `_value_sources` case below is resolved through. Identity, because these
+# statements qualify their columns with the table's own name and the question under test is which
+# POSITION a column sits in, never which alias it was written under.
+VALUE_SCOPE = {"orders": "orders", "order_items": "order_items"}
+
+# Every branch of `_value_sources`, exercised on the function directly. `expected` is a set of TABLE
+# names rather than a list of columns, because the grain of a value is a fact about tables: two
+# columns of one table are one grain, and `CASE WHEN p THEN orders.total_amount ELSE orders.revenue
+# END` is at `orders` grain on both branches while sharing no column between them.
+VALUE_SOURCE_CASES = [
+    ("a bare column", "orders.total_amount", {"orders"}),
     ("arithmetic, the generic branch",
      "SUM(order_items.quantity * orders.total_amount)",
-     ["order_items.quantity", "orders.total_amount"]),
+     {"order_items", "orders"}),
     ("a searched CASE, whose WHEN is a predicate",
      "SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount END)",
-     ["orders.total_amount"]),
+     {"orders"}),
     ("a searched CASE with an ELSE, which is a value",
      "SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount ELSE orders.revenue END)",
-     ["orders.total_amount", "orders.revenue"]),
+     {"orders"}),
     ("a simple CASE, whose operand is a predicate input",
      "SUM(CASE orders.status WHEN 'x' THEN order_items.quantity END)",
-     ["order_items.quantity"]),
+     {"order_items"}),
     ("a CASE inside a CASE branch",
      "SUM(CASE WHEN order_items.quantity > 0 "
      "THEN CASE WHEN orders.flag THEN orders.total_amount END END)",
-     ["orders.total_amount"]),
+     {"orders"}),
     ("an ordering arm, which is neither predicate nor value",
      "STRING_AGG(orders.status, ',' ORDER BY order_items.id)",
-     ["orders.status"]),
+     {"orders"}),
     ("DISTINCT, which the generic branch reaches with no case of its own",
      "SUM(DISTINCT orders.total_amount)",
-     ["orders.total_amount"]),
-    ("no column at all", "COUNT(*)", []),
+     {"orders"}),
+    ("no column at all", "COUNT(*)", set()),
+    # The branches added because the union reading of an alternation cleared a real fan.
+    ("a CASE whose branches disagree about the grain",
+     "SUM(CASE WHEN orders.flag THEN orders.total_amount ELSE order_items.quantity END)",
+     set()),
+    ("a CASE whose branches agree about the grain",
+     "SUM(CASE WHEN orders.flag THEN order_items.quantity ELSE order_items.id END)",
+     {"order_items"}),
+    ("an alternation nested inside arithmetic, which distributes",
+     "SUM(order_items.quantity * CASE WHEN orders.flag THEN orders.total_amount "
+     "ELSE orders.revenue END)",
+     {"order_items", "orders"}),
+    ("IF, which is not an exp.Case and whose condition is a predicate",
+     "SUM(IF(order_items.quantity > 0, orders.total_amount, 0))",
+     set()),
+    ("IF with no ELSE arm at all",
+     "SUM(IF(orders.flag, order_items.quantity))",
+     {"order_items"}),
+    ("NULLIF, whose second argument is a comparand",
+     "SUM(NULLIF(orders.total_amount, order_items.quantity))",
+     {"orders"}),
+    ("a GROUP_CONCAT separator, which is punctuation and not a value",
+     "STRING_AGG(orders.status, order_items.product_id)",
+     {"orders"}),
+    ("COALESCE, an alternation spelled as a function",
+     "SUM(COALESCE(orders.total_amount, order_items.quantity))",
+     set()),
 ]
 
 # --- S1: the aggregates a duplication cannot move --------------------------
@@ -543,25 +575,51 @@ def test_a_filter_clause_predicate_is_outside_the_aggregate_the_analysis_reads()
     assert reports[0].joins == [FAN_EDGE], reports[0].joins
 
 
-@pytest.mark.parametrize("label,expression,expected", VALUE_COLUMN_CASES)
-def test_the_value_path_holds_only_the_columns_the_result_is_built_from(label, expression, expected):
-    """A7. Every branch of `_value_columns`, asserted on the function rather than through a receipt.
+@pytest.mark.parametrize("label,expression,expected", VALUE_SOURCE_CASES)
+def test_the_value_path_holds_only_the_tables_the_result_is_built_from(label, expression, expected):
+    """A7. Every branch of `_value_sources`, asserted on the function rather than through a receipt.
 
     The analysis reaches most of these branches, but it reaches them in combination and reports one
-    status per statement, so a branch that dropped a column the value does use and a branch that
-    kept one it does not can cancel out in the answer. Called directly, each shape says which
-    columns it thinks the value is built from, and a wrong one is wrong visibly.
+    status per statement, so a branch that dropped a table the value does use and a branch that kept
+    one it does not can cancel out in the answer. Called directly, each shape says which tables it
+    thinks the value is built from, and a wrong one is wrong visibly.
 
-    The two guard branches are the reason this is a unit test at all. A simple `CASE`'s operand
+    The guard branches are the reason this is a unit test at all. A simple `CASE`'s operand
     (`CASE orders.status WHEN 'x' THEN …`) is an input to the branch CHOICE, not to the result, so
     it belongs with the `WHEN` predicates and not with the `THEN` values — and it lives under
     `Case.this`, which the generic branch would have taken. The nested case proves the recursion
     applies the same rule at depth rather than only at the top. `DISTINCT` is the opposite check:
     it carries a genuine value column under `args["expressions"]`, so the generic branch must reach
     it and no case may intercept it.
+
+    The alternation cases are what an earlier reading of this function got wrong. Reading a `CASE`
+    as the UNION of its branches puts a many-side column on the value path whenever ANY branch
+    carries one, so a value that is a one-side amount on the rows where the predicate holds reads as
+    though it were at many-side grain throughout — and the fan that really does duplicate those rows
+    is cleared. `IF` is the same defect with a sharper edge, because sqlglot parses `IF` / `IIF` /
+    `IFF` to `exp.If` rather than to `exp.Case` and then RENDERS it back as `CASE WHEN … END`, so
+    without a case of its own the two spellings produce a byte-identical receipt label carrying
+    opposite statuses.
     """
     node = parse_one(f"SELECT {expression} FROM orders").expressions[0]
-    assert [c.sql() for c in rt._value_columns(node)] == expected, label
+    assert rt._value_sources(node, VALUE_SCOPE) == expected, label
+
+
+@pytest.mark.parametrize("dialect", [None, "bigquery", "duckdb", "mysql", "tsql", "snowflake"])
+def test_the_conditional_function_parses_to_exp_if_on_every_dialect_this_layer_speaks(dialect):
+    """`exp.If`'s case exists because of a PARSE fact, so the parse fact is what is pinned.
+
+    `IF` is spelled `IIF` on T-SQL and `IFF` on Snowflake, and every one of them lands on `exp.If`
+    rather than on `exp.Case`. A future sqlglot that folded the conditional into `exp.Case` would
+    make the `exp.If` branch dead rather than wrong, and one that introduced a THIRD node for it
+    would silently drop back to the generic branch — which reads the condition as a value and clears
+    the fan. That is the direction this asserts against, so it asserts on the node type directly.
+    """
+    spelling = {"tsql": "IIF", "snowflake": "IFF"}.get(dialect, "IF")
+    sql = f"SELECT SUM({spelling}(order_items.quantity > 0, orders.total_amount, 0)) FROM orders"
+    node = parse_one(sql, read=dialect).expressions[0]
+    assert isinstance(node.this, exp.If), (dialect, repr(node))
+    assert rt._value_sources(node, VALUE_SCOPE) == set(), dialect
 
 
 def test_the_value_path_of_something_that_is_not_an_expression_is_empty():
@@ -571,8 +629,99 @@ def test_the_value_path_of_something_that_is_not_an_expression_is_empty():
     bools, and an absent optional argument is `None`. The alternative to this guard is a type check
     at every call site inside the walk, which is the same test written four times.
     """
-    assert rt._value_columns(None) == []
-    assert rt._value_columns(True) == []
+    assert rt._value_sources(None, VALUE_SCOPE) == frozenset()
+    assert rt._value_sources(True, VALUE_SCOPE) == frozenset()
+
+
+# --- the direction the corpus above cannot reach ---------------------------
+#
+# Every member of `INFLATED_SHAPES` puts the MANY-side column somewhere unusual. Not one puts a
+# ONE-side column off the value path, and that is the only direction that can manufacture a clean:
+# a value path narrowed until it holds no one-side column stops the aggregate reading the one side
+# at all, so the fan loop never reaches it and a total the join really does inflate reports sound.
+# Each of these was measured `not_multiplied` while the value path decided `sources`, and
+# `multiplied` on the base the spec is written against.
+
+ONE_SIDE_OFF_THE_VALUE_PATH = [
+    ("a searched CASE testing a one-side column",
+     f"SELECT SUM(CASE WHEN orders.status = 'shipped' THEN 1 ELSE 0 END) {FAN_JOIN}"),
+    ("a simple CASE whose operand is a one-side column",
+     f"SELECT SUM(CASE orders.status WHEN 'shipped' THEN 1 ELSE 0 END) {FAN_JOIN}"),
+    ("a conditional COUNT over a one-side predicate",
+     f"SELECT COUNT(CASE WHEN orders.status = 'shipped' THEN 1 END) {FAN_JOIN}"),
+    ("branches that disagree about the grain",
+     f"SELECT SUM(CASE WHEN orders.flag THEN orders.total_amount "
+     f"ELSE order_items.quantity END) {FAN_JOIN}"),
+    ("IF, which sqlglot renders back as a CASE",
+     f"SELECT SUM(IF(order_items.quantity > 0, orders.total_amount, 0)) {FAN_JOIN}"),
+    ("NULLIF, whose second argument is a comparand",
+     f"SELECT SUM(NULLIF(orders.total_amount, order_items.quantity)) {FAN_JOIN}"),
+    ("a GROUP_CONCAT separator read off the many side",
+     f"SELECT STRING_AGG(orders.status, order_items.product_id) {FAN_JOIN}"),
+]
+
+# Two fans off ONE dimension. The value is a product of `customers` and `tickets` columns, so the
+# tickets join is the grain the value was defined at and multiplies nothing, while the orders join
+# duplicates it. Exactly one of the two edges is a reason to say nothing.
+TWO_FAN_JOIN = ("FROM customers JOIN orders ON orders.customer_id = customers.id "
+                "JOIN tickets ON tickets.customer_id = customers.id")
+TWO_FANS_ONE_ON_THE_VALUE_PATH = f"SELECT SUM(customers.id * tickets.id) {TWO_FAN_JOIN}"
+
+# Two independent measures over one shared dimension, one of them wrapped in a CASE that puts its
+# only column in the predicate. `SUM(tickets.id)` is untouched by that CASE.
+CHASM_WITH_ONE_WRAPPED_AGGREGATE = (
+    f"SELECT SUM(CASE WHEN orders.status = 'x' THEN 1 ELSE 0 END), SUM(tickets.id) {TWO_FAN_JOIN}"
+)
+
+
+@pytest.mark.parametrize("label,sql", ONE_SIDE_OFF_THE_VALUE_PATH)
+def test_a_one_side_column_off_the_value_path_still_reports_the_multiplication(label, sql):
+    """The value path decides WHICH EDGE is suppressed, and nothing else about the aggregate.
+
+    `sources` answers three questions and only one of them is a value-path question. "Which
+    many-side table's duplication is this value's own grain" is; "which table is the measure on the
+    one side" and "which tables does this aggregate read, for the chasm rule" are not. Narrowing
+    `sources` to the value path answered all three with the narrow answer, and for a value built
+    from no column at all — `THEN 1 ELSE 0` — the narrow answer is that the aggregate reads nothing,
+    so the fan loop skipped it and the receipt asserted the total was sound.
+
+    The last three members are the same defect reached through a node the value walk had no case
+    for, where the GENERIC branch contributed the condition's columns and put the MANY side on the
+    value path instead. That is the inverted polarity: for a node that only combines values,
+    contributing by default is honest, but for one that mixes a predicate with its values it is
+    contributing the predicate that clears the fan.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], (label, reports)
+    assert reports[0].joins == [FAN_EDGE], (label, reports[0].joins)
+
+
+def test_only_the_edge_that_is_not_the_values_own_grain_is_suppressed():
+    """A fan is suppressed PER EDGE, because `many_tables` can hold more than one.
+
+    `SUM(customers.id * tickets.id)` sits on the one side of two fans off `customers`. The tickets
+    join is the grain the product was already defined at and multiplies nothing; the orders join
+    duplicates every one of those products. Suppressing the whole finding because ONE edge is the
+    value's grain reported the statement clean, and reporting both edges names a join that did not
+    move the number. Only the `orders` edge is true, so only the `orders` edge is named.
+    """
+    reports = _reports(TWO_FANS_ONE_ON_THE_VALUE_PATH)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], reports
+    assert reports[0].joins == ["customers (1) <- orders (N)"], reports[0].joins
+
+
+def test_one_wrapped_aggregate_does_not_clear_the_chasm_for_the_others():
+    """The chasm reads the UNION of every site's sources, so a narrowing there is not local.
+
+    `agg_sources` is derived across all the sites in one SELECT. When the value path decided
+    `sources`, a single aggregate whose value is a literal emptied its own contribution — and with
+    two measures needed for a shared dimension to be a chasm at all, one wrapped aggregate took the
+    finding away from every OTHER aggregate in the statement too. `SUM(tickets.id)` is not inside
+    that CASE and never was; its rows are still crossed against every order of the same customer.
+    """
+    reports = _reports(CHASM_WITH_ONE_WRAPPED_AGGREGATE)
+    assert [a.status for a in reports] == [rt.MULTIPLIED, rt.MULTIPLIED], reports
+    assert all("chasm_trap" in [f.risk for f in a.findings] for a in reports), reports
 
 
 # --- A24: the same report in every process ---------------------------------

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -955,6 +955,36 @@ def test_the_conditional_function_parses_to_exp_if_on_every_dialect_this_layer_s
     assert rt._value_sources(node, VALUE_SCOPE) == set(), dialect
 
 
+@pytest.mark.parametrize("label, sql", [
+    ("COALESCE", "SELECT SUM(COALESCE(orders.total_amount, 0)) FROM orders"),
+    ("IF", "SELECT SUM(IF(orders.flag, orders.total_amount, 0)) FROM orders"),
+    ("GREATEST", "SELECT SUM(GREATEST(orders.total_amount, orders.revenue)) FROM orders"),
+    ("LEAST", "SELECT SUM(LEAST(orders.total_amount, orders.revenue)) FROM orders"),
+])
+def test_an_alternation_is_attributed_on_a_sqlglot_that_never_heard_of_decode(label, sql, monkeypatch):
+    """The dispatch may not read a late-added class by attribute, only through `_exp_nodes`.
+
+    `_exp_nodes` exists because the package pins `sqlglot>=20` and `exp.Nvl2` / `exp.DecodeCase`
+    are later additions, and it is what keeps the module importable against a sqlglot that reads
+    every statement here perfectly well. A bare `exp.DecodeCase` inside `_value_operands` defeats
+    it completely, because the attribute is read when the LINE runs rather than at import: the
+    `DECODE` arm sits above the ternary and the leading-argument arms, so on such a version every
+    `COALESCE`, `IF`, `GREATEST` and `LEAST` raises `AttributeError` on the way past it.
+
+    That is not a crash the caller sees. `execute_sql._receipt_for` catches it and returns
+    `RECEIPT_BUILD_FAILED`, so the statement executes and answers while the trust layer silently
+    disappears — the same shape `_MAX_CTE_CHAIN` and the iterative `_value_sources` walk exist for.
+    `COALESCE` over an aggregate is ordinary SQL, so this was not an exotic configuration.
+
+    Deleting the attribute is the honest simulation: the module-level tuples resolved at import on
+    the real sqlglot, and what is under test is whether the dispatch reaches for the name again.
+    """
+    monkeypatch.delattr(exp, "DecodeCase", raising=False)
+    reports = _reports(sql)
+    assert [(r.aggregate, r.status) for r in reports] == [
+        (reports[0].aggregate, rt.NOT_MULTIPLIED)], label
+
+
 def test_the_value_path_of_something_that_is_not_an_expression_is_empty():
     """The guard that lets the generic branch iterate `node.args` without inspecting what it holds.
 

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -322,6 +322,14 @@ MATCH_RECOGNIZE_SOURCE = (
     "PATTERN (a+) DEFINE a AS a.id > 0)"
 )
 
+# A grain-changing CTE that RENAMES its grain column on the way out. `_group_by_grain` reads the
+# body's input names and the join key is the body's output name, so the comparison was between two
+# spellings of one column and reported a fan on a CTE that is one row per join key. Over-reporting,
+# so it is not a corpus member; a false positive on legitimate SQL all the same.
+CTE_RENAMING_ITS_GRAIN = (
+    "WITH x AS (SELECT id AS order_id FROM customers GROUP BY id) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN x ON x.order_id = orders.id"
+)
 
 # The corpus, named so the later slices can re-run it unchanged rather than restating it. Labels are
 # what a failure prints, so they name the disguise and not the SQL.
@@ -1288,6 +1296,7 @@ ALL_ANALYSED_SHAPES = [
     ("an UNPIVOT on the table itself", UNPIVOT_SOURCE),
     ("a CONNECT BY beside the FROM clause", CONNECT_BY_SOURCE),
     ("a PIVOT on the table itself", PIVOT_SOURCE),
+    ("a CTE that renames its grain column", CTE_RENAMING_ITS_GRAIN),
 ]
 
 
@@ -2566,3 +2575,98 @@ def test_a_lateral_that_a_join_already_bound_is_not_bound_twice():
     sql = "SELECT SUM(orders.total_amount) FROM orders, LATERAL (SELECT 1) l"
     sites = rt._reference_sites(_parse(sql).find(exp.Select), bind_derived=True)
     assert [(s.ref.bare, s.ref.alias) for s in sites] == [("", "l"), ("orders", None)], sites
+
+
+def test_the_cte_chain_bound_admits_exactly_the_number_it_is_written_as():
+    """`depth > _MAX_CTE_CHAIN` admitted sixty-FIVE hops for a constant that reads sixty-four.
+
+    `depth` is 0 on the first hop, so the comparison has to be `>=` for the bound to be the number
+    beside it. Nothing depended on the extra hop; a bound nobody can read off its own constant is
+    the defect, because the next person to reason about it will reason from the constant.
+
+    Both sides of the boundary, because either alone is satisfiable by a bound that is off by one in
+    the other direction.
+    """
+    org, tidx = _sales_org(), None
+
+    def chain(links: int) -> str:
+        bodies = ["c0 AS (SELECT * FROM order_items)"]
+        bodies += [f"c{i} AS (SELECT * FROM c{i - 1})" for i in range(1, links)]
+        return ("WITH " + ", ".join(bodies) +
+                f" SELECT SUM(orders.total_amount) FROM orders JOIN c{links - 1} "
+                f"ON c{links - 1}.order_id = orders.id")
+
+    tidx = rt._model_table_index(org)
+    assert rt._MAX_CTE_CHAIN == 64
+    at_the_bound = _parse(chain(rt._MAX_CTE_CHAIN))
+    assert rt._grain_preserving_source(
+        "c63", rt._visible_cte_bodies(at_the_bound.find(exp.Select)), tidx, set()) == "order_items"
+    past_it = _parse(chain(rt._MAX_CTE_CHAIN + 1))
+    assert rt._grain_preserving_source(
+        "c64", rt._visible_cte_bodies(past_it.find(exp.Select)), tidx, set()) is None
+
+    assert [a.status for a in _reports(chain(rt._MAX_CTE_CHAIN))] == [rt.MULTIPLIED]
+    assert [a.status for a in _reports(chain(rt._MAX_CTE_CHAIN + 1))] == [rt.UNDETERMINED]
+
+
+def test_a_cte_that_renames_its_grain_column_is_not_a_fan():
+    """The two names `_cte_edge` compares came from opposite sides of the CTE.
+
+    `_group_by_grain` reads what the body groups BY, which are its INPUT columns, and the join key
+    is what the outer statement writes, which is the body's OUTPUT column. `SELECT id AS order_id …
+    GROUP BY id` makes those differ, so `order_id` was compared against a grain of `{id}`, found no
+    cover, and a CTE that really is one row per join key reported `multiplied`. Over-reporting, so
+    no receipt said anything false — and still a false positive on legitimate SQL, which is what a
+    reader learns to discount reports over.
+
+    The unresolvable direction is asserted beside it. `SELECT id + 1 AS k` gives `k` no input column
+    to stand for, so the key is compared as written and the fan is reported: what does not resolve
+    stays over-reporting rather than becoming a guess.
+    """
+    reports = _reports(CTE_RENAMING_ITS_GRAIN)
+    assert [(a.aggregate, a.status, a.joins) for a in reports] == [
+        ("SUM(orders.total_amount)", rt.NOT_MULTIPLIED, [])], reports
+
+    body = _parse(CTE_RENAMING_ITS_GRAIN).find(exp.CTE).this
+    assert rt._projection_sources(body) == {"order_id": "id"}
+
+    computed = ("WITH x AS (SELECT id + 1 AS k FROM customers GROUP BY id) "
+                "SELECT SUM(orders.total_amount) FROM orders JOIN x ON x.k = orders.id")
+    assert rt._projection_sources(_parse(computed).find(exp.CTE).this) == {}
+    assert [a.status for a in _reports(computed)] == [rt.MULTIPLIED], computed
+
+    # Two projections under one output name are two answers to a question that has to have one, so
+    # the name is dropped rather than resolved to whichever was written last. `SELECT *` names no
+    # column to resolve at all, and an output name that stands for itself is left as it is.
+    ambiguous = _parse("SELECT id AS k, customer_id AS k FROM customers GROUP BY id")
+    assert rt._projection_sources(ambiguous.find(exp.Select)) == {}
+    repeated = _parse("SELECT id AS k, id AS k FROM customers GROUP BY id")
+    assert rt._projection_sources(repeated.find(exp.Select)) == {"k": "id"}
+    star = _parse("SELECT * FROM customers GROUP BY id")
+    assert rt._projection_sources(star.find(exp.Select)) == {}
+
+
+def test_the_derived_edge_does_not_depend_on_which_source_the_statement_wrote_first():
+    """A receipt has to read the same way twice for the same SQL, which this module says of itself.
+
+    `_resolve_cte_scope` resolved the far side of a derived edge out of the map it was still
+    mutating, so whichever alias the statement wrote FIRST was resolved against a map the other one
+    had not reached yet. One statement, two spellings of its FROM clause, two answers: `multiplied`
+    naming the derived edge one way and `undetermined` the other. Both are the safe direction and
+    neither is determinism.
+
+    Two passes fix it: every grain-preserving rebinding settles first, and every edge is then
+    derived against that one settled map. Asserted on the ANSWER rather than on the pass structure,
+    because the property is that the two spellings agree and not that any particular internal order
+    was used to make them.
+    """
+    withs = ("WITH p AS (SELECT * FROM orders), "
+             "g AS (SELECT order_id, SUM(quantity) q FROM order_items "
+             "GROUP BY order_id, product_id) ")
+    preserving_first = withs + "SELECT SUM(p.total_amount) FROM p JOIN g ON g.order_id = p.id"
+    changing_first = withs + "SELECT SUM(p.total_amount) FROM g JOIN p ON g.order_id = p.id"
+
+    answers = [[(a.aggregate, a.status, a.joins) for a in _reports(sql)]
+               for sql in (preserving_first, changing_first)]
+    assert answers[0] == answers[1], answers
+    assert answers[0] == [("SUM(p.total_amount)", rt.MULTIPLIED, ["orders (1) <- g (N)"])], answers

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -12,11 +12,18 @@ number into `not_multiplied`, which is a positive claim on the receipt that the 
 Nothing on `main` fails when that happens. So the reverse corpus lands FIRST, in its own file,
 before a line of production code moves.
 
-Everything here passes on the base implementation. That is the point: these are not the tests for
-the new behaviour, they are the tests for the behaviour that must survive it.
+The reverse corpus passes on the base implementation. That is the point: those are not the tests for
+the new behaviour, they are the tests for the behaviour that must survive it. The batteries below it
+are the per-slice tests of what each correction actually changed, and they land beside the corpus
+rather than in files of their own so that a loosening and the pins guarding it are read together.
+
+Slice 2 (S1) is here: an aggregate a duplication cannot move keeps the multiplication and loses the
+word trap, and the marker sentence that reported the detector's old shortcoming is deleted.
 """
 
 from __future__ import annotations
+
+from typing import get_args
 
 import pytest
 
@@ -96,6 +103,57 @@ CONDITIONAL_SUM = (
 )
 
 FAN_EDGE = "orders (1) <- order_items (N)"
+
+# --- S1: the aggregates a duplication cannot move --------------------------
+#
+# Six spellings of one property. Duplicating a row does not move a minimum, a maximum, an aggregate
+# over the distinct values it was handed, or a fold over booleans. All six sit on the ONE side of
+# the same fan as `PLAIN_FAN`, so the multiplication behind them is identical and the only thing
+# that differs is whether the number moved with it.
+DISTINCT_COUNT_OVER_FAN = f"SELECT COUNT(DISTINCT orders.id) {FAN_JOIN}"
+MIN_OVER_FAN = f"SELECT MIN(orders.total_amount) {FAN_JOIN}"
+MAX_OVER_FAN = f"SELECT MAX(orders.total_amount) {FAN_JOIN}"
+# The spelling the predicate is most easily got wrong on: sqlglot parses this to
+# `exp.Sum(this=exp.Distinct(...))` and leaves `args["distinct"]` at `None`, so a check written
+# against the arg alone sees no DISTINCT here at all.
+DISTINCT_SUM_OVER_FAN = f"SELECT SUM(DISTINCT orders.total_amount) {FAN_JOIN}"
+# The boolean folds, which are `exp.LogicalOr` / `exp.LogicalAnd` whichever dialect wrote them and
+# whatever it called them. They are echoed on the receipt as `LOGICAL_OR` / `LOGICAL_AND`.
+BOOL_OR_OVER_FAN = f"SELECT BOOL_OR(orders.total_amount > 0) {FAN_JOIN}"
+BOOL_AND_OVER_FAN = f"SELECT BOOL_AND(orders.total_amount > 0) {FAN_JOIN}"
+
+# And four over the same fan that a duplication does move. `PLAIN_FAN` is the SUM.
+AVG_OVER_FAN = f"SELECT AVG(orders.total_amount) {FAN_JOIN}"
+COUNT_COLUMN_OVER_FAN = f"SELECT COUNT(orders.id) {FAN_JOIN}"
+# Echoed as the sqlglot-normalized `GROUP_CONCAT(...)`, not as the `STRING_AGG` that was written.
+STRING_AGG_OVER_FAN = f"SELECT STRING_AGG(orders.status, ',') {FAN_JOIN}"
+
+# `COUNT(*)` names no column, so ACE-060's rule resolves it to no table and it settles as
+# `undetermined` before any fan is considered.
+COUNT_STAR_OVER_FAN = f"SELECT COUNT(*) {FAN_JOIN}"
+
+# --- the marker, after the fan-immune clause is deleted --------------------
+#
+# Four statements, one per state `_aggregates_marker` can be in that this spec could have disturbed,
+# each carrying an aggregate a duplication cannot move so that the deleted clause would fire if it
+# were still there. The fifth clause (the cap's "further aggregate(s) are not listed") is pinned by
+# `test_ace060_trap_free_aggregates.py::test_the_cap_counts_aggregates_and_says_so`.
+MARKER_NULL = "SELECT MIN(orders.total_amount) FROM orders"
+MARKER_NESTED_SCOPE = (
+    "WITH x AS (SELECT SUM(orders.total_amount) AS t FROM orders) SELECT MAX(x.t) FROM x"
+)
+MARKER_FILTER_OR_SORT = (
+    "SELECT orders.id, MAX(orders.total_amount) FROM orders GROUP BY orders.id "
+    "HAVING SUM(orders.total_amount) > 1"
+)
+MARKER_UNRESOLVED = (
+    "SELECT COUNT(*), MIN(orders.total_amount) FROM customers "
+    "JOIN orders ON orders.customer_id = customers.id"
+)
+
+# The sentence this slice deleted, quoted by the fragment that identifies it rather than in full, so
+# that a reworded survivor cannot accidentally re-satisfy the absence assertions below.
+DELETED_MARKER_PHRASE = "MIN, MAX and COUNT(DISTINCT)"
 
 
 def _reports(sql: str) -> list["rt.AggregateReport"]:
@@ -180,3 +238,164 @@ def test_a_conditional_count_over_the_many_side_still_says_it_is_clean(label, sq
     reports = _reports(sql)
     assert [a.status for a in reports] == [rt.NOT_MULTIPLIED], (label, reports)
     assert [f.risk for f in reports[0].findings] == [], (label, reports[0].findings)
+
+
+def _every_risk(sql: str) -> list[str]:
+    """Every risk label the pre-flight produced for `sql`, from BOTH channels it reports on.
+
+    `PreFlightResult.findings` is the flat list the CLI reads and `.aggregates[].findings` is the
+    per-aggregate roster the receipt reads. They are meant to be projections of one analysis, so a
+    test that read only one of them would pass while the other still said `fan_trap` at whichever
+    surface it did not check.
+    """
+    pf = rt.pre_flight_check(sql, _sales_org())
+    assert pf.unchecked is None, pf.unchecked
+    return [f.risk for f in pf.findings] + [f.risk for a in pf.aggregates for f in a.findings]
+
+
+# --- S1: the fan is reported, and it is not called a trap -------------------
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("COUNT(DISTINCT)", DISTINCT_COUNT_OVER_FAN),
+    ("MIN", MIN_OVER_FAN),
+    ("MAX", MAX_OVER_FAN),
+    ("SUM(DISTINCT)", DISTINCT_SUM_OVER_FAN),
+    ("BOOL_OR", BOOL_OR_OVER_FAN),
+    ("BOOL_AND", BOOL_AND_OVER_FAN),
+])
+def test_an_aggregate_a_duplication_cannot_move_reports_the_fan_without_calling_it_a_trap(
+    label, sql,
+):
+    """A1-A5. The multiplication survives; the word `trap` does not.
+
+    The rows behind a `MAX` over the one side of a fan really are duplicated, so the report keeps
+    saying `multiplied` and keeps naming the edge that did it. Suppressing the finding instead would
+    make the item say `not_multiplied`, which is the positive claim that the rows were not
+    duplicated, and they were. What was false is only the label: `fan_trap` names a defect, and
+    there is no defect in a number a duplication cannot move. So `fan_out_invariant` is a second
+    derivable property of the same aggregate reported alongside the first fact, not a reason to drop
+    it — which is why it is a member of `_MULTIPLYING_RISKS` and `status` is untouched.
+
+    `joins` is asserted because it is what makes the finding actionable at all: a reader told the
+    rows were multiplied and not told by what has been given a fact they cannot check. It comes off
+    the same shared `triggering_joins` the trap branch builds, so the two labels describe one edge.
+
+    The `BOOL_OR` / `BOOL_AND` cases are the `exp.LogicalOr` / `exp.LogicalAnd` arms of the
+    predicate, and `SUM(DISTINCT)` is the arm that only `isinstance(agg.this, exp.Distinct)`
+    reaches. All three are TYPE tests: ACE-079 reads each statement in its engine's own dialect, so
+    the written function name is whatever that dialect spells the fold, and a name allowlist would
+    be wrong the first time the two differ.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], (label, reports)
+    assert reports[0].joins == [FAN_EDGE], (label, reports[0].joins)
+    assert [f.risk for f in reports[0].findings] == ["fan_out_invariant"], (label, reports)
+    assert "fan_trap" not in _every_risk(sql), (label, _every_risk(sql))
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("SUM", PLAIN_FAN),
+    ("AVG", AVG_OVER_FAN),
+    ("COUNT of a column", COUNT_COLUMN_OVER_FAN),
+    ("STRING_AGG", STRING_AGG_OVER_FAN),
+])
+def test_an_aggregate_a_duplication_moves_carries_no_invariance(label, sql):
+    """A6. The other half of the split, and the half that must not move at all.
+
+    Each of these four returns a different number when its rows are duplicated: the sum and the
+    average shift, the count counts line items instead of orders, and the concatenation repeats
+    every status once per item. Whatever widened the invariance predicate, it may not reach them —
+    an aggregate wrongly labelled `fan_out_invariant` tells a reader the number is the same either
+    way, which is the one false statement this split makes possible and the reason the negative
+    assertion is here rather than left implicit in the positive one above.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], (label, reports)
+    assert [f.risk for f in reports[0].findings] == ["fan_trap"], (label, reports)
+    assert "fan_out_invariant" not in _every_risk(sql), (label, _every_risk(sql))
+
+
+def test_count_star_over_a_fan_stays_undetermined_and_claims_no_invariance():
+    """A6. `COUNT(*)` names no column, so there is nothing to be invariant about.
+
+    ACE-060's rule is that an aggregate whose reads the analysis could not attribute to a table says
+    it could not tell, rather than claiming to be clean. `COUNT(*)` is that case exactly, and it is
+    reached before any fan is considered — no source table means no measure table, so the fan branch
+    never looks at it and the invariance predicate is never asked.
+
+    It is pinned because `COUNT(*)` parses to `exp.Count(this=exp.Star())`, one node type away from
+    the `exp.Count(this=exp.Distinct())` the predicate does accept. A widening that stopped
+    distinguishing them would attach `fan_out_invariant` here, and because that risk is a member of
+    `_MULTIPLYING_RISKS` the status would flip from `undetermined` to `multiplied` — turning "we
+    could not tell" into an assertion, over a join that genuinely does multiply what it counts.
+    """
+    reports = _reports(COUNT_STAR_OVER_FAN)
+    assert [(a.aggregate, a.status) for a in reports] == [("COUNT(*)", rt.UNDETERMINED)], reports
+    assert reports[0].joins == [], reports[0].joins
+    assert _every_risk(COUNT_STAR_OVER_FAN) == [], _every_risk(COUNT_STAR_OVER_FAN)
+
+
+# --- A21: what the marker says once the detector no longer has that gap -----
+
+
+@pytest.mark.parametrize("label,sql,phrase", [
+    ("nothing left unsaid", MARKER_NULL, None),
+    ("an aggregate in a CTE body", MARKER_NESTED_SCOPE, "CTE or a subquery"),
+    ("an aggregate in HAVING", MARKER_FILTER_OR_SORT, "HAVING or ORDER BY"),
+    ("an aggregate that resolved to no table", MARKER_UNRESOLVED, "could not be resolved"),
+])
+def test_the_marker_stops_calling_an_invariant_aggregate_a_fan_out_risk(label, sql, phrase):
+    """A21. The deleted clause is gone; the four it stood among are unchanged.
+
+    It said "MIN, MAX and COUNT(DISTINCT) are counted as fan-out risks although a fan-out cannot
+    change what they return" — a true statement about a shortcoming in the DETECTOR, which is why
+    ACE-060 put it on the marker rather than on an item. This slice removed the shortcoming: those
+    aggregates now carry `fan_out_invariant` on the item itself, where the reader is already
+    looking. Left in place the sentence would report a gap the analysis no longer has, and by the
+    four-state contract that costs the section its null marker, which is the only way it can make
+    the positive claim "established, here it is".
+
+    Nothing else moves, and the other clauses are pinned here rather than assumed because they were
+    deleted from a shared tuple: each of the three remaining conditional clauses is still true of
+    the statements it fires on. An aggregate inside a CTE or a subquery is still not reported, one
+    in `HAVING` or `ORDER BY` is still not reported, and one that resolved to no table still says
+    so. Every statement here carries a `MIN` or a `MAX` in its output list, so the deleted clause
+    would fire on all four if it survived — including the null case, which is the state it made
+    unreachable for every statement containing one.
+    """
+    marker = rt.assemble_receipt(_sales_org(), sql)["aggregates"]["undetermined"]
+    assert (marker is None) == (phrase is None), (label, marker)
+    assert phrase is None or phrase in marker, (label, marker)
+    assert DELETED_MARKER_PHRASE not in (marker or ""), (label, marker)
+
+
+# --- A22: a fact about correctness is still not a refusal -------------------
+
+
+def test_no_correctness_finding_can_become_a_refusal():
+    """A22. `fan_out_invariant` is not a refusal reason, and the type is what makes it so.
+
+    Asserted against `guardrail.RefusalReason` itself rather than by searching the tree for the
+    string, because the question is not whether some path happens to refuse today. It is whether one
+    could: the reason vocabulary is a closed three-member `Literal`, so a correctness finding has no
+    member to become, and adding a fourth means editing that one line in a diff a reviewer reads.
+    ACE-094 made a multiplication a fact rather than a refusal, and this slice adds a member to the
+    fact vocabulary — the assertion is that the new member landed on the side of that line it was
+    meant to.
+
+    `rt.guardrail` and not a fresh import: it is the module object `runtime` itself resolved, so
+    this cannot pass against a second copy of `guardrail` reached down a different `sys.path` entry
+    than the detector came down.
+
+    The disjointness check covers `_MULTIPLYING_RISKS` whole rather than the new member alone, so
+    the next risk added to it is held to the same rule without anyone remembering to come back here.
+    """
+    reasons = get_args(rt.guardrail.RefusalReason)
+    assert reasons == ("unsafe", "out_of_scope", "undetermined"), reasons
+    assert set(rt._MULTIPLYING_RISKS).isdisjoint(reasons), rt._MULTIPLYING_RISKS
+    assert "fan_out_invariant" in rt._MULTIPLYING_RISKS, rt._MULTIPLYING_RISKS
+    # And end to end: the statement that produces it produces a finding, not a refusal.
+    pf = rt.pre_flight_check(MIN_OVER_FAN, _sales_org())
+    assert {f.risk for f in pf.findings} == {"fan_out_invariant"}, pf.findings
+    assert pf.unchecked is None, pf.unchecked

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -833,6 +833,10 @@ VALUES_SOURCE = (
     "JOIN (VALUES (1), (2)) AS v(order_id) ON v.order_id = orders.id"
 )
 LATERAL_SOURCE = "SELECT SUM(o.total_amount) FROM orders o, LATERAL (SELECT 1) l"
+# The third one, and the reason the derived binding is a denylist. `UNNEST` is an `exp.Unnest`, a
+# node type an allowlist of Subquery / Lateral / Values does not hold, so it never entered the map
+# at all — and a source absent from the map is a source the analysis reads as not being there.
+UNNEST_SOURCE = "SELECT SUM(orders.total_amount) FROM orders, UNNEST([1, 2]) AS t(x)"
 
 # Every way `_grain_preserving_source` and `_cte_edge` can decline, one row per guard. Each body
 # below differs from a grain-preserving one in exactly one respect, so a guard that stopped firing
@@ -1043,7 +1047,8 @@ def test_a_cte_grain_that_does_not_cover_the_join_key_still_fans():
     """
     tree = _parse(CTE_GRAIN_BELOW_JOIN_KEY)
     scope, derived = rt._resolve_cte_scope(
-        tree, rt._alias_map(tree, in_scope_only=True), rt._model_table_index(_sales_org()))
+        tree, rt._visible_cte_bodies(tree), rt._alias_map(tree, in_scope_only=True),
+        rt._model_table_index(_sales_org()))
     assert scope == {"orders": "orders", "oi": "oi"}, scope
     assert [(r.from_table, r.to_table, r.from_column, r.to_column, r.relationship)
             for r in derived] == [("oi", "orders", "order_id", "id", "many_to_one")], derived
@@ -1066,7 +1071,8 @@ def test_a_cte_grain_that_covers_the_join_key_is_not_multiplied():
     """
     tree = _parse(GRAIN_CHANGING_CTE)
     scope, derived = rt._resolve_cte_scope(
-        tree, rt._alias_map(tree, in_scope_only=True), rt._model_table_index(_sales_org()))
+        tree, rt._visible_cte_bodies(tree), rt._alias_map(tree, in_scope_only=True),
+        rt._model_table_index(_sales_org()))
     assert scope == {"orders": "orders", "oi": "oi"}, scope
     assert [(r.from_table, r.to_table, r.from_column, r.to_column, r.relationship)
             for r in derived] == [("oi", "orders", "order_id", "id", "one_to_one")], derived
@@ -1093,7 +1099,8 @@ def test_the_join_key_is_read_in_either_orientation(label, on, expected):
            f"SELECT SUM(orders.total_amount) FROM orders JOIN oi ON {on}")
     tree = _parse(sql)
     _scope, derived = rt._resolve_cte_scope(
-        tree, rt._alias_map(tree, in_scope_only=True), rt._model_table_index(_sales_org()))
+        tree, rt._visible_cte_bodies(tree), rt._alias_map(tree, in_scope_only=True),
+        rt._model_table_index(_sales_org()))
     assert [(r.from_table, r.to_table, r.from_column, r.to_column, r.relationship)
             for r in derived] == [("oi", "orders", "order_id", "id", expected)], label
     assert [a.status for a in _reports(sql)] == [rt.NOT_MULTIPLIED], label
@@ -1306,11 +1313,12 @@ def test_a_parenthesized_table_is_the_table_and_not_a_source_of_its_own():
 @pytest.mark.parametrize("label,sql", [
     ("a VALUES list", VALUES_SOURCE),
     ("a LATERAL", LATERAL_SOURCE),
+    ("an UNNEST", UNNEST_SOURCE),
 ])
 def test_a_source_the_guarded_path_refuses_is_still_answered_honestly_on_the_prepare_surface(
     label, sql,
 ):
-    """Why the `exp.Lateral` and `exp.Values` binding arms are not dead code.
+    """Why the derived binding arm is not dead code.
 
     `check_scopable` (ACE-037) refuses both of these source kinds at the `execute_guarded`
     chokepoint, so no query that RUNS ever reaches the multiplication analysis carrying one. That is
@@ -1323,9 +1331,15 @@ def test_a_source_the_guarded_path_refuses_is_still_answered_honestly_on_the_pre
     prepare receipt has no way to know a gate they never invoked would have refused the statement;
     what they have is the sentence in front of them, and it said the number was sound.
 
-    So the analysis answers honestly on both surfaces, and the two arms exist for the one that has
+    So the analysis answers honestly on both surfaces, and the binding exists for the one that has
     no gate in front of it. `pre_flight_check` is called directly here for the same reason: driving
     this through `execute_guarded` would measure the refusal and never reach the claim.
+
+    `UNNEST` is the member that proves the binding has to be a DENYLIST. It is an `exp.Unnest`, and
+    an allowlist naming `Subquery`, `Lateral` and `Values` simply did not hold it: the source never
+    entered the map, the scope-completeness conjunct saw nothing missing, and the statement read
+    `not_multiplied` over rows an unnest can multiply. A source kind nobody anticipated has to
+    default to `undetermined`, which only binding by exclusion gives.
     """
     assert rt.check_scopable(sql, _sales_org()) is not None, label
     pf = rt.pre_flight_check(sql, _sales_org())
@@ -1528,10 +1542,10 @@ def test_a_set_operation_arm_sees_the_cte_the_statement_bound_above_it():
     the undeclared name `oi`. The unreadable-body shape failed the same way and is a row in the
     guard table above.
 
-    The fix is narrow on purpose and both halves are asserted here. CTE NAMES and BODIES come off
-    the root, because a WITH binds its name for every arm below it — the same reason
-    `_aggregate_reports` computes `visible` on the root. Which TABLES an arm reads does NOT: the
-    alias map stays strictly per-arm, so the second arm below, which reads only `orders`, is
+    The fix is narrow on purpose and both halves are asserted here. CTE names and bodies come from
+    the arm's LEXICAL ANCESTORS, because a WITH binds its name for every arm below it — the same
+    reason `_aggregate_reports` computes `visible` on the root. Which TABLES an arm reads does NOT:
+    the alias map stays strictly per-arm, so the second arm below, which reads only `orders`, is
     honestly clean and is not dragged into the first arm's fan.
 
     The scope labels are asserted too. They are what tells a reader which arm an item belongs to,
@@ -1547,3 +1561,313 @@ def test_a_set_operation_arm_sees_the_cte_the_statement_bound_above_it():
     mixed = _reports(f"{CTE_LAUNDERED_FAN} UNION ALL SELECT SUM(orders.total_amount) FROM orders")
     assert [(a.scope, a.status) for a in mixed] == [
         ("main#1", rt.MULTIPLIED), ("main#2", rt.NOT_MULTIPLIED)], mixed
+
+
+# --- and a WITH that does NOT bind here binds nothing -----------------------
+#
+# The other half of the same rule, and the one that was measured wrong. `sel.root().find_all(
+# exp.CTE)` collects every CTE in the statement, keyed by folded name with last-writer-wins, so a
+# CTE from a scope that does not bind for this SELECT could win the name. Both shapes below were
+# receipts calling an inflated number sound.
+
+# Two arms, each declaring its OWN `x` over a different table. Only the first arm joins, and only
+# the first arm's `x` is the one side of that join. Written in both orders because the defect was
+# order-dependent: whichever arm's body the root walk reached last won the name for both.
+SAME_NAME_PER_ARM = (
+    "(WITH x AS (SELECT * FROM orders) SELECT SUM(x.total_amount) FROM x "
+    "JOIN order_items oi ON oi.order_id = x.id) UNION ALL "
+    "(WITH x AS (SELECT * FROM order_items) SELECT SUM(x.quantity) FROM x)"
+)
+SAME_NAME_PER_ARM_SWAPPED = (
+    "(WITH x AS (SELECT * FROM order_items) SELECT SUM(x.quantity) FROM x) UNION ALL "
+    "(WITH x AS (SELECT * FROM orders) SELECT SUM(x.total_amount) FROM x "
+    "JOIN order_items oi ON oi.order_id = x.id)"
+)
+
+# A `WITH` inside a `WHERE … IN (…)` subquery. It binds `order_items` for that subquery and for
+# nothing else, and the outer statement's `order_items` is the real declared table it joins.
+NESTED_WITH_SHADOWING_A_REAL_TABLE = (
+    "SELECT SUM(orders.total_amount) FROM orders "
+    "JOIN order_items ON order_items.order_id = orders.id "
+    "WHERE orders.id IN (WITH order_items AS (SELECT id FROM customers) "
+    "SELECT id FROM order_items)"
+)
+
+
+def test_a_cte_declared_in_a_sibling_arm_does_not_bind_for_this_one():
+    """Same name, two arms, and the answer may not depend on which was written first.
+
+    Each arm declares its own `x`. In the joining arm `x` is `orders`, the one side of a fan over
+    `order_items`; in the other it is `order_items` itself, read with no join at all. Read off the
+    root, the two bodies collided on the folded key `x` and the last one written won for both arms,
+    so the joining arm was told its `x` was `order_items` — no table on the one side of anything —
+    and reported `not_multiplied`. Swapping the arms swapped which statement got the wrong body.
+
+    Asserted as a PAIR rather than as two expected values, because the property is that the fan arm
+    answers the same way whichever position it is written in. Per-arm expectations would pass on an
+    implementation that is right for one ordering and wrong for the other, which is what it was.
+    """
+    forward = {a.scope: a.status for a in _reports(SAME_NAME_PER_ARM)}
+    swapped = {a.scope: a.status for a in _reports(SAME_NAME_PER_ARM_SWAPPED)}
+    assert forward["main#1"] == swapped["main#2"] == rt.MULTIPLIED, (forward, swapped)
+    assert forward["main#2"] == swapped["main#1"] == rt.NOT_MULTIPLIED, (forward, swapped)
+
+
+def test_a_with_inside_a_subquery_does_not_rebind_the_statements_own_table():
+    """A CTE bound inside a `WHERE … IN (…)` is not in scope for the statement that contains it.
+
+    `order_items` in the outer FROM is the declared table, and the join to it is the fan. Read off
+    the root, the subquery's `WITH order_items AS (SELECT id FROM customers)` took the name, the
+    outer `order_items` resolved to `customers`, and the fan the statement really takes vanished.
+    """
+    reports = _reports(NESTED_WITH_SHADOWING_A_REAL_TABLE)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], reports
+    assert reports[0].joins == [FAN_EDGE], reports[0].joins
+
+
+def test_the_with_argument_is_read_under_the_spelling_sqlglot_actually_uses():
+    """`with_`, not `with` — the same rename trap already documented for `from`.
+
+    Read under one spelling only, `_visible_cte_bodies` returns the empty dict for every statement
+    ever written. Nothing fails loudly: every CTE reference falls to the fail-closed binding and the
+    receipt answers `undetermined` for statements it can answer. The corpus above forbids false
+    cleans and would not notice, so the argument key is pinned directly.
+    """
+    tree = _parse(CTE_LAUNDERED_FAN)
+    assert tree.args.get("with_") is not None, tree.args.keys()
+    assert set(rt._visible_cte_bodies(tree)) == {"oi"}, rt._visible_cte_bodies(tree)
+
+
+# --- the body's own FROM, and only its own ----------------------------------
+
+# The docstring's own worked example for the no-FROM guard. `body.find(exp.From)` is RECURSIVE, so
+# it reached the FROM inside the EXISTS and the guard never tested what it said it tested.
+EXISTS_ONLY_CTE = (
+    "WITH c AS (SELECT 1 AS x WHERE EXISTS (SELECT 1 FROM order_items)) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN c ON c.x = orders.id"
+)
+# A body whose FROM is a derived table. It hands back one row per DISTINCT order, not one row per
+# order item, so reading through the wrapper named a join the statement does not take.
+DERIVED_FROM_CTE = (
+    "WITH c AS (SELECT * FROM (SELECT DISTINCT order_id FROM order_items) g) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN c ON c.order_id = orders.id"
+)
+# The count of tables stays WHOLE-SUBTREE. This body's own FROM is a plain table, and it is caught
+# only because the IN subquery's table is counted too.
+IN_SUBQUERY_CTE = (
+    "WITH c AS (SELECT order_id FROM order_items WHERE order_id IN (SELECT id FROM orders)) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN c ON c.order_id = orders.id"
+)
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("the only FROM is inside a WHERE EXISTS", EXISTS_ONLY_CTE),
+    ("the FROM is a derived table", DERIVED_FROM_CTE),
+    ("a table in an IN subquery, counted whole-subtree", IN_SUBQUERY_CTE),
+])
+def test_a_cte_body_whose_own_from_names_no_table_is_undetermined(label, sql):
+    """The grain-preserving guard reads the body's OWN `FROM`, under both argument spellings.
+
+    Each of these bodies produces a row count that is not the row count of any table it mentions,
+    and each was resolved to `order_items` anyway — the first two by `body.find(exp.From)` reaching
+    one scope further in, and all three by a table count that is deliberately whole-subtree. The
+    first two then reported `multiplied` naming `orders (1) <- order_items (N)`, a join the
+    statement does not take; `undetermined` is what a body the analysis cannot read is worth.
+
+    The third is here to hold the count where it is. Its own FROM is a plain `exp.Table`, so a fix
+    that narrowed the COUNT to the body's own FROM as well would resolve it to `order_items` and
+    credit it with a row count it does not have.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.UNDETERMINED], (label, reports)
+    assert reports[0].joins == [], (label, reports[0].joins)
+
+
+# --- a grain is what its columns say, and only when they say it -------------
+
+# `GROUP BY orders.id, order_items.id` is two columns. Strip the qualifiers and it is one, matching
+# the single join key exactly and declaring the CTE unique on a key it is not unique on.
+GRAIN_WITH_COLLIDING_BARE_NAMES = (
+    "WITH g AS (SELECT orders.id AS id, order_items.id AS iid, SUM(order_items.quantity) q "
+    "FROM orders JOIN order_items ON order_items.order_id = orders.id "
+    "GROUP BY orders.id, order_items.id) "
+    "SELECT SUM(customers.id) FROM customers JOIN g ON g.id = customers.id"
+)
+# `ROLLUP` adds a subtotal row per order, so the grain is not `{order_id}` and the join to it fans.
+GRAIN_WITH_ROLLUP = (
+    "WITH g AS (SELECT order_id, product_id, SUM(quantity) q FROM order_items "
+    "GROUP BY order_id, ROLLUP(product_id)) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN g ON g.order_id = orders.id"
+)
+GRAIN_WITH_CUBE = (
+    "WITH g AS (SELECT order_id, product_id, SUM(quantity) q FROM order_items "
+    "GROUP BY CUBE(order_id, product_id)) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN g ON g.order_id = orders.id"
+)
+GRAIN_WITH_GROUPING_SETS = (
+    "WITH g AS (SELECT order_id, product_id, SUM(quantity) q FROM order_items "
+    "GROUP BY GROUPING SETS ((order_id), (product_id))) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN g ON g.order_id = orders.id"
+)
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("two grain columns whose bare names collide", GRAIN_WITH_COLLIDING_BARE_NAMES),
+    ("a column list beside a ROLLUP", GRAIN_WITH_ROLLUP),
+    ("a pure CUBE", GRAIN_WITH_CUBE),
+    ("pure GROUPING SETS", GRAIN_WITH_GROUPING_SETS),
+])
+def test_a_grain_the_group_by_does_not_state_is_undetermined(label, sql):
+    """A grain read off `group.expressions` alone is not the grain the body emits.
+
+    The bare-name case is the sharper one, because it produces a grain that is not merely incomplete
+    but WRONG: `[k.name for k in keys]` strips the qualifier, `GROUP BY orders.id, order_items.id`
+    becomes a one-element list, `infer_cardinality` finds it equal to the single join key, and the
+    receipt declares the CTE unique on `id` — one row per customer — when it is one row per order
+    item. The three grouping constructs each add rows the column list does not describe; `ROLLUP`
+    beside a column list is the one that was silently wrong, since `CUBE` and `GROUPING SETS`
+    written alone leave `expressions` empty and so failed closed by accident.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.UNDETERMINED], (label, reports)
+
+
+@pytest.mark.parametrize("label,expressions,expected", [
+    ("plain columns", "GROUP BY order_id, product_id", ["order_id", "product_id"]),
+    ("qualified columns that differ", "GROUP BY o.order_id, i.product_id",
+     ["order_id", "product_id"]),
+    ("folded to one spelling", "GROUP BY ORDER_ID", ["order_id"]),
+    ("bare names that collide", "GROUP BY o.id, i.id", []),
+    ("an expression rather than a column", "GROUP BY DATE_TRUNC('month', created_at)", []),
+    ("a column list beside a ROLLUP", "GROUP BY order_id, ROLLUP(product_id)", []),
+    ("a pure CUBE", "GROUP BY CUBE(order_id, product_id)", []),
+    ("pure GROUPING SETS", "GROUP BY GROUPING SETS ((order_id), (product_id))", []),
+    ("no GROUP BY at all", "", []),
+])
+def test_the_group_by_grain_is_empty_whenever_the_columns_do_not_state_it(
+    label, expressions, expected,
+):
+    """`_group_by_grain` on the function, because every way of being empty means the same thing.
+
+    Empty is `undetermined` downstream, and each row here is a different way the body's row grain is
+    not the list of columns it wrote. Folding is asserted rather than assumed: the comparison this
+    feeds is against a declared `Table.grain` that a Snowflake or Oracle catalog hands back in a
+    different case from the one the query writes.
+    """
+    body = parse_one(f"SELECT order_id, SUM(quantity) FROM order_items o {expressions}")
+    assert rt._group_by_grain(body) == expected, label
+
+
+# --- one spelling on both sides of every comparison -------------------------
+
+# The CTE is grouped to exactly the key it is joined on, so it is one row per order and nothing
+# fans. The join key is written in a different case from the GROUP BY, which is a difference no
+# database makes and this comparison did.
+JOIN_KEY_IN_ANOTHER_CASE = (
+    "WITH g AS (SELECT order_id, SUM(quantity) q FROM order_items GROUP BY order_id) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN g ON g.ORDER_ID = orders.id"
+)
+
+
+def test_a_join_key_written_in_another_case_does_not_invent_a_fan():
+    """Case folding, on the one comparison in this module that was missing it.
+
+    `check_column_scope` states the module's convention as "matching is case-insensitive", and
+    `_cte_names` and `_model_table_index` both fold. The grain comparison did not: the GROUP BY
+    grain `order_id` and the join key `ORDER_ID` were read as different columns, `infer_cardinality`
+    concluded the CTE is not unique on its join key, and a `many_to_one` edge put `orders` on the
+    one side of a fan the statement does not have. It also walks straight past the empty-grain
+    guard, since a case-mismatched grain is a non-empty one.
+
+    The derived EDGE is asserted beside the status because the cardinality is the thing that was
+    wrong; a status alone cannot tell a corrected edge from an abstention.
+    """
+    tree = _parse(JOIN_KEY_IN_ANOTHER_CASE)
+    _scope, derived = rt._resolve_cte_scope(
+        tree, rt._visible_cte_bodies(tree), rt._alias_map(tree, in_scope_only=True),
+        rt._model_table_index(_sales_org()))
+    assert [(r.from_table, r.to_table, r.relationship) for r in derived] == [
+        ("g", "orders", "one_to_one")], derived
+    assert [a.status for a in _reports(JOIN_KEY_IN_ANOTHER_CASE)] == [rt.NOT_MULTIPLIED]
+
+
+def test_a_declared_grain_the_catalog_upper_cased_is_still_the_grain():
+    """The same fold, on the side that comes from the MODEL rather than from the SQL.
+
+    Snowflake and Oracle catalogs return uppercase identifiers, so `Table.grain` can arrive as
+    `["ID"]` for a query that writes `orders.id`. Unfolded, the declared grain matched no join key,
+    `infer_cardinality` read the far side as non-unique, and the derived edge came back
+    `one_to_many` — a cardinality nobody declared, sitting on a receipt.
+    """
+    org = _sales_org()
+    orders = next(t for t in org.subject_areas[0].tables_defined if t.name == "orders")
+    orders.grain = ["ID"]
+    tree = _parse(GRAIN_CHANGING_CTE)
+    _scope, derived = rt._resolve_cte_scope(
+        tree, rt._visible_cte_bodies(tree), rt._alias_map(tree, in_scope_only=True),
+        rt._model_table_index(org))
+    assert [(r.from_table, r.to_table, r.relationship) for r in derived] == [
+        ("oi", "orders", "one_to_one")], derived
+
+
+# --- availability on caller-controlled SQL ---------------------------------
+
+
+def test_a_long_chain_of_ctes_declines_to_answer_rather_than_losing_the_receipt():
+    """A linear chain is not a cycle, and `seen` only catches a cycle.
+
+    990 CTEs each reading the one before fit in 29,573 characters, well under the 50,000-character
+    statement cap, and raised `RecursionError` out of the resolver. `_receipt_for` catches bare
+    `Exception` and returns `RECEIPT_BUILD_FAILED`, so the statement still ran and returned rows
+    while the caller silently lost the trust layer — caller-chosen input that turns off the receipt
+    without turning off the answer. A depth bound turns it into the fail-closed answer instead.
+
+    The character count is asserted so the premise stays true: if the cap or the shape changed
+    enough that this no longer fits inside it, the test would be measuring nothing.
+    """
+    links = 990
+    bodies = ["c0 AS (SELECT * FROM order_items)"]
+    bodies += [f"c{i} AS (SELECT * FROM c{i - 1})" for i in range(1, links)]
+    sql = ("WITH " + ", ".join(bodies) +
+           f" SELECT SUM(orders.total_amount) FROM orders JOIN c{links - 1} "
+           f"ON c{links - 1}.order_id = orders.id")
+    assert len(sql) < 50_000, len(sql)
+
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.UNDETERMINED], reports
+
+
+def test_the_root_cte_set_and_the_model_index_are_built_once_per_statement(monkeypatch):
+    """Neither of these is per-arm work, and both were.
+
+    `_cte_names(tree.root())` was the unconditional left operand of the CTE guard's `&`, so it
+    walked the WHOLE tree once per set-operation arm: measured at 471 arms, that one call was 93 to
+    95% of the total, and a statement with NO CTE anywhere regressed from 0.14s to 5.4s while the
+    comment beside it said such a statement "pays nothing for this". `_model_table_index` walks
+    every table in the model and was rebuilt per arm on the `assemble_receipt` path, which already
+    holds one.
+
+    Counted rather than timed, because a wall-clock threshold on a shared runner is a flake and the
+    property is not "fast" but "not once per arm". Ten arms, so a per-arm implementation cannot
+    coincide with a per-statement one.
+    """
+    calls = {"cte_names": 0, "model_index": 0}
+    real_cte_names, real_index = rt._cte_names, rt._model_table_index
+
+    def counted_cte_names(tree):
+        calls["cte_names"] += 1
+        return real_cte_names(tree)
+
+    def counted_index(org):
+        calls["model_index"] += 1
+        return real_index(org)
+
+    monkeypatch.setattr(rt, "_cte_names", counted_cte_names)
+    monkeypatch.setattr(rt, "_model_table_index", counted_index)
+
+    arms = " UNION ALL ".join([CTE_LAUNDERED_FAN.split(") ", 1)[1]] * 10)
+    sql = "WITH oi AS (SELECT * FROM order_items) " + arms
+    reports = rt.pre_flight_check(sql, _sales_org()).aggregates
+    assert len(reports) == 10, reports
+    assert calls["cte_names"] == 1, calls
+    assert calls["model_index"] == 1, calls

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -628,9 +628,14 @@ def test_the_value_path_of_something_that_is_not_an_expression_is_empty():
     Argument values are not all nodes: `Count(big_int=True)` and `Ordered(nulls_first=True)` carry
     bools, and an absent optional argument is `None`. The alternative to this guard is a type check
     at every call site inside the walk, which is the same test written four times.
+
+    An alternation with no branch at all is the same guard on the other arm. `frozenset.intersection`
+    with no argument at all is a `TypeError`, not an empty set, so a `CASE` node carrying neither an
+    `ifs` list nor a `default` has to be answered before the fold rather than inside it.
     """
     assert rt._value_sources(None, VALUE_SCOPE) == frozenset()
     assert rt._value_sources(True, VALUE_SCOPE) == frozenset()
+    assert rt._value_sources(exp.Case(), VALUE_SCOPE) == frozenset()
 
 
 # --- the direction the corpus above cannot reach ---------------------------

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -19,16 +19,26 @@ rather than in files of their own so that a loosening and the pins guarding it a
 
 Slice 2 (S1) is here: an aggregate a duplication cannot move keeps the multiplication and loses the
 word trap, and the marker sentence that reported the detector's old shortcoming is deleted.
+
+Slice 3 (S2) is here: the fan is attributed by where a column sits on the aggregate's VALUE path
+rather than by its presence anywhere inside the aggregate.
 """
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 from typing import get_args
 
 import pytest
 
 pytest.importorskip("pydantic")
 pytest.importorskip("sqlglot")
+
+from sqlglot import exp, parse_one  # noqa: E402
 
 # `rt` is imported FROM the fixture's module rather than beside it, and that is load-bearing.
 # `test_semantic_model_runtime` puts `plugins/agami/scripts` on `sys.path`, while the ACE-060 and
@@ -37,6 +47,13 @@ pytest.importorskip("sqlglot")
 # `MULTIPLIED` / `NOT_MULTIPLIED` string objects and its own detector — so an assertion here could
 # compare a status produced by one copy against a constant defined by the other. One import.
 from test_semantic_model_runtime import _sales_org, rt  # noqa: E402
+
+# Where the subprocess probe below finds the SAME source `rt` was imported from, derived from the
+# module object rather than rebuilt from the repo root. The header above explains why two copies of
+# `semantic_model` reached down two `sys.path` entries is a real hazard in this file; a determinism
+# test that compared a child process running one copy against a parent running the other would be
+# measuring the wrong difference.
+PKG_SRC = Path(rt.__file__).resolve().parents[1]
 
 # The one-to-many the whole corpus is built on: `orders` is the ONE side, `order_items` the MANY,
 # and the model declares that edge. Written once so "the same fan join in every member" is a fact
@@ -103,6 +120,56 @@ CONDITIONAL_SUM = (
 )
 
 FAN_EDGE = "orders (1) <- order_items (N)"
+
+# --- S2: the value path ----------------------------------------------------
+#
+# The statement S2 is about. Its value is a product computed once per `order_items` row, so the
+# duplication the join performs is the grain the value was already at.
+VALUE_AT_MANY_GRAIN = f"SELECT SUM(order_items.quantity * orders.total_amount) {FAN_JOIN}"
+
+# The same one-side measure with the many-side column moved OUT of the aggregate entirely, into a
+# `FILTER (WHERE …)` clause. Structurally different from every other member here — see the test.
+FILTERED_FAN = (
+    f"SELECT SUM(orders.total_amount) FILTER (WHERE order_items.quantity > 0) {FAN_JOIN}"
+)
+
+# One statement carrying all three statuses and both risk labels, for the cross-process pin. Four
+# aggregates over one fan: a value already at the many side's grain, a one-side measure the join
+# inflates, a one-side measure the duplication cannot move, and one that names no column at all.
+EVERY_STATUS_SQL = (
+    "SELECT SUM(i.quantity * o.total_amount), SUM(o.total_amount), MIN(o.total_amount), COUNT(*) "
+    "FROM orders o JOIN order_items i ON i.order_id = o.id"
+)
+
+# Every branch of `_value_columns`, exercised on the function directly. `expected` is a LIST and not
+# a set: the walk's order decides the order of nothing the receipt renders today, but `sources` is
+# built from it and a list says what was measured rather than what happened to be enough.
+VALUE_COLUMN_CASES = [
+    ("a bare column", "orders.total_amount", ["orders.total_amount"]),
+    ("arithmetic, the generic branch",
+     "SUM(order_items.quantity * orders.total_amount)",
+     ["order_items.quantity", "orders.total_amount"]),
+    ("a searched CASE, whose WHEN is a predicate",
+     "SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount END)",
+     ["orders.total_amount"]),
+    ("a searched CASE with an ELSE, which is a value",
+     "SUM(CASE WHEN order_items.quantity > 0 THEN orders.total_amount ELSE orders.revenue END)",
+     ["orders.total_amount", "orders.revenue"]),
+    ("a simple CASE, whose operand is a predicate input",
+     "SUM(CASE orders.status WHEN 'x' THEN order_items.quantity END)",
+     ["order_items.quantity"]),
+    ("a CASE inside a CASE branch",
+     "SUM(CASE WHEN order_items.quantity > 0 "
+     "THEN CASE WHEN orders.flag THEN orders.total_amount END END)",
+     ["orders.total_amount"]),
+    ("an ordering arm, which is neither predicate nor value",
+     "STRING_AGG(orders.status, ',' ORDER BY order_items.id)",
+     ["orders.status"]),
+    ("DISTINCT, which the generic branch reaches with no case of its own",
+     "SUM(DISTINCT orders.total_amount)",
+     ["orders.total_amount"]),
+    ("no column at all", "COUNT(*)", []),
+]
 
 # --- S1: the aggregates a duplication cannot move --------------------------
 #
@@ -399,3 +466,138 @@ def test_no_correctness_finding_can_become_a_refusal():
     pf = rt.pre_flight_check(MIN_OVER_FAN, _sales_org())
     assert {f.risk for f in pf.findings} == {"fan_out_invariant"}, pf.findings
     assert pf.unchecked is None, pf.unchecked
+
+
+# --- S2: the fan is attributed by position on the value path ----------------
+
+
+def test_a_value_at_many_side_grain_is_not_multiplied_by_the_fan():
+    """A7. The join duplicates the rows, and the value was already one per duplicated row.
+
+    `SUM(order_items.quantity * orders.total_amount)` computes one product per `order_items` row.
+    `orders.total_amount` appears in it as a scalar co-factor: the join hands the expression the
+    same amount once per item, and multiplying each item's quantity by it and summing is the same
+    number the statement asked for. The duplication IS the grain the value is defined at, so there
+    is nothing for the fan to inflate.
+
+    The old rule attributed the fan by SYNTACTIC presence — every table with a column anywhere
+    inside the aggregate — so this reported `fan_trap` on the strength of `orders` being named. That
+    is a false statement on the receipt about a correct statement, and the cost of it is the one
+    that matters: a reader who is told a sound number was inflated learns to discount the report.
+
+    `joins` is asserted empty as well as the status, because the two are separable. A report that
+    said `not_multiplied` while still naming the edge would be internally contradictory, and it is
+    the second half of that pair that a rule attributing by presence would leave behind.
+    """
+    reports = _reports(VALUE_AT_MANY_GRAIN)
+    assert [a.status for a in reports] == [rt.NOT_MULTIPLIED], reports
+    assert reports[0].joins == [], reports[0].joins
+    assert [f.risk for f in reports[0].findings] == [], reports[0].findings
+
+
+def test_a_filter_clause_predicate_is_outside_the_aggregate_the_analysis_reads():
+    """`_value_columns` has no `exp.Filter` branch because the parse makes one unnecessary.
+
+    `SUM(orders.total_amount) FILTER (WHERE order_items.quantity > 0)` parses to
+    `Filter(this=Sum(...), expression=Where(...))` — the `Filter` is the PARENT of the aggregate, so
+    `order_items.quantity` is not in the `Sum` subtree at all. `_select_aggregates` collects
+    `exp.AggFunc` nodes, so the aggregate that reaches `_value_columns` is the bare `Sum` and the
+    predicate is structurally invisible to it. A branch for `exp.Filter` would be dead code.
+
+    That is a fact about sqlglot's tree and not about this module, which is exactly why it is pinned
+    here rather than trusted. If a future sqlglot re-parented the predicate under the aggregate, or
+    if this layer started reading `exp.Filter` as the aggregate node, the predicate's many-side
+    column would silently join the value path and clear a genuinely inflated total. The measured
+    behaviour is asserted through the analysis so that either change fails: the summed value is a
+    one-side amount, once per surviving order item, and the join multiplies it.
+    """
+    agg = parse_one(FILTERED_FAN).find(exp.AggFunc)
+    assert isinstance(agg, exp.Sum), agg
+    assert isinstance(agg.parent, exp.Filter), agg.parent
+    assert [c.sql() for c in agg.find_all(exp.Column)] == ["orders.total_amount"], agg
+
+    reports = _reports(FILTERED_FAN)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], reports
+    assert reports[0].joins == [FAN_EDGE], reports[0].joins
+
+
+@pytest.mark.parametrize("label,expression,expected", VALUE_COLUMN_CASES)
+def test_the_value_path_holds_only_the_columns_the_result_is_built_from(label, expression, expected):
+    """A7. Every branch of `_value_columns`, asserted on the function rather than through a receipt.
+
+    The analysis reaches most of these branches, but it reaches them in combination and reports one
+    status per statement, so a branch that dropped a column the value does use and a branch that
+    kept one it does not can cancel out in the answer. Called directly, each shape says which
+    columns it thinks the value is built from, and a wrong one is wrong visibly.
+
+    The two guard branches are the reason this is a unit test at all. A simple `CASE`'s operand
+    (`CASE orders.status WHEN 'x' THEN …`) is an input to the branch CHOICE, not to the result, so
+    it belongs with the `WHEN` predicates and not with the `THEN` values — and it lives under
+    `Case.this`, which the generic branch would have taken. The nested case proves the recursion
+    applies the same rule at depth rather than only at the top. `DISTINCT` is the opposite check:
+    it carries a genuine value column under `args["expressions"]`, so the generic branch must reach
+    it and no case may intercept it.
+    """
+    node = parse_one(f"SELECT {expression} FROM orders").expressions[0]
+    assert [c.sql() for c in rt._value_columns(node)] == expected, label
+
+
+def test_the_value_path_of_something_that_is_not_an_expression_is_empty():
+    """The guard that lets the generic branch iterate `node.args` without inspecting what it holds.
+
+    Argument values are not all nodes: `Count(big_int=True)` and `Ordered(nulls_first=True)` carry
+    bools, and an absent optional argument is `None`. The alternative to this guard is a type check
+    at every call site inside the walk, which is the same test written four times.
+    """
+    assert rt._value_columns(None) == []
+    assert rt._value_columns(True) == []
+
+
+# --- A24: the same report in every process ---------------------------------
+
+_PROBE = """
+import json, sys
+sys.path.insert(0, sys.argv[1])
+from semantic_model import models as m
+from semantic_model import runtime as rt
+org = m.Datasource.model_validate_json(sys.argv[3])
+print(json.dumps([a.as_dict() for a in rt.pre_flight_check(sys.argv[2], org).aggregates]))
+"""
+
+
+def test_the_aggregate_report_is_the_same_in_every_process():
+    """A24 / REQ-022: the receipt is "the same for the same SQL and model version".
+
+    That is a claim about PROCESSES, so nothing inside one can check it. The hazards it names are
+    invisible under a fixed seed: `sources` is a `frozenset` and `many_tables` is a `set`, the fan
+    branch iterates a sorted copy of one of them and intersects the other, and `_shared_dimension`
+    picks its dimension by walking a set. Any answer derived from one of those is stable within an
+    interpreter and free to differ in the next. Four seeds, four processes, one answer.
+
+    The whole serialized item list is compared rather than the statuses alone, and it is NOT sorted:
+    the aggregates are reported in the order the statement wrote them, so a re-ordered list is as
+    much a difference as a flipped status and sorting here would hide exactly one of the two modes
+    this exists to catch.
+
+    `EVERY_STATUS_SQL` carries all three statuses and both risk labels over a single fan, so one
+    comparison covers the value-path attribution that produced `not_multiplied`, the fan that
+    produced `multiplied`, and the unresolved read that produced `undetermined`.
+
+    The model crosses the process boundary as JSON rather than as a path, because this fixture is
+    built in Python and has no profile on disk; `model_validate_json` of `model_dump_json` is the
+    same object by construction, so the child analyses the model the parent declared.
+    """
+    payload = _sales_org().model_dump_json()
+    seen = set()
+    for seed in ("0", "1", "42", "12345"):
+        proc = subprocess.run(
+            [sys.executable, "-c", _PROBE, str(PKG_SRC), EVERY_STATUS_SQL, payload],
+            capture_output=True, text=True, env={**os.environ, "PYTHONHASHSEED": seed},
+        )
+        assert proc.returncode == 0, proc.stderr
+        seen.add(proc.stdout.strip())
+
+    assert len(seen) == 1, f"the aggregate report differed across hash seeds: {seen}"
+    # And it is the answer this process gets, so four children agreeing on something wrong would
+    # still fail rather than agree quietly.
+    assert json.loads(seen.pop()) == [a.as_dict() for a in _reports(EVERY_STATUS_SQL)]

--- a/tests/test_ace083_trap_soundness.py
+++ b/tests/test_ace083_trap_soundness.py
@@ -22,6 +22,14 @@ word trap, and the marker sentence that reported the detector's old shortcoming 
 
 Slice 3 (S2) is here: the fan is attributed by where a column sits on the aggregate's VALUE path
 rather than by its presence anywhere inside the aggregate.
+
+Slices 4 and 5 (S3) are here, and they are ONE commit rather than two. The scope filter and the
+grain plumbing were planned as separate slices; they cannot be, and the corpus is what proved it.
+The filter stops a reference written inside a CTE body from entering the outer query's map, which
+is correct and is half of S3 — but `CTE_LAUNDERED_FAN` reported `multiplied` at HEAD only BECAUSE
+of that leak, and with the leak gone and no resolution for what `oi` stands for, a genuinely
+inflated statement read `not_multiplied`. The intermediate state fails the corpus's own criterion,
+so it is not a legal place to stop.
 """
 
 from __future__ import annotations
@@ -46,7 +54,7 @@ from sqlglot import exp, parse_one  # noqa: E402
 # different path than the fixture came down yields a second module object with its own
 # `MULTIPLIED` / `NOT_MULTIPLIED` string objects and its own detector — so an assertion here could
 # compare a status produced by one copy against a constant defined by the other. One import.
-from test_semantic_model_runtime import _sales_org, rt  # noqa: E402
+from test_semantic_model_runtime import _sales_org, m, rt  # noqa: E402
 
 # Where the subprocess probe below finds the SAME source `rt` was imported from, derived from the
 # module object rather than rebuilt from the repo root. The header above explains why two copies of
@@ -100,6 +108,12 @@ JOINED_CTE_BODY = (
     "JOIN order_items i ON i.order_id = o.id) SELECT SUM(j.total_amount) FROM j"
 )
 
+# 8. The rows come from a source with no name at all. A `VALUES` list in a comma join multiplies
+#    every order by the number of tuples in it, and there is no alias to hang the fact on. Added
+#    when the scope filter's own alias guard was measured: the guard has to drop the wrapper of a
+#    parenthesized table, and dropping this one with it would have been a false clean.
+UNALIASED_VALUES_FAN = "SELECT SUM(orders.total_amount) FROM orders, (VALUES (1), (2))"
+
 # The corpus, named so the later slices can re-run it unchanged rather than restating it. Labels
 # are what a failure prints, so they name the disguise and not the SQL.
 INFLATED_SHAPES = [
@@ -110,6 +124,7 @@ INFLATED_SHAPES = [
     ("many side behind a derived table", DERIVED_TABLE_FAN),
     ("many side behind a CTE", CTE_LAUNDERED_FAN),
     ("join inside the CTE body", JOINED_CTE_BODY),
+    ("rows from an unaliased VALUES list", UNALIASED_VALUES_FAN),
 ]
 
 # A conditional count and a conditional sum over the many side. Both are honestly clean: one row
@@ -601,3 +616,571 @@ def test_the_aggregate_report_is_the_same_in_every_process():
     # And it is the answer this process gets, so four children agreeing on something wrong would
     # still fail rather than agree quietly.
     assert json.loads(seen.pop()) == [a.as_dict() for a in _reports(EVERY_STATUS_SQL)]
+
+
+# --- S3: what a SELECT can see, and what a CTE reference stands for ---------
+#
+# The two statements S3 names. Both were wrong at HEAD and wrong in opposite directions, which is
+# why one fix could not have been enough on its own.
+#
+# The first names a join only the CTE BODY takes. `oi` groups `order_items` to one row per order,
+# so the outer join is one-to-one and nothing is multiplied — but `order_items` leaked out of the
+# body into the outer scope map and the report claimed a fan over a table the statement never
+# joined to.
+GRAIN_CHANGING_CTE = (
+    "WITH oi AS (SELECT order_id, SUM(quantity) q FROM order_items GROUP BY order_id) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id"
+)
+# The second MISSES the join it does take. `o` hands back the rows of `orders` unchanged and the
+# outer query joins that to `order_items`, which is the plain fan wearing one disguise — but `o`
+# resolved to the string `'o'`, a name the model never declared, so nothing was found at all.
+GRAIN_PRESERVING_CTE = (
+    "WITH o AS (SELECT * FROM orders) SELECT SUM(o.total_amount) FROM o "
+    "JOIN order_items ON order_items.order_id = o.id"
+)
+# The same laundering one hop further out. Two grain-preserving CTEs in a chain are still the same
+# rows, so the resolution has to be transitive or it answers correctly only at depth one.
+TRANSITIVE_CTE = (
+    "WITH a AS (SELECT * FROM order_items), b AS (SELECT * FROM a) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN b ON b.order_id = orders.id"
+)
+# Grouped FINER than the join key: one row per (order, product), joined on the order alone. The
+# CTE is genuinely the many side of its own edge and the fan is real.
+CTE_GRAIN_BELOW_JOIN_KEY = (
+    "WITH oi AS (SELECT order_id, product_id, SUM(quantity) q FROM order_items "
+    "GROUP BY order_id, product_id) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id"
+)
+# `_cte_names` and `_model_table_index` fold case; `_alias_map` preserves it. Every comparison the
+# resolution makes therefore has to be explicit about which side it is on, and this is the shape
+# that catches one that is not.
+CASE_FOLDED_CTE = (
+    "WITH OI AS (SELECT * FROM order_items) "
+    "SELECT SUM(orders.total_amount) FROM orders JOIN OI ON OI.order_id = orders.id"
+)
+
+# The derived-table shape, with its aggregate's column UNQUALIFIED. Two independent mechanisms
+# would each have to fail for this to read clean: without the derived binding the outer scope is
+# the single table `orders`, so `total_amount` resolves by being the only candidate.
+DERIVED_TABLE_UNQUALIFIED = (
+    "SELECT SUM(total_amount) FROM orders "
+    "JOIN (SELECT order_id FROM order_items) d ON d.order_id = orders.id"
+)
+
+# A parenthesized named table. `Subquery(this=Table)` binds no name of its own — the `exp.Table`
+# arm already bound `orders` — so this reads one declared table and must stay clean.
+PARENTHESIZED_TABLE = "SELECT SUM(orders.total_amount) FROM (orders)"
+
+# The two shapes `check_scopable` refuses at the guarded chokepoint and `sm prepare` does not.
+VALUES_SOURCE = (
+    "SELECT SUM(orders.total_amount) FROM orders "
+    "JOIN (VALUES (1), (2)) AS v(order_id) ON v.order_id = orders.id"
+)
+LATERAL_SOURCE = "SELECT SUM(o.total_amount) FROM orders o, LATERAL (SELECT 1) l"
+
+# Every way `_grain_preserving_source` and `_cte_edge` can decline, one row per guard. Each body
+# below differs from a grain-preserving one in exactly one respect, so a guard that stopped firing
+# would show up as one row rather than as a general collapse.
+UNREADABLE_CTE_BODIES = [
+    ("the body is a set operation, not a SELECT",
+     "WITH u AS (SELECT order_id FROM order_items UNION SELECT id FROM orders) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN u ON u.order_id = orders.id"),
+    ("the body is DISTINCT, which collapses rows",
+     "WITH d AS (SELECT DISTINCT order_id FROM order_items) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN d ON d.order_id = orders.id"),
+    ("the body aggregates without grouping",
+     "WITH s AS (SELECT SUM(quantity) AS order_id FROM order_items) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN s ON s.order_id = orders.id"),
+    ("the body takes a join of its own",
+     "WITH j AS (SELECT o.id AS id FROM orders o JOIN order_items i ON i.order_id = o.id) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN j ON j.id = orders.id"),
+    ("the body has no FROM at all",
+     "WITH n AS (SELECT 1 AS order_id) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN n ON n.order_id = orders.id"),
+    ("the body reads more than one table",
+     "WITH t AS (SELECT order_id FROM order_items WHERE order_id IN (SELECT id FROM orders)) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN t ON t.order_id = orders.id"),
+    ("the body reads a table the model does not declare",
+     "WITH x AS (SELECT * FROM shipments) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN x ON x.order_id = orders.id"),
+    ("two CTEs read each other, so the walk would not terminate",
+     "WITH a AS (SELECT * FROM b), b AS (SELECT * FROM a) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN a ON a.order_id = orders.id"),
+    ("the join key is composite",
+     "WITH oi AS (SELECT order_id, product_id, SUM(quantity) q FROM order_items "
+     "GROUP BY order_id) SELECT SUM(orders.total_amount) FROM orders "
+     "JOIN oi ON oi.order_id = orders.id AND oi.product_id = orders.id"),
+    ("there is no join key, because it is a comma join",
+     "WITH oi AS (SELECT order_id, SUM(quantity) q FROM order_items GROUP BY order_id) "
+     "SELECT SUM(orders.total_amount) FROM orders, oi"),
+    ("the join predicate is an inequality, not an equality",
+     "WITH oi AS (SELECT order_id, SUM(quantity) q FROM order_items GROUP BY order_id) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id > orders.id"),
+    ("the far side of the join key is a literal, not a column",
+     "WITH oi AS (SELECT order_id, SUM(quantity) q FROM order_items GROUP BY order_id) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = 1"),
+    ("the far side resolves to nothing in scope",
+     "WITH oi AS (SELECT order_id, SUM(quantity) q FROM order_items GROUP BY order_id) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = zzz.id"),
+    ("the grain is an expression with no column name to compare",
+     "WITH oi AS (SELECT SUM(quantity) q FROM order_items GROUP BY order_id + 1) "
+     "SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.q = orders.id"),
+]
+
+
+def _parse(sql: str):
+    """One parse, so every assertion on the resolver reads the tree the analysis reads."""
+    return parse_one(sql)
+
+
+def _no_grain_org() -> "m.Datasource":
+    """`orders` with `grain: []` — the one thing `_sales_org` cannot express and must not learn.
+
+    Every `_sales_org` table declares a non-empty grain, which is what makes its assertions mean
+    what they say; weakening one of them to reach this branch would silently change what several
+    other tests are testing. So the empty-grain case gets its own two-table model, cut down to the
+    single edge the assertion is about.
+    """
+    tables = [
+        m.Table(name="orders", schema="public", storage_connection="c", grain=[],
+                description="orders",
+                columns=[m.Column(name="id", type="integer"),
+                         m.Column(name="total_amount", type="decimal")]),
+        m.Table(name="order_items", schema="public", storage_connection="c",
+                grain=["order_id", "product_id"], description="order items",
+                columns=[m.Column(name="order_id", type="integer"),
+                         m.Column(name="product_id", type="integer"),
+                         m.Column(name="quantity", type="integer")]),
+    ]
+    rels = [m.Relationship(from_table="order_items", to_table="orders", from_column="order_id",
+                           to_column="id", relationship="many_to_one")]
+    return m.Datasource(datasource="Shop",
+                        subject_areas=[m.SubjectArea(name="sales", tables_defined=tables,
+                                                     relationships=rels)])
+
+
+def _averageable_org() -> "m.Datasource":
+    """One table with one `averageable` column — the smallest model `bad_aggregation` fires on.
+
+    `_sales_org` deliberately leaves every `Column.aggregation` at `unknown` so that the exact
+    risk-list assertions elsewhere stay about the fan/chasm detector. This model exists only to
+    hold `_check_aggregation_semantics` still while the scope map underneath it changes.
+    """
+    t = m.Table(name="facts", schema="public", storage_connection="c", grain=["id"],
+                description="facts",
+                columns=[m.Column(name="id", type="integer", aggregation="dimension"),
+                         m.Column(name="unit_price", type="decimal", aggregation="averageable")])
+    return m.Datasource(datasource="F",
+                        subject_areas=[m.SubjectArea(name="a", description="d",
+                                                     tables_defined=[t])])
+
+
+def test_a_grain_changing_cte_is_not_the_table_it_reads():
+    """A10. The join a CTE BODY takes is not a join the statement takes.
+
+    `oi` groups `order_items` to one row per order. The outer statement joins `orders` to that, one
+    order to one row, and `SUM(orders.total_amount)` is exactly the sum of the orders. Nothing is
+    multiplied and the receipt may say so.
+
+    What it said before was `multiplied`, naming `orders (1) <- order_items (N)` — an edge that
+    appears nowhere in the outer query. `order_items` is read once, inside the CTE body, under a
+    `GROUP BY` that is the whole point of writing the CTE. Reporting it is not an over-cautious
+    answer, it is a false one: it names a join the reader can look for and not find, and it does so
+    on a statement that is correct.
+
+    Both halves are asserted because they fail independently. Abstaining would fix the naming and
+    lose the answer; resolving the CTE without checking its grain would keep the answer and keep
+    naming the wrong edge. `joins` is asserted over EVERY item rather than the first, since the
+    criterion is that no item names `order_items` — a second aggregate would be a second chance to
+    get it wrong.
+    """
+    reports = _reports(GRAIN_CHANGING_CTE)
+    assert [a.status for a in reports] == [rt.NOT_MULTIPLIED], reports
+    assert [j for a in reports for j in a.joins] == [], reports
+    assert not any("order_items" in j for a in reports for j in a.joins), reports
+    assert [f.risk for a in reports for f in a.findings] == [], reports
+
+
+def test_a_grain_preserving_cte_carries_the_join_it_launders():
+    """A11. A CTE that hands back a table's rows unchanged IS that table, for this question.
+
+    `WITH o AS (SELECT * FROM orders)` produces exactly the rows of `orders`, so joining `o` to
+    `order_items` multiplies `SUM(o.total_amount)` precisely as joining `orders` would. The
+    statement is the plain fan with one indirection, and the fan is real.
+
+    It reported `undetermined` before, and that was not a cautious answer either — it was the
+    detector failing to resolve `o` to anything and then having nothing to say. The edge is asserted
+    by name: `order_items` and not `o`, because a reader who is told their number was multiplied
+    and handed back the alias they invented has been told something they already knew.
+    """
+    reports = _reports(GRAIN_PRESERVING_CTE)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], reports
+    assert reports[0].joins == [FAN_EDGE], reports[0].joins
+    assert [f.risk for f in reports[0].findings] == ["fan_trap"], reports[0].findings
+
+
+def test_a_grain_preserving_cte_resolves_through_another_one():
+    """A13. Two grain-preserving hops are still the same rows, so the resolution is transitive.
+
+    `b` reads `a` and `a` reads `order_items`, neither changing a thing. A resolver that stopped at
+    the first hop would find `b` bound to `a`, which is not a declared table either, and fall back
+    to the same `undetermined` the single-hop case used to give — correct-looking on the corpus,
+    which only asks that nothing read clean, and wrong on the one assertion that matters here.
+
+    The cycle guard makes this safe rather than unbounded: `seen` is what stops `a` reading `b`
+    reading `a` from recursing forever, and it is exercised by its own row in the guard table below.
+    """
+    reports = _reports(TRANSITIVE_CTE)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], reports
+    assert reports[0].joins == [FAN_EDGE], reports[0].joins
+
+
+def test_a_cte_grain_that_does_not_cover_the_join_key_still_fans():
+    """A14. Grouped finer than the join key, the CTE is the many side of its own edge.
+
+    `oi` is one row per (order, product) and the join uses `order_id` alone, so an order with three
+    products meets three rows and `SUM(orders.total_amount)` triples. That is a fan, and it is a fan
+    over a source the model never declared — which is exactly why the analysis has to DERIVE the
+    edge rather than abstain. Abstaining would report `undetermined` on a statement whose answer is
+    known and wrong.
+
+    The derived edge is asserted, not just the status. `many_to_one` from the CTE to `orders` is the
+    claim the report rests on, and `infer_cardinality` read it off the two grains — the CTE's
+    `(order_id, product_id)` against the join key `order_id`. A status assertion alone would pass
+    just as well if the fan came from somewhere else entirely.
+
+    The edge names `oi` because that is the only name this source has. It is the one place a join
+    on the receipt names an alias, and it is honest: there is no table to name.
+    """
+    tree = _parse(CTE_GRAIN_BELOW_JOIN_KEY)
+    scope, derived = rt._resolve_cte_scope(
+        tree, rt._alias_map(tree, in_scope_only=True), rt._model_table_index(_sales_org()))
+    assert scope == {"orders": "orders", "oi": "oi"}, scope
+    assert [(r.from_table, r.to_table, r.from_column, r.to_column, r.relationship)
+            for r in derived] == [("oi", "orders", "order_id", "id", "many_to_one")], derived
+
+    reports = _reports(CTE_GRAIN_BELOW_JOIN_KEY)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], reports
+    assert reports[0].joins == ["orders (1) <- oi (N)"], reports[0].joins
+
+
+def test_a_cte_grain_that_covers_the_join_key_is_not_multiplied():
+    """A15. `not_multiplied` BECAUSE the grain covers the join key, not because we declined.
+
+    `oi` is one row per order and the join is on `order_id`, so each order meets exactly one row.
+    The derived edge is `one_to_one`, and that is the assertion: `undetermined` and `not_multiplied`
+    are different answers, and so are two routes to `not_multiplied`. A resolver that bound every
+    grain-changing CTE to nothing would also produce no fan here, and the item would then say
+    `undetermined` — so the status alone cannot tell the working rule from the abstaining one.
+
+    Same SQL as A10, read one layer down. A10 asserts what the receipt says; this asserts why.
+    """
+    tree = _parse(GRAIN_CHANGING_CTE)
+    scope, derived = rt._resolve_cte_scope(
+        tree, rt._alias_map(tree, in_scope_only=True), rt._model_table_index(_sales_org()))
+    assert scope == {"orders": "orders", "oi": "oi"}, scope
+    assert [(r.from_table, r.to_table, r.from_column, r.to_column, r.relationship)
+            for r in derived] == [("oi", "orders", "order_id", "id", "one_to_one")], derived
+
+
+@pytest.mark.parametrize("label,on,expected", [
+    ("the CTE is written on the left", "oi.order_id = orders.id", "one_to_one"),
+    ("the CTE is written on the right", "orders.id = oi.order_id", "one_to_one"),
+])
+def test_the_join_key_is_read_in_either_orientation(label, on, expected):
+    """Which side of the equality the CTE sits on is the author's typing, not a fact about the join.
+
+    `a = b` and `b = a` are the same predicate, and sqlglot keeps the two apart in the tree, so the
+    orientation has to be resolved rather than assumed. Getting it wrong is not a crash: the pair
+    would simply never be found, `_cte_edge` would see no join key, and the statement would report
+    `undetermined` — a receipt that declines to answer half the statements it can answer, on a
+    difference nobody writing SQL considers a difference.
+
+    The derived edge is compared rather than the status, because both orientations of THIS statement
+    happen to end at `not_multiplied` — one by deriving a `one_to_one` and one by abstaining — and
+    only the edge tells those apart.
+    """
+    sql = ("WITH oi AS (SELECT order_id, SUM(quantity) q FROM order_items GROUP BY order_id) "
+           f"SELECT SUM(orders.total_amount) FROM orders JOIN oi ON {on}")
+    tree = _parse(sql)
+    _scope, derived = rt._resolve_cte_scope(
+        tree, rt._alias_map(tree, in_scope_only=True), rt._model_table_index(_sales_org()))
+    assert [(r.from_table, r.to_table, r.from_column, r.to_column, r.relationship)
+            for r in derived] == [("oi", "orders", "order_id", "id", expected)], label
+    assert [a.status for a in _reports(sql)] == [rt.NOT_MULTIPLIED], label
+
+
+@pytest.mark.parametrize("label,sql", UNREADABLE_CTE_BODIES)
+def test_a_cte_body_the_analysis_cannot_read_is_undetermined(label, sql):
+    """A16. Every way the resolution can decline ends in `undetermined`, never in a clean answer.
+
+    Each row differs from a resolvable statement in exactly one respect, and each of those respects
+    is a way the rows behind the aggregate could differ from what the outer query appears to join.
+    A set-operation body sums its arms; `DISTINCT` and an aggregate collapse rows; a join inside the
+    body multiplies where the outer walk does not look; a body reading two tables or none, or a
+    table the model does not declare, resolves to nothing that can be reasoned about; and two CTEs
+    reading each other would not terminate at all.
+
+    The last six are the edge rather than the body: a composite or absent join key is not the single
+    -column cardinality rule's to state, an inequality and a literal are not a key, a far side that
+    resolves to nothing has no grain to compare against, and a grain written as an expression has no
+    column name to compare a join key to.
+
+    They share one assertion because they share one contract. This layer is allowed to say a number
+    was multiplied, or that it was not, or that it could not tell — and every one of these is the
+    third. What none of them may be is absent or clean: `not_multiplied` on any row here would be
+    the receipt asserting a statement is sound on the strength of a body it could not read.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.UNDETERMINED], (label, reports)
+    assert [j for a in reports for j in a.joins] == [], (label, reports)
+
+
+def test_an_undeclared_grain_is_undetermined_rather_than_a_default_cardinality():
+    """A26. An EMPTY declared grain is not a grain, and the guard sits before the inference.
+
+    `infer_cardinality` tests `bool(from_pk)` and `bool(to_pk)`, so a table declared `grain: []` and
+    a table with no grain at all are the same thing to it, and both fall through to its
+    `many_to_one` default. That default is right for a model-authoring tool proposing an edge for
+    review. It is wrong here, where the answer lands on a receipt as a fact: the cardinality would
+    be one nobody declared.
+
+    Measured, and this is why the guard is placed before the call rather than after: with the guard
+    removed this same statement reports `not_multiplied`. The inference makes the CTE the ONE side
+    of a `one_to_many` — its own grain covers the join key, the far side's does not — so no fan
+    fires and the item claims the number is clean. A false clean out of a cardinality nobody
+    declared is the exact failure this spec exists to remove.
+
+    Its own model, because the branch is unreachable on `_sales_org` and weakening a fixture to
+    reach a branch changes what every other test on that fixture is asserting.
+    """
+    pf = rt.pre_flight_check(GRAIN_CHANGING_CTE, _no_grain_org())
+    assert pf.unchecked is None, pf.unchecked
+    assert [(a.aggregate, a.status) for a in pf.aggregates] == [
+        ("SUM(orders.total_amount)", rt.UNDETERMINED)], pf.aggregates
+
+
+def test_a_cte_name_is_resolved_case_insensitively_but_reported_as_written():
+    """The fold hazard, pinned in both directions on one statement.
+
+    `_cte_names` lowercases and `_model_table_index` is keyed folded, while `_alias_map` preserves
+    exactly what the statement wrote. So `WITH OI AS (…) … JOIN OI` has to fold on the way IN — to
+    recognise `OI` as a CTE and to look up its source's grain — and preserve on the way OUT, because
+    the derived edge has to name the source the way the scope map holds it or the detector matches
+    nothing at all.
+
+    A comparison that folded on neither side would leave this reading clean, which is the direction
+    that matters: `OI` is `order_items` under another spelling and the fan is real.
+    """
+    reports = _reports(CASE_FOLDED_CTE)
+    assert [a.status for a in reports] == [rt.MULTIPLIED], reports
+    assert reports[0].joins == [FAN_EDGE], reports[0].joins
+
+
+# --- A12: the map a caller may reason about joins from ----------------------
+
+
+@pytest.mark.parametrize("label,sql,scopes,expected", [
+    ("a reference inside a CTE body is not in the outer scope", CTE_LAUNDERED_FAN,
+     ["cte:oi", "main", "main"], {"orders": "orders", "oi": "oi"}),
+    ("a reference inside a derived table is not in the outer scope", DERIVED_TABLE_FAN,
+     ["main", "subquery"], {"orders": "orders", "d": ""}),
+    ("both arms of a set operation are the main query",
+     "SELECT SUM(orders.total_amount) FROM orders "
+     "UNION SELECT SUM(order_items.quantity) FROM order_items",
+     ["main#1", "main#2"], {"orders": "orders", "order_items": "order_items"}),
+])
+def test_the_scope_filtered_alias_map_keeps_only_references_the_select_can_see(
+    label, sql, scopes, expected,
+):
+    """A12. Asserted on the function, because the filter is a claim about the map and not about a
+    receipt.
+
+    Three shapes, one per thing the filter has to get right. A reference scoped `cte:oi` is written
+    in a body whose rows the outer query only sees through the CTE, so it is not a table the outer
+    FROM/JOIN clauses bind; a reference scoped `subquery` is the same case one construct over; and
+    an arm of a set operation IS the main query, which is why the family is compared after the arm
+    ordinal is stripped rather than before.
+
+    Each case asserts the scopes its references actually carry BEFORE asserting the map, so a case
+    proves what it claims rather than passing because the shape it names never arose. The third one
+    needs it most: `main#1` and `main#2` are two different scope STRINGS, equal to `"main"` only
+    once the ordinal is split off the right, and a filter written as a bare `scope == "main"` would
+    drop both arms and leave an empty map — which no assertion on the map alone tells apart from a
+    filter that is simply too keen.
+    """
+    tree = _parse(sql)
+    assert sorted(r.scope for r in rt._table_references(tree)) == sorted(scopes), label
+    assert rt._alias_map(tree, in_scope_only=True) == expected, label
+
+
+def test_the_arm_ordinal_is_split_off_the_right_and_a_cte_name_can_carry_no_hash():
+    """`_scope_family` splits from the RIGHT, and both halves of that choice are pinned.
+
+    The ordinal `_arm_suffixes` appends is ours and always last, while everything to its left can
+    hold a CTE name, which is caller-written text. Splitting from the left would read `cte:a#b` as
+    the family `cte:a` — a scope that is not the main query either way, so nothing observable moves
+    today, but the rule would be about the wrong thing.
+
+    That no CTE name can actually carry a `#` is a fact about `_echo_name` and not about this
+    function, so it is measured rather than assumed: the label a reference carries is echoed, and
+    `#` is not a character that survives echoing. The right-side split is simply the form that stays
+    correct without depending on it.
+    """
+    assert rt._scope_family("main") == "main"
+    assert rt._scope_family("main#2") == "main"
+    assert rt._scope_family("cte:recent#1") == "cte:recent"
+    assert rt._scope_family("subquery") == "subquery"
+    assert rt._echo_name("a#b") == "a?b"
+
+    tree = _parse("SELECT SUM(orders.total_amount) FROM orders "
+                  "UNION SELECT SUM(order_items.quantity) FROM order_items")
+    assert sorted(r.scope for r in rt._table_references(tree)) == ["main#1", "main#2"]
+
+
+@pytest.mark.parametrize("label,sql,expected", [
+    ("an aliased derived table in a JOIN", DERIVED_TABLE_FAN,
+     {"orders": "orders", "order_items": "order_items"}),
+    ("an unaliased VALUES list in a comma join", UNALIASED_VALUES_FAN, {"orders": "orders"}),
+])
+def test_the_default_alias_map_is_unchanged_by_the_derived_binding(label, sql, expected):
+    """A12b. The default path is bit-identical, on the shapes that could have moved.
+
+    `tests/test_ace099_resolver_parity.py` pins the default against the helper it replaced, and it
+    stays unedited — but it covers CTE and subquery shapes, none of which bind a FROM/JOIN derived
+    source. Those are precisely the shapes the new walk added a node type for, so they are precisely
+    the ones where a default that quietly picked up the binding would go unnoticed.
+
+    Three callers read this map on the default and two of them would change what they DISCLOSE if
+    the filter or the binding reached them: `_projected_sensitive` refuses, and `assemble_receipt`
+    builds the receipt's `joins` and `tables` sections. So the assertion is equality with the exact
+    map, plus the absence of the two keys the binding would have added.
+    """
+    tree = _parse(sql)
+    assert rt._alias_map(tree) == expected, label
+    assert "" not in rt._alias_map(tree), label
+    assert "d" not in rt._alias_map(tree), label
+
+
+# --- the false clean the filter itself creates ------------------------------
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("the aggregate's column is qualified", DERIVED_TABLE_FAN),
+    ("the aggregate's column is unqualified", DERIVED_TABLE_UNQUALIFIED),
+])
+def test_an_alias_bound_to_nothing_is_undetermined_rather_than_clean(label, sql):
+    """The proof that the derived binding had to ship in the same commit as the scope filter.
+
+    `d` is an `exp.Subquery`, so it never entered the alias map at all, and `order_items` reached
+    the outer map only by leaking out of `d`'s body — which is the single reason this shape reported
+    `multiplied` before. Land the filter alone and the leak stops, the outer scope is the one table
+    `orders`, `SUM(orders.total_amount)` resolves perfectly, and a statement whose rows a join
+    genuinely multiplied reports `not_multiplied`. That is the receipt asserting something false,
+    and no test on `main` would have failed.
+
+    The second row is the same shape with the column unqualified, and it needs both halves to fail
+    before it reads clean: with `d` bound, the scope holds two entries and `_resolve_col_table`
+    declines to attribute an unqualified column at all; with `d` absent, `orders` is the only
+    candidate and the column resolves cleanly to it. Either mechanism alone would have caught this
+    one, so it is the row that says the two are not the same mechanism.
+    """
+    reports = _reports(sql)
+    assert [a.status for a in reports] == [rt.UNDETERMINED], (label, reports)
+    assert [j for a in reports for j in a.joins] == [], (label, reports)
+
+
+def test_a_parenthesized_table_is_the_table_and_not_a_source_of_its_own():
+    """`FROM (orders)` binds no name, so the scope-completeness rule must not fire on it.
+
+    sqlglot parses it to `Subquery(this=Table)` with an empty alias — structurally the same node
+    kind as a derived table, and semantically just a bracket around a table name the `exp.Table`
+    arm has already bound. Binding it too would put an empty key in the map, and by the
+    scope-completeness conjunct that one entry turns EVERY aggregate in the SELECT `undetermined`.
+
+    Measured both ways while the guard was being placed: without the discriminator this statement
+    reports `undetermined`, with it `not_multiplied`. The distinction is `.this` being an
+    `exp.Table` and nothing else — an unaliased `VALUES`, `LATERAL` or derived `SELECT` in the same
+    position introduces rows nothing can name and MUST bind, which is the corpus member above.
+    """
+    reports = _reports(PARENTHESIZED_TABLE)
+    assert [(a.aggregate, a.status) for a in reports] == [
+        ("SUM(orders.total_amount)", rt.NOT_MULTIPLIED)], reports
+    assert rt._alias_map(_parse(PARENTHESIZED_TABLE), in_scope_only=True) == {"orders": "orders"}
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("a VALUES list", VALUES_SOURCE),
+    ("a LATERAL", LATERAL_SOURCE),
+])
+def test_a_source_the_guarded_path_refuses_is_still_answered_honestly_on_the_prepare_surface(
+    label, sql,
+):
+    """Why the `exp.Lateral` and `exp.Values` binding arms are not dead code.
+
+    `check_scopable` (ACE-037) refuses both of these source kinds at the `execute_guarded`
+    chokepoint, so no query that RUNS ever reaches the multiplication analysis carrying one. That is
+    asserted here rather than assumed, because it is the premise of the whole question.
+
+    But `cmd_preflight` and `cmd_prepare` in `semantic_model/cli.py` call `pre_flight_check`
+    directly, with no gate battery at all — `cmd_prepare`'s own docstring says it is not a gate and
+    never was — and the query skill runs `sm prepare` on every tier. On that surface both of these
+    reported `not_multiplied` over a source that can produce many rows per order. A reader of a
+    prepare receipt has no way to know a gate they never invoked would have refused the statement;
+    what they have is the sentence in front of them, and it said the number was sound.
+
+    So the analysis answers honestly on both surfaces, and the two arms exist for the one that has
+    no gate in front of it. `pre_flight_check` is called directly here for the same reason: driving
+    this through `execute_guarded` would measure the refusal and never reach the claim.
+    """
+    assert rt.check_scopable(sql, _sales_org()) is not None, label
+    pf = rt.pre_flight_check(sql, _sales_org())
+    assert pf.unchecked is None, (label, pf.unchecked)
+    assert [a.status for a in pf.aggregates] == [rt.UNDETERMINED], (label, pf.aggregates)
+
+
+# --- what the narrowed scope map costs the semantic checks ------------------
+
+
+@pytest.mark.parametrize("label,sql", [
+    ("qualified", "SELECT SUM(facts.unit_price) FROM facts"),
+    ("unqualified, one table in scope", "SELECT SUM(unit_price) FROM facts"),
+])
+def test_an_aggregation_class_violation_still_fires_on_the_statement_that_makes_it(label, sql):
+    """`_check_aggregation_semantics` reads the same narrowed map, so its floor is pinned here.
+
+    It resolves the summed column's table through the scope map `_preflight_select` hands it, and
+    that map now holds only what this SELECT's own FROM/JOIN clauses bind. Two `bad_aggregation`
+    findings were measured to stop firing as a result, and both fired only by reading a table out of
+    a scope the outer statement cannot see: `SUM(unit_price) FROM (SELECT unit_price FROM facts) f`
+    and its CTE equivalent. That is ACE-099's rule applied consistently — a column in a CTE body is
+    not a reference of the outer statement — and it is recorded as a contract change rather than
+    hidden, since one of the two traded a lost finding for a killed false clean.
+
+    What may not narrow is the case the check exists for: a statement that sums an `averageable`
+    column off a table it plainly reads. Both spellings are pinned, because they take different
+    paths through the resolver — the qualified one through the map, the unqualified one through the
+    single-in-scope-table fallback — and the fallback reads the map's VALUES, which is the half the
+    filter changed.
+    """
+    pf = rt.pre_flight_check(sql, _averageable_org())
+    assert [f.risk for f in pf.findings] == ["bad_aggregation"], (label, pf.findings)
+    assert "unit_price" in pf.findings[0].reason, (label, pf.findings[0].reason)
+
+
+def test_the_chasm_still_reports_both_of_the_aggregates_it_inflates():
+    """The chasm reads `table_set` off the same map the filter narrowed, so it is re-pinned here.
+
+    `tests/test_semantic_model_runtime.py::test_chasm_trap_is_reported` is the gate and stays
+    unedited; this asserts the same property from the file that changed the map, so a narrowing that
+    cost the chasm one of its two items fails beside the change that caused it rather than in
+    another file. Both aggregates are inflated by the cross-product and both must say so — a chasm
+    reported on one of the two numbers it ruins is a receipt that reads as half a fact.
+    """
+    sql = ("SELECT c.id, SUM(o.revenue), COUNT(t.id) FROM customers c "
+           "LEFT JOIN orders o ON o.customer_id = c.id "
+           "LEFT JOIN tickets t ON t.customer_id = c.id GROUP BY c.id")
+    reports = _reports(sql)
+    assert [(a.aggregate, a.status) for a in reports] == [
+        ("SUM(o.revenue)", rt.MULTIPLIED), ("COUNT(t.id)", rt.MULTIPLIED)], reports
+    assert [f.risk for a in reports for f in a.findings] == ["chasm_trap", "chasm_trap"], reports

--- a/tests/test_semantic_model_runtime.py
+++ b/tests/test_semantic_model_runtime.py
@@ -18,6 +18,47 @@ from semantic_model import runtime as rt  # noqa: E402
 
 
 def _sales_org():
+    """Four tables, three many-to-one edges, and a declared grain for every table.
+
+    `tables_defined` used to be absent, which made `_model_table_index(org)` empty. ACE-060 derives
+    its `visible` set from that index, so no aggregate on this org could ever be seen behind, and
+    `not_multiplied` — the positive claim that a number is clean — was unreachable here for every
+    statement. The tests below already assert things like "aggregating the many side is allowed",
+    a claim the fixture could not express. Declaring the tables is what lets them say it.
+
+    Two things are deliberately NOT declared. Every `Column.aggregation` stays at its default
+    `unknown` and no `metrics` are declared, which is what keeps `_check_aggregation_semantics`
+    silent: a declared `averageable` or a semi-additive metric would add `bad_aggregation` /
+    `semi_additive` findings to the exact risk lists the tests below assert, and those lists are
+    about the fan/chasm detector, not about aggregation class.
+
+    Extended in place rather than beside: a second sales org is drift, and every assertion here is
+    written against this one set of names and edges.
+    """
+    tables = [
+        m.Table(name="orders", schema="public", storage_connection="c", grain=["id"],
+                description="orders",
+                columns=[m.Column(name="id", type="integer"),
+                         m.Column(name="customer_id", type="integer"),
+                         m.Column(name="total_amount", type="decimal"),
+                         m.Column(name="revenue", type="decimal"),
+                         m.Column(name="status", type="string"),
+                         m.Column(name="created_at", type="timestamp"),
+                         m.Column(name="flag", type="boolean")]),
+        m.Table(name="order_items", schema="public", storage_connection="c",
+                grain=["order_id", "product_id"], description="order items",
+                columns=[m.Column(name="id", type="integer"),
+                         m.Column(name="order_id", type="integer"),
+                         m.Column(name="product_id", type="integer"),
+                         m.Column(name="quantity", type="integer")]),
+        m.Table(name="customers", schema="public", storage_connection="c", grain=["id"],
+                description="customers",
+                columns=[m.Column(name="id", type="integer")]),
+        m.Table(name="tickets", schema="public", storage_connection="c", grain=["id"],
+                description="support tickets",
+                columns=[m.Column(name="id", type="integer"),
+                         m.Column(name="customer_id", type="integer")]),
+    ]
     rels = [
         m.Relationship(from_table="order_items", to_table="orders", from_column="order_id",
                        to_column="id", relationship="many_to_one"),
@@ -27,7 +68,8 @@ def _sales_org():
                        to_column="id", relationship="many_to_one"),
     ]
     return m.Datasource(datasource="Shop",
-                          subject_areas=[m.SubjectArea(name="sales", relationships=rels)])
+                          subject_areas=[m.SubjectArea(name="sales", tables_defined=tables,
+                                                       relationships=rels)])
 
 
 # --- pre-flight ---
@@ -123,12 +165,20 @@ def test_clean_set_operation_passes_preflight():
 
 
 def test_aggregating_many_side_is_allowed():
-    # aggregating the MANY side (order_items) is legitimate, not a fan trap
+    """Aggregating the MANY side (order_items) is legitimate, not a fan trap.
+
+    The status is asserted alongside the empty finding list because an empty list is also what a
+    statement the analysis could not read returns, so on its own it cannot tell "nothing is wrong"
+    apart from "nothing was established". `not_multiplied` is the positive claim, and it is the one
+    this test's name has always made.
+    """
     org = _sales_org()
     pf = rt.pre_flight_check(
         "SELECT SUM(order_items.quantity) FROM orders JOIN order_items ON order_items.order_id=orders.id",
         org)
     assert pf.findings == []
+    assert [(a.aggregate, a.status) for a in pf.aggregates] == [
+        ("SUM(order_items.quantity)", rt.NOT_MULTIPLIED)]
 
 
 # --- examples-first ---

--- a/tests/test_semantic_model_runtime.py
+++ b/tests/test_semantic_model_runtime.py
@@ -125,10 +125,23 @@ def test_fan_trap_mixed_raw_and_aggregate_is_reported():
 
 
 def test_explicit_cross_product_is_not_a_trap():
+    """A cross-product with nothing aggregated over it multiplies no number, so there is nothing
+    to report — both traps are statements about the rows an aggregate is computed from.
+
+    `unchecked` is asserted beside the empty finding list for the reason
+    `test_aggregating_many_side_is_allowed` states: an empty list is also what a statement that did
+    not parse returns, so on its own it cannot tell "nothing is wrong" from "nothing was
+    established". This statement is a comma join with a `SELECT *` and no GROUP BY, which is exactly
+    the shape a parser or a scope gate is most likely to give up on quietly.
+
+    The empty aggregate roster is the other half, and it is the premise rather than a bonus: the
+    finding list is empty BECAUSE there is no aggregate, not because a fan was cleared."""
     org = _sales_org()
     pf = rt.pre_flight_check(
         "SELECT * FROM orders, tickets WHERE orders.customer_id = tickets.customer_id", org)
+    assert pf.unchecked is None, pf.unchecked
     assert pf.findings == []
+    assert pf.aggregates == []
 
 
 def test_fan_trap_in_a_set_operation_arm_is_reported():
@@ -157,11 +170,21 @@ def test_every_trapped_arm_is_reported():
 
 
 def test_clean_set_operation_passes_preflight():
-    """A set operation with no trapped arm reports nothing — arm-walking must not over-report."""
+    """A set operation with no trapped arm reports nothing — arm-walking must not over-report.
+
+    A set operation parses to `exp.SetOperation` rather than to `exp.Select`, so a walk that gave up
+    on it would report nothing too, and this test's whole subject is the walk. `unchecked` is what
+    separates the two readings: null says the analysis ran over both arms and found nothing, where
+    the empty finding list on its own says only that nothing came back.
+
+    Neither arm aggregates, so the roster is empty as well, and that is the reason the finding list
+    is: no aggregate means no fan and no chasm before either arm's tables are considered."""
     org = _sales_org()
     pf = rt.pre_flight_check(
         "SELECT id FROM orders UNION SELECT id FROM customers", org)
+    assert pf.unchecked is None, pf.unchecked
     assert pf.findings == []
+    assert pf.aggregates == []
 
 
 def test_aggregating_many_side_is_allowed():


### PR DESCRIPTION
Principle 6c says the receipt states, for each aggregate, whether a join multiplied the rows its
value was computed from and **which join did it**. ACE-094 made that a fact rather than a refusal and
ACE-060 keyed it per aggregate. Neither changed what the analysis computes, and on `main` it gets 6c
wrong three ways. Every one is a **false receipt statement**, not a false refusal: the answer comes
back, and the sentence beside it is untrue.

**S1.** `MIN`, `MAX`, every `DISTINCT`-qualified aggregate and the boolean folds report
`risk="fan_trap"`. `runtime.py` confessed it in a comment: *"MIN, MAX and COUNT(DISTINCT) are counted
as fan-out risks although a fan-out cannot change what they return."* The rows behind that `MAX`
really **are** multiplied, so 6c's fact is true and suppressing it would make ACE-060's item claim
`not_multiplied`, falsely. What is wrong is the word *trap*, not the finding. Invariance is a second
derivable property of the aggregate node, not grounds to drop the first.

**S2.** `SUM(order_items.quantity * orders.total_amount)` reports a fan trap, because the site walk
added every table whose column appeared **anywhere** inside the aggregate. Here the value is one row
per `order_items` row and the one-side column is a scalar co-factor. Attribution has to follow the
value path, not syntactic presence.

**S3.** ACE-099 built the scope notion this needs, and `_alias_map` discarded it: it kept every
reference whatever its scope. So the analysis named a join only a CTE body takes, and missed one the
statement does take.

```
WITH oi AS (SELECT order_id, SUM(quantity) q FROM order_items GROUP BY order_id)
SELECT SUM(orders.total_amount) FROM orders JOIN oi ON oi.order_id = orders.id
  -> fan_trap naming `order_items`, a join only the CTE body takes
```

`oi` is grouped to `order_id` and joins 1:1. Nothing fans, so 6c's *"which join does it"* has no true
answer here.

## What this does

`fan_out_invariant` joins `_MULTIPLYING_RISKS`, so a duplication-invariant aggregate keeps
`status: multiplied` and nothing is labelled a trap. `AggregateReport` gains no field and
`as_dict()`'s key set is byte-identical to base, so the item shape stays ACE-060's. Attribution
follows the value path. `_alias_map` gains an **opt-in** scope filter, and a CTE reference is resolved
to what it actually stands for: a grain-preserving body binds to its source table, a grain-changing
one becomes its own entity at its `GROUP BY` grain and is compared to the join key through
`build.infer_cardinality`, and anything else is `undetermined`.

The filter is opt-in for a reason. `_alias_map` also feeds `_projected_sensitive`, a gate that
**refuses**, and `assemble_receipt`'s scope, which drives the receipt's own `joins` and `tables`.
Narrowing what a refusing gate can see is a security change this slice has no business making, so
only the fan/chasm path passes the flag and `tests/test_ace099_resolver_parity.py` stays green
unedited.

## The scope filter creates a false clean, so the binding ships in the same commit

Once `cte:*` and `subquery` references are dropped, this reads clean:

```sql
SELECT SUM(orders.total_amount) FROM orders
  JOIN (SELECT order_id FROM order_items) d ON d.order_id = orders.id
```

`d` is an `exp.Subquery` and never entered `_alias_map` at all. Today `order_items` leaks into the
outer map from *inside* the subquery, which is the only reason that shape currently reports
`multiplied`. Filter the leak and the outer scope is one table, the aggregate resolves cleanly, and a
genuinely inflated statement says `not_multiplied`. So `_reference_sites` binds FROM/JOIN-bound
non-table sources in the one existing walk, and an alias that resolves to nothing forces
`undetermined`.

## The lesson this PR is really about

Two review rounds found the same defect eight times, and every instance was one shape: **a denylist
with an unsafe default.**

The value-path walk enumerated alternation node types and let everything else union all its children.
The grain-preserving check rejected three `exp.Select` args and accepted the rest. Both defaults put
an unanticipated shape on the side that **clears a real fan**. Round one extended the enumerations;
round two found `GREATEST`, `LEAST`, `NVL2` and `DECODE` sitting just past them, with `NVL2` being
`exp.If` under another name, and `LATERAL VIEW`, `UNPIVOT` and `CONNECT BY` on the CTE side, all of
which change a row count. Every one was a regression against base: base said `multiplied`, the
half-fixed branch said `not_multiplied`.

Extending a list is not a fix when the list is the only thing holding the polarity. So both walks now
enumerate what they understand and **contribute nothing otherwise**: three node sets (alternation,
which intersects its arms, because an alternation is at a table's grain only if *every* alternative
is; structural; combining, which unions its operands), and an argument allowlist for a
grain-preserving body. The combining set was derived by instrumenting the old code and recording what
actually reached the generic branch across the suite, not from imagination. `exp.Mul` is load-bearing
in it: without it S2 stops reaching `not_multiplied`.

One measured correction to the strictest form: `ORDER BY` stays in the grain-preserving allowlist.
Excluding it loses a real finding rather than failing closed, and ordering provably cannot change a
row count.

## Availability, on caller-controlled SQL

Two holes, both found by review, both closed.

`_cte_names(tree.root())` walked the whole tree as the unconditional left operand of `&`, while
`_preflight_select` runs once per set-operation arm: O(K²). Measured at 471 arms and 49,915 characters
(just under the 50,000 cap), 0.081s became 2.021s, that one call being 93% of it. A statement with
**no CTE anywhere** regressed 37x, which made the in-code justification measurably false. Replaced by
a lexical-ancestor walk, which removes the per-arm whole-tree pass outright.

Both `_grain_preserving_source` and `_value_sources` could be driven to `RecursionError` by input
under the character cap: a 990-link CTE chain at 29,573 characters, and a wide expression at 6,496.
`execute_sql.py::_receipt_for` catches that under bare `except Exception` and returns
`RECEIPT_BUILD_FAILED`, so **the statement still executes and returns rows while the caller silently
loses the receipt**. Caller-chosen input that turns off the trust layer without turning off the
answer. The CTE side takes a depth bound; the expression walk is now iterative, following the
precedent `_and_conjuncts` already set in this file. A 12,476-term expression at exactly 50,000
characters now answers, and the test asserts that length so the premise cannot drift.

## Blast radius, stated plainly

**A shared test fixture gained declared tables.** `_sales_org` declared only `relationships`, so
`_model_table_index(org)` was empty, ACE-060's `visible` set was empty, and **no aggregate could ever
report `not_multiplied` on it**. It now declares `tables_defined` with columns and grains. Every
`Column.aggregation` stays at the default `unknown` and no metrics are declared, which is what keeps
`_check_aggregation_semantics` silent so the exact risk-list assertions do not move. Measured over all
8 consumers: 7 byte-identical, and `test_aggregating_many_side_is_allowed` moves `SUM(order_items.quantity)`
from `undetermined` to `not_multiplied`, which is the fixture becoming able to express the claim the
test's name already makes. Its assertion is strengthened to pin the status rather than rest on an
empty finding list.

**One marker clause dies, and two tests with it.** The fan-immune sentence is what S1 exists to
retire. The other four clauses stand, including the unreached-scope one, because nothing here makes an
aggregate inside a CTE reported. The two parametrize rows in
`test_each_residual_clause_is_conditional_on_the_statement` that asserted the deleted clause cannot
pass once it is gone. Both are recorded in the spec's `## Decisions`.

**Three `bad_aggregation` outcomes move**, net minus one plus two, because
`_check_aggregation_semantics` reads the one alias map this change re-scopes. Measured over a 20-shape
differential; both directions are pinned.

**Two shapes newly report `not_multiplied` and both answers are correct**: a semi-join
(`WHERE id IN (SELECT ...)`) and a scalar subquery in the SELECT list. Base was reading the subquery's
tables out of its scope. That is the S3 fix generalizing.

## Verification

3369 collected on base, 3568 now (3559 passed, 9 skipped). `dev.py check` green, `dev.py cover`
reports 100% on the changed lines.

The **reverse non-regression corpus landed first**, before any loosening, and earned it: it caught a
false clean the moment the scope filter went in without the grain resolution, before anything was
committed. It is 29 members carrying `(label, sql, inflated_aggregate_labels)` and asserts
`status != not_multiplied` over the **named** items, so a statement may hold an honestly clean
aggregate beside an inflated one. A label selecting nothing fails its own existence assertion, so a
typo cannot make a row vacuous.

The determinism test was **provably vacuous** and is not any more: deleting all three `sorted()` calls
used to leave the whole suite green. Its statement had one fanning source and one many-side table, so
no multi-element set was ever iterated. It now runs four statements, and each of the three `sorted()`
calls is caught by exactly one of them, verified by mutation.

`runtime.py` is not in `dev.py::_VENDORED` and neither `guardrail.py` nor `execute_sql.py` is touched,
so `sync-lib` is a no-op here.

## Two notes on the gate itself

`dev.py check` runs no type checker and no coverage. Coverage is enforced only in CI at
`--cov-fail-under=85`, and `dev.py cover` runs `diff-cover` against `origin/main` with no
`--fail-under`, so it effectively demands the changed lines be covered. `check` going green is not
sufficient before review.

## Known limitations, all measured and none introduced here

- A CTE that **shadows** a declared table name still over-reports: the derived `one_to_one` edge is
  appended, but the model's own `many_to_one` edge is still in the list and wins.
- `_one_side_facing_many` and `_many_side_facing_one` compare table names case-sensitively while
  `check_table_scope` folds, so an uppercase-spelled statement gets a clean receipt over a real fan.
  Same false-clean class, two functions from the case-folding fix this branch does land, and Snowflake
  and Oracle return uppercase identifiers.
- `_shared_dimension` iterates a set, so a tie between two candidate dimensions can resolve differently
  between runs. This change narrows the window but does not close it.

All three are identical on base and all three are filed as follow-ups.

## Reviewed and declined

Review argued the value-path suppression should still emit a finding naming the edge, since the rows
really were multiplied and only the value sat at the finer grain. Declined: S2 pins `joins == []` on
that shape, and a `not_multiplied` item carrying a join contradicts the item vocabulary ACE-060 owns.
The observation is fair and belongs in a spec conversation, not this diff.

Spec: ACE-083
