### PR TITLE
fix(agami-connect): run catalog and dictionary reads under a raised row cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,20 @@ below corresponds to one such version.
 
 ### Fixed
 
+- **Catalog and dictionary reads no longer hit the row cap that exists to bound your queries.** The
+  executor refuses (never truncates) any result over `AGAMI_SQL_MAX_ROWS`, default 1000. That bound
+  is sized for a question someone asks; a *catalog* read exceeds it on schema size alone. The visible
+  symptom was `sm enrich-metadata` dying on any platform whose data dictionary is a real table
+  (`RuntimeError: … "rule": "resource_limit"`), but the quieter cases were worse: the bulk
+  `information_schema.columns` read behind `sm discover`, and the table/foreign-key reads behind
+  `sm introspect`, are wrapped in a swallow — so on a wide catalog they degraded to one round-trip
+  per table, or produced a model with no join graph, with nothing said about either.
+
+  The connect skill now runs those three commands with a raised cap and **tells you it did, along
+  with your unchanged query-time cap**. Nothing about the bound on an ordinary question changes: a
+  query returning more than the cap is still refused rather than quietly truncated, and no new lever
+  is reachable from a generated query.
+
 - **The guard now reads your SQL in your database's own grammar, and refuses what it cannot read
   (ACE-079).** Every model-scoping check decided by parsing the statement, and every one of them
   parsed in a generic SQL dialect rather than your engine's. On MySQL, BigQuery, Databricks and SQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,9 @@ below corresponds to one such version.
   symptom was `sm enrich-metadata` dying on any platform whose data dictionary is a real table
   (`RuntimeError: … "rule": "resource_limit"`), but the quieter cases were worse: the bulk
   `information_schema.columns` read behind `sm discover`, and the table/foreign-key reads behind
-  `sm introspect`, are wrapped in a swallow — so on a wide catalog they degraded to one round-trip
-  per table, or produced a model with no join graph, with nothing said about either.
+  `sm introspect`, discard a refused read instead of reporting it — so on a wide catalog they
+  degraded to one round-trip per table, or produced a model with no join graph, and said nothing
+  about either.
 
   The connect skill now runs those three commands with a raised cap and **tells you it did, along
   with your unchanged query-time cap**. Nothing about the bound on an ordinary question changes: a

--- a/plugins/agami/skills/agami-connect/SKILL.md
+++ b/plugins/agami/skills/agami-connect/SKILL.md
@@ -539,12 +539,18 @@ Stash everything gathered (doc text + repo definitions) as `$DATA_MODEL_DOC_TEXT
 
 ```bash
 ts=$(date -u +%Y%m%d-%H%M%S)
-bash "$AGAMI_PLUGIN_ROOT/scripts/sm" discover \
+AGAMI_SQL_MAX_ROWS=200000 bash "$AGAMI_PLUGIN_ROOT/scripts/sm" discover \
   --profile <profile> --db-type <db_type> \
   --artifacts "<artifacts_dir>" \
   --out "<artifacts_dir>/local/prune/<profile>/$ts.html" \
   [--schemas <selected_schemas…>]   # the 1.3 pick, if you narrowed schemas
 ```
+
+> **<a id="raised-cap"></a>Why the `AGAMI_SQL_MAX_ROWS` prefix — and why it must stay a prefix.** The executor **refuses** (never truncates) any result over the row cap, default 1000. That bound is sized for a *user query*, where a runaway is the thing it exists to stop. A **catalog read** blows past it on schema size alone — `information_schema.columns` for a 500-table catalog is tens of thousands of rows — and the engine **swallows that refusal silently**, degrading to one round-trip per table, or reporting "catalog enumeration denied" when the catalog was in fact readable. So the three commands that read catalog or dictionary tables — `discover` (1.6), `introspect` (1.7), `enrich-metadata` (2a.0) — run with a raised cap.
+>
+> - **Inline on the command, never `export`.** An exported value is still set when Phase 6 runs the demo *user* query, quietly raising the bound for exactly the caller it exists to hold. The inline form dies with the process.
+> - **Never on `seed-examples` (Phase 5).** That command validates SQL which later runs as a real user query; validating under a raised cap green-lights examples that get refused in production.
+> - **Tell the user you did it**, once, with the real numbers the commands print — and say their query-time cap is unchanged. See 2a.0 for the wording.
 
 It writes the inventory to `<artifacts_dir>/<profile>/.introspect/inventory.json`, renders a standalone **prune page**, and prints JSON with `table_count` + `prune_html`. (This page is a deliberately minimal, separate artifact — *not* the model explorer — so there's no description/metric/review machinery, just tables + columns + checkboxes.)
 
@@ -568,12 +574,14 @@ This is the deterministic core — it replaces hand-authoring tables/columns/FK 
 ```bash
 # write the kept allowlist to a file first (zsh-safe — no word-splitting to get wrong)
 printf '%s\n' incident problem change_request sys_user ... > /tmp/agami-keep.txt
-bash "$AGAMI_PLUGIN_ROOT/scripts/sm" introspect \
+AGAMI_SQL_MAX_ROWS=200000 bash "$AGAMI_PLUGIN_ROOT/scripts/sm" introspect \
   --profile <profile> --db-type <db_type> \
   --artifacts "<artifacts_dir>" \
   [--tables-file /tmp/agami-keep.txt] \
   [--exclude-columns <schema.table.column list from 1.6>]
 ```
+
+(The raised cap is the same one 1.6 explains — [why](#raised-cap). Without it a large schema's `sql_tables` / foreign-key reads are refused, the engine swallows it, and you get a model with no join graph and no error to show for it.)
 
 `--tables-file` is the prune step's **kept set** (it also covers the no-catalog/probe-only case from 1.2). `--exclude-columns` marks the dropped columns excluded during the build — one validated write, no follow-up curate call. Omit both only when the user kept everything or skipped pruning. (If a table name is bogus / can't be described, the engine now drops it with a note and — if *nothing* describes — errors clearly instead of writing a partial model.)
 
@@ -583,7 +591,8 @@ bash "$AGAMI_PLUGIN_ROOT/scripts/sm" introspect \
    ```bash
    split -l 12 /tmp/agami-keep.txt /tmp/agami-batch-      # batch files
    for b in /tmp/agami-batch-*; do
-     bash "$AGAMI_PLUGIN_ROOT/scripts/sm" introspect --profile <p> --db-type <t> \
+     AGAMI_SQL_MAX_ROWS=200000 bash "$AGAMI_PLUGIN_ROOT/scripts/sm" introspect \
+       --profile <p> --db-type <t> \
        --artifacts "<artifacts_dir>" --tables-file "$b" --append
    done
    ```
@@ -613,10 +622,19 @@ The engine gives structure; you add meaning. Load the model with `cli bundle <ro
 **Many databases describe themselves.** Metadata-driven platforms ship their own data dictionary + value-label tables (ServiceNow `sys_dictionary` + `sys_choice`, SAP `DD03L`, Salesforce metadata…), and plenty of ordinary schemas have code→label lookup/dimension tables. When that metadata is present it is **authoritative** — strictly better than LLM guessing or fetching JS-walled vendor docs. Always try it first:
 
 ```bash
-bash "$AGAMI_PLUGIN_ROOT/scripts/sm" enrich-metadata "$ROOT" --profile <profile> --db-type <db_type>
+AGAMI_SQL_MAX_ROWS=200000 bash "$AGAMI_PLUGIN_ROOT/scripts/sm" enrich-metadata "$ROOT" \
+  --profile <profile> --db-type <db_type>
 ```
 
 It auto-detects a preset (e.g. `servicenow`) or takes `--preset`, reads the dictionary/lookup tables, and applies — in validated curate batches — **column descriptions** (stamped `description_source: metadata`, authoritative), **`choice_field` labels**, and **reference/FK relationships** (the `caller_id → sys_user` edges that `<x>_id` name-matching can't find). On ServiceNow this alone closes most of the column-coverage, enum-decode, and join-graph gaps deterministically. It prints what it enriched. **Then** hand-enrich only what it didn't cover (2a–2c below). `--skip-references` if you want descriptions/choices only.
+
+**The raised cap is not optional here — [why](#raised-cap).** A real `sys_dictionary` is tens of thousands of rows, so without the prefix this command doesn't degrade, it **dies**: the read is refused and the runner re-raises the refusal as `RuntimeError: {"refusal": … "rule": "resource_limit" …}`. Nothing is half-applied when that happens (the fetch is above the first `curate` write), so re-running with the prefix is clean. Two things when you run it: **never pipe it through `tail`** — that masks the exit code and a hard failure reads as success; and if the command still refuses even at 200,000, read the `fetched` counts, raise the prefix to clear the largest source table, and say so.
+
+**Then tell the user, once, using the numbers it printed** (`fetched` is a per-role row count, on both the success and the nothing-applicable paths):
+
+> *Read `<dictionary_rows>` dictionary rows and `<choice_rows>` choice rows. Catalog and dictionary reads run with a temporarily raised row cap (200,000) — a data dictionary is far larger than the 1,000-row default. **Your query-time cap is unchanged:** a normal question that would return more than 1,000 rows is still refused rather than quietly truncated.*
+
+The second sentence is the load-bearing one. Without it a user reasonably concludes their safety bound was weakened.
 
 ### 2a — Descriptions (describe coded columns; leave only self-evident ones empty)
 


### PR DESCRIPTION
Closes #207.

## The problem

The executor **refuses** (never truncates) any result over `AGAMI_SQL_MAX_ROWS`, default
1000. That bound is sized for a generated query, where "narrow the statement" is a fix the
caller can actually take. A **catalog read** exceeds it on schema size alone, and there is
no statement to narrow.

The visible symptom was `sm enrich-metadata` dying on any platform whose data dictionary is
a real table, with the refusal JSON re-raised verbatim as a `RuntimeError`. The quieter
cases were worse, because they don't crash:

- `sm discover` → bulk `information_schema.columns` read, `_try`-wrapped
  (`introspect.py:422`) → silently degrades to one round-trip per table.
- `sm introspect` → `sql_tables` / `sql_foreign_keys`, also `_try`-wrapped → a large schema
  silently yields zero tables ("catalog table enumeration denied", which is misleading) or
  silently drops the join graph.

A fix scoped to the crash would have left both armed, which is why the raise here is
proactive rather than retry-on-failure.

## The change

The three affected commands are invoked from exactly one place — the connect skill — so
that is where the "this is a catalog read" fact lives. They now run with a raised
`AGAMI_SQL_MAX_ROWS` (200,000), and the skill discloses it.

Three rules are written into the skill next to the change, because each is a way this
could be quietly undone later:

- **Inline per command, never `export`.** An exported value is still set when Phase 6 runs
  the demo *user* query, raising the bound for exactly the caller it exists to hold.
- **Never on `seed-examples`.** It validates SQL that later runs as a real user query, so a
  raised cap there green-lights examples that get refused in production.
- **Disclose it, with the unchanged query-time cap stated.** Otherwise a user reasonably
  concludes their safety bound was weakened.

## What this deliberately does not touch

- No change to `execute_sql.py`, so no `dev.py sync-lib` and no test churn.
- The row cap stays composed around the executor, outside `--no-safety` and outside
  `AGAMI_GOVERNANCE_ENFORCED`. Reaching for the safety switch was the first instinct and it
  is the wrong hook: the row-cap suite passes `no_safety=True` precisely to isolate the
  executor bound from the model pass, so coupling them would also destroy the ability to
  test the bound.
- No new lever is reachable from a generated query. `plugins/agami/shared/sql-generation-rules.md`
  is prompt payload loaded verbatim into the query model's context and is untouched, so the
  query model does not learn that a cap lever exists.

## Version

No version bump — this follows the convention of the last dozen skill-touching commits:
land under `[Unreleased]`, bump in a dedicated `release:` commit. Flagging it explicitly
since `plugins/` is the cache-keyed tree, so if you'd rather this ship as a patch release
now, say the word and I'll add the three-place bump.

## Verification

- `uv run --no-project dev.py check` → ruff (lint + format), 4332 passed / 11 skipped,
  gitleaks clean.
- Docs-only change to a skill; the residuals it does **not** close are enumerated in #207
  (chiefly: running these commands outside the skill still hits the default cap, which is
  the argument for a raise-only `--max-rows` on the CLI later).

Reproduction note for reviewers: do not pipe these commands through `tail` — it masks the
exit code and a hard failure reads as a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
