### PR TITLE
The refusal's own sentence reaches the record, so a console reader can act on it

### DIFF
--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -239,6 +239,13 @@ class ToolCallRecord(_Contract):
     execution_ms: int | None = None
     success: bool = True
     error_kind: str | None = None
+    # The gate's own sentences when this call was refused (018), bounded by the writer
+    # (`tools.AUDIT_DETAIL_MAX_CHARS`). `error_kind` names the rule; these say what it fired on and
+    # what to do instead. Value-free by `guardrail.Refusal`'s contract, which is what makes them
+    # showable to a customer's administrator — unlike `QueryExecutionRecord.error_detail`, which is
+    # the driver's own text and operator-only. NULL on every non-refusal.
+    refusal_detail: str | None = None
+    refusal_remediation: str | None = None
     user_question: str | None = None
     agent_query: str | None = None
     thread_id: str | None = None

--- a/packages/agami-core/src/migrations/core/018_tool_calls_refusal_sentence.sql
+++ b/packages/agami-core/src/migrations/core/018_tool_calls_refusal_sentence.sql
@@ -1,0 +1,39 @@
+-- Record WHAT a refusal fired on, next to the call it refused. `tool_calls.error_kind` already names
+-- the rule (`table_scope`, `column_scope`, `read_only`); these two carry the gate's own sentences —
+-- "orders_archive is not declared in the semantic model", and what to do instead. Without them a
+-- console reader can tell a server fault from a user fault and can act on neither, because the only
+-- copy of the specific fact is a line in the server log correlatable by timestamp, by someone with
+-- shell access to the container. That is the same as not recording it.
+--
+-- SAFE TO STORE AND TO SHOW, BY CONTRACT. `guardrail.Refusal` requires `detail` and `remediation` to
+-- be value-free — never raw SQL, never driver text, never a data value — and enforces it at
+-- construction. That is what makes these two different in kind from
+-- `query_executions.error_detail` (016), which holds the DRIVER's own words: those name declared
+-- columns the caller never sent and are deliberately operator-only. The absence of a column for a
+-- refusal's own sentence, next to a column holding text that must never be shown, is exactly why
+-- this could not be solved by reading what was already there.
+--
+-- COLUMNS ON `tool_calls`, though `query_executions` already stores `detail`. The two logs are read
+-- independently and already overlap on purpose — `sql`, `row_count`, `source` and the rule all
+-- appear in both — because each has to be legible on its own. They are also not joinable: there is
+-- no key between them (`Envelope.audit_id` is `query_executions.id`, which `tool_calls` does not
+-- carry), so the alternative is not "read the existing column" but "add a foreign key, add the
+-- missing `remediation` over there, and join" — more schema, for a row that is 1:1 either way. This
+-- is the argument 014 and 016 both make.
+--
+-- NULL IS THE ORDINARY CASE, not a gap: only a refusal has these, so every successful call and every
+-- failure leaves them NULL — a failure carries the database's error, not a rule of ours. Rows written
+-- before this migration ran are NULL because the sentence was never kept, and a back-fill would be
+-- inventing history.
+--
+-- BOUNDED BY THE WRITER (`tools.AUDIT_DETAIL_MAX_CHARS`, the bound the execution row's copy already
+-- uses). The content is ours, but a detail ECHOES identifiers the caller sent, so its length is
+-- caller-controlled — and 015's argument applies verbatim: a refused statement must not become a way
+-- to grow the store.
+--
+-- Forward-only and portable (runs on SQLite + Postgres unchanged) — same shape as
+-- 016_query_executions_error_detail.sql. No `IF NOT EXISTS`: SQLite's ALTER TABLE does not accept it,
+-- and re-run safety comes from the runner's `schema_migrations` ledger, which skips an applied file.
+
+ALTER TABLE tool_calls ADD COLUMN refusal_detail TEXT;
+ALTER TABLE tool_calls ADD COLUMN refusal_remediation TEXT;

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -437,8 +437,8 @@ class DbActivitySink:
         self._store.execute(
             "INSERT INTO tool_calls (id, ts, org_id, actor, tool_name, datasource, sql, row_count, "
             "execution_ms, success, error_kind, source, user_question, agent_query, thread_id, "
-            "correlation_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "correlation_id, refusal_detail, refusal_remediation) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 uuid4().hex,
                 record.ts,
@@ -456,6 +456,12 @@ class DbActivitySink:
                 record.agent_query,
                 record.thread_id,
                 record.correlation_id,
+                # The gate's own two sentences (018). `getattr` with a default, like the execution
+                # row's later columns above: an embedder still on the older record shape writes NULLs
+                # rather than raising, and NULL is the ordinary value here anyway — only a refusal
+                # has them.
+                getattr(record, "refusal_detail", None),
+                getattr(record, "refusal_remediation", None),
             ),
         )
         self._store.commit()
@@ -467,7 +473,8 @@ class DbActivitySink:
 
 _TOOL_CALL_COLS = (
     "id, ts, actor, tool_name, datasource, sql, row_count, execution_ms, success, error_kind, "
-    "user_question, agent_query, thread_id, correlation_id, source"
+    "user_question, agent_query, thread_id, correlation_id, source, "
+    "refusal_detail, refusal_remediation"
 )
 
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2038,6 +2038,18 @@ def record_tool_call(
     """
     args = arguments or {}
     derived_success, derived_row_count, derived_error_kind = True, None, None
+    # The refusal's own two sentences, for the reader of THIS log. `error_kind` says which rule fired;
+    # these say what it fired on and what to do about it — "orders_archive is not declared in the
+    # model", not just `table_scope`. Without them an administrator reading a conversation can tell a
+    # server fault from a user fault but cannot act on either without shell access to the server log.
+    #
+    # Safe to store and to show BY CONTRACT, not by inspection: `guardrail.Refusal` requires both to
+    # be value-free — never raw SQL, never driver text, never a data value — so this is the opposite
+    # of `query_executions.error_detail`, which holds the driver's own words for the operator alone
+    # and is deliberately never surfaced. That distinction is why a field for these could not simply
+    # be added beside the driver text.
+    derived_refusal_detail: str | None = None
+    derived_refusal_remediation: str | None = None
     if raised:
         derived_success, derived_error_kind = False, "exception"
     else:
@@ -2066,6 +2078,14 @@ def record_tool_call(
                     # behaving correctly AND the request not being carried out.
                     derived_success = False
                     derived_error_kind = refusal.get("rule") or "refused"
+                    # Bounded on the same argument as the execution row's copy: the detail ECHOES
+                    # identifiers the caller sent, so its length is caller-controlled even though its
+                    # content is ours.
+                    detail, remediation = refusal.get("detail"), refusal.get("remediation")
+                    if isinstance(detail, str) and detail:
+                        derived_refusal_detail = _bounded_audit_detail(detail)
+                    if isinstance(remediation, str) and remediation:
+                        derived_refusal_remediation = _bounded_audit_detail(remediation)
                 elif isinstance(parsed.get("error"), dict):
                     derived_success = False
                     derived_error_kind = parsed["error"].get("kind") or "error"
@@ -2082,6 +2102,11 @@ def record_tool_call(
         derived_success = success if success is not None else error_kind is None
         derived_error_kind = None if derived_success else error_kind
         derived_row_count = row_count
+        # The sentences belong to the classification, so they are replaced WITH it rather than
+        # surviving it. A caller who states the outcome is not offering these, and body-derived
+        # prose describing a rule the caller just overrode would explain a decision the row no
+        # longer claims — the same contradiction the coherence rule above exists to prevent.
+        derived_refusal_detail = derived_refusal_remediation = None
     if raised:
         # A raise outranks every override. `raised` is not a classification the caller is offering —
         # it is a fact this function was told about what the tool actually did, and no argument can
@@ -2093,6 +2118,10 @@ def record_tool_call(
         # the success rule above. Their success claim loses; their diagnosis has no reason to.
         derived_success = False
         derived_error_kind = error_kind or derived_error_kind or "exception"
+        # A call that threw did not reach a gate, so any sentences parsed out of a body are not this
+        # call's account of itself. Dropped rather than kept beside `"exception"`, where they would
+        # read as the reason it threw.
+        derived_refusal_detail = derived_refusal_remediation = None
     rec: dict[str, Any] = {
         "ts": _now_iso(),
         "tool_name": name,
@@ -2104,6 +2133,8 @@ def record_tool_call(
         "execution_ms": execution_ms,
         "success": derived_success,
         "error_kind": derived_error_kind,
+        "refusal_detail": derived_refusal_detail,
+        "refusal_remediation": derived_refusal_remediation,
         "user_question": user_question if user_question is not None else args.get("user_question"),
         "agent_query": args.get("raw_query"),  # the existing arg is the agent's framing of the query
         "thread_id": thread_id if thread_id is not None else args.get("thread_id"),

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2118,10 +2118,9 @@ def record_tool_call(
         # the success rule above. Their success claim loses; their diagnosis has no reason to.
         derived_success = False
         derived_error_kind = error_kind or derived_error_kind or "exception"
-        # A call that threw did not reach a gate, so any sentences parsed out of a body are not this
-        # call's account of itself. Dropped rather than kept beside `"exception"`, where they would
-        # read as the reason it threw.
-        derived_refusal_detail = derived_refusal_remediation = None
+        # Nothing to clear here: `raised` skips the body parse entirely (the `else` above), so a call
+        # that threw has no sentences to begin with. Setting them to None again would be a line that
+        # can never change anything.
     rec: dict[str, Any] = {
         "ts": _now_iso(),
         "tool_name": name,

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -134,6 +134,80 @@ def test_record_falls_back_to_a_marker_when_a_refusal_names_no_rule(db):
     assert r["success"] == 0 and r["error_kind"] == "refused"
 
 
+def test_a_refusal_records_the_gate_s_own_sentences(db):
+    """The specific fact and the action, beside the rule — the whole point of 018.
+
+    `error_kind` tells an administrator WHICH rule fired; alone it separates "your server is unwell"
+    from "your user overstepped" and lets them act on neither. These two carry what it fired on and
+    what to do instead, so a conversation in the console is actionable without shell access to the
+    server log — which was the only other copy.
+
+    Safe to record and to show BY CONTRACT: `guardrail.Refusal` requires both to be value-free, which
+    is what separates them from the driver's own text (operator-only, and deliberately never stored
+    on this row).
+    """
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT id FROM orders_archive"},
+        result_text=json.dumps({"status": "refused", "refusal": {
+            "reason": "out_of_scope", "rule": "table_scope",
+            "detail": "orders_archive is not declared in the semantic model",
+            "remediation": "Declare the table in the model, or ask a question that stays in scope.",
+        }}),
+        execution_ms=1, actor="a",
+    )
+    (r,) = _rows(db)
+    assert r["error_kind"] == "table_scope"
+    assert r["refusal_detail"] == "orders_archive is not declared in the semantic model"
+    assert r["refusal_remediation"] == (
+        "Declare the table in the model, or ask a question that stays in scope."
+    )
+
+
+def test_a_call_that_was_not_refused_records_no_sentences(db):
+    """NULL is the ordinary case, and the reason the columns are nullable. A successful call has no
+    gate verdict to explain, and a row carrying refusal prose beside `success=1` would be read as a
+    refusal that ran anyway."""
+    tools.record_tool_call(name="execute_sql", arguments={"sql": "SELECT 1"},
+                           result_text='{"row_count": 1}', execution_ms=1, actor="a")
+    (r,) = _rows(db)
+    assert r["success"] == 1
+    assert r["refusal_detail"] is None and r["refusal_remediation"] is None
+
+
+def test_an_overridden_outcome_drops_sentences_parsed_from_the_body(db):
+    """The sentences are replaced WITH the classification, not left behind it.
+
+    An embedder that states the outcome is not offering these, and prose describing a rule the
+    caller just overrode would explain a decision this row no longer claims — the same contradiction
+    the existing coherence rule (`success`/`row_count`/`error_kind` replaced as a group) prevents.
+    """
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "DELETE FROM t"},
+        result_text=json.dumps({"status": "refused", "refusal": {
+            "reason": "unsafe", "rule": "read_only", "detail": "d", "remediation": "r"}}),
+        execution_ms=1, actor="a", error_kind="stated_by_the_caller",
+    )
+    (r,) = _rows(db)
+    assert r["error_kind"] == "stated_by_the_caller"
+    assert r["refusal_detail"] is None and r["refusal_remediation"] is None
+
+
+def test_a_long_refusal_detail_is_bounded_before_it_is_stored(db):
+    """A detail ECHOES identifiers the caller sent, so its LENGTH is caller-controlled even though
+    its content is ours. Same argument as the statement bound: a refused call must not be a way to
+    grow the store."""
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT 1"},
+        result_text=json.dumps({"status": "refused", "refusal": {
+            "reason": "out_of_scope", "rule": "column_scope",
+            "detail": "x" * 5_000, "remediation": "y" * 5_000}}),
+        execution_ms=1, actor="a",
+    )
+    (r,) = _rows(db)
+    assert len(r["refusal_detail"]) == tools.AUDIT_DETAIL_MAX_CHARS
+    assert len(r["refusal_remediation"]) == tools.AUDIT_DETAIL_MAX_CHARS
+
+
 def test_record_logs_every_tool_with_null_self_report(db):
     tools.record_tool_call(name="list_datasources", arguments={}, result_text="[]",
                            execution_ms=2, actor="a")


### PR DESCRIPTION
## Summary

`tool_calls.error_kind` already names the rule that fired (`table_scope`, `column_scope`, `read_only`), which is enough to separate **"your server is unwell"** from **"your user overstepped"**. It does not say what the rule fired *on*, so an administrator can categorise a refusal and act on neither half of it: the only copy of *"orders_archive is not declared in the semantic model"* is a line in the server log, correlatable by timestamp, by someone with shell access to the container.

Two columns on `tool_calls` carrying `Refusal.detail` and `Refusal.remediation`, derived at the seam that already reads `rule` off the refused body.

## Changes

- `018_tool_calls_refusal_sentence.sql` — `refusal_detail`, `refusal_remediation`, nullable, forward-only, portable.
- `record_tool_call` derives both from the refused body, bounded by `AUDIT_DETAIL_MAX_CHARS` (the bound the execution row's copy already uses).
- `ToolCallRecord` gains the two fields; the store writes and reads them.
- Four tests, each mutation-checked against the line it guards.

## Why these are safe to show when the driver's text is not

`guardrail.Refusal` **requires** `detail` and `remediation` to be value-free — never raw SQL, never driver text, never a data value — and enforces it at construction. That is the whole distinction from `query_executions.error_detail` (016), which holds the driver's own words and is deliberately operator-only: Postgres appends hints naming declared columns the caller never sent.

A column for a refusal's own sentence could not simply be added beside text that must never be surfaced. That is why the console has had no field for this.

## Why not read what already exists

`query_executions` stores `detail` but **not** `remediation`, and the two tables have no key between them — `Envelope.audit_id` is `query_executions.id`, which `tool_calls` does not carry. So the alternative is a foreign key, plus the missing column, plus a join, for a row that is 1:1 either way. The two logs already overlap on `sql`, `row_count`, `source` and the rule, deliberately, because each has to be legible on its own.

## Why remediation is stored rather than derived

It is not a function of the rule. `read_only` alone carries six different remediations — empty, too long, multi-statement, not-a-select, denied keyword, row lock — and the resource bound picks its wording from the query's shape at runtime. A screen cannot reconstruct it from `error_kind`.

## Checklist

- [x] `pytest` — 4394 passed, 12 skipped, coverage 89.24% (floor 85)
- [x] `ruff check` clean
- [x] Vendored mirror synced (`dev.py sync-lib`)
- [x] **Upgrade path verified on a database deployed before this change**: columns added, pre-existing rows intact and NULL, re-run a no-op via the filename ledger
- [x] **Each test mutation-checked** — removing the recording fails two, removing the coherence rule fails the third
- [x] Migration number checked against every remote branch, not just `main`
- [x] No real customer data, names or credentials

Spec: AH-065

🤖 Generated with [Claude Code](https://claude.com/claude-code)