### PR TITLE
release: 0.6.0 — the five-section receipt, a dialect-aware guard, and mandatory audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.5.3",
+    "version": "0.6.0",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-08-08
+
 ### Added
 
 - **A server can now run with the semantic-model pass off, and always says so
@@ -37,57 +39,39 @@ below corresponds to one such version.
   The server logs one warning at startup naming the variable and the exposure whenever it boots with
   the pass off.
 
-### Fixed
+- **The receipt now tells you which of a table's declared filters your statement actually applied
+  (ACE-099).** Declaring `default_filters` on a table has never applied them to your SQL, and since
+  the filter injector was removed nothing reported on them either — so `SELECT COUNT(*) FROM orders`
+  returned every row where it once returned the undeleted ones, and nothing on the answer said the
+  number meant something different from what the model says the table means.
 
-- **Catalog and dictionary reads no longer hit the row cap that exists to bound your queries.** The
-  executor refuses (never truncates) any result over `AGAMI_SQL_MAX_ROWS`, default 1000. That bound
-  is sized for a question someone asks; a *catalog* read exceeds it on schema size alone. The visible
-  symptom was `sm enrich-metadata` dying on any platform whose data dictionary is a real table
-  (`RuntimeError: … "rule": "resource_limit"`), but the quieter cases were worse: the bulk
-  `information_schema.columns` read behind `sm discover`, and the table/foreign-key reads behind
-  `sm introspect`, discard a refused read instead of reporting it — so on a wide catalog they
-  degraded to one round-trip per table, or produced a model with no join graph, and said nothing
-  about either.
+  Each entry in the receipt's `tables` section now carries `filters`, one `{expr, status}` per
+  declared filter, with `status` one of `applied`, `omitted` or `undetermined`, plus a `scope`
+  naming where in the statement that reference sits.
 
-  The connect skill now runs those three commands with a raised cap and **tells you it did, along
-  with your unchanged query-time cap**. Nothing about the bound on an ordinary question changes: a
-  query returning more than the cap is still refused rather than quietly truncated, and no new lever
-  is reachable from a generated query.
+  The determination is **per reference, not per table**, which is the part that makes it worth
+  trusting. A filter satisfied inside a CTE and absent from the outer query is two different answers
+  about the same table, and reporting one verdict for both is what made the old injection unsafe:
 
-- **The guard now reads your SQL in your database's own grammar, and refuses what it cannot read
-  (ACE-079).** Every model-scoping check decided by parsing the statement, and every one of them
-  parsed in a generic SQL dialect rather than your engine's. On MySQL, BigQuery, Databricks and SQL
-  Server that is not a subtlety: a backtick is not an identifier quote in the generic grammar, so
-  `` SELECT `ssn` FROM `customers` `` parsed to **no tables and no columns**. The scope checks were
-  not bypassed by a trick — they inspected the tree, found nothing to object to, and passed. So on
-  those engines a query could read any table in the database regardless of what your model declared,
-  and the trust receipt reported no tables read, which made the answer look clean.
+  ```
+  WITH recent AS (SELECT id FROM orders o WHERE o.status != 'cancelled')
+  SELECT o.id FROM orders o JOIN recent r ON o.id = r.id
+  ```
+  ```
+  orders  scope=cte:recent  filters=[{expr: "o.status != 'cancelled'", status: applied}]
+  orders  scope=main        filters=[{expr: "o.status != 'cancelled'", status: omitted}]
+  ```
 
-  The error posture was the other half. `error_level="ignore"` was not a lenient setting, it was no
-  setting at all: sqlglot compares that argument against enum members, so a string matched no branch
-  and every parse error was silently discarded, leaving a truncated tree that read as valid. Both
-  halves are fixed together, because either alone leaves a hole.
+  `applied` means the declared predicate is one of the top-level `AND` conjuncts of that reference's
+  own scope; extra conditions beside it do not weaken that. Anything the check cannot stand behind
+  is `undetermined` rather than a verdict — a predicate on the same column that is not identical, one
+  reachable only through an `OR`, one that only appears in an outer join's `ON`. Only an outright
+  absence is `omitted`, because a confident "you left this out" that turns out to be wrong is worse
+  than saying nothing. **An omitted filter is never a refusal**: whether it matters depends on the
+  question, which only you have.
 
-  Four situations are now refused rather than run blind, each with the next step it actually needs:
-
-  - the datasource does not say which engine it runs on (undeclared, unmapped, or two connections
-    disagreeing) — `model_unavailable`, and the fix is the operator's: declare
-    `storage_connections[].storage_type`. It does not invite you to retry the query, because no
-    rewrite of the query helps.
-  - the statement does not parse in that engine's grammar — `unparseable`, and you can re-emit it.
-  - a double-quoted token on a backtick-quoting engine, which means a column under `ANSI_QUOTES` and
-    a string literal otherwise. The server setting is not visible to the guard, so rather than guess
-    it asks for the statement in the engine's own quoting.
-  - the statement parses, reads from something, and resolves to no named table at all — `unscopable`.
-    A backstop that does not depend on the engine map being complete.
-
-  A model that declares one engine while its credentials connect to another is also refused
-  (`engine_mismatch`): those are two independent pieces of configuration, and a mismatch means the
-  statement was checked against the wrong grammar.
-
-  **If your model does not declare a `storage_type`, queries against it now refuse** with the
-  message above. This is deliberate: a datasource whose engine is unknown cannot be governed, and
-  the alternative was to keep parsing it in a grammar no engine uses.
+  The shipped sample declares one (`orders`: `status != 'cancelled'`), so this is visible the first
+  time you run it.
 
 ### Changed
 
@@ -149,44 +133,6 @@ below corresponds to one such version.
   For operators this is an availability change, and a deliberate one: a briefly unreachable audit
   database now produces refusals rather than unrecorded answers.
 
-### Added
-
-- **The receipt now tells you which of a table's declared filters your statement actually applied
-  (ACE-099).** Declaring `default_filters` on a table has never applied them to your SQL, and since
-  the filter injector was removed nothing reported on them either — so `SELECT COUNT(*) FROM orders`
-  returned every row where it once returned the undeleted ones, and nothing on the answer said the
-  number meant something different from what the model says the table means.
-
-  Each entry in the receipt's `tables` section now carries `filters`, one `{expr, status}` per
-  declared filter, with `status` one of `applied`, `omitted` or `undetermined`, plus a `scope`
-  naming where in the statement that reference sits.
-
-  The determination is **per reference, not per table**, which is the part that makes it worth
-  trusting. A filter satisfied inside a CTE and absent from the outer query is two different answers
-  about the same table, and reporting one verdict for both is what made the old injection unsafe:
-
-  ```
-  WITH recent AS (SELECT id FROM orders o WHERE o.status != 'cancelled')
-  SELECT o.id FROM orders o JOIN recent r ON o.id = r.id
-  ```
-  ```
-  orders  scope=cte:recent  filters=[{expr: "o.status != 'cancelled'", status: applied}]
-  orders  scope=main        filters=[{expr: "o.status != 'cancelled'", status: omitted}]
-  ```
-
-  `applied` means the declared predicate is one of the top-level `AND` conjuncts of that reference's
-  own scope; extra conditions beside it do not weaken that. Anything the check cannot stand behind
-  is `undetermined` rather than a verdict — a predicate on the same column that is not identical, one
-  reachable only through an `OR`, one that only appears in an outer join's `ON`. Only an outright
-  absence is `omitted`, because a confident "you left this out" that turns out to be wrong is worse
-  than saying nothing. **An omitted filter is never a refusal**: whether it matters depends on the
-  question, which only you have.
-
-  The shipped sample declares one (`orders`: `status != 'cancelled'`), so this is visible the first
-  time you run it.
-
-### Changed
-
 - **A result too large to return is refused, not trimmed.** A query whose result exceeded the
   deployment ceiling (`AGAMI_SQL_MAX_ROWS`, default 1000, unchanged) used to come back cut down to
   that many rows with a flag saying so. It now comes back as a structured refusal carrying no rows.
@@ -200,95 +146,6 @@ below corresponds to one such version.
   than none: a row listing should be bounded with a `LIMIT` and an `ORDER BY`, while an aggregate
   should have its grouping narrowed or a filter added — putting a `LIMIT` on a grouped result drops
   groups, and the breakdown you get back reads exactly like a complete one.
-
-### Removed
-
-- **`max_rows` is no longer an argument to `execute_sql`,** and `--max-rows` is gone from the
-  command line. It could only ever *lower* the deployment ceiling, so the one case where a caller
-  knows better than the operator — wanting more data — was the case it could not serve. Ask for the
-  rows you want in the statement: `LIMIT 200` says what it means to everything that reads it.
-
-- **`truncated` is no longer a field on a successful result.** With an oversized result refused, it
-  could only ever be `false`, and a field that is always `false` is one a client can only branch on
-  wrongly.
-
-- **Agami no longer rewrites your SQL to fix a fan-out join.** A query that aggregated a measure
-  across a one-to-many join, touching the many side nowhere but the `ON` clause, used to have that
-  join silently dropped and the rewritten statement executed in place of yours. Your statement is
-  what runs now, byte for byte — comments, whitespace and quoting included — and that is asserted
-  rather than assumed.
-
-- **Four correctness checks stopped refusing.** A fan trap, a chasm trap, a `SUM` of a rate or an
-  identifier, and a `SUM` of a balance across time were all refused. They **return a result** now,
-  and what the check found rides on the answer's receipt, under `aggregates`.
-
-  This is the point of the change rather than a relaxation of it. Whether a multiplied total is
-  *wrong* depends on what you asked: the same statement is wrong for order revenue and right for
-  line-item exposure. The check has your SQL and your model and never your question, so it describes
-  what it found and leaves the judgement to you — or to the assistant, which does have the question
-  and is asked to say out loud when it restructures a query because of a finding.
-
-  A statement that trips two conditions now reports both. The old code stopped at the first, so a
-  query that both fanned out *and* summed a rate was reported as having one problem.
-
-- **`sensitive` is a description, not a gate.** Marking a column `sensitive` no longer blocks
-  projecting it. The answer's receipt reports which sensitive columns it projected, under
-  `columns`, and the authoring guidance asks the assistant to prefer aggregates and to say when it
-  did project them.
-
-  **If you relied on this to keep values from coming back, read this.** The gate was never a
-  boundary: it inspected the projection list and nothing else, so `WHERE email LIKE …` always
-  answered the same question one bit at a time. What it bounded was the *rate* of that, which is an
-  access policy, and Agami holds none of its own — it reads exactly as the connecting database role
-  reads. Two things do enforce, and neither changed: a column left out of the model is out of scope
-  and any statement naming it is refused, and the connecting role's grants and your warehouse's
-  masking policies apply as they always did. If a value must not come back, exclude the column from
-  the model or make sure the role cannot read it.
-
-- **The `model_safety` refusal rule is gone.** It stood in for two branches that refused without
-  naming a rule. Both branches went, so every refusal now names the gate that chose it. A consumer
-  keying on `refusal.rule == "model_safety"` will stop matching, which is the point.
-
-### Contract changes
-
-- Receipt `tables` items carry an **arm ordinal on `scope`** (ACE-043). When a reference's scope is
-  one of two or more arms of a `UNION` / `INTERSECT` / `EXCEPT`, its label gains a trailing 1-based
-  `#<n>`: `main#1`, `main#2`, `cte:recent#2`. A plain `SELECT` and a single-arm CTE body are
-  unchanged and carry no suffix, and `subquery` never takes one. **If you branch on
-  `scope === 'main'` or `scope === 'cte:x'`, that branch stops matching inside a set operation —
-  strip the ordinal with `scope.replace(/#\d+$/, '')` (or `scope.rsplit('#', 1)[0]`) and branch on
-  that.** Split from the RIGHT, not the left: the CTE-name half is caller-written text, and it is
-  only sanitization to an identifier alphabet excluding `#` that keeps a left split working today. The ordinal is the arm's position in the SQL, which
-  is not the order of this list: items are in parse-walk order, so a capped receipt can list
-  ordinals that are neither contiguous nor monotonic, and the largest one is not the arm count.
-- Receipt `tables` items gain **`scope`** and **`filters`** (ACE-099). `ref` is unchanged and is
-  still a string. A `refused` or `failed` receipt is unchanged too — it carries `{ref, declared}`
-  and neither new field, because a declared filter names the columns and literals the model author
-  wrote and a refusal is the one outcome a caller can provoke on purpose.
-- `tables.undetermined` is now **`null` when the section is complete** (ACE-099). It used to be a
-  fixed sentence on every receipt saying the filter accounting was not done. It now names only what
-  was genuinely not established — references whose filters could not be accounted for, references a
-  shadowing CTE name stopped resolving, and the count the reference cap dropped. If you branch on
-  this field being present, that branch changes meaning: present now means something really is
-  missing.
-- `sm receipt --applied-filters` is **gone**, and the receipt no longer emits a top-level
-  `default_filters_applied` key (ACE-099). Nothing had produced either since the filter injector was
-  removed; the fact lives in `tables.items[].filters` now, in one shape rather than two.
-- `sm prepare` returns `{sql, findings, units}` and **always exits 0**. It previously returned
-  `{action, risk, sql, units, reason}`, or exited 1 with a refusal. It runs the reporting checks,
-  not the refusing gates — do not pair it with `--no-safety`.
-- `sm preflight` returns `{findings: [...]}`, replacing the single
-  `{risk, action, reason, suggestion, triggering_joins}` verdict.
-- The receipt's `aggregates` section can now be non-empty, and its `undetermined` sentence changed:
-  it says the checks ran and names what they still do not reach, rather than saying the check does
-  not happen. `columns` items may carry `sensitive: true`.
-- The `{"error": {"kind": "preflight_refused"}}` and `{"kind": "sensitive_columns"}` diagnostics no
-  longer appear on stderr. Every refusal is a single JSON object on every path.
-- A refused `SELECT *` reports `reason: "undetermined"`, not `reason: "out_of_scope"`. The refusal
-  and its message are unchanged; only the reason moves. If you route, count or alert on `reason`,
-  this row changes bucket.
-
-### Changed
 
 - **A `#` is no longer mistaken for the SQL it hides, and is now refused wherever it appears
   outside a string (ACE-096).** `SELECT a FROM t # DROP TABLE t` came back as *"keyword 'DROP' is
@@ -350,6 +207,52 @@ below corresponds to one such version.
 
 ### Removed
 
+- **`max_rows` is no longer an argument to `execute_sql`,** and `--max-rows` is gone from the
+  command line. It could only ever *lower* the deployment ceiling, so the one case where a caller
+  knows better than the operator — wanting more data — was the case it could not serve. Ask for the
+  rows you want in the statement: `LIMIT 200` says what it means to everything that reads it.
+
+- **`truncated` is no longer a field on a successful result.** With an oversized result refused, it
+  could only ever be `false`, and a field that is always `false` is one a client can only branch on
+  wrongly.
+
+- **Agami no longer rewrites your SQL to fix a fan-out join.** A query that aggregated a measure
+  across a one-to-many join, touching the many side nowhere but the `ON` clause, used to have that
+  join silently dropped and the rewritten statement executed in place of yours. Your statement is
+  what runs now, byte for byte — comments, whitespace and quoting included — and that is asserted
+  rather than assumed.
+
+- **Four correctness checks stopped refusing.** A fan trap, a chasm trap, a `SUM` of a rate or an
+  identifier, and a `SUM` of a balance across time were all refused. They **return a result** now,
+  and what the check found rides on the answer's receipt, under `aggregates`.
+
+  This is the point of the change rather than a relaxation of it. Whether a multiplied total is
+  *wrong* depends on what you asked: the same statement is wrong for order revenue and right for
+  line-item exposure. The check has your SQL and your model and never your question, so it describes
+  what it found and leaves the judgement to you — or to the assistant, which does have the question
+  and is asked to say out loud when it restructures a query because of a finding.
+
+  A statement that trips two conditions now reports both. The old code stopped at the first, so a
+  query that both fanned out *and* summed a rate was reported as having one problem.
+
+- **`sensitive` is a description, not a gate.** Marking a column `sensitive` no longer blocks
+  projecting it. The answer's receipt reports which sensitive columns it projected, under
+  `columns`, and the authoring guidance asks the assistant to prefer aggregates and to say when it
+  did project them.
+
+  **If you relied on this to keep values from coming back, read this.** The gate was never a
+  boundary: it inspected the projection list and nothing else, so `WHERE email LIKE …` always
+  answered the same question one bit at a time. What it bounded was the *rate* of that, which is an
+  access policy, and Agami holds none of its own — it reads exactly as the connecting database role
+  reads. Two things do enforce, and neither changed: a column left out of the model is out of scope
+  and any statement naming it is refused, and the connecting role's grants and your warehouse's
+  masking policies apply as they always did. If a value must not come back, exclude the column from
+  the model or make sure the role cannot read it.
+
+- **The `model_safety` refusal rule is gone.** It stood in for two branches that refused without
+  naming a rule. Both branches went, so every refusal now names the gate that chose it. A consumer
+  keying on `refusal.rule == "model_safety"` will stop matching, which is the point.
+
 - **The `GovernancePolicy` port and the `Adapters.governance` field (ACE-095).** `GovernancePolicy`,
   its `GovernanceVerdict` value type, and the `WarnOnlyGovernancePolicy` default adapter are gone,
   along with the `governance` field on `ports.Adapters`. The port was declared but never called: no
@@ -361,6 +264,97 @@ below corresponds to one such version.
   is now `executor`, so `Adapters(sink, resolver, auth, my_policy)` still constructs but binds the
   policy as the executor and fails later at query time with `AttributeError: 'MyPolicy' object has
   no attribute 'execute'`. Construct `Adapters` by keyword.
+
+### Fixed
+
+- **Catalog and dictionary reads no longer hit the row cap that exists to bound your queries.** The
+  executor refuses (never truncates) any result over `AGAMI_SQL_MAX_ROWS`, default 1000. That bound
+  is sized for a question someone asks; a *catalog* read exceeds it on schema size alone. The visible
+  symptom was `sm enrich-metadata` dying on any platform whose data dictionary is a real table
+  (`RuntimeError: … "rule": "resource_limit"`), but the quieter cases were worse: the bulk
+  `information_schema.columns` read behind `sm discover`, and the table/foreign-key reads behind
+  `sm introspect`, discard a refused read instead of reporting it — so on a wide catalog they
+  degraded to one round-trip per table, or produced a model with no join graph, and said nothing
+  about either.
+
+  The connect skill now runs those three commands with a raised cap and **tells you it did, along
+  with your unchanged query-time cap**. Nothing about the bound on an ordinary question changes: a
+  query returning more than the cap is still refused rather than quietly truncated, and no new lever
+  is reachable from a generated query.
+
+- **The guard now reads your SQL in your database's own grammar, and refuses what it cannot read
+  (ACE-079).** Every model-scoping check decided by parsing the statement, and every one of them
+  parsed in a generic SQL dialect rather than your engine's. On MySQL, BigQuery, Databricks and SQL
+  Server that is not a subtlety: a backtick is not an identifier quote in the generic grammar, so
+  `` SELECT `ssn` FROM `customers` `` parsed to **no tables and no columns**. The scope checks were
+  not bypassed by a trick — they inspected the tree, found nothing to object to, and passed. So on
+  those engines a query could read any table in the database regardless of what your model declared,
+  and the trust receipt reported no tables read, which made the answer look clean.
+
+  The error posture was the other half. `error_level="ignore"` was not a lenient setting, it was no
+  setting at all: sqlglot compares that argument against enum members, so a string matched no branch
+  and every parse error was silently discarded, leaving a truncated tree that read as valid. Both
+  halves are fixed together, because either alone leaves a hole.
+
+  Four situations are now refused rather than run blind, each with the next step it actually needs:
+
+  - the datasource does not say which engine it runs on (undeclared, unmapped, or two connections
+    disagreeing) — `model_unavailable`, and the fix is the operator's: declare
+    `storage_connections[].storage_type`. It does not invite you to retry the query, because no
+    rewrite of the query helps.
+  - the statement does not parse in that engine's grammar — `unparseable`, and you can re-emit it.
+  - a double-quoted token on a backtick-quoting engine, which means a column under `ANSI_QUOTES` and
+    a string literal otherwise. The server setting is not visible to the guard, so rather than guess
+    it asks for the statement in the engine's own quoting.
+  - the statement parses, reads from something, and resolves to no named table at all — `unscopable`.
+    A backstop that does not depend on the engine map being complete.
+
+  A model that declares one engine while its credentials connect to another is also refused
+  (`engine_mismatch`): those are two independent pieces of configuration, and a mismatch means the
+  statement was checked against the wrong grammar.
+
+  **If your model does not declare a `storage_type`, queries against it now refuse** with the
+  message above. This is deliberate: a datasource whose engine is unknown cannot be governed, and
+  the alternative was to keep parsing it in a grammar no engine uses.
+
+### Contract changes
+
+- Receipt `tables` items carry an **arm ordinal on `scope`** (ACE-043). When a reference's scope is
+  one of two or more arms of a `UNION` / `INTERSECT` / `EXCEPT`, its label gains a trailing 1-based
+  `#<n>`: `main#1`, `main#2`, `cte:recent#2`. A plain `SELECT` and a single-arm CTE body are
+  unchanged and carry no suffix, and `subquery` never takes one. **If you branch on
+  `scope === 'main'` or `scope === 'cte:x'`, that branch stops matching inside a set operation —
+  strip the ordinal with `scope.replace(/#\d+$/, '')` (or `scope.rsplit('#', 1)[0]`) and branch on
+  that.** Split from the RIGHT, not the left: the CTE-name half is caller-written text, and it is
+  only sanitization to an identifier alphabet excluding `#` that keeps a left split working today. The ordinal is the arm's position in the SQL, which
+  is not the order of this list: items are in parse-walk order, so a capped receipt can list
+  ordinals that are neither contiguous nor monotonic, and the largest one is not the arm count.
+- Receipt `tables` items gain **`scope`** and **`filters`** (ACE-099). `ref` is unchanged and is
+  still a string. A `refused` or `failed` receipt is unchanged too — it carries `{ref, declared}`
+  and neither new field, because a declared filter names the columns and literals the model author
+  wrote and a refusal is the one outcome a caller can provoke on purpose.
+- `tables.undetermined` is now **`null` when the section is complete** (ACE-099). It used to be a
+  fixed sentence on every receipt saying the filter accounting was not done. It now names only what
+  was genuinely not established — references whose filters could not be accounted for, references a
+  shadowing CTE name stopped resolving, and the count the reference cap dropped. If you branch on
+  this field being present, that branch changes meaning: present now means something really is
+  missing.
+- `sm receipt --applied-filters` is **gone**, and the receipt no longer emits a top-level
+  `default_filters_applied` key (ACE-099). Nothing had produced either since the filter injector was
+  removed; the fact lives in `tables.items[].filters` now, in one shape rather than two.
+- `sm prepare` returns `{sql, findings, units}` and **always exits 0**. It previously returned
+  `{action, risk, sql, units, reason}`, or exited 1 with a refusal. It runs the reporting checks,
+  not the refusing gates — do not pair it with `--no-safety`.
+- `sm preflight` returns `{findings: [...]}`, replacing the single
+  `{risk, action, reason, suggestion, triggering_joins}` verdict.
+- The receipt's `aggregates` section can now be non-empty, and its `undetermined` sentence changed:
+  it says the checks ran and names what they still do not reach, rather than saying the check does
+  not happen. `columns` items may carry `sensitive: true`.
+- The `{"error": {"kind": "preflight_refused"}}` and `{"kind": "sensitive_columns"}` diagnostics no
+  longer appear on stderr. Every refusal is a single JSON object on every path.
+- A refused `SELECT *` reports `reason: "undetermined"`, not `reason: "out_of_scope"`. The refusal
+  and its message are unchanged; only the reason moves. If you route, count or alert on `reason`,
+  this row changes bucket.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,21 @@ below corresponds to one such version.
 
 ### Fixed
 
+- **Updating the plugin now updates the library it runs on.** The plugin's own files are refetched on
+  every version bump — the cache directory is the version — but the pip-installed `agami-core` was
+  not, and the loader prefers that installed package over the fresh copy bundled beside the scripts.
+  The readiness check only asked whether the library *imported*, which a stale one does perfectly
+  well, so updating the plugin left new skills running against an old library with nothing anywhere
+  saying so.
+
+  This release is the first where that combination breaks outright rather than drifting quietly: the
+  receipt below is five sections, and the chart renderer rejects a receipt shaped the old way, so
+  every charted query would have failed on `receipt.columns is missing` until the library was
+  upgraded by hand. The launcher now compares the installed distribution against the plugin's own
+  version and reinstalls with `--upgrade` when it is behind. A library at or above that floor is left
+  alone, so this costs nothing on an ordinary run, and a source checkout with no distribution
+  metadata is not disturbed.
+
 - **Catalog and dictionary reads no longer hit the row cap that exists to bound your queries.** The
   executor refuses (never truncates) any result over `AGAMI_SQL_MAX_ROWS`, default 1000. That bound
   is sized for a question someone asks; a *catalog* read exceeds it on schema size alone. The visible

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,10 +97,13 @@ So: **bump the version on any commit that changes user-visible behavior.**
 
 ### When to bump what
 
-The version lives in **three places across two files**. They must always match:
+The version lives in **four places across three files**. They must always match:
 
 - `.claude-plugin/marketplace.json` — `metadata.version` and `plugins[0].version`
 - `plugins/agami/.claude-plugin/plugin.json` — `version`
+- `packages/agami-core/pyproject.toml` — `version`, the one published to PyPI. `release-pypi.yml`
+  fails the publish when the release tag doesn't match it, so a bump that misses this file doesn't
+  ship a wrong version — it doesn't ship at all.
 
 Use semver:
 
@@ -137,7 +140,12 @@ When opening a PR that warrants a version bump, the checklist is:
 
 1. `.claude-plugin/marketplace.json` — bump both `metadata.version` and `plugins[0].version` to the same string.
 2. `plugins/agami/.claude-plugin/plugin.json` — bump `version`.
-3. Add a note to the PR description summarizing the user-visible change and which version it lands in.
+3. `packages/agami-core/pyproject.toml` — bump `version` to that same string.
+4. Add a note to the PR description summarizing the user-visible change and which version it lands in.
+
+Publishing is a **separate, deliberate step**: merging the bump ships nothing. `release-pypi.yml` and
+`release-image.yml` both trigger on `release: published`, so PyPI and GHCR only move once a GitHub
+release is cut with a `v<version>` tag matching `packages/agami-core/pyproject.toml`.
 
 Record notable user-visible changes in [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format) under the version that ships them.
 

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.5.3"
+version = "0.6.0"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",

--- a/plugins/agami/scripts/sm
+++ b/plugins/agami/scripts/sm
@@ -105,17 +105,67 @@ _pip_try() {
 # sys.path[0]).
 _imports_ok() { ( cd / && "$PY" -c 'import semantic_model.cli, pydantic, sqlglot, yaml' ) 2>/dev/null; }
 
+# The installed agami-core must be at least as new as the plugin — and `_imports_ok` cannot see when it
+# isn't, because a stale library imports perfectly well. That gap is silent and it bites: the plugin's
+# own files are refetched on every version bump (the cache dir is the version), but the pip-installed
+# library is not, and `_agami_lib.ensure_importable()` prefers that installed package over the fresh copy
+# bundled in `lib/`. So a user who updates the plugin runs new skills against an old library — 0.6.0's
+# render_chart.py rejects a pre-0.6.0 receipt outright, and every charted query dies on the first run.
+#
+# $VER is the floor because the plugin and the package are bumped to the same string on every release
+# (CONTRIBUTING → "Files to touch on a release"), so the plugin's own version is exactly the library its
+# skills were written against — no second constant to drift out of sync with the first.
+_version_ok() {
+  # Only meaningful in a versioned cache dir. A dev checkout's $VER is a directory name, not a version,
+  # and its editable install already tracks the source.
+  case "$VER" in [0-9]*) ;; *) return 0 ;; esac
+  ( cd / && "$PY" - "$VER" <<'PY'
+import re, sys
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:      # Python too old to ask — not this gate's problem to report.
+    sys.exit(0)
+try:
+    have = version("agami-core")
+except PackageNotFoundError:
+    # Importable but carrying no distribution metadata: a source/PYTHONPATH layout a developer set up
+    # deliberately. There is nothing to compare, and forcing a reinstall over "unknown" would churn a
+    # working environment, so treat it as satisfied.
+    sys.exit(0)
+
+def release(v: str) -> tuple:
+    """The numeric release segment only, so `0.6.0rc1` and `0.6.0.dev3` both compare as 0.6.0 —
+    a prerelease of the floor is close enough to run, and packaging isn't guaranteed importable here."""
+    m = re.match(r"\d+(?:\.\d+)*", v)
+    return tuple(int(p) for p in m.group(0).split(".")) if m else ()
+
+sys.exit(0 if release(have) >= release(sys.argv[1]) else 1)
+PY
+  ) 2>/dev/null
+}
+
 ensure_pkg() {
-  _imports_ok && return 0
-  echo "agami: installing agami-core (semantic model) into $PY …" >&2
-  # Re-verify the imports after each attempt: a pip that exits 0 but leaves the import broken (e.g.
+  _imports_ok && _version_ok && return 0
+  # A MISSING library and a STALE one need different pip invocations: pip counts an already-present
+  # distribution as satisfying a bare requirement, so the stale case would no-op without `--upgrade`
+  # and leave the user exactly where they started — with the failure still ahead of them.
+  local up=""
+  if _imports_ok; then
+    up="--upgrade"
+    echo "agami: agami-core in $PY is older than this plugin ($VER); upgrading …" >&2
+  else
+    echo "agami: installing agami-core (semantic model) into $PY …" >&2
+  fi
+  # Re-verify after each attempt: a pip that exits 0 but leaves the import broken (e.g.
   # "already satisfied" into the wrong site) must fall through to the next source, not falsely succeed.
-  { [ -n "$DEV_PKG_DIR" ] && _pip_try -e "$DEV_PKG_DIR[model]"; } && _imports_ok && return 0
-  _pip_try "agami-core[model]" && _imports_ok && return 0
-  _pip_try "agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core" && _imports_ok && return 0
-  _pip_try "agami-core[model] @ ${GIT_BASE}@main#subdirectory=packages/agami-core" && _imports_ok && return 0
-  echo "agami: couldn't install agami-core into $PY." >&2
-  echo "       Try:  $PY -m pip install --user \"agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core\"" >&2
+  # The version is re-checked too, so a source that resolves to a too-old build (an index that hasn't
+  # published this release yet) falls through to git rather than passing as done.
+  { [ -n "$DEV_PKG_DIR" ] && _pip_try ${up:+"$up"} -e "$DEV_PKG_DIR[model]"; } && _imports_ok && _version_ok && return 0
+  _pip_try ${up:+"$up"} "agami-core[model]" && _imports_ok && _version_ok && return 0
+  _pip_try ${up:+"$up"} "agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core" && _imports_ok && _version_ok && return 0
+  _pip_try ${up:+"$up"} "agami-core[model] @ ${GIT_BASE}@main#subdirectory=packages/agami-core" && _imports_ok && _version_ok && return 0
+  echo "agami: couldn't install a current agami-core into $PY." >&2
+  echo "       Try:  $PY -m pip install --user --upgrade \"agami-core[model] @ ${GIT_BASE}@${GIT_REF}#subdirectory=packages/agami-core\"" >&2
   echo "       Or point agami at a Python that has it:  export AGAMI_PYTHON=/path/to/python" >&2
   exit 3
 }

--- a/tests/test_sm_install_resolution.py
+++ b/tests/test_sm_install_resolution.py
@@ -65,6 +65,29 @@ sys.exit(0)
 """
 
 
+# A library that IMPORTS fine but is older than the plugin — the case `_imports_ok` alone cannot see.
+# The import probe (`-c`) always passes; the version probe (`python - <ver>`, script on stdin) fails
+# until an `--upgrade` install lands the marker. Without the version gate this shim would make `sm`
+# return immediately and log no install at all, which is exactly the silent staleness being fixed.
+_SHIM_STALE = """#!/usr/bin/env python3
+import os, sys
+args = sys.argv[1:]
+with open(os.environ["SM_SHIM_LOG"], "a") as f:
+    f.write(" ".join(args) + "\\n")
+marker = os.environ["SM_SHIM_INSTALLED"]
+if args[:1] == ["-c"]:
+    sys.exit(0)                                    # the stale library imports perfectly well
+if args[:1] == ["-"]:
+    sys.exit(0 if os.path.exists(marker) else 1)   # ...but is below the floor until upgraded
+if "pip" in args and "install" in args:
+    if "--upgrade" not in args:
+        sys.exit(1)      # pip would treat the present dist as satisfying a bare requirement
+    open(marker, "w").close()
+    sys.exit(0)
+sys.exit(0)
+"""
+
+
 def _run_install(sm_path: Path, tmp_path: Path, shim_src: str = _SHIM):
     shim = tmp_path / "pyshim"
     shim.write_text(shim_src)
@@ -120,6 +143,46 @@ def test_pep668_reaches_break_system_packages(tmp_path):
     r, installs = _run_install(SM, tmp_path, shim_src=_SHIM_PEP668)
     assert r.returncode == 0, r.stderr
     assert any("--break-system-packages" in ln for ln in installs), installs
+
+
+def test_stale_library_is_upgraded_not_left_alone(tmp_path):
+    # The regression this guards: the plugin's own files are refetched on a version bump, but the
+    # pip-installed library is not — and `_agami_lib` prefers that installed package over the fresh
+    # bundled `lib/`. An import-only readiness check passes, so new skills run against an old library
+    # (0.6.0's render_chart.py rejects a pre-0.6.0 receipt and every charted query dies).
+    cache = tmp_path / "agami-core" / PLUGIN_VERSION
+    shutil.copytree(SCRIPTS, cache / "scripts")
+    shutil.copytree(LIB, cache / "lib")
+    r, installs = _run_install(cache / "scripts" / "sm", tmp_path, shim_src=_SHIM_STALE)
+
+    assert r.returncode == 0, r.stderr
+    assert installs, "a stale-but-importable library was left in place — no install attempted"
+    assert all("--upgrade" in ln.split() for ln in installs), (
+        f"every attempt must carry --upgrade or pip no-ops on the present dist: {installs}"
+    )
+    assert f"older than this plugin ({PLUGIN_VERSION})" in r.stderr, r.stderr
+
+
+def test_current_library_is_left_alone(tmp_path):
+    # The other half: a library at or above the floor must NOT provoke a reinstall on every invocation.
+    # Same shim, but the marker exists from the start, so the version probe passes immediately.
+    cache = tmp_path / "agami-core" / PLUGIN_VERSION
+    shutil.copytree(SCRIPTS, cache / "scripts")
+    shutil.copytree(LIB, cache / "lib")
+    (tmp_path / "installed.marker").write_text("")
+    r, installs = _run_install(cache / "scripts" / "sm", tmp_path, shim_src=_SHIM_STALE)
+
+    assert r.returncode == 0, r.stderr
+    assert installs == [], f"a current library must not be reinstalled: {installs}"
+
+
+def test_version_floor_is_the_plugin_version_not_a_second_constant():
+    # The floor must stay the plugin's own version. A hand-maintained constant is one a release can
+    # forget to bump, which would silently retire the gate this test exists to protect.
+    txt = SM.read_text()
+    assert "_version_ok" in txt, "the version floor gate must exist"
+    assert 'version("agami-core")' in txt, "the gate must read the INSTALLED distribution's version"
+    assert "_imports_ok && _version_ok" in txt, "readiness must require both probes, not just imports"
 
 
 def test_readiness_probes_cli_entrypoint_and_isolates_cwd():


### PR DESCRIPTION
Cuts **0.6.0** — 94 commits since `v0.5.3`.

## What this PR does

1. Bumps the version in the four places that must match: `.claude-plugin/marketplace.json` (×2), `plugins/agami/.claude-plugin/plugin.json`, and `packages/agami-core/pyproject.toml`. The last one is what `release-pypi.yml` publishes and what its tag-vs-version guard checks, so the release tag must be `v0.6.0`.
2. Cuts the accumulated `[Unreleased]` section into `[0.6.0] — 2026-08-08`, leaving `[Unreleased]` empty at the top.

## The changelog change is grouping only

Since v0.5.3 the `[Unreleased]` section accumulated ten `###` blocks — repeated `Added` / `Changed` / `Removed`, one set per PR that landed. They are merged into one block each, in Keep a Changelog order (Added, Changed, Removed, Fixed, Contract changes, Docs).

**No entry text changed.** Verified by sorting every non-heading, non-blank line of the section before and after and diffing: identical. The diff is heading placement and block order, nothing else.

## Why 0.6.0 and not a patch

The section carries genuine removals and contract changes, so anyone pinned `~=0.5.3` must not pick this up silently:

- `max_rows` is no longer an argument to `execute_sql`, and `--max-rows` is gone from the CLI
- `truncated` is no longer a field on a successful result
- the `model_safety` refusal rule is gone — a consumer keying on `refusal.rule == "model_safety"` stops matching
- `sm prepare` returns `{sql, findings, units}` and always exits 0; `sm preflight` returns `{findings: [...]}`
- receipt `scope` gained a set-operation arm ordinal (`main#1`), which breaks a `scope == "main"` equality branch
- `sm receipt --applied-filters` and the top-level `default_filters_applied` key are gone
- `Adapters.governance` is removed — and `Adapters` is not keyword-only, so a positional 4th argument now binds as `executor`

Pre-1.0, so a minor bump is the semver signal for those rather than a major.

## Also worth an operator's attention in this release

`AGAMI_GOVERNANCE_ENFORCED` (ACE-101) ships **off by default**, so a fresh server does not enforce table scope, column scope, the `SELECT *` ban, or the engine-mismatch check until it is turned on. The read-only guard, dangerous-function guard, statement timeout and row cap enforce in both postures. This is documented in the changelog entry, `docs/self-hosting.md` and `SECURITY.md`, and the server logs a startup warning naming the exposure.

## Verification

- `uv run dev.py check` — 4394 passed, 12 skipped; ruff check + format clean; gitleaks clean
- `python -m build --sdist --wheel packages/agami-core` — builds `agami_core-0.6.0.tar.gz` and `agami_core-0.6.0-py3-none-any.whl`
- `twine check` — both artifacts PASSED
- wheel `top_level.txt` still carries the flat-module invariant (`semantic_model`, `mcp_harness`, `execute_sql`, `agami_paths`)

## After merge

Publishing is **not** automatic on merge — `release-pypi.yml` and `release-image.yml` both trigger on `release: published`. A `v0.6.0` GitHub release still has to be created to push to PyPI and GHCR.