### PR TITLE
A refusal's sentence survives a stated outcome, so it is recorded at all

### DIFF
--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2050,6 +2050,11 @@ def record_tool_call(
     # be added beside the driver text.
     derived_refusal_detail: str | None = None
     derived_refusal_remediation: str | None = None
+    # The rule the BODY said fired, kept apart from `derived_error_kind` because the override block
+    # below overwrites that one. It is what lets a stated outcome be checked for AGREEMENT with the
+    # body rather than assumed to replace it — see the override block for why that distinction is the
+    # whole difference between this feature working and not.
+    body_refusal_rule: str | None = None
     if raised:
         derived_success, derived_error_kind = False, "exception"
     else:
@@ -2078,6 +2083,7 @@ def record_tool_call(
                     # behaving correctly AND the request not being carried out.
                     derived_success = False
                     derived_error_kind = refusal.get("rule") or "refused"
+                    body_refusal_rule = derived_error_kind
                     # Bounded on the same argument as the execution row's copy: the detail ECHOES
                     # identifiers the caller sent, so its length is caller-controlled even though its
                     # content is ours.
@@ -2102,11 +2108,22 @@ def record_tool_call(
         derived_success = success if success is not None else error_kind is None
         derived_error_kind = None if derived_success else error_kind
         derived_row_count = row_count
-        # The sentences belong to the classification, so they are replaced WITH it rather than
-        # surviving it. A caller who states the outcome is not offering these, and body-derived
-        # prose describing a rule the caller just overrode would explain a decision the row no
-        # longer claims — the same contradiction the coherence rule above exists to prevent.
-        derived_refusal_detail = derived_refusal_remediation = None
+        # **Kept when the stated outcome AGREES with the body, dropped when it does not.**
+        #
+        # This block used to clear them unconditionally, reasoning that a caller who states the
+        # outcome is not offering these. That is true of a caller who CONTRADICTS the body, and
+        # false of every real one: both surfaces state an outcome they derived from this same call,
+        # so the unconditional clear meant the sentences were recorded on exactly one path — a
+        # caller that hands over a body and states nothing — which is the path neither the served
+        # MCP transport (`typed_outcome_overrides`) nor a consumer's own sink actually takes. The
+        # column was therefore NULL on every production refusal while the unit tests, which state no
+        # overrides, passed.
+        #
+        # Agreement is `derived_error_kind == body_refusal_rule`, and the failure it still guards is
+        # unchanged: a stated success has no refusal to explain, and a stated kind naming a
+        # DIFFERENT failure is describing something these sentences are not about.
+        if derived_success or derived_error_kind != body_refusal_rule:
+            derived_refusal_detail = derived_refusal_remediation = None
     if raised:
         # A raise outranks every override. `raised` is not a classification the caller is offering —
         # it is a fact this function was told about what the tool actually did, and no argument can

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -174,6 +174,35 @@ def test_a_call_that_was_not_refused_records_no_sentences(db):
     assert r["refusal_detail"] is None and r["refusal_remediation"] is None
 
 
+def test_a_stated_outcome_that_agrees_with_the_body_keeps_the_sentences(db):
+    """**The path every real caller takes, and the one the first version of this got wrong.**
+
+    Both surfaces state the outcome rather than leaving it to be parsed: the served MCP transport
+    passes `typed_outcome_overrides` for every tool that speaks the Envelope, and a consumer's own
+    sink states `success`/`error_kind` from what it observed. Clearing the sentences whenever an
+    outcome is stated therefore recorded them on exactly one path — a caller that hands over a body
+    and states nothing — which is the path nothing in production uses. Every real refusal wrote NULL,
+    while the tests below, which state no overrides, passed.
+
+    The stated kind here is the rule the body already named, because that is what a caller derives
+    from this same call. Agreement means the sentences still describe the decision the row claims.
+    """
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT id FROM orders_archive"},
+        result_text=json.dumps({"status": "refused", "refusal": {
+            "reason": "out_of_scope", "rule": "table_scope",
+            "detail": "orders_archive is not declared in the semantic model",
+            "remediation": "Declare the table, or ask a question that stays in scope."}}),
+        execution_ms=1, actor="a",
+        # What a real caller states, derived from the same outcome.
+        success=False, error_kind="table_scope",
+    )
+    (r,) = _rows(db)
+    assert r["error_kind"] == "table_scope"
+    assert r["refusal_detail"] == "orders_archive is not declared in the semantic model"
+    assert r["refusal_remediation"] == "Declare the table, or ask a question that stays in scope."
+
+
 def test_an_overridden_outcome_drops_sentences_parsed_from_the_body(db):
     """The sentences are replaced WITH the classification, not left behind it.
 
@@ -189,6 +218,20 @@ def test_an_overridden_outcome_drops_sentences_parsed_from_the_body(db):
     )
     (r,) = _rows(db)
     assert r["error_kind"] == "stated_by_the_caller"
+    assert r["refusal_detail"] is None and r["refusal_remediation"] is None
+
+
+def test_a_stated_success_drops_them_however_the_body_read(db):
+    """The other half of agreement, and the one that matters most: a successful call has no refusal
+    to explain, so prose from the body would assert a decision the row denies."""
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT 1"},
+        result_text=json.dumps({"status": "refused", "refusal": {
+            "reason": "unsafe", "rule": "read_only", "detail": "d", "remediation": "r"}}),
+        execution_ms=1, actor="a", success=True, row_count=1,
+    )
+    (r,) = _rows(db)
+    assert r["success"] == 1
     assert r["refusal_detail"] is None and r["refusal_remediation"] is None
 
 


### PR DESCRIPTION
## Summary

Migration 018 added `tool_calls.refusal_detail` / `refusal_remediation`, and they were **NULL on every refusal a real deployment recorded**. Confirmed against a live server: a table-scope refusal wrote the rule and neither sentence.

The cause is the coherence rule shipped beside them (#211). It cleared both whenever a caller **stated** the outcome instead of leaving it to be parsed, on the reasoning that such a caller isn't offering them.

That's true of a caller who *contradicts* the body. It's false of every real one:

- the served MCP transport passes `**typed_outcome_overrides(...)` for every tool that speaks the Envelope — which `execute_sql` does;
- a consumer's own sink states `success` / `error_kind` from what it observed, with no body to hand over.

So the sentences were recorded on exactly one path — a caller that hands over a body and states nothing — and nothing in production takes it.

## The fix

Kept when the stated outcome **agrees** with the body (`derived_error_kind == body_refusal_rule`), dropped when it doesn't. The failures the rule guarded are unchanged: a stated success has no refusal to explain, and a stated kind naming a different failure is describing something these sentences are not about.

No consumer changes — both surfaces already state the rule itself.

## The tests were the real defect

Four tests, each mutation-checked, **all exercising the one path production never takes**. They proved they *could* fail, not that they described how the recorder is actually called. Mutation testing shows a test is wired to its line; it says nothing about whether the line is reached the way the world reaches it.

The new pass states `success=False, error_kind="table_scope"` the way a caller does, and fails against the shipped behaviour.

## Verified end-to-end

Same live database, same query, before and after the fix:

```
16:13:19  table_scope  (NULL)                       (NULL)
16:31:45  table_scope  "query references table(s)    "Add the table to the model,
                        not in the semantic model:    or remove it from the query."
                        employee_salaries …"
```

## Checklist

- [x] `pytest` — 4399 passed, coverage 89.23% (floor 85)
- [x] `ruff check` clean; vendored mirror synced
- [x] New test **fails against the shipped behaviour**
- [x] Verified on a live deployment, not only in the suite
- [x] No real customer data, names or credentials

Spec: AH-065

🤖 Generated with [Claude Code](https://claude.com/claude-code)