### PR TITLE
release: 0.6.1 — a refusal's sentence reaches the audit row again

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,12 @@ below corresponds to one such version.
   naming a different failure is describing something these sentences are not about. No consumer
   change is needed — both surfaces already state the rule itself.
 
-  The tests are worth naming, because they were the real defect. Every test covering these sentences
-  drove the recorder the way no production caller does — handing over a body and stating nothing — so
-  they went on passing against behaviour that recorded nothing. A test can be demonstrably wired to
-  the line it covers and still say nothing about whether that line is reached the way the world
-  reaches it. The new tests state the outcome the way a caller does, and fail against the shipped
-  behaviour.
+  The tests are worth naming, because they were the real defect. Every test that asserted these
+  sentences were **present** drove the recorder the way no production caller does — handing over a
+  body and stating nothing — so they went on passing while every path the world actually takes
+  recorded nothing. A test can be demonstrably wired to the line it covers and still say nothing
+  about whether that line is reached the way the world reaches it. The new test that states an
+  outcome agreeing with the body is the one that fails against the shipped behaviour.
 
 ## [0.6.0] — 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ below corresponds to one such version.
 ### Fixed
 
 - **A refusal's own sentence reaches the audit row again, so a console reader can act on it.**
-  `tool_calls.refusal_detail` and `refusal_remediation` — the two columns added in 0.6.0 so that a row
-  says what the decision was made against and what you were told — were **NULL on every refusal a real
-  deployment recorded**. The rule was recorded; neither sentence was.
+  `tool_calls.refusal_detail` and `tool_calls.refusal_remediation` — the two columns added in 0.6.0 so
+  that a row says what the decision was made against and what you were told — were **NULL on every
+  refusal a real deployment recorded**. The rule was recorded; neither sentence was.
 
   The cause was the coherence rule that shipped beside them. It cleared both whenever a caller
   *stated* the outcome rather than leaving it to be parsed out of the response body, reasoning that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-08-08
+
+### Fixed
+
+- **A refusal's own sentence reaches the audit row again, so a console reader can act on it.**
+  `tool_calls.refusal_detail` and `refusal_remediation` — the two columns added in 0.6.0 so that a row
+  says what the decision was made against and what you were told — were **NULL on every refusal a real
+  deployment recorded**. The rule was recorded; neither sentence was.
+
+  The cause was the coherence rule that shipped beside them. It cleared both whenever a caller
+  *stated* the outcome rather than leaving it to be parsed out of the response body, reasoning that
+  such a caller is not offering these sentences. That is true of a caller who **contradicts** the
+  body, and false of every real one: the served MCP transport states the outcome for every tool that
+  speaks the Envelope, which `execute_sql` does, and a consumer's own sink states what it observed
+  with no body to hand over. So the sentences survived on exactly one path — a caller that hands over
+  a body and states nothing — and nothing in production takes it.
+
+  They are now kept when the stated outcome **agrees** with the body, and dropped when it does not.
+  What the rule guarded is unchanged: a stated success has no refusal to explain, and a stated kind
+  naming a different failure is describing something these sentences are not about. No consumer
+  change is needed — both surfaces already state the rule itself.
+
+  The tests are worth naming, because they were the real defect. Every test covering these sentences
+  drove the recorder the way no production caller does — handing over a body and stating nothing — so
+  they went on passing against behaviour that recorded nothing. A test can be demonstrably wired to
+  the line it covers and still say nothing about whether that line is reached the way the world
+  reaches it. The new tests state the outcome the way a caller does, and fail against the shipped
+  behaviour.
+
 ## [0.6.0] — 2026-08-08
 
 ### Added

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts **0.6.1** — one commit since `v0.6.0` ([#213](https://github.com/AgamiAI/agami-core/pull/213)).

## What this PR does

1. Bumps the version in the four places that must match: `.claude-plugin/marketplace.json` (×2), `plugins/agami/.claude-plugin/plugin.json`, and `packages/agami-core/pyproject.toml`. The release tag must be `v0.6.1` or `release-pypi.yml`'s guard fails the publish.
2. Adds the `[0.6.1]` changelog section for #213, which shipped without one.

## Why a patch bump

#213 changes *what gets recorded*, not any interface: no argument, return shape, refusal rule, receipt key or CLI flag moves. `tool_calls.refusal_detail` / `refusal_remediation` go from NULL to populated on a real refusal. Nothing a consumer branches on changes meaning — a row that was empty starts carrying the sentence it was always supposed to.

## Changelog accuracy

I verified the entry against the code rather than the PR summary:

- **"the two columns added in 0.6.0"** — `018_tool_calls_refusal_sentence.sql` is present at the `v0.6.0` tag. Confirmed.
- **"kept when the stated outcome agrees with the body"** — [tools.py:2125](https://github.com/AgamiAI/agami-core/blob/main/packages/agami-core/src/tools.py#L2125) clears on `derived_success or derived_error_kind != body_refusal_rule`, so they survive only when the call is unsuccessful *and* the stated kind equals the rule the body named. Matches.
- **"four tests, each mutation-checked"** — this phrasing from #213's summary is **not** in the entry. Four tests at `v0.6.0` touch refusals, but only two (`test_a_refusal_records_the_gate_s_own_sentences`, `test_a_long_refusal_detail_is_bounded_before_it_is_stored`) cover these sentences, and mutation-checking isn't a property I can verify from the tree. The entry states what is true of all of them and checkable: each drove the recorder on a path no production caller takes.

## Verification

- `uv run dev.py check` — 4399 passed, 12 skipped; ruff check + format clean; gitleaks clean
- `python -m build --sdist --wheel packages/agami-core` — builds `agami_core-0.6.1.tar.gz` + `.whl`
- `twine check` — both artifacts PASSED
- `0.6.1` confirmed free on PyPI

## After merge

Merging publishes nothing. Both release workflows fire on `release: published`, so a `v0.6.1` GitHub release still has to be cut to reach PyPI and GHCR.