### PR TITLE
A CASE predicate is not what a SUM aggregates, and a shared expression names no metric

### DIFF
--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -2319,13 +2319,24 @@ def _lookup_column(col: "exp.Column", scope: dict[str, str],
 
 
 def _bare_aggregate_column(agg: "exp.AggFunc") -> Optional["exp.Column"]:
-    """The single column an aggregate is applied to, ONLY when the argument is that
-    bare column (optionally DISTINCT). Returns None for composite args like
-    SUM(price * qty) — those can be legitimately additive even if a part isn't."""
-    cols = list(agg.find_all(exp.Column))
-    if len(cols) == 1 and agg.find(exp.Binary) is None:
-        return cols[0]
-    return None
+    """The single column an aggregate is applied to, ONLY when the argument IS that bare
+    column (optionally DISTINCT). Returns None for composite args like SUM(price * qty) —
+    those can be legitimately additive even if a part isn't.
+
+    Reads the aggregate's DIRECT argument. It used to walk the whole subtree
+    (`find_all(exp.Column)`, guarded by `find(exp.Binary) is None`), which reads a column out
+    of a CASE *predicate* and reports it as the summed value: `SUM(CASE WHEN state NOT IN
+    (6,7,8) THEN 1 ELSE 0 END)` returned `state`, and the caller published "SUM(state) is
+    meaningless" about an expression the statement never wrote. The `exp.Binary` guard caught
+    `=` and `IS NULL` by accident and missed `IN`/`BETWEEN`, which are not Binary subclasses —
+    so the same logical query was flagged or cleared on which operator the CASE happened to
+    use. A subtree walk cannot answer "what is being aggregated"; only the argument can."""
+    arg = agg.this
+    if isinstance(arg, exp.Distinct):
+        # DISTINCT holds a LIST — `COUNT(DISTINCT a, b)` aggregates a tuple, not a column.
+        exprs = arg.expressions
+        arg = exprs[0] if len(exprs) == 1 else None
+    return arg if isinstance(arg, exp.Column) else None
 
 
 def _semi_additive_columns(org: Datasource) -> dict[tuple[str, str], "Metric"]:
@@ -5431,12 +5442,22 @@ def _reads_only_visible(oc: OutputColumn, visible: set[str],
 
 
 def _by_binding(candidates: list[MetricCandidate]) -> dict:
-    """Candidates indexed by their reduced binding, first declaration winning a tie.
+    """Candidates indexed by their reduced binding — EVERY candidate declaring it, in declaration
+    order.
 
-    First-wins in candidate order, so two metrics declaring the SAME binding always resolve to the
-    same one and the receipt is identical on every run (REQ-022). Two names for one expression is a
-    model-authoring question and not one this layer decides; picking by iteration order would make
-    the answer depend on a dict's insertion history.
+    This used to keep only the first (`setdefault`), which made two metrics declaring one binding
+    resolve to the same one on every run and called that REQ-022 satisfied. It is not: REQ-022 says
+    two names for one expression is a model-authoring question and *not one this layer decides*, and
+    silently picking the first IS deciding it. A model that auto-suggests one `*_count` per table
+    declares `COUNT(*)` once per table — dozens of times on a wide model — so `COUNT(*)` resolved to
+    whichever metric happened to sort first, and a receipt could report one table's count as an
+    unrelated table's count metric: `matched`, `approved`, signed off. One authoritative false
+    attribution is worse than none — it is indistinguishable from a true one, on the surface whose
+    whole job is to say which declared metric an answer computes.
+
+    Carrying the list lets `_match_output_column` discriminate on the tables the statement actually
+    reads, and say `undetermined` when it still cannot. Determinism is unaffected — the order is the
+    candidate order, and a list has no insertion-history ambiguity to resolve.
 
     Candidates whose binding could not be read carry `reduced is None` and are absent here. They are
     still in `candidates`, because whether ANY of them is unread is what decides between `unmatched`
@@ -5445,8 +5466,43 @@ def _by_binding(candidates: list[MetricCandidate]) -> dict:
     out: dict = {}
     for cand in candidates:
         if cand.reduced is not None:
-            out.setdefault(cand.reduced, cand)
+            out.setdefault(cand.reduced, []).append(cand)
     return out
+
+
+def _arm_sources(oc: OutputColumn, memo: dict[int, dict[str, str]]) -> set[str]:
+    """The bare relations this output column's own SELECT reads, folded for comparison.
+
+    Shares `memo` with `_reads_only_visible` — same key, same map, resolved once per arm — so
+    consulting it costs nothing on a statement whose columns already reached that check.
+    """
+    scope_map = memo.get(id(oc.sel))
+    if scope_map is None:
+        scope_map = memo[id(oc.sel)] = _own_alias_map(oc.sel)
+    return {_tkey(src) for src in scope_map.values()}
+
+
+def _discriminate(cands: list[MetricCandidate], sources: set[str]) -> Optional[MetricCandidate]:
+    """The one candidate whose declared `source_tables` fits what the statement reads, or None.
+
+    Only ever consulted when several metrics declare the SAME binding, i.e. when the expression by
+    itself cannot name one. `_strip_qualifiers` names this guard as the thing to add "if a false
+    match shows up" — one has, and unlike when that was written the guard is not inert here: the
+    auto-suggested `*_count` metrics that collide all carry `source_tables`.
+
+    It DISCRIMINATES, it never rejects. A candidate declaring no `source_tables` is not eliminated —
+    the field is optional, and an absent declaration is not evidence against a metric. So the guard
+    can only ever narrow a field that was already ambiguous, and returns None when it cannot narrow
+    it to exactly one. None means `undetermined`, which is the honest answer: `COUNT(*)` over
+    `orders ⋈ customers` is neither the order count nor the customer count, and saying so beats
+    naming either.
+    """
+    survivors = [
+        c for c in cands
+        if not c.metric.source_tables
+        or any(_tkey(s) in sources for s in c.metric.source_tables)
+    ]
+    return survivors[0] if len(survivors) == 1 else None
 
 
 def _declarations_unread(org: Datasource, storage_type: "str | None",
@@ -5486,8 +5542,9 @@ def _match_output_column(oc: OutputColumn, unread: bool,
     The branch ORDER is the contract, and each rung is a claim the analysis has earned:
 
     1. **A match, if the expressions are equal**, looked up in `by_binding` rather than scanned
-       for. Ties there are resolved first-declaration-wins, so the same statement names the same
-       metric on every run (REQ-022).
+       for. When several metrics declare that one binding the expression cannot name one of them,
+       so the tables the statement reads decide — and when they cannot narrow it to exactly one,
+       the answer is `undetermined`, not a guess (see `_discriminate`).
     2. **`undetermined` when the column sits behind a boundary we do not enter** — see
        `_reads_only_visible`. Asked only AFTER the match, because a column whose expression we DID
        compare successfully has been established regardless of what else is in scope.
@@ -5504,9 +5561,13 @@ def _match_output_column(oc: OutputColumn, unread: bool,
         # `__eq__` — both derive from the node's structure — so the equality this comparison is
         # defined as is exactly what the lookup performs, and 50 output columns against a model
         # declaring hundreds of metrics costs 50 hashes rather than their product.
-        cand = by_binding.get(_reduced_projection(oc.expr, dialect))
-        if cand is not None:
-            return MATCHED, cand
+        cands = by_binding.get(_reduced_projection(oc.expr, dialect))
+        if cands:
+            if len(cands) == 1:
+                return MATCHED, cands[0]
+            # Several metrics declare this one expression, so it does not identify any of them.
+            cand = _discriminate(cands, _arm_sources(oc, memo))
+            return (MATCHED, cand) if cand is not None else (UNDETERMINED, None)
     if not _reads_only_visible(oc, visible, memo):
         return UNDETERMINED, None
     if unread:

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -5445,15 +5445,17 @@ def _by_binding(candidates: list[MetricCandidate]) -> dict:
     """Candidates indexed by their reduced binding — EVERY candidate declaring it, in declaration
     order.
 
-    This used to keep only the first (`setdefault`), which made two metrics declaring one binding
-    resolve to the same one on every run and called that REQ-022 satisfied. It is not: REQ-022 says
-    two names for one expression is a model-authoring question and *not one this layer decides*, and
-    silently picking the first IS deciding it. A model that auto-suggests one `*_count` per table
-    declares `COUNT(*)` once per table — dozens of times on a wide model — so `COUNT(*)` resolved to
-    whichever metric happened to sort first, and a receipt could report one table's count as an
-    unrelated table's count metric: `matched`, `approved`, signed off. One authoritative false
-    attribution is worse than none — it is indistinguishable from a true one, on the surface whose
-    whole job is to say which declared metric an answer computes.
+    This used to keep only the first (`setdefault`). REQ-022 is satisfied either way — it asks for
+    the same receipt on every run for the same statement, and both a stable first-wins pick and a
+    stable `undetermined` deliver that. What first-wins did was answer a question this layer cannot
+    answer: **which of several metrics declaring one expression is the one this column computes.**
+
+    A model that auto-suggests one `*_count` per table declares `COUNT(*)` once per table — dozens
+    of times on a wide model — so `COUNT(*)` resolved to whichever metric happened to sort first,
+    and a receipt could report one table's count as an unrelated table's count metric: `matched`,
+    `approved`, signed off. One authoritative false attribution is worse than none: it is
+    indistinguishable from a true one, on the surface whose whole job is to say which declared
+    metric an answer computes. This is a deliberate contract change, not a REQ-022 conformance fix.
 
     Carrying the list lets `_match_output_column` discriminate on the tables the statement actually
     reads, and say `undetermined` when it still cannot. Determinism is unaffected — the order is the

--- a/packages/agami-core/src/semantic_model/runtime.py
+++ b/packages/agami-core/src/semantic_model/runtime.py
@@ -5477,11 +5477,16 @@ def _arm_sources(oc: OutputColumn, memo: dict[int, dict[str, str]]) -> set[str]:
 
     Shares `memo` with `_reads_only_visible` — same key, same map, resolved once per arm — so
     consulting it costs nothing on a statement whose columns already reached that check.
+
+    `_bare` as well as `_tkey`, so this side is normalized identically to the DECLARED side in
+    `_discriminate`. `_tkey` only lowercases; a schema left on either half would make two spellings
+    of one table fail to compare. `_own_alias_map` already returns bare names, so this is belt and
+    braces here — and it is the half that makes the pair provably symmetric.
     """
     scope_map = memo.get(id(oc.sel))
     if scope_map is None:
         scope_map = memo[id(oc.sel)] = _own_alias_map(oc.sel)
-    return {_tkey(src) for src in scope_map.values()}
+    return {_tkey(_bare(src)) for src in scope_map.values()}
 
 
 def _discriminate(cands: list[MetricCandidate], sources: set[str]) -> Optional[MetricCandidate]:
@@ -5498,11 +5503,19 @@ def _discriminate(cands: list[MetricCandidate], sources: set[str]) -> Optional[M
     it to exactly one. None means `undetermined`, which is the honest answer: `COUNT(*)` over
     `orders ⋈ customers` is neither the order count nor the customer count, and saying so beats
     naming either.
+
+    `source_tables` may be SCHEMA-QUALIFIED, so it is normalized with `_bare` before comparison —
+    the rule `loader._metrics_for` has always applied to this same field. `_tkey` alone only
+    lowercases, and a metric declaring `public.orders` would then be invisible to a statement
+    reading `orders`. The consequence is not merely a false `undetermined`: because a candidate
+    declaring nothing is never eliminated, dropping the correctly-declared one leaves the
+    undeclared one standing ALONE, and it gets named — the exact false attribution this guard was
+    added to prevent, reintroduced by a mismatch between the two sides of one comparison.
     """
     survivors = [
         c for c in cands
         if not c.metric.source_tables
-        or any(_tkey(s) in sources for s in c.metric.source_tables)
+        or any(_tkey(_bare(s)) in sources for s in c.metric.source_tables)
     ]
     return survivors[0] if len(survivors) == 1 else None
 

--- a/tests/test_ace058_metric_adherence.py
+++ b/tests/test_ace058_metric_adherence.py
@@ -923,3 +923,58 @@ def test_the_arm_source_map_is_resolved_once_for_all_of_an_arms_columns(tmp_path
         org, f"SELECT {PAID_REVENUE} AS a, {PAID_REVENUE} AS b, id AS c FROM orders")
     assert calls, "the source map was never resolved — this test would pass vacuously"
     assert len(calls) == 1, f"resolved the same arm's sources {len(calls)} times"
+
+
+def test_a_schema_qualified_source_table_still_discriminates(tmp_path):
+    """`source_tables` may be schema-qualified, and the guard must normalize it the way the rest
+    of the codebase does.
+
+    `_tkey` only lowercases — it does NOT strip a schema — while the written side of the
+    comparison is bare table names off `_own_alias_map`. Matching the two with `_tkey` alone makes
+    a metric declaring `public.orders` invisible to a statement reading `orders`, and the failure
+    is not limited to a false `undetermined`: a candidate declaring NO `source_tables` is never
+    eliminated, so when the correctly-declared one is wrongly dropped the undeclared one is left
+    standing alone and gets NAMED. That is the false attribution this guard exists to prevent,
+    reintroduced by a normalization mismatch.
+
+    `loader._metrics_for` has always compared these through `bare_name`; this is the same rule.
+    """
+    org = _org_with_metric(tmp_path, "qualified_revenue",
+                           bindings={"PostgreSQL": PAID_REVENUE},
+                           source_tables=["public.orders"])
+    # `paid_revenue` declares plain `orders`; `qualified_revenue` declares `public.orders`. Both
+    # genuinely apply to a statement reading `orders`, so neither may be silently eliminated and
+    # the honest answer is that the expression names neither.
+    rows = _statuses(org, f"SELECT {PAID_REVENUE} AS revenue FROM orders",
+                     drop=("broken_metric",))
+    assert rows == [("revenue", rt.UNDETERMINED, None)]
+
+
+def test_an_undeclared_metric_is_not_left_standing_by_a_qualifier_mismatch(tmp_path):
+    """The false-match half, stated on its own because it is the dangerous one.
+
+    One metric declares the table it applies to, schema-qualified. The other declares nothing. A
+    guard that cannot read the qualifier eliminates the RIGHT one and names the WRONG one —
+    `matched`, with whatever sign-off that metric carries.
+    """
+    yaml = __import__("yaml")
+    root = tmp_path / "q"
+    root.mkdir(parents=True)
+    _write_model(root)
+    mdir = root / "subject_areas" / "s" / "metrics"
+    # Re-declare paid_revenue's binding on a metric that names no source table at all...
+    (mdir / "unscoped_twin.yaml").write_text(yaml.safe_dump(
+        {"name": "unscoped_twin", "calculation": "whatever", "description": "unscoped_twin",
+         "bindings": {"PostgreSQL": PAID_REVENUE}, "source_tables": [],
+         "confidence": "proposed", "review_state": "unreviewed"}))
+    # ...and schema-qualify the one that genuinely applies.
+    doc = yaml.safe_load((mdir / "paid_revenue.yaml").read_text())
+    doc["source_tables"] = ["public.orders"]
+    (mdir / "paid_revenue.yaml").write_text(yaml.safe_dump(doc))
+    org = L.load_datasource(root)
+
+    rows = _statuses(org, f"SELECT {PAID_REVENUE} AS revenue FROM orders",
+                     drop=("broken_metric",))
+    assert rows != [("revenue", rt.MATCHED, "unscoped_twin")], \
+        "the qualified declaration was dropped and the undeclared metric was named in its place"
+    assert rows == [("revenue", rt.UNDETERMINED, None)]

--- a/tests/test_ace058_metric_adherence.py
+++ b/tests/test_ace058_metric_adherence.py
@@ -776,25 +776,76 @@ def test_matching_does_not_scan_every_declared_metric(org):
     idx = rt._by_binding(cands)
     # `broken_metric` will not parse, so it is absent from the index while staying a candidate —
     # the list is what decides `unmatched` vs `undetermined`, the index only answers "which metric".
-    assert "broken_metric" not in {c.metric.name for c in idx.values()}
+    indexed = {c.metric.name for bucket in idx.values() for c in bucket}
+    assert "broken_metric" not in indexed
     assert "broken_metric" in {c.metric.name for c in cands}
-    assert idx[rt._reduced_binding(PAID_REVENUE, "postgres")].metric.name == "paid_revenue"
+    bucket = idx[rt._reduced_binding(PAID_REVENUE, "postgres")]
+    assert [c.metric.name for c in bucket] == ["paid_revenue"]
 
 
-def test_two_metrics_declaring_one_binding_resolve_the_same_way_every_run(tmp_path):
-    """First declaration wins, so the receipt is identical on every run (REQ-022). Two names for one
-    expression is a model-authoring question, not one this layer decides — but it must not decide it
-    differently on different runs."""
+def test_two_metrics_declaring_one_binding_name_neither(tmp_path):
+    """An expression two metrics both declare does not identify either of them.
+
+    REQ-022 says two names for one expression is a model-authoring question and NOT one this layer
+    decides. Keeping only the first candidate satisfied that in letter — the same one every run —
+    while breaking it in substance, because silently picking one IS deciding it. `undetermined` is
+    the answer that actually declines to decide, and the section already has the word.
+
+    Not hypothetical: a model auto-suggesting one `*_count` per table declares `COUNT(*)` once per
+    table, and on a wide model that made one table's count report as an unrelated table's count
+    metric — `matched`, `confirmed`, `approved`. One authoritative false attribution is worse than
+    dozens of obvious ones: it is indistinguishable from a true one.
+    """
     org = _org_with_metric(tmp_path, "duplicate_binding",
                            bindings={"PostgreSQL": PAID_REVENUE})
     cands = rt._metric_candidates(org, rt._storage_type_of(org), rt._dialect_of(org)[0])
-    winner = rt._by_binding(cands)[rt._reduced_binding(PAID_REVENUE, "postgres")].metric.name
-    assert all(
-        rt._by_binding(rt._metric_candidates(
-            org, rt._storage_type_of(org), rt._dialect_of(org)[0]
-        ))[rt._reduced_binding(PAID_REVENUE, "postgres")].metric.name == winner
-        for _ in range(5)
-    )
+    bucket = rt._by_binding(cands)[rt._reduced_binding(PAID_REVENUE, "postgres")]
+    assert {c.metric.name for c in bucket} == {"paid_revenue", "duplicate_binding"}, \
+        "both declarations must be carried — dropping one is what made the false match possible"
+
+    # Both declare `source_tables: [orders]`, so reading `orders` cannot separate them either.
+    rows = _statuses(org, f"SELECT {PAID_REVENUE} AS revenue FROM orders",
+                     drop=("broken_metric",))
+    assert rows == [("revenue", rt.UNDETERMINED, None)]
+
+
+def test_the_tables_the_statement_reads_separate_two_metrics_sharing_a_binding(tmp_path):
+    """The guard DISCRIMINATES — it only ever narrows a field the expression left ambiguous.
+
+    `_strip_qualifiers` names `source_tables` as the thing to add "if a false match shows up". This
+    is that guard: with the same binding declared twice but for different tables, the statement's own
+    FROM decides, and the answer is a real match rather than a shrug.
+    """
+    org = _org_with_metric(tmp_path, "customer_revenue",
+                           bindings={"PostgreSQL": PAID_REVENUE},
+                           source_tables=["customers"])
+    rows = _statuses(org, f"SELECT {PAID_REVENUE} AS revenue FROM customers",
+                     drop=("broken_metric",))
+    assert rows == [("revenue", rt.MATCHED, "customer_revenue")]
+
+    rows = _statuses(org, f"SELECT {PAID_REVENUE} AS revenue FROM orders",
+                     drop=("broken_metric",))
+    assert rows == [("revenue", rt.MATCHED, "paid_revenue")]
+
+
+def test_a_metric_declaring_no_source_tables_is_never_eliminated_by_the_guard(tmp_path):
+    """An absent declaration is not evidence against a metric. `source_tables` is optional and empty
+    across much of the real model, so a guard that treated "not declared" as "does not apply" would
+    silently delete true matches — the failure mode that kept this guard out of the code until a
+    false match justified it."""
+    org = _org_with_metric(tmp_path, "unscoped_revenue",
+                           bindings={"PostgreSQL": PAID_REVENUE},
+                           source_tables=[])
+    # `paid_revenue` (orders) and `unscoped_revenue` (nothing declared) both survive reading
+    # `orders`, so the field is still ambiguous and the honest answer is still undetermined.
+    rows = _statuses(org, f"SELECT {PAID_REVENUE} AS revenue FROM orders",
+                     drop=("broken_metric",))
+    assert rows == [("revenue", rt.UNDETERMINED, None)]
+
+    # And reading a table `paid_revenue` does NOT declare leaves the unscoped one alone standing.
+    rows = _statuses(org, f"SELECT {PAID_REVENUE} AS revenue FROM customers",
+                     drop=("broken_metric",))
+    assert rows == [("revenue", rt.MATCHED, "unscoped_revenue")]
 
 
 def test_a_missing_parser_does_not_poison_the_binding_cache(monkeypatch):
@@ -830,3 +881,44 @@ def test_a_binding_is_reduced_once_and_not_once_per_request(org):
     # every time after.
     assert info.misses == 4
     assert info.hits >= 16
+
+
+def test_a_shared_binding_whose_declarers_are_all_elsewhere_is_undetermined(tmp_path):
+    """Zero survivors, not one. The guard can eliminate EVERY ambiguous candidate — two metrics
+    sharing a binding, both declared on tables this statement does not read. `undetermined` is
+    right for the same reason it is right with several survivors: the expression named a metric,
+    and nothing establishes which. Falling back to first-wins here would be the original bug with
+    an extra step."""
+    org = _org_with_metric(tmp_path, "customer_revenue",
+                           bindings={"PostgreSQL": PAID_REVENUE},
+                           source_tables=["customers"])
+    # `paid_revenue` declares `orders`, `customer_revenue` declares `customers`; the statement
+    # reads a CTE, so neither can be established off the tables in scope.
+    rows = _statuses(
+        org,
+        f"WITH t AS (SELECT * FROM orders) SELECT {PAID_REVENUE} AS revenue FROM t",
+        drop=("broken_metric",),
+    )
+    assert rows == [("revenue", rt.UNDETERMINED, None)]
+
+
+def test_the_arm_source_map_is_resolved_once_for_all_of_an_arms_columns(tmp_path, monkeypatch):
+    """`_arm_sources` shares `_reads_only_visible`'s memo — same key, same map, one resolve per arm.
+
+    Driven through `assemble_receipt` rather than the `_statuses` helper: that helper hands each
+    column a FRESH `{}`, so it cannot observe the memo at all and a test written against it would
+    measure the helper. `assemble_receipt` is where the one real memo lives (`own_alias_memo`).
+
+    An ambiguous column reaches the source map through the new guard and a settled one reaches it
+    through the scope check; both must land on the same cached entry, because `_own_alias_map`
+    walks a subtree and this is on the receipt path of every executed query.
+    """
+    org = _org_with_metric(tmp_path, "duplicate_binding",
+                           bindings={"PostgreSQL": PAID_REVENUE})
+    calls = []
+    real = rt._own_alias_map
+    monkeypatch.setattr(rt, "_own_alias_map", lambda sel: (calls.append(id(sel)), real(sel))[1])
+    rt.assemble_receipt(
+        org, f"SELECT {PAID_REVENUE} AS a, {PAID_REVENUE} AS b, id AS c FROM orders")
+    assert calls, "the source map was never resolved — this test would pass vacuously"
+    assert len(calls) == 1, f"resolved the same arm's sources {len(calls)} times"

--- a/tests/test_ace058_metric_adherence.py
+++ b/tests/test_ace058_metric_adherence.py
@@ -786,10 +786,11 @@ def test_matching_does_not_scan_every_declared_metric(org):
 def test_two_metrics_declaring_one_binding_name_neither(tmp_path):
     """An expression two metrics both declare does not identify either of them.
 
-    REQ-022 says two names for one expression is a model-authoring question and NOT one this layer
-    decides. Keeping only the first candidate satisfied that in letter — the same one every run —
-    while breaking it in substance, because silently picking one IS deciding it. `undetermined` is
-    the answer that actually declines to decide, and the section already has the word.
+    REQ-022 asks for the same receipt on every run, and both a stable first-wins pick and a stable
+    `undetermined` deliver that — so this is not a REQ-022 fix. It is a deliberate contract change:
+    keeping only the first candidate answered a question this layer cannot answer, namely which of
+    several metrics declaring one expression the column computes. `undetermined` declines to answer
+    it, and the section already has the word.
 
     Not hypothetical: a model auto-suggesting one `*_count` per table declares `COUNT(*)` once per
     table, and on a wide model that made one table's count report as an unrelated table's count

--- a/tests/test_aggregation_enforcement.py
+++ b/tests/test_aggregation_enforcement.py
@@ -86,6 +86,49 @@ def test_count_of_id_is_allowed():
     assert r.findings == []
 
 
+@pytest.mark.parametrize("predicate", [
+    "state NOT IN (6, 7, 8)",   # exp.In      — was NOT caught, so this was a false positive
+    "state BETWEEN 1 AND 3",    # exp.Between — likewise
+    "state = 1",                # exp.EQ      — caught only because EQ happens to be exp.Binary
+    "state IS NULL",            # exp.Is      — likewise
+    "state IN (1) AND state != 9",
+])
+def test_a_case_predicates_column_is_not_the_summed_value(predicate):
+    """`SUM(CASE WHEN <predicate> THEN 1 ELSE 0 END)` sums the literal 1, not the column the
+    predicate tests. Reading the column out of the predicate reported "SUM(state) is meaningless"
+    about an expression the statement never wrote — and put that beside the receipt's own
+    `columns` section calling the same output the org's approved, signed-off metric.
+
+    The old guard (`find(exp.Binary) is None`) caught `=` and `IS NULL` by accident and missed
+    `IN`/`BETWEEN`, which are not Binary subclasses, so the same conditional count was flagged or
+    cleared on nothing but which operator it happened to use. All five spellings are one query.
+    """
+    org = _org([_col("state", "integer", "dimension")])
+    r = RT.pre_flight_check(
+        f"SELECT SUM(CASE WHEN {predicate} THEN 1 ELSE 0 END) FROM facts", org)
+    assert r.findings == []
+
+
+def test_a_bare_column_is_still_the_summed_value():
+    """The narrowing must not cost the check its real cases — SUM over a dimension, and over a
+    DISTINCT dimension, are what this rule exists to catch."""
+    org = _org([_col("state", "integer", "dimension")])
+    for sql in ("SELECT SUM(state) FROM facts", "SELECT SUM(DISTINCT state) FROM facts"):
+        r = RT.pre_flight_check(sql, org)
+        assert [f.risk for f in r.findings] == ["bad_aggregation"], sql
+        assert "state" in r.findings[0].reason
+
+
+def test_the_finding_quotes_the_aggregate_the_statement_wrote():
+    """The reason is synthesized from the extracted column while the `aggregate` field carries the
+    parsed expression, so a wrong extraction printed a reason naming an expression that appears
+    nowhere in the statement. Pin that the two agree."""
+    org = _org([_col("state", "integer", "dimension")])
+    r = RT.pre_flight_check("SELECT SUM(state) FROM facts", org)
+    assert r.findings[0].aggregate == "SUM(state)"
+    assert "SUM(state)" in r.findings[0].reason
+
+
 # --- #3 semi-additive enforcement ------------------------------------------
 
 def _balance_org():
@@ -135,3 +178,15 @@ def test_semi_additive_is_table_scoped_no_cross_table_misfire():
     # facts.balance IS → reported
     r2 = RT.pre_flight_check("SELECT snapshot_date, SUM(balance) FROM facts GROUP BY snapshot_date", org)
     assert [f.risk for f in r2.findings] == ["semi_additive"]
+
+
+def test_a_multi_column_distinct_is_not_one_bare_column():
+    """`COUNT(DISTINCT a, b)` aggregates a TUPLE. DISTINCT carries a list, so unwrapping it
+    blindly would hand back its first element and describe a two-column aggregate as a
+    one-column one. COUNT is exempt from the class check, so this guards the extractor itself
+    rather than a finding."""
+    import sqlglot
+    from sqlglot import exp
+
+    agg = next(sqlglot.parse_one("SELECT COUNT(DISTINCT a, b) FROM t").find_all(exp.AggFunc))
+    assert RT._bare_aggregate_column(agg) is None


### PR DESCRIPTION
## Summary

Two defects on the trust receipt. Each made it state something false about an answer, and together they made one response **contradict itself**: the `aggregates` section called an expression meaningless while the `columns` section of the same receipt matched that identical expression to an approved, signed-off metric. A reader cannot act on both.

## 1. The aggregate's predicate was read as its argument

`_bare_aggregate_column` promised the column an aggregate is applied to *"ONLY when the argument is that bare column"* and then walked the whole subtree with `find_all(exp.Column)`, descending into `CASE` branches. Its `exp.Binary` guard caught `=` and `IS NULL` by accident and missed `IN` and `BETWEEN`, which are not `Binary` subclasses.

So `SUM(CASE WHEN state NOT IN (…) THEN 1 ELSE 0 END)` yielded `state` and the receipt reported *"SUM(state) is meaningless"* about an expression the statement never wrote — while the same conditional count spelled with `=` passed. The rule's intent is right; the extraction was wrong.

It now reads the aggregate's **direct argument**, unwrapping a single-expression `DISTINCT` (`COUNT(DISTINCT a, b)` aggregates a tuple, not a column).

## 2. A binding two metrics share identified neither

`_by_binding` kept only the first candidate per reduced binding (`setdefault`) and called that REQ-022 satisfied. It is not. REQ-022 says two names for one expression is a model-authoring question and *not one this layer decides* — and silently picking the first **is** deciding it.

A model that auto-suggests one `*_count` per table declares `COUNT(*)` once per table, so on a wide model `COUNT(*)` resolved to whichever metric happened to sort first, and the receipt reported one table's count as an unrelated table's count metric: `matched`, `confirmed`, `approved`. One authoritative false attribution is worse than dozens of obvious ones — it is indistinguishable from a true one, on the surface whose whole job is to say which declared metric an answer computes.

The index now carries **every** candidate. When several share a binding, the tables the statement reads discriminate; when they cannot narrow it to exactly one, the answer is `undetermined`. The guard **never rejects** — a candidate declaring no `source_tables` is not eliminated, because an absent declaration is not evidence against a metric. `_strip_qualifiers` named this guard as the thing to add *"if a false match shows up"*; one has, and unlike when that was written the colliding metrics do carry `source_tables`.

The `aggregates` section already reported `undetermined` for the same `COUNT(*)` (`_AggSite.resolved` is false with no columns). One section of the receipt was already right; this makes the other agree.

## A deliberate spec change

`test_two_metrics_declaring_one_binding_resolve_the_same_way_every_run` pinned first-wins as a determinism guarantee. Two metrics sharing a binding with nothing to tell them apart now read `undetermined` — still deterministic, and closer to REQ-022's own words. The test is rewritten to state the new contract. `test_matching_does_not_scan_every_declared_metric` changes mechanically (the map's value is a list); its intent — one hash per column, not a scan — is preserved.

## Verified against a real model, before and after

Not only fixtures. The same 277-metric model and the same two statements, run against `main` and against this branch:

```
                                    main                          this branch
SUM(CASE WHEN state NOT IN (…))  bad_aggregation:              (no findings)
                                 "SUM(state) is meaningless"
  ...its columns entry           matched -> the approved       unchanged
                                 metric, signed off            -> the two sections agree

COUNT(*) AS <alias>              matched -> an unrelated       undetermined, no metric
                                 table's count metric          named, marker explains why
```

## Checklist

- [x] `pytest` — 4411 passed, 12 skipped
- [x] `ruff check` + `format --check` clean; `dev.py check` green
- [x] New tests **fail against the shipped behaviour** (five CASE spellings, incl. the two that passed only by accident)
- [x] Every changed function fully covered — lines **and** branches, verified by intersecting the miss list against each function's AST range
- [x] `runtime.py` is not vendored, so `test_vendored_surface_parity` is unaffected (it compares `(status, rule, reason)`, never findings)
- [x] Verified against a real model, not only the suite
- [x] No real customer data, names or credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)