### PR TITLE
An omitted datasource names the choices instead of a datasource nobody has

### DIFF
--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -251,6 +251,25 @@ def _sole_served_datasource(org_id: str) -> "str | None":
     hit = _SOLE_SERVED.get(org_id)
     if hit is not None:
         return hit
+    served = _served_datasources(org_id)
+    if served is None or len(served) != 1:
+        return None
+    _SOLE_SERVED[org_id] = served[0]
+    return served[0]
+
+
+def _served_datasources(org_id: str) -> "list[str] | None":
+    """Every datasource this deployment serves, or None when the store cannot answer.
+
+    None and `[]` are deliberately different. `[]` means "asked, and this org has none"; None means
+    "could not ask" — an unreachable store, or a local install with no store at all. Only the second
+    is a reason to stay silent about the choices, and a caller that conflates them tells a customer
+    they have no datasources when the truth is that we could not look.
+
+    Not memoized here. The one hot caller, `_sole_served_datasource`, keeps its own positive-only
+    cache for the reason its docstring gives; the other caller runs on a path that has already
+    failed to resolve a model, where one query is not the cost that matters.
+    """
     try:
         from store import Store
 
@@ -260,15 +279,45 @@ def _sole_served_datasource(org_id: str) -> "str | None":
         try:
             from model_store import list_datasources
 
-            served = [ds for ds in list_datasources(store, org_id=org_id) if ds]
+            return [ds for ds in list_datasources(store, org_id=org_id) if ds]
         finally:
             store.close()
     except Exception:
         return None
-    if len(served) != 1:
+
+
+def _choose_datasource_error(org_id: str) -> "str | None":
+    """The refusal for an omitted `datasource` that resolved to nothing — naming the real choices.
+
+    Returns None when the store cannot answer, so the caller keeps whatever message it already had:
+    a guess about the customer's datasources is exactly what this function exists to stop.
+    """
+    served = _served_datasources(org_id)
+    if served is None:
         return None
-    _SOLE_SERVED[org_id] = served[0]
-    return served[0]
+    if not served:
+        return json.dumps(
+            {
+                "error": {
+                    "kind": "not_found",
+                    "remediation": "no datasources are deployed for this organization.",
+                }
+            },
+            indent=2,
+        )
+    return json.dumps(
+        {
+            "error": {
+                "kind": "datasource_required",
+                "datasources": served,
+                "remediation": (
+                    "name one of this organization's datasources in `datasource`: "
+                    + ", ".join(served)
+                ),
+            }
+        },
+        indent=2,
+    )
 
 
 # Same name tests already reach for on `resolved_org_id`, so a test that varies the store clears
@@ -1182,6 +1231,15 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
     try:
         org = get_cached_org(profile)
     except FileNotFoundError as e:
+        # An omission and a typo deserve different answers. A caller who NAMED a datasource wants to
+        # hear that that name is wrong; a caller who named none has not made a mistake yet — they are
+        # mid-decision, and the useful reply is the list they were choosing from. Without this split
+        # both arrived as "no such datasource: default", which reads to an administrator like the
+        # customer's data has gone missing, and to a model like a reason to invent another name.
+        if args.get("datasource") is None:
+            choose = _choose_datasource_error(_current_org_id())
+            if choose is not None:
+                return choose
         return json.dumps({"error": {"kind": "not_found", "remediation": str(e)}}, indent=2)
     except ImportError:
         return json.dumps(
@@ -2439,7 +2497,11 @@ TOOLS: dict[str, dict[str, Any]] = {
             "properties": {
                 "datasource": {
                     "type": "string",
-                    "description": "Profile name; defaults to the active profile.",
+                    "description": (
+                        "Datasource name — call list_datasources first if you do not know it. "
+                        "Omitting it resolves to the active profile locally, or to the sole "
+                        "served datasource; where several are served there is no default."
+                    ),
                 },
                 "mode": {
                     "type": "string",
@@ -2479,7 +2541,11 @@ TOOLS: dict[str, dict[str, Any]] = {
             "properties": {
                 "datasource": {
                     "type": "string",
-                    "description": "Profile name; defaults to the active profile.",
+                    "description": (
+                        "Datasource name — call list_datasources first if you do not know it. "
+                        "Omitting it resolves to the active profile locally, or to the sole "
+                        "served datasource; where several are served there is no default."
+                    ),
                 },
                 "query": {
                     "type": "string",
@@ -2537,7 +2603,11 @@ TOOLS: dict[str, dict[str, Any]] = {
                 "sql": {"type": "string", "description": "One SELECT or WITH...SELECT statement."},
                 "datasource": {
                     "type": "string",
-                    "description": "Profile name; defaults to the active profile.",
+                    "description": (
+                        "Datasource name — call list_datasources first if you do not know it. "
+                        "Omitting it resolves to the active profile locally, or to the sole "
+                        "served datasource; where several are served there is no default."
+                    ),
                 },
                 "area": {
                     "type": "string",

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1236,7 +1236,13 @@ def tool_get_datasource_schema(args: dict[str, Any]) -> str:
         # mid-decision, and the useful reply is the list they were choosing from. Without this split
         # both arrived as "no such datasource: default", which reads to an administrator like the
         # customer's data has gone missing, and to a model like a reason to invent another name.
-        if args.get("datasource") is None:
+        #
+        # FALSY, not `is None`, and the two must agree with `resolve_profile`'s own `if explicit:`.
+        # It treats `""` as omitted and falls through to the fallback chain, so an `is None` test here
+        # would send a caller who sent `"datasource": ""` down the typo branch and hand them back the
+        # exact `no such datasource: default` sentence this function exists to stop. One notion of
+        # "named nothing", checked the same way in both places.
+        if not args.get("datasource"):
             choose = _choose_datasource_error(_current_org_id())
             if choose is not None:
                 return choose

--- a/tests/test_omitted_datasource_names_the_choices.py
+++ b/tests/test_omitted_datasource_names_the_choices.py
@@ -1,0 +1,96 @@
+"""An omitted `datasource` on a multi-datasource deployment must name the real choices.
+
+`_sole_served_datasource` already removed the invented `'default'` for a deployment serving exactly
+one. Serving several, resolution still falls through to that literal — correctly, because guessing
+between three is worse than refusing — and the caller then heard `no such datasource: default`.
+
+Two audiences read that sentence and both are misled. An administrator sees a name no customer has
+and concludes their data has gone missing. A model sees a failed lookup and invents another name,
+because the tool's own description told it a default existed.
+
+So the split under test is between a caller who NAMED a datasource (a typo — tell them the name is
+wrong) and one who named none (a decision not yet made — tell them what there is to choose from).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+import tools  # noqa: E402
+
+
+@pytest.fixture()
+def served(tmp_path, monkeypatch):
+    """A deployment serving three datasources, none of them called 'default'.
+
+    `get_cached_org` is left real: pointing artifacts at an empty directory is what makes it raise
+    the `FileNotFoundError` this branch hangs off, so the test enters the code the way production
+    does rather than through a patched exception.
+    """
+    for var in ("AGAMI_PROFILE", "AGAMI_DB_URL", "APP_DATABASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    tools.bootstrap_paths()
+    tools._sole_served_datasource.cache_clear()
+    monkeypatch.setattr(
+        tools, "_served_datasources", lambda _org: ["acme_crm", "acme_erp", "acme_tickets"]
+    )
+    yield
+    tools._sole_served_datasource.cache_clear()
+
+
+def test_omitting_the_datasource_returns_the_organizations_own_datasources(served):
+    """The whole point: the reply names what the caller can choose, not a name nobody has."""
+    out = json.loads(tools.tool_get_datasource_schema({}))
+    assert out["error"]["kind"] == "datasource_required"
+    assert out["error"]["datasources"] == ["acme_crm", "acme_erp", "acme_tickets"]
+    # The literal that caused the bug must not appear anywhere in what the caller reads.
+    assert "default" not in json.dumps(out)
+
+
+def test_naming_a_datasource_that_does_not_exist_still_says_so(served):
+    """A typo is not an undecided choice. Answering it with the catalog would bury the correction."""
+    out = json.loads(tools.tool_get_datasource_schema({"datasource": "acme_crmm"}))
+    assert out["error"]["kind"] == "not_found"
+
+
+def test_an_org_with_nothing_deployed_is_told_that_and_not_given_a_fake_name(served, monkeypatch):
+    monkeypatch.setattr(tools, "_served_datasources", lambda _org: [])
+    out = json.loads(tools.tool_get_datasource_schema({}))
+    assert out["error"]["kind"] == "not_found"
+    assert "no datasources are deployed" in out["error"]["remediation"]
+
+
+def test_an_unreachable_store_keeps_the_old_message_rather_than_guessing(served, monkeypatch):
+    """None means "could not ask", and is the one case where saying nothing is right. Claiming an
+    org has no datasources because the database blinked is worse than the message we already had."""
+    monkeypatch.setattr(tools, "_served_datasources", lambda _org: None)
+    out = json.loads(tools.tool_get_datasource_schema({}))
+    assert out["error"]["kind"] == "not_found"
+    assert "datasources" not in out["error"]
+
+
+def test_the_sole_served_shortcut_survives_the_refactor(monkeypatch):
+    """`_sole_served_datasource` now reads through `_served_datasources`; its rule is unchanged —
+    exactly one resolves, several do not."""
+    tools._sole_served_datasource.cache_clear()
+    monkeypatch.setattr(tools, "_served_datasources", lambda _org: ["only_one"])
+    assert tools._sole_served_datasource("acme") == "only_one"
+    tools._sole_served_datasource.cache_clear()
+    monkeypatch.setattr(tools, "_served_datasources", lambda _org: ["a", "b"])
+    assert tools._sole_served_datasource("acme") is None
+    tools._sole_served_datasource.cache_clear()
+
+
+def test_no_tool_promises_a_default_that_a_served_deployment_cannot_honour():
+    """The description is half the defect. A model that reads "defaults to the active profile"
+    omits the argument on purpose, so fixing only the refusal would leave it still being triggered
+    every turn — and on `/mcp` there is no prompt of ours to correct it with."""
+    for name in ("get_datasource_schema", "get_prompt_examples", "execute_sql"):
+        described = tools.TOOLS[name]["inputSchema"]["properties"]["datasource"]["description"]
+        assert "list_datasources" in described
+        assert "no default" in described or "there is no default" in described

--- a/tests/test_omitted_datasource_names_the_choices.py
+++ b/tests/test_omitted_datasource_names_the_choices.py
@@ -52,6 +52,21 @@ def test_omitting_the_datasource_returns_the_organizations_own_datasources(serve
     assert "default" not in json.dumps(out)
 
 
+def test_an_empty_datasource_counts_as_omitted_not_as_a_name(served):
+    """`resolve_profile` treats `""` as omitted — its check is `if explicit:` — so a caller who sends
+    an empty string lands on exactly the fallback chain an absent argument does, and must get the same
+    answer here. Testing `is None` instead would send them down the typo branch and hand back the
+    `no such datasource: default` sentence this whole change exists to remove.
+
+    Whitespace is deliberately NOT special-cased: `resolve_profile` returns `"   "` unchanged, so it
+    is a name that does not exist, and reporting it as a name is the honest answer.
+    """
+    out = json.loads(tools.tool_get_datasource_schema({"datasource": ""}))
+    assert out["error"]["kind"] == "datasource_required"
+    assert out["error"]["datasources"] == ["acme_crm", "acme_erp", "acme_tickets"]
+    assert "default" not in json.dumps(out)
+
+
 def test_naming_a_datasource_that_does_not_exist_still_says_so(served):
     """A typo is not an undecided choice. Answering it with the catalog would bury the correction."""
     out = json.loads(tools.tool_get_datasource_schema({"datasource": "acme_crmm"}))


### PR DESCRIPTION
## Summary

**#216 fixed this for a deployment serving exactly one datasource. Serving several, it still resolves to a datasource nobody has.**

`resolve_profile` falls through to the literal `'default'` when several are served — correctly, since guessing between three is worse than refusing. But the caller then hears `no such datasource: default`, and two audiences read that sentence differently, both wrongly. An administrator sees a name no customer has and concludes their data has gone missing. A model sees a failed lookup and invents another name, because the tool's own description told it a default existed.

Observed against a three-datasource deployment from a desktop MCP client. It listed all three correctly and then reported:

> None is currently active (the active profile is just `default`).

A sentence about a developer's local config file, presented to a customer as a fact about their account — with an offer to "set one as active", which is not a thing this product has.

## Two halves, and the description is the one that matters

A model that reads *"defaults to the active profile"* omits the argument **on purpose**, so fixing only the refusal leaves it triggered every turn. All three tools now describe what is actually true on each install and point at `list_datasources`.

This is the part that could not be fixed downstream. The consumer already patched its own agent's instructions; on `/mcp` the customer's client supplies the prompt, so there is no instruction of ours to correct it with. **A prompt-side fix does not hold on a surface where someone else writes the prompt.**

## The refusal splits on whether the caller named anything

A typo wants to hear the name is wrong. An omission is a decision not yet made, and wants the list it was choosing from — so `get_datasource_schema` answers it with `datasource_required` plus the org's actual datasources.

`_served_datasources` is `_sole_served_datasource`'s store read, generalized. `None` ("could not ask") stays distinct from `[]` ("asked, and there are none"), because conflating them tells a customer they have no data when the truth is that the database blinked.

**Left alone deliberately:** `execute_sql`'s equivalent path. The model reaches the schema tool first, and that one is the audited guarded path where a change earns its own review rather than riding along here.

## Checks

- `pytest tests/` — **4460 passed**, 12 skipped. The 7 failures in `test_admin_model` / `test_hosted_instruction_truth` reproduce identically on unmodified `origin/main` on this machine (a local `~/.config/agami/path` pointer leaks a real artifacts dir into those fixtures); `main`'s own CI is green.
- `ruff check` clean. `ruff format` deliberately **not** run — the tree has the known ~74-file backlog the CI step calls informational, and formatting this file would have added 180 unrelated lines to the diff.
- Regression guard: 6 tests. The new branch was **removed** to confirm two of them fail on it — without the fix the message reads `.../default/datasource.yaml`, which is the bug verbatim.

Bug: `agami-sdlc BUG-schema-tool-defaults-to-a-datasource-nobody-has`

🤖 Generated with [Claude Code](https://claude.com/claude-code)