### PR TITLE
release: 0.6.2 — an omitted datasource names the choices, and the tool surface tells the truth

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,20 @@ below corresponds to one such version.
 
 ### Fixed
 
-- **An omitted `datasource` names the org's real datasources instead of one nobody has.** 0.6.1 removed
-  the invented `'default'` for a deployment serving exactly ONE datasource; serving several, resolution
-  still fell through to that literal and the caller heard `no such datasource: default`. Two audiences
-  read that and both were misled — an administrator sees a name no customer has and concludes their data
-  has gone missing, and a model sees a failed lookup and invents another name, because the tool's own
-  description told it a default existed. Both halves are fixed: the three tool descriptions now say what
-  is true on each install and point at `list_datasources`, and an omitted argument gets the catalogue
-  back (`datasource_required`) while a NAMED one that does not exist is still told so. An empty string
-  counts as omitted, matching `resolve_profile`'s own `if explicit:`. (#218)
+- **An omitted `datasource` names the org's real datasources instead of one nobody has.** #216 (also in
+  this release) removed the invented `'default'` for a deployment serving exactly ONE datasource;
+  serving several, resolution still fell through to that literal and the caller heard
+  `no such datasource: default` — so the one-datasource case and the several-datasource case are fixed
+  together in this release, and nothing in 0.6.1 or earlier ever consulted the store to resolve a
+  profile at all.
+
+  Two audiences read that sentence and both were misled: an administrator sees a name no customer has
+  and concludes their data has gone missing, and a model sees a failed lookup and invents another name,
+  because the tool's own description told it a default existed. So the description is fixed as well as
+  the refusal — all three tools now say what is true on each install and point at `list_datasources`.
+  An omitted argument gets the catalogue back (`datasource_required`); a NAMED one that does not exist
+  is still told so; an empty string counts as omitted, matching `resolve_profile`'s own
+  `if explicit:`. (#218)
 
 - **A CASE predicate is not what a SUM aggregates, and a shared expression names no metric.** (#215)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,38 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.6.2] — 2026-08-09
+
+### Fixed
+
+- **An omitted `datasource` names the org's real datasources instead of one nobody has.** 0.6.1 removed
+  the invented `'default'` for a deployment serving exactly ONE datasource; serving several, resolution
+  still fell through to that literal and the caller heard `no such datasource: default`. Two audiences
+  read that and both were misled — an administrator sees a name no customer has and concludes their data
+  has gone missing, and a model sees a failed lookup and invents another name, because the tool's own
+  description told it a default existed. Both halves are fixed: the three tool descriptions now say what
+  is true on each install and point at `list_datasources`, and an omitted argument gets the catalogue
+  back (`datasource_required`) while a NAMED one that does not exist is still told so. An empty string
+  counts as omitted, matching `resolve_profile`'s own `if explicit:`. (#218)
+
+- **A CASE predicate is not what a SUM aggregates, and a shared expression names no metric.** (#215)
+
+### Changed
+
+- **The tool surface reports what it checked, and accepts what it advertises** — nine findings from a
+  connector audit, all one shape: the server stated something it had not established, or named a field
+  the agent could not reach. `model_present` dropped from the served listing (it was the literal `True`);
+  `resolve_profile` consults the store; a hosted server no longer claims "All execution is local";
+  `bindings` is actually sent; `area` reaches `get_prompt_examples`; `list_datasources` returns
+  `description`; `for_questions_about` dropped from the payload. (#216)
+
+  **Released as a patch deliberately, and it is the one judgement call in this version.** #216 REMOVES
+  fields from emitted tool payloads, which a consumer reading them would notice — normally a minor bump
+  under 0.x. It ships as 0.6.2 because every field removed was provably dead: `model_present` could only
+  ever be `True` on that path, and `for_questions_about` had no writer anywhere in the product. A
+  consumer reading either was reading a constant or an empty list. The field stays DECLARED on the model
+  format, so no model on disk fails to load.
+
 ## [0.6.1] — 2026-08-08
 
 ### Fixed

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.6.1"
+version = "0.6.2"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary

Bumps the package, the plugin and both marketplace entries to **0.6.2**, and adds the CHANGELOG section for the three PRs that have shipped since 0.6.1:

| | |
|---|---|
| **#215** | a CASE predicate is not what a SUM aggregates |
| **#216** | the tool surface reports what it checked, and accepts what it advertises |
| **#218** | an omitted datasource names the choices instead of a datasource nobody has |

## Why a patch, given #216 removes payload fields

This is the one judgement call in the version. #216 **removes** `model_present` and `for_questions_about` from emitted tool payloads, and a consumer reading them would notice — normally a minor bump under 0.x.

It goes out as a patch because **every removed field was provably dead**: `model_present` could only ever be the literal `True` on that path (the listing is built *from* the model rows), and `for_questions_about` had no writer anywhere in the product. A consumer reading either was reading a constant or an empty list.

`for_questions_about` also stays **declared** on the model format — these models `forbid` unknown keys and generation wrote it to disk — so no model on disk fails to load.

Checked against the one consumer we control: **agami reads `for_questions_about` from the model objects** through its own projection, not from core's tool payload, so it is unaffected.

## What happens on merge

Nothing publishes. `release-pypi.yml` fires on `release: published`, verifies the tag matches the package version, and publishes over trusted OIDC — so cutting `v0.6.2` is the separate, deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)