### PR TITLE
release: 0.6.3 — an administrator can give a colleague a new password

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,6 @@ below corresponds to one such version.
   `claim_done_html`, which take the purpose.
 - Password hashing on `/claim` runs off the event loop. It is deliberately slow and memory-hard, and
   this is a public endpoint, so hashing inline stalled every other request in flight.
-
-### Changed
-
 - `get_datasource_schema` answers **within the scope the caller declares**, and the never-hide
   guarantee is now stated relative to that scope: within it, nothing is hidden — the scope's own
   metrics plus the cross-area bucket. A new `area` parameter narrows to one subject area

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.6.3] — 2026-08-11
+
+### Added
+
+- **An administrator can give a colleague a new password.** The setup link works exactly once —
+  claiming an account flips it out of `pending`, and every later use is refused — so an administrator
+  could create somebody's account and then never help them back into it, and with no mail path there
+  is no self-service reset either. `/claim` now carries a second purpose: `setup` still means a
+  pending account choosing its first password, and `reset` means a claimed account being given a new
+  one because an administrator asked. The two are matched against the state of the account rather
+  than trusted from the link, so neither can do the other's job.
+- A reset link is **single-use**, by a mechanism the setup link does not need: a reset leaves an
+  account exactly as claimed as it was, so nothing about it would change and the link would work
+  forever. The link is bound to the credential it was minted against, and that credential is a
+  condition of the write — so the first successful reset retires it, a password change by any other
+  route retires it, and two simultaneous uses cannot both succeed.
+- A reset **ends the sessions running on the old password** by revoking that person's refresh
+  tokens. Stated precisely because a security control believed to cover more than it does is worse
+  than a narrow one: a session already holding an access token lasts until that token expires, and
+  the `/admin` console cookie and any outstanding authorization code are untouched.
+- A reset can never give a password to an identity that signs in through a provider, and can never
+  revive a switched-off account.
+
+### Changed
+
+- The claim page is worded for what the link is for — somebody with an account is not told to
+  "finish setting up" — and `setup_page_html` / `setup_done_html` are now `claim_page_html` /
+  `claim_done_html`, which take the purpose.
+- Password hashing on `/claim` runs off the event loop. It is deliberately slow and memory-hard, and
+  this is a public endpoint, so hashing inline stalled every other request in flight.
+
 ### Changed
 
 - `get_datasource_schema` answers **within the scope the caller declares**, and the never-hide

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.6.2"
+version = "0.6.3"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary

Cuts **0.6.3**. Two things ship in it:

- **#220** — `/claim` gains a `reset` purpose, so an administrator can give a colleague a new password. The setup link works exactly once, which left an administrator able to create an account and never help anybody back into it; with no mail path there is no self-service reset either.
- **#217** — the scoped `get_datasource_schema`, which landed after 0.6.2 and had been sitting in `[Unreleased]`.

## Changes

- `CHANGELOG.md` — `[Unreleased]` promoted to `[0.6.3]`, with the reset's own entries added above #217's.
- Version bumped in the four places that carry it: `packages/agami-core/pyproject.toml`, `plugins/agami/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` (twice).

No link reference added at the bottom of the changelog: that list stopped at 0.3.9 and 0.6.0–0.6.2 have none, so this matches recent practice rather than reviving a lapsed one.

## Why this release is needed now

The private product's seat-and-password work calls `mint_reset_token`, which exists only from this version. That branch cannot open as a PR until this is on PyPI and its floor is raised.

## Checklist

- [x] `Spec:` line present
- [x] All four version strings bumped and checked — no `0.6.2` left anywhere in the plugin or package metadata
- [x] Version-parity tests pass (`test_marketplace_script_imports`, `test_sm_install_resolution`) — they read the marketplace version directly
- [x] Changelog entry states what the reset does **and what it does not**: a live access token, the `/admin` cookie and an outstanding authorization code all survive it