### PR TITLE
The claim page says whose account it is

### DIFF
--- a/packages/agami-core/src/onboarding.py
+++ b/packages/agami-core/src/onboarding.py
@@ -324,12 +324,21 @@ async def claim(request: Request) -> Response:
         return HTMLResponse(setup_invalid_html(), status_code=400)
     username, purpose, expected_hash = actionable
     password = form.get("password", "")
+    # Both bounds, and each says which one was missed. One message for both read "Use at least 8
+    # characters" to somebody who had just typed three hundred — advice that makes the problem worse
+    # the more carefully it is followed. Neither message names the password back, and neither is
+    # branched on anything but its length.
     if not _MIN_PASSWORD_LEN <= len(password) <= _MAX_PASSWORD_LEN:
+        too_short = len(password) < _MIN_PASSWORD_LEN
         return HTMLResponse(
             claim_page_html(
                 token,
                 purpose,
-                error=f"Use at least {_MIN_PASSWORD_LEN} characters.",
+                error=(
+                    f"Use at least {_MIN_PASSWORD_LEN} characters."
+                    if too_short
+                    else f"Use at most {_MAX_PASSWORD_LEN} characters."
+                ),
                 username=username,
             ),
             status_code=400,

--- a/packages/agami-core/src/onboarding.py
+++ b/packages/agami-core/src/onboarding.py
@@ -179,11 +179,26 @@ _WORDING: dict[str, dict[str, str]] = {
 }
 
 
-def claim_page_html(token: str, purpose: str = _SETUP_PURPOSE, error: str = "") -> str:
-    """The choose-a-password page reached from a valid link, worded for what the link is for."""
+def claim_page_html(
+    token: str, purpose: str = _SETUP_PURPOSE, error: str = "", username: str = ""
+) -> str:
+    """The choose-a-password page reached from a valid link, worded for what the link is for.
+
+    **It names the account.** Without that, somebody following a link is asked to choose a password
+    with no way to tell WHOSE it is — and the link is shared out-of-band, so the person holding it may
+    have been sent the wrong one, or two of them. That was tolerable while the only link set a first
+    password on an account the recipient was expecting; it is not now that a link can REPLACE a working
+    password, where following the wrong one silently locks somebody out of their own account.
+
+    It discloses nothing new: whoever holds the link already holds a token whose payload is base64url
+    and carries this same address in the clear (the module note says so). Showing it turns something
+    they could decode into something they can check.
+    """
     words = _WORDING[purpose]
     alert = f'<div class="alert error">{ui.esc(error)}</div>' if error else ""
+    whose = f'<p class="small">for <strong>{ui.esc(username)}</strong></p>' if username else ""
     body = f"""<div class="consent"><p class="who">{ui.esc(words["title"])}</p>
+{whose}
 <p class="small">{ui.esc(words["lead"])}</p></div>
 {alert}
 <form method="post" action="/claim">
@@ -300,7 +315,7 @@ async def claim(request: Request) -> Response:
         actionable = _actionable(token)
         if actionable is None:
             return HTMLResponse(setup_invalid_html(), status_code=400)
-        return HTMLResponse(claim_page_html(token, actionable[1]))
+        return HTMLResponse(claim_page_html(token, actionable[1], username=actionable[0]))
 
     form = await _form(request)
     token = form.get("token", "")
@@ -311,7 +326,12 @@ async def claim(request: Request) -> Response:
     password = form.get("password", "")
     if not _MIN_PASSWORD_LEN <= len(password) <= _MAX_PASSWORD_LEN:
         return HTMLResponse(
-            claim_page_html(token, purpose, error=f"Use at least {_MIN_PASSWORD_LEN} characters."),
+            claim_page_html(
+                token,
+                purpose,
+                error=f"Use at least {_MIN_PASSWORD_LEN} characters.",
+                username=username,
+            ),
             status_code=400,
         )
     # Off the event loop. Argon2 is deliberately slow and memory-hard, and this handler is `async` on a

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -144,6 +144,23 @@ def test_claim_link_is_single_use(client, env):
     s.close()
 
 
+def test_the_claim_page_says_whose_account_it_is(client, env):
+    """A link is shared out-of-band, so the person holding it may have been sent the wrong one — or
+    two. While the only link set a FIRST password that was tolerable; a reset link replaces a working
+    one, and following the wrong one locks somebody out of their own account.
+
+    Asserted on both purposes and on the re-render after a rejected password, because that last one is
+    the render most easily forgotten and the one somebody is staring at when they are confused.
+    """
+    setup = onboarding.mint_setup_token(PENDING)
+    assert PENDING in client.get("/claim", params={"token": setup}).text
+    reset = _reset_token(env, ADMIN_USER)
+    assert ADMIN_USER in client.get("/claim", params={"token": reset}).text
+    # ...and when the password is refused for being too short.
+    again = client.post("/claim", data={"token": setup, "password": "short"})
+    assert again.status_code == 400 and PENDING in again.text
+
+
 def test_claim_rejects_a_bad_token(client):
     assert client.get("/claim", params={"token": "nope"}, follow_redirects=False).status_code == 400
     assert (

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -177,6 +177,25 @@ def test_claim_rejects_a_short_password(client, env):
     s.close()
 
 
+def test_a_password_refused_for_being_too_long_says_so(client, env):
+    """The advice has to match the bound that was missed.
+
+    Both ends shared one message, so somebody who pasted three hundred characters was told to "use at
+    least 8" — guidance that makes the problem worse the more carefully it is followed, on the one
+    page they cannot get past. Raised by Copilot on PR #222.
+    """
+    token = onboarding.mint_setup_token(PENDING)
+    r = client.post("/claim", data={"token": token, "password": "x" * 300})
+    assert r.status_code == 400
+    assert "at most" in r.text and "at least" not in r.text
+    # ...and the page still names the account, so the re-render did not lose it — the whole point of
+    # the change this test file is attached to.
+    assert PENDING in r.text
+    s = Store.connect(env)
+    assert onboarding.is_pending(user_store.get_user(s, PENDING))  # nothing was written
+    s.close()
+
+
 def test_claim_for_an_already_password_user_is_refused(client, env):
     # The admin (a password user) isn't pending; a token for them can't overwrite their password.
     token = onboarding.mint_setup_token(ADMIN_USER)


### PR DESCRIPTION
## Summary

Somebody following a setup or reset link was asked to choose a password with **no indication of which account it was for**.

A link is shared out of band, so the person holding it may have been sent the wrong one, or two of them. That was tolerable while the only link set a *first* password on an account the recipient was expecting. It is not now that a link can **replace a working password** — following the wrong one silently locks somebody out of their own account, and nothing on the page would have told them.

Reported from using it: *"On that screen we are not showing which email that is relevant for."*

## Changes

- `claim_page_html` takes the account it is for and shows it under the title. The handler already resolved it — `_actionable` returns the username — so nothing new is looked up.
- Shown on both purposes and on the re-render after a rejected password.

## Disclosure

None added. Whoever holds the link already holds a token whose payload is base64url and carries the same address in the clear — the module docstring says exactly that. This turns something they could decode into something they can check.

## Checklist

- [x] `Spec:` line present
- [x] Test asserts both purposes **and** the short-password re-render — the render most easily forgotten, and the one somebody is looking at when already confused
- [x] Mutation-checked: drop the name and the test fails
- [x] Full suite: 4517 passed, 7 failed — the 7 are pre-existing in `test_hosted_instruction_truth.py` and identical on clean `main`
- [x] Public repo: synthetic addresses only