### PR TITLE
Profile resolution reads the suite's .config, not the developer's

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,32 @@ def _isolate_query_log(tmp_path_factory, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_active_profile(tmp_path_factory, monkeypatch):
+    """Keep the developer's own `.config` out of `resolve_profile`.
+
+    Same hazard as `_isolate_query_log` above, on the read side. `tools.CONFIG_PATH` is resolved at
+    import time from the real artifacts dir and only re-resolved by `bootstrap_paths()`, so a test
+    that sets `AGAMI_ARTIFACTS_DIR` to a `tmp_path` does NOT move it — `_load_config()` still reads
+    `~/agami-artifacts/local/.config`. `resolve_profile` consults `.config.active_profile` BEFORE
+    the sole-served-datasource step, so on any machine that has run the CLI, that file's real
+    profile name short-circuits resolution and every test of the store step asserts against it
+    instead of against what the test set up.
+
+    That made the store-step tests pass in CI (no `.config` there) and fail on a contributor's
+    machine — the failure mode a test is least able to explain, since the value it reports comes
+    from a file the test never mentions. Point it at a path that does not exist, which is the state
+    `_load_config()` is written for and the one CI already had; a test that wants a `.config` sets
+    the attribute itself and this fixture is then simply overwritten."""
+    try:
+        import tools
+    except Exception:
+        yield
+        return
+    monkeypatch.setattr(tools, "CONFIG_PATH", tmp_path_factory.mktemp("cfg") / ".config")
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _restore_raw_logger():
     """`execute_sql.main()` silences `_RAW_LOG` for the lifetime of the process it owns, and a test
     that calls it in-process owns the whole session instead.


### PR DESCRIPTION
## What

Adds one autouse fixture, `_isolate_active_profile`, that points `tools.CONFIG_PATH` at a path that does not exist for the duration of each test.

## Why

`uv run dev.py check` left 7 failures on a contributor machine, clustered in `test_admin_model.py` (3) and `test_hosted_instruction_truth.py` (4). CI was green on the same commit, so the suite passed in the one place it was checked and failed in the one place it was written.

`tools.CONFIG_PATH` is bound at import (`tools.py:73`) and only re-resolved by `bootstrap_paths()`. All 7 tests set `AGAMI_ARTIFACTS_DIR` to a `tmp_path` via monkeypatch after import, so the constant never moved and `_load_config()` kept reading the real `~/agami-artifacts/local/.config`.

`resolve_profile` consults `.config.active_profile` (`tools.py:329`) one step **before** the sole-served-datasource step, so that file's real profile name short-circuited resolution. Every failure read `assert '<real profile>' == <expected>`: a value sourced from a file the test never mentions, which is the failure mode a test is least able to explain.

`_sole_served_datasource` was never at fault. In each test the preceding `assert tools._sole_served_datasource(...) is None` passes; only the following `resolve_profile()` line fails. The store step was simply never reached.

## Evidence

Before touching anything, running the two files with `AGAMI_ARTIFACTS_DIR` pointed at an empty dir at process start (which is CI's state) passed all 50 tests unmodified. That isolated the cause to the import-time binding rather than to the code under test.

## Test plan

Full local gate, `uv run dev.py check`:

```
4535 passed, 12 skipped, 6 warnings in 118.91s
✓ all checks passed
```

## Notes

This is the same hazard `_isolate_query_log` already documents for the write side ("a module-level constant resolved at import time from the real artifacts dir, so a test setting `AGAMI_ARTIFACTS_DIR` afterwards does not move it"), extended to the read side. The new fixture sits directly beneath it and follows its override contract: a test that wants a `.config` sets the attribute itself.

`CREDENTIALS_PATH` and `AGAMI_LOCAL` are bound in the same block and carry the identical hazard. Nothing fails on them today, so this change deliberately leaves them alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)