### PR TITLE
release: 0.6.4 — the claim page says whose account it is

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.6.4] — 2026-08-12
+
+### Added
+
+- **The claim page says whose account it is.** Somebody following a setup or reset link was asked to
+  choose a password with no indication of which account it belonged to. A link is shared out of band,
+  so the person holding it may have been sent the wrong one, or two of them — and now that a link can
+  REPLACE a working password rather than only set a first one, following the wrong one silently locks
+  somebody out of their own account with nothing on the page to warn them. It discloses nothing new:
+  whoever holds the link already holds a token naming that account.
+- **The MCP surface states what the server already does.** Four capabilities shipped working and
+  undocumented, and a silent feature is worse than a broken one — a broken one gets reported.
+  `execute_sql` returns three statuses and described two; the third carries the whole database-error
+  channel with a `kind` from a declared enum, which tells an agent whether a failure is repairable
+  from the schema it already holds or whether retrying is pointless. Documented, so it can be used.
+
+### Fixed
+
+- A password refused for being **too long** said "use at least 8 characters" — the same message as
+  one refused for being too short, and advice that makes the problem worse the more carefully it is
+  followed. Each bound now names itself.
+- Seven store-step tests resolved the profile from the developer's own `~/agami-artifacts` rather
+  than from the temporary directory they had set, so they compared against a value from a file the
+  test never mentions. CI has no such file, so they passed there and failed only on a machine that
+  had run the CLI.
+
 ## [0.6.3] — 2026-08-11
 
 ### Added

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.6.3"
+version = "0.6.4"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
## Summary

Cuts **0.6.4**. Three PRs have landed since 0.6.3 (#222, #223, #224) and none of them is on PyPI yet.

## Changes

- `packages/agami-core/pyproject.toml` → `0.6.4`
- `.claude-plugin/marketplace.json` (both entries) and `plugins/agami/.claude-plugin/plugin.json` → `0.6.4` — the version a host installs against, and what invalidates a user's plugin cache
- `CHANGELOG.md` — a `0.6.4` section, `Unreleased` emptied

### What ships

**Added**
- The claim page names the account a setup/reset link belongs to (#222). It matters more now that a link can *replace* a working password: following the wrong one silently locks somebody out of their own account.
- The MCP surface documents four capabilities the server already had (#223), including `execute_sql`'s third status — the database-error channel that tells an agent whether a failure is worth retrying.

**Fixed**
- A password refused for being too long said "use at least 8 characters" (#222, raised in review).
- Seven store-step tests read the developer's own artifacts directory instead of their `tmp_path`, so they passed in CI and failed only on a machine that had run the CLI (#224).

## Checklist

- [x] `uv run dev.py check` green on this branch
- [x] Version bumped in all four places; nothing else pins it
- [x] CHANGELOG entry describes behaviour, not commits
- [x] No real customer data

Publishing the GitHub Release is what triggers `release-pypi.yml` — merging this does not ship it.