### PR TITLE
chore: remove stray ace042-smoke/ directory from the repo root

### DIFF
--- a/ace042-smoke/artifacts/.gitignore
+++ b/ace042-smoke/artifacts/.gitignore
@@ -1,2 +1,0 @@
-# agami secrets + per-user state — never commit
-local/


### PR DESCRIPTION
`ace042-smoke/` sat at the repo root holding exactly one tracked file, `ace042-smoke/artifacts/.gitignore` (contents: `local/`).

It was auto-written by an `agami-connect` run into a throwaway artifacts dir used to verify ACE-042 against a real database, then swept into #180 alongside the real changes. Nothing in the tree references the path.

Deleting it. No code, config, or docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)