### PR TITLE
Two tables joined more than once no longer collide on load

### DIFF
--- a/packages/agami-core/src/migrations/core/001_serving.sql
+++ b/packages/agami-core/src/migrations/core/001_serving.sql
@@ -83,7 +83,7 @@ CREATE TABLE relationship (
     org_id     TEXT NOT NULL DEFAULT 'local',
     datasource TEXT NOT NULL,
     area       TEXT NOT NULL,
-    name       TEXT NOT NULL,      -- "from->to"
+    name       TEXT NOT NULL,      -- "<position>:<from>-><to>" (model_store._relationship_key)
     doc        TEXT NOT NULL,
     PRIMARY KEY (org_id, datasource, area, name)
 );

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -46,6 +46,42 @@ def _est_rows(table_doc: dict[str, Any]) -> int | None:
     return ph.get("estimated_row_count") if isinstance(ph, dict) else None
 
 
+def _relationship_key(position: int, rel_doc: dict[str, Any]) -> str:
+    """The `relationship.name` for one join — unique within its subject area BY CONSTRUCTION.
+
+    `relationship` is PRIMARY KEY (org_id, datasource, area, name), and a duplicate name does not
+    lose one edge: the INSERT raises part-way through `write_datasource`, nothing commits, and the
+    deployment serves NO model at all. So the only acceptable property here is that a collision
+    cannot happen, for any model that validates.
+
+    **Hence the ordinal**, rather than a name assembled from whichever fields look discriminating.
+    That was the previous approach twice over — first the table pair alone, which collides for a
+    self-join written two ways (`manager_id` and `mentor_id` on one employee table), then the pair
+    plus columns, which still collides for two `on:`-expression joins (both columns are None there)
+    and for same-named tables in two schemas. Each fix enumerated the cases its author had in mind
+    and the next shape found the gap. A position in a list cannot repeat.
+
+    The rest is for the human reading the table, and carries no uniqueness burden: schema-qualified
+    endpoints, with the columns when the simple form is used. The `on:` expression is deliberately
+    NOT appended — it would add unbounded length to a primary key to describe an edge whose
+    definition is already in `doc`.
+
+    Nothing READS this. No query selects a relationship by name, and `load_datasource` rebuilds each
+    one from `doc` — so the format is not a contract, and a redeploy replaces a datasource's rows
+    wholesale (the DELETE in `write_datasource`), leaving nothing keyed the old way to migrate.
+    """
+
+    def endpoint(schema: Any, table: Any, column: Any) -> str:
+        qualified = f"{schema}.{table}" if schema else f"{table}"
+        return f"{qualified}.{column}" if column else qualified
+
+    frm = endpoint(
+        rel_doc.get("from_schema"), rel_doc.get("from_table"), rel_doc.get("from_column")
+    )
+    to = endpoint(rel_doc.get("to_schema"), rel_doc.get("to_table"), rel_doc.get("to_column"))
+    return f"{position}:{frm}->{to}"
+
+
 def write_datasource(
     store: Store, datasource: str, org: Datasource, org_id: str = DEFAULT_ORG
 ) -> None:
@@ -100,27 +136,12 @@ def write_datasource(
                 "VALUES (?, ?, ?, ?, ?, ?)",
                 (org_id, datasource, sa.name, e.name, edoc.get("value_pattern"), json.dumps(edoc)),
             )
-        for r in sa.relationships:
+        for position, r in enumerate(sa.relationships):
             rdoc = r.model_dump(mode="json")
-            # **The join columns belong in the key, not just the tables.** `relationship` is UNIQUE on
-            # (org_id, datasource, area, name), and a table pair joined two ways — an employee row
-            # pointing at another as `manager_id` and again as `mentor_id` — produced one name twice
-            # and aborted the whole load on the constraint. Self-referencing tables make that ordinary
-            # rather than exotic, and the failure was total: nothing is written, so the deployment ends
-            # up with no model at all.
-            #
-            # Safe to change the format because nothing READS it. No query selects a relationship by
-            # name, and `load_datasource` rebuilds each one from `doc`; the column exists to keep rows
-            # distinct. A redeploy also replaces a datasource's rows wholesale (the DELETE above), so
-            # models stored under the old key need no migration.
-            name = (
-                f"{rdoc.get('from_table')}.{rdoc.get('from_column')}"
-                f"->{rdoc.get('to_table')}.{rdoc.get('to_column')}"
-            )
             store.execute(
                 "INSERT INTO relationship (org_id, datasource, area, name, doc) "
                 "VALUES (?, ?, ?, ?, ?)",
-                (org_id, datasource, sa.name, name, json.dumps(rdoc)),
+                (org_id, datasource, sa.name, _relationship_key(position, rdoc), json.dumps(rdoc)),
             )
     store.commit()
 

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -102,7 +102,21 @@ def write_datasource(
             )
         for r in sa.relationships:
             rdoc = r.model_dump(mode="json")
-            name = f"{rdoc.get('from_table')}->{rdoc.get('to_table')}"
+            # **The join columns belong in the key, not just the tables.** `relationship` is UNIQUE on
+            # (org_id, datasource, area, name), and a table pair joined two ways — an employee row
+            # pointing at another as `manager_id` and again as `mentor_id` — produced one name twice
+            # and aborted the whole load on the constraint. Self-referencing tables make that ordinary
+            # rather than exotic, and the failure was total: nothing is written, so the deployment ends
+            # up with no model at all.
+            #
+            # Safe to change the format because nothing READS it. No query selects a relationship by
+            # name, and `load_datasource` rebuilds each one from `doc`; the column exists to keep rows
+            # distinct. A redeploy also replaces a datasource's rows wholesale (the DELETE above), so
+            # models stored under the old key need no migration.
+            name = (
+                f"{rdoc.get('from_table')}.{rdoc.get('from_column')}"
+                f"->{rdoc.get('to_table')}.{rdoc.get('to_column')}"
+            )
             store.execute(
                 "INSERT INTO relationship (org_id, datasource, area, name, doc) "
                 "VALUES (?, ?, ?, ?, ?)",

--- a/tests/test_model_store_roundtrip.py
+++ b/tests/test_model_store_roundtrip.py
@@ -95,6 +95,51 @@ def test_reseed_replaces_rows():
     s.close()
 
 
+def test_a_table_pair_joined_two_ways_survives_the_roundtrip():
+    """Two joins between the SAME pair of tables are two relationships, not one.
+
+    A self-referencing table is the ordinary case — an employee row pointing at another as its
+    manager, and again as its mentor — and any pair joined on two different column pairs is the same
+    shape. `relationship` is UNIQUE on (org_id, datasource, area, name), and the name used to be
+    built from the table names alone, so the second row collided with the first and the write raised
+    mid-load. The failure was total rather than partial: nothing is committed, so a deployment ends
+    up serving no model at all.
+
+    Asserted through `load_datasource` rather than by counting rows, deliberately. A row count also
+    passes if a future change quietly folds the two joins into one — the same lost relationship,
+    wearing the shape of a successful load. Reading the joins back is what says both survived
+    intact.
+    """
+    doc = json.loads(json.dumps(FULL_ORG))
+    doc["subject_areas"][0]["relationships"] = [
+        {
+            "from_table": "employee",
+            "from_column": "manager_id",
+            "to_table": "employee",
+            "to_column": "id",
+            "relationship": "many_to_one",
+        },
+        {
+            "from_table": "employee",
+            "from_column": "mentor_id",
+            "to_table": "employee",
+            "to_column": "id",
+            "relationship": "many_to_one",
+        },
+    ]
+    org = Datasource.model_validate(doc)
+    s = Store.connect("sqlite://")
+    s.run_migrations()
+    model_store.write_datasource(s, "main", org)
+    rebuilt = model_store.load_datasource(s, "main")
+    assert rebuilt is not None
+    joins = {(r.from_column, r.to_column) for r in rebuilt.subject_areas[0].relationships}
+    assert joins == {("manager_id", "id"), ("mentor_id", "id")}, (
+        "a table pair joined two ways lost one of its joins on the way through the database"
+    )
+    s.close()
+
+
 # --- file → DB parity + tools wiring ---------------------------------------
 
 

--- a/tests/test_model_store_roundtrip.py
+++ b/tests/test_model_store_roundtrip.py
@@ -95,49 +95,116 @@ def test_reseed_replaces_rows():
     s.close()
 
 
-def test_a_table_pair_joined_two_ways_survives_the_roundtrip():
-    """Two joins between the SAME pair of tables are two relationships, not one.
+def _roundtrip_relationships(relationships):
+    """Write a subject area holding `relationships`, read it back, return what survived.
 
-    A self-referencing table is the ordinary case — an employee row pointing at another as its
-    manager, and again as its mentor — and any pair joined on two different column pairs is the same
-    shape. `relationship` is UNIQUE on (org_id, datasource, area, name), and the name used to be
-    built from the table names alone, so the second row collided with the first and the write raised
-    mid-load. The failure was total rather than partial: nothing is committed, so a deployment ends
-    up serving no model at all.
-
-    Asserted through `load_datasource` rather than by counting rows, deliberately. A row count also
-    passes if a future change quietly folds the two joins into one — the same lost relationship,
-    wearing the shape of a successful load. Reading the joins back is what says both survived
-    intact.
+    Through `load_datasource` rather than a row count, deliberately. A count of two also passes if a
+    later change folds two joins into one — the same lost edge, wearing the shape of a successful
+    load. Reading them back is what says both survived intact.
     """
     doc = json.loads(json.dumps(FULL_ORG))
-    doc["subject_areas"][0]["relationships"] = [
-        {
-            "from_table": "employee",
-            "from_column": "manager_id",
-            "to_table": "employee",
-            "to_column": "id",
-            "relationship": "many_to_one",
-        },
-        {
-            "from_table": "employee",
-            "from_column": "mentor_id",
-            "to_table": "employee",
-            "to_column": "id",
-            "relationship": "many_to_one",
-        },
-    ]
+    doc["subject_areas"][0]["relationships"] = relationships
     org = Datasource.model_validate(doc)
     s = Store.connect("sqlite://")
     s.run_migrations()
     model_store.write_datasource(s, "main", org)
     rebuilt = model_store.load_datasource(s, "main")
-    assert rebuilt is not None
-    joins = {(r.from_column, r.to_column) for r in rebuilt.subject_areas[0].relationships}
-    assert joins == {("manager_id", "id"), ("mentor_id", "id")}, (
-        "a table pair joined two ways lost one of its joins on the way through the database"
-    )
     s.close()
+    assert rebuilt is not None
+    return rebuilt.subject_areas[0].relationships
+
+
+# Three shapes where one pair of tables is joined twice. Each one collided on
+# PRIMARY KEY (org_id, datasource, area, name) under some earlier version of the key, and a
+# collision is not a lost edge — the INSERT raises mid-write, nothing commits, and the deployment
+# serves NO model. They are listed together because the lesson is that they are the same bug: a key
+# assembled from whichever fields looked discriminating misses the shape its author did not picture.
+
+
+def test_a_table_pair_joined_on_two_column_pairs_survives_the_roundtrip():
+    """The simple form — an employee row pointing at another as its manager, and as its mentor.
+
+    Self-referencing tables make this ordinary rather than exotic. It collided when the key was the
+    table pair alone.
+    """
+    kept = _roundtrip_relationships(
+        [
+            {
+                "from_table": "employee",
+                "from_column": "manager_id",
+                "to_table": "employee",
+                "to_column": "id",
+                "relationship": "many_to_one",
+            },
+            {
+                "from_table": "employee",
+                "from_column": "mentor_id",
+                "to_table": "employee",
+                "to_column": "id",
+                "relationship": "many_to_one",
+            },
+        ]
+    )
+    assert {(r.from_column, r.to_column) for r in kept} == {
+        ("manager_id", "id"),
+        ("mentor_id", "id"),
+    }
+
+
+def test_a_table_pair_joined_by_two_on_expressions_survives_the_roundtrip():
+    """The `on:` escape hatch — where BOTH columns are None, so a column-aware key does not separate
+    them either. Two function-based joins between one pair of tables are two edges."""
+    kept = _roundtrip_relationships(
+        [
+            {
+                "from_table": "orders",
+                "to_table": "customers",
+                "on": "orders.customer_id = customers.id",
+                "relationship": "many_to_one",
+            },
+            {
+                "from_table": "orders",
+                "to_table": "customers",
+                "on": "CAST(orders.legacy_customer AS INTEGER) = customers.id",
+                "relationship": "many_to_one",
+            },
+        ]
+    )
+    assert {r.on for r in kept} == {
+        "orders.customer_id = customers.id",
+        "CAST(orders.legacy_customer AS INTEGER) = customers.id",
+    }
+
+
+def test_same_named_tables_in_two_schemas_survive_the_roundtrip():
+    """Schema-qualified endpoints exist so two schemas holding a same-named table are not conflated
+    (see `Relationship.from_schema`). A key that drops the schema conflates them again."""
+    kept = _roundtrip_relationships(
+        [
+            {
+                "from_table": "orders",
+                "from_schema": "sales",
+                "from_column": "customer_id",
+                "to_table": "customers",
+                "to_schema": "sales",
+                "to_column": "id",
+                "relationship": "many_to_one",
+            },
+            {
+                "from_table": "orders",
+                "from_schema": "archive",
+                "from_column": "customer_id",
+                "to_table": "customers",
+                "to_schema": "archive",
+                "to_column": "id",
+                "relationship": "many_to_one",
+            },
+        ]
+    )
+    assert {(r.from_schema, r.to_schema) for r in kept} == {
+        ("sales", "sales"),
+        ("archive", "archive"),
+    }
 
 
 # --- file → DB parity + tools wiring ---------------------------------------


### PR DESCRIPTION
Fixes #227.

## Summary

`write_datasource` keyed each relationship row by its two table names alone, and `relationship` is
UNIQUE on `(org_id, datasource, area, name)`. A subject area holding **two joins between the same
pair of tables** therefore produced one name twice, and the insert raised part-way through the load.

The failure is total rather than partial: nothing is committed, so the deployment ends up serving
**no model at all** rather than a model missing one join.

Self-referencing tables make this ordinary rather than exotic — an `employee` row pointing at another
as `manager_id` and again as `mentor_id` is one table pair and two genuinely different joins. Found
when a real model aborted its load on exactly that shape.

## Changes

- `packages/agami-core/src/model_store.py` — the relationship key includes the join columns, so
  `employee.manager_id->employee.id` and `employee.mentor_id->employee.id` are distinct.
- `tests/test_model_store_roundtrip.py` — regression test: a table pair joined two ways survives the
  round trip with both joins intact.

## Why changing the key format is safe

Nothing reads it. No query selects a relationship by name, and `load_datasource` rebuilds each
relationship from the `doc` column; the name exists only to keep rows distinct, so its format is not
a contract with any reader.

Redeploy is self-correcting too: `write_datasource` deletes a datasource's rows before re-inserting,
so a model stored under the old keys is replaced wholesale on the next load. No migration, no
backfill, no compatibility window.

## Why the test asserts the round trip, not a row count

A count of two also passes if a later change folds the two joins into one — the same lost
relationship, wearing the shape of a successful load. Reading the joins back is what says both
survived.

## Verification

- The new test fails on `main` with the exact `UNIQUE constraint failed` this fixes, and passes here.
  Confirmed by running it against the released package as well as against this branch.
- Full suite green: **4538 passed, 12 skipped**.
- `ruff check` clean on both files.
- Loaded a large real model end to end — 22 subject areas, 76 tables, 162 metrics, 50 relationships,
  44 prompt examples — which fails outright on `main`. The model files themselves needed no edit,
  which is the point: the defect was never in the data.

## Notes for review

- `ruff format` wants two unrelated hunks in `model_store.py` that this PR does not touch. Left
  alone deliberately — CI's format check is informational pending the tree-wide pass, and
  reformatting untouched lines would put unrelated churn in a bug-fix diff.
- Worth a follow-up, not done here: the failure surfaces as a raw constraint message naming a column
  tuple, which says nothing about *which* join collided. Diagnosing this took longer than fixing it.
