### PR TITLE
release: 0.6.5 — a model that joins one table pair twice now loads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.6.5] — 2026-08-13
+
+### Fixed
+
+- **A model whose subject area joins one pair of tables twice now loads.** It did not before: each
+  relationship row was keyed by its two table names, and that key is the table's primary key — so the
+  second join collided with the first and the INSERT raised part-way through the write. The failure
+  was total rather than partial. Nothing commits, so the deployment ends up serving **no semantic
+  model at all**, and the error names a column tuple rather than the join that collided.
+
+  Self-referencing tables make this ordinary rather than exotic: an employee row pointing at another
+  as its manager, and again as its mentor, is one pair of tables and two genuinely different joins.
+  Two `on:`-expression joins between one pair, and same-named tables living in two schemas, failed
+  the same way.
+
+  The key now carries the relationship's position within its subject area, so a collision is
+  impossible for any model that validates rather than impossible for the shapes somebody enumerated
+  — which is what the two previous versions of this key each attempted, and each missed. Nothing
+  reads the value (a relationship is rebuilt from its stored document), and a redeploy replaces a
+  datasource's rows wholesale, so models written under the old key need no migration and no backfill.
+
 ## [0.6.4] — 2026-08-12
 
 ### Added

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.6.4"
+version = "0.6.5"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts **0.6.5**. One fix since 0.6.4, and it is a blocker rather than an improvement.

A semantic model whose subject area joins the same pair of tables in two different ways could not be loaded into the database at all — the relationship key was the two table names, that key is the table's primary key, and the second join collided with the first. Nothing commits when the write raises, so the deployment serves **no model whatsoever**.

Self-referencing tables make the shape ordinary: an employee row pointing at another as its manager and again as its mentor is one table pair and two real joins.

Merged in #228 (closes #227).

## Changes

- Version 0.6.4 → 0.6.5 in `packages/agami-core/pyproject.toml`, `plugins/agami/.claude-plugin/plugin.json` and both entries in `.claude-plugin/marketplace.json`.
- CHANGELOG entry under 0.6.5.

No code changes in this PR — the fix is already on `main`.

## After merge

Publish the GitHub Release for `v0.6.5`, which is what triggers the PyPI workflow.

## Notes

No changelog link reference added: that block has not been maintained since 0.3.9, and 0.6.4 did not add one either.