### PR TITLE
The activity log can name the execution it ran

### DIFF
--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -293,4 +293,8 @@ class ToolCallRecord(_Contract):
     agent_query: str | None = None
     thread_id: str | None = None
     correlation_id: str | None = None  # the turn: one user question -> N agent sub-queries
+    # This call's execution, where it ran one (019) — `query_executions.id`, the same id `_emit` puts
+    # on the envelope the caller receives. `correlation_id` identifies the turn, which may run several
+    # statements; this identifies the statement. NULL wherever none ran.
+    audit_id: str | None = None
     org_id: str = "local"  # the tenant this call ran for; defaults to the single-tenant org

--- a/packages/agami-core/src/migrations/core/019_tool_calls_audit_id.sql
+++ b/packages/agami-core/src/migrations/core/019_tool_calls_audit_id.sql
@@ -1,0 +1,22 @@
+-- The key between the two logs. `tool_calls` records that a tool ran; `query_executions` records what
+-- the warehouse was asked and what the guard decided. Both are written for every `execute_sql` and are
+-- 1:1, and until now nothing joined them: 018's own comment records the gap — "there is no key between
+-- them (`Envelope.audit_id` is `query_executions.id`, which `tool_calls` does not carry)".
+--
+-- `correlation_id` is not that key. It identifies the TURN, and one turn may run several statements, so
+-- it cannot distinguish them.
+--
+-- The value is one the caller already received: `_emit` stamps `audit_id` onto every envelope, for
+-- `ok`, `refused` and `failed` alike, and `query_executions.id` is that same id. So this column
+-- reconciles nothing and mints nothing — it stores the id the answer carried back.
+--
+-- NULL IS THE ORDINARY CASE, not a gap. Only a tool that ran a statement has an execution: a schema
+-- read, a datasource list, or a refusal thrown before the executor has none.
+--
+-- NO FOREIGN KEY, matching this table's existing stance. The two logs are read independently and are
+-- each legible alone; a retention sweep over executions must not block or cascade into the activity
+-- log.
+--
+-- PORTABLE: one nullable TEXT column added by ALTER — the only form SQLite and Postgres both accept
+-- without a table rebuild.
+ALTER TABLE tool_calls ADD COLUMN audit_id TEXT;

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -490,8 +490,8 @@ class DbActivitySink:
         self._store.execute(
             "INSERT INTO tool_calls (id, ts, org_id, actor, tool_name, datasource, sql, row_count, "
             "execution_ms, success, error_kind, source, user_question, agent_query, thread_id, "
-            "correlation_id, refusal_detail, refusal_remediation) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "correlation_id, refusal_detail, refusal_remediation, audit_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 uuid4().hex,
                 record.ts,
@@ -515,6 +515,10 @@ class DbActivitySink:
                 # has them.
                 getattr(record, "refusal_detail", None),
                 getattr(record, "refusal_remediation", None),
+                # This call's execution (019), `getattr`-guarded like the two above so an embedder on
+                # an older record shape writes NULL rather than raising. NULL is ordinary here too:
+                # those are NULL on every non-refusal, this on every call that ran no statement.
+                getattr(record, "audit_id", None),
             ),
         )
         self._store.commit()

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2453,6 +2453,7 @@ def record_tool_call(
     success: bool | None = None,
     row_count: int | None = None,
     error_kind: str | None = None,
+    audit_id: str | None = None,
     org_id: str | None = None,
 ) -> None:
     """Record one MCP tool call to the activity log (the transport calls this for **every** tool). The
@@ -2484,6 +2485,10 @@ def record_tool_call(
       "succeeded" beside an error. **`raised=True` outranks all of them** — a call that threw is a
       failure whatever the caller passes, though it may still be given a more specific kind than the
       generic `"exception"`.
+    - `audit_id` replaces the execution id otherwise **read out of `result_text`** (019). Same reason
+      as the trio above and one more: a caller with no body to hand over can still record which
+      execution this call was, and unlike the trio it can state nothing incoherent, because an
+      identity makes no claim about how the call went.
     - `org_id` replaces the tenant otherwise stamped downstream from this process's context. A caller
       that read the tenant at the point which actually scoped the work states it, rather than leaving it
       to be re-read later from a context that may no longer be the same one. The fallback when that
@@ -2492,6 +2497,10 @@ def record_tool_call(
     """
     args = arguments or {}
     derived_success, derived_row_count, derived_error_kind = True, None, None
+    # This call's execution id (019), read off the same body as the trio below. Its own variable
+    # rather than one of them because it states nothing about the outcome: it is read on `ok`,
+    # `refused` and `failed` alike, and the coherence rules the trio is forced through do not apply.
+    derived_audit_id: str | None = None
     # The refusal's own two sentences, for the reader of THIS log. `error_kind` says which rule fired;
     # these say what it fired on and what to do about it — "orders_archive is not declared in the
     # model", not just `table_scope`. Without them an administrator reading a conversation can tell a
@@ -2550,6 +2559,9 @@ def record_tool_call(
                     derived_success = False
                     derived_error_kind = parsed["error"].get("kind") or "error"
                 derived_row_count = parsed.get("row_count")
+                # Outside the status branches above, because the envelope carries it on all three.
+                found = parsed.get("audit_id")
+                derived_audit_id = found if isinstance(found, str) and found else None
         except (ValueError, TypeError):
             pass
     if success is not None or row_count is not None or error_kind is not None:
@@ -2611,6 +2623,9 @@ def record_tool_call(
         "correlation_id": (  # the turn (one user question)
             correlation_id if correlation_id is not None else args.get("correlation_id")
         ),
+        # The statement, where one ran. A plain override rather than one of the coherent trio: it is
+        # an identity, so a stated value cannot contradict a derived one the way an outcome can.
+        "audit_id": audit_id if audit_id is not None else derived_audit_id,
     }
     if org_id is not None:
         # Set rather than left absent, so `_record_tool_call`'s `setdefault` keeps it instead of

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -683,3 +683,79 @@ def test_no_combination_of_outcome_arguments_can_write_a_dishonest_row(db):
                 assert r["success"] == 0, f"a stated error kind logged as a success: {case}"
     finally:
         store.close()
+
+
+# --- the execution id (019) --------------------------------------------------
+
+
+def test_record_reads_the_execution_id_off_every_envelope_status(db):
+    """`audit_id` is on the envelope for `ok`, `refused` and `failed` alike, so it is read outside the
+    status branches. Reading it only on success would leave exactly the calls an auditor most wants to
+    trace — the blocked and the broken ones — unable to reach their execution row."""
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT 1"},
+        result_text='{"status": "ok", "row_count": 1, "audit_id": "qe-ok"}',
+        execution_ms=5, actor="you@example.com",
+    )
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT 1"},
+        result_text='{"status": "refused", "refusal": {"rule": "table_scope"}, "audit_id": "qe-ref"}',
+        execution_ms=6, actor="you@example.com",
+    )
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT 1"},
+        result_text='{"status": "failed", "failure": {"kind": "syntax"}, "audit_id": "qe-fail"}',
+        execution_ms=7, actor="you@example.com",
+    )
+
+    assert [r["audit_id"] for r in _rows(db)] == ["qe-ok", "qe-ref", "qe-fail"]
+
+
+def test_a_call_that_ran_no_statement_records_no_execution_id(db):
+    """NULL is the ordinary value, not a gap: a schema read runs no query, so there is no execution
+    for it to point at. A synthetic id here would imply a statement nobody ran."""
+    tools.record_tool_call(
+        name="get_datasource_schema", arguments={"datasource": "SALES_DATA"},
+        result_text='{"tables": []}', execution_ms=2, actor="you@example.com",
+    )
+
+    (r,) = _rows(db)
+    assert r["audit_id"] is None
+
+
+def test_a_caller_with_no_body_can_still_state_the_execution_id(db):
+    """The override, for a caller that classified the outcome itself and hands over no `result_text`.
+    Without it such a caller records a row that can never be joined to its execution."""
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT 1"}, result_text=None,
+        execution_ms=9, actor="you@example.com",
+        success=True, row_count=3, audit_id="qe-stated",
+    )
+
+    (r,) = _rows(db)
+    assert r["audit_id"] == "qe-stated" and r["success"] == 1 and r["row_count"] == 3
+
+
+def test_a_stated_execution_id_wins_over_the_body(db):
+    """Same precedence as the outcome overrides: the caller observed the call, the body is a
+    re-parse. Nothing here can be incoherent — an id makes no claim about how the call went."""
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT 1"},
+        result_text='{"status": "ok", "audit_id": "qe-from-body"}',
+        execution_ms=4, actor="you@example.com", audit_id="qe-stated",
+    )
+
+    (r,) = _rows(db)
+    assert r["audit_id"] == "qe-stated"
+
+
+def test_a_body_whose_execution_id_is_not_a_string_records_none(db):
+    """A body is caller-influenced, and the column is a key. A number or an object arriving here
+    would be written straight through and then never match anything on the other side of the join."""
+    tools.record_tool_call(
+        name="execute_sql", arguments={"sql": "SELECT 1"},
+        result_text='{"status": "ok", "audit_id": 17}', execution_ms=4, actor="you@example.com",
+    )
+
+    (r,) = _rows(db)
+    assert r["audit_id"] is None


### PR DESCRIPTION
## Summary

`tool_calls` records that a tool ran; `query_executions` records what the warehouse was asked and what the guard decided. Both are written for every `execute_sql` and are 1:1 — and nothing joined them.

`018`'s own comment records the gap and chose duplication over a join:

> *"They are also not joinable: there is no key between them (`Envelope.audit_id` is `query_executions.id`, which `tool_calls` does not carry), so the alternative is not 'read the existing column' but 'add a foreign key, add the missing `remediation` over there, and join' — more schema, for a row that is 1:1 either way."*

That reasoning holds for one sentence-shaped column. It does not extend to anything that has to be attached to a **statement**: `correlation_id` identifies the *turn*, one turn may run several statements, and no column distinguishes them. A reader wanting per-statement facts has to guess, and the only material to guess with is the agent's own framing text — which repeats whenever a turn retries a sub-question, so it mis-attributes silently.

This adds the key. The value is one the caller already received: `_emit` stamps `audit_id` onto every envelope, and `query_executions.id` is that same id — so the column reconciles nothing and mints nothing.

## Changes

| file | |
|---|---|
| `migrations/core/019_tool_calls_audit_id.sql` | `ALTER TABLE tool_calls ADD COLUMN audit_id TEXT` |
| `contracts.py` | `audit_id` on `ToolCallRecord` |
| `model_store.py` | one column, one binding in the INSERT |
| `tools.py` | `audit_id` parameter, derived from the body already being parsed |
| `tests/test_tool_calls.py` | 5 tests |

**123 lines, all additive.** No behaviour change for any existing caller: the column is nullable, the parameter defaults to `None`, and the derive only populates a value that was previously discarded.

## Three decisions worth reviewing

**Read outside the status branches.** `audit_id` is on the envelope for `ok`, `refused` and `failed` alike, so it is read after them rather than inside one. Reading it only on success would leave exactly the calls an auditor most wants to trace — the blocked and the broken ones — unable to reach their execution row.

**A plain override, not one of the coherent trio.** `success`/`row_count`/`error_kind` are forced coherent because a row saying "succeeded" beside an error kind is worse than either fact alone. An identity makes no claim about the outcome, so it cannot be incoherent and does not need those rules. It does inherit the trio's other reason for existing: a caller that hands over no `result_text` — having classified the outcome itself — can still say which execution the call was.

**A non-string body value is dropped rather than written through.** The body is caller-influenced and this column is a key; `{"audit_id": 17}` stored verbatim would silently never match on the other side of a join.

## Not in scope

**NULL is the ordinary case, not a gap.** Only a tool that ran a statement has an execution — a schema read, a datasource list, or a refusal thrown before the executor has none, and those keep the NULL they deserve rather than a synthetic id implying a query nobody ran.

**No foreign key**, matching this table's existing stance: the two logs are read independently and are each legible alone, and a retention sweep over executions must not block or cascade into the audit trail.

**No version bump** — releases are their own commits here.

## Checklist

- [x] `ruff check plugins packages tests` — All checks passed
- [x] Coverage **87.96%**, above the enforced 85% floor
- [x] 5 new tests pass
- [x] **No test failures introduced** — see the note below
- [x] Portable DDL: one nullable TEXT column added by `ALTER`, the only form SQLite and Postgres both accept without a table rebuild
- [x] No customer data, names or credentials — placeholders only (`SALES_DATA`, `you@example.com`, `qe-ok`)
- [ ] Review

> **On the local suite:** running `pytest tests/` on a machine that has an agami deployment produces 38 failures on `main` *and* on this branch — identical sorted failure lists, zero introduced. The cause is environmental, not this change: `resolved_org_id()` prefers a deployment's `organization.yaml` over `"local"`, so a developer with real artifacts gets fixture rows written under `"local"` and read back under their own org. With `AGAMI_ORG_ID=local` the suite is **4544 passed, 1 failed** — and that one is `test_org_resolver_defaults_to_local`, which the override short-circuits by design. CI has no artifacts dir, so it is unaffected.

> **`ruff format`:** these files are left unformatted, matching the tree. CI's format step is `continue-on-error: true` pending the dedicated pass its comment describes, and running `ruff format` on `tools.py` would rewrite the whole file around a 15-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
