### PR TITLE
A client asking what this server looks like gets the icon, not a 401

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -41,7 +41,7 @@ from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from store import Store
@@ -136,6 +136,7 @@ def _org_id_from_scope(scope: dict) -> str | None:
 
 # The brand assets (logo, provider icons, favicon) served at /static — packaged alongside this module.
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
+_FAVICON_FILE = _STATIC_DIR / "logo_icon.png"
 
 
 def _build_auth_provider() -> AuthProvider:
@@ -243,7 +244,7 @@ _OAUTH_PATHS = (
 
 def _is_public_path(path: str) -> bool:
     """True for the surface reachable without an MCP bearer token: the OAuth discovery routes + flow
-    endpoints, the static brand assets, the root landing, and the `/admin/*` pages. Discovery and
+    endpoints, the static brand assets, the root landing, its favicon, and the `/admin/*` pages. Discovery and
     static use boundary matching (they have suffix/sub-path routes, and a bare `startswith` would let
     `/.well-known/oauth-protected-resource-x` or `/static-x` slip through); the OAuth + admin
     endpoints are matched *exactly* (only those exact paths are routed), so a future
@@ -256,7 +257,7 @@ def _is_public_path(path: str) -> bool:
         return True
     if path == "/static" or path.startswith("/static/"):
         return True
-    if path == "/":
+    if path == "/" or path == "/favicon.ico":
         return True
     return path in _OAUTH_PATHS or path in admin.ADMIN_PATHS or path in onboarding.PUBLIC_PATHS
 
@@ -636,8 +637,19 @@ def create_app(
         """The bare base URL in a browser → a branded landing (connector URL + admin link), not a 404."""
         return HTMLResponse(admin.landing_body_html(public_base_url()))
 
+    async def _favicon(request: Request) -> Response:
+        """The conventional icon path, answered from the same PNG the pages link.
+
+        Routed because without it the path is not merely absent but *gated*: the bearer middleware
+        challenges anything off its public list before routing can 404 it, so a client asking what
+        this server looks like got a 401 and an auth prompt. That matters beyond tidiness — an MCP
+        client showing a server in a connector list has no credentials to offer for an icon, and a
+        deployment that redirects `/` elsewhere leaves this the only path left to ask on."""
+        return FileResponse(_FAVICON_FILE, media_type="image/png")
+
     routes = [
         Route("/", _root, methods=["GET"]),
+        Route("/favicon.ico", _favicon, methods=["GET"]),
         Route("/.well-known/oauth-protected-resource", _protected_resource),
         Route("/.well-known/oauth-protected-resource/{rest:path}", _protected_resource),
         Route("/.well-known/oauth-authorization-server", _auth_server),

--- a/tests/test_mcp_http.py
+++ b/tests/test_mcp_http.py
@@ -206,6 +206,21 @@ def test_http_tools_list_is_the_same_four(base_url):
     assert names == PRODUCT_TOOLS
 
 
+def test_favicon_is_served_without_a_bearer_token(base_url):
+    """An anonymous fetcher asking for the conventional icon path gets the PNG.
+
+    Before this route existed the answer was a 401 with an auth challenge, because the bearer gate
+    fires ahead of routing — so the one request a client makes to learn what a server looks like was
+    met with "authenticate first". A 404 would at least be honest; a challenge reads as a walled
+    origin.
+    """
+    with TestClient(mcp_http.build_app()) as c:
+        res = c.get("/favicon.ico")
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "image/png"
+    assert res.content == mcp_http._FAVICON_FILE.read_bytes()
+
+
 def test_presence_auth_yields_no_session_id(base_url):
     """The fallback that matters most: presence auth mints no token at all, so there is no session to
     report. It must read as "no session" — never break the caller."""


### PR DESCRIPTION
## Summary

`/favicon.ico` returned **401 with an auth challenge**, not a 404. The bearer middleware challenges anything off its public list *before* routing can 404 it, so the one unauthenticated request a client makes to learn what a server looks like was answered with "authenticate first".

This routes it to the same PNG the pages already link, and adds the path to the public list beside `/`.

## Why

An MCP client showing a server in a connector list has no credentials to offer for an icon fetch — the MCP spec explicitly has clients fetch icons *without* credentials. And a deployment that redirects `/` elsewhere (agami's browser app does exactly this) leaves `/favicon.ico` the only path left to ask on. Today such a server draws a letter avatar in Claude's connector list next to servers that answer.

Observed on a live deployment before this change:

| path | before |
|---|---|
| `/` | 307 → `/app/` |
| `/favicon.ico` | **401** |
| `/static/logo_icon.png` | 200 image/png |

## Changes

- `mcp_http.py` — `_FAVICON_FILE` constant; a `GET /favicon.ico` route returning `FileResponse(..., media_type="image/png")`; `/favicon.ico` added to `_is_public_path` beside `/`.
- `tests/test_mcp_http.py` — one test asserting an unauthenticated GET returns 200, `image/png`, and the packaged bytes.

30 lines across two files. No new dependency, no config surface, no change to any authenticated path.

## What this does not claim

That any particular client fetches this path. It closes an auth wall on a conventional public path that previously read as a walled origin — whether an icon then renders is the client's decision, not ours. Published reports are contradictory on whether Claude fetches it for custom connectors, so this is a cheap correct change, not a promised fix.

## Checklist

- [x] `uv run dev.py check` green — full suite, ruff lint + format, gitleaks
- [x] New behaviour has a test
- [x] Test mutation-checked — removing the public-list entry reproduces the original 401; removing the route 404s
- [x] Public repo: no customer names, data, hostnames or credentials in the diff
- [x] Serves one packaged asset, takes no user input — no traversal surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)