### PR TITLE
A curated example keeps the same id across deploys, and the caller can see it

### DIFF
--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -13,6 +13,7 @@ collections (those are their own rows); load re-attaches them.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from typing import Any
@@ -369,6 +370,29 @@ def _tokens(s: str | None) -> set[str]:
     return set(_WORD_RE.findall((s or "").lower()))
 
 
+def example_id(ex: dict[str, Any]) -> str:
+    """The example's identity, derived from its own content: `question` + `sql`, 12 hex characters —
+    the construction `compute_model_hash` uses (`snapshot.py::_hash_and_manifest`).
+
+    Derived rather than minted because a minted id changes on every deploy, and derived rather than
+    authored because authoring gives the id two homes that can disagree. Each part is NUL-*terminated*
+    rather than joined, so ("ab", "c") and ("a", "bc") cannot collapse onto one id.
+
+    `area` is excluded deliberately: it is not carried in the example file — the deploy injects it
+    from the subject-area directory name — so hashing it would tie the id to a value resolved outside
+    the example. Two examples sharing question and sql are the same example.
+
+    Byte-exact, no normalization: a normalizer is a second thing that can disagree between the two
+    things it exists to hold in agreement. So a reworded question or a corrected query is a different
+    example, which is the intended property; metadata edits leave the id alone.
+    """
+    h = hashlib.sha256()
+    for part in (str(ex.get("question") or ""), str(ex.get("sql") or "")):
+        h.update(part.encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()[:12]
+
+
 def write_examples(
     store: Store, datasource: str, examples: list[dict[str, Any]], org_id: str = DEFAULT_ORG
 ) -> None:
@@ -377,10 +401,21 @@ def write_examples(
     store.execute(
         "DELETE FROM prompt_example WHERE org_id = ? AND datasource = ?", (org_id, datasource)
     )
+    # Since ids are derived from content, the same example filed under two subject areas now resolves
+    # to one id — and `area` is not in the primary key, so the second INSERT would raise and abort the
+    # deploy. First wins, which also keeps the surviving row's `area` stable across re-seeds. It also
+    # only serves the area it won under, so an example deliberately filed twice is no longer returned
+    # for the second one. Two examples carrying the *same authored* id skip here too, where they used
+    # to take the deploy down. The rows above were just deleted, so a within-this-call repeat is the
+    # only collision reachable.
+    seen: set[str] = set()
     for ex in examples:
         # Keep a stable id across re-seeds when the example carries one (so per-example identity
-        # survives a redeploy); mint one only when absent.
-        ex_id = str(ex.get("id") or uuid4().hex)
+        # survives a redeploy); derive one from its content when absent.
+        ex_id = str(ex.get("id") or example_id(ex))
+        if ex_id in seen:
+            continue
+        seen.add(ex_id)
         store.execute(
             "INSERT INTO prompt_example (org_id, datasource, area, id, question, doc) "
             "VALUES (?, ?, ?, ?, ?, ?)",
@@ -403,13 +438,13 @@ def select_examples(
     context. No embeddings (that tier is deploy-time + off by default)."""
     if area:
         rows = store.query(
-            "SELECT question, doc FROM prompt_example WHERE org_id = ? AND datasource = ? "
+            "SELECT id, question, doc FROM prompt_example WHERE org_id = ? AND datasource = ? "
             "AND (area = ? OR area IS NULL)",
             (org_id, datasource, area),
         )
     else:
         rows = store.query(
-            "SELECT question, doc FROM prompt_example WHERE org_id = ? AND datasource = ?",
+            "SELECT id, question, doc FROM prompt_example WHERE org_id = ? AND datasource = ?",
             (org_id, datasource),
         )
     q = _tokens(query)
@@ -418,13 +453,35 @@ def select_examples(
     out: list[dict[str, Any]] = []
     used = 0
     for r in rows[:top_k]:
-        doc = json.loads(r["doc"])
+        # The column wins over any `id` inside `doc` — they agree by construction, but the column is
+        # the identity `example_by_id` resolves. Merged before measuring, so the budget accounts for
+        # the dict actually returned.
+        doc = {**json.loads(r["doc"]), "id": r["id"]}
         size = len(json.dumps(doc))
         if out and used + size > char_budget:
             break
         out.append(doc)
         used += size
     return out
+
+
+def example_by_id(
+    store: Store, *, org_id: str = DEFAULT_ORG, datasource: str, example_id: str
+) -> dict[str, Any] | None:
+    """The one example carrying `example_id`, in the shape `select_examples` returns it, or None when
+    no such example is seeded for this org and datasource.
+
+    The derivation is one-way, so a caller holding an id has no way back to the example it names
+    without this. Scoped like every other read here: an id identifies an example *within* an org's
+    datasource, even though the same curated example imported elsewhere derives the same characters.
+    """
+    rows = store.query(
+        "SELECT id, doc FROM prompt_example WHERE org_id = ? AND datasource = ? AND id = ?",
+        (org_id, datasource, example_id),
+    )
+    if not rows:
+        return None
+    return {**json.loads(rows[0]["doc"]), "id": rows[0]["id"]}
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -147,9 +147,7 @@ def write_datasource(
     store.commit()
 
 
-def load_datasource(
-    store: Store, datasource: str, org_id: str = DEFAULT_ORG
-) -> Datasource | None:
+def load_datasource(store: Store, datasource: str, org_id: str = DEFAULT_ORG) -> Datasource | None:
     """Rebuild the Datasource for `datasource` from rows, or None if it isn't seeded."""
     org_rows = store.query(
         "SELECT doc FROM datasource_model WHERE org_id = ? AND datasource = ?", (org_id, datasource)
@@ -254,8 +252,7 @@ def write_memory(
             (org_id, datasource),
         )
         store.execute(
-            "INSERT INTO memory (org_id, datasource, kind, content) "
-            "VALUES (?, ?, 'datasource', ?)",
+            "INSERT INTO memory (org_id, datasource, kind, content) VALUES (?, ?, 'datasource', ?)",
             (org_id, datasource, datasource_doc),
         )
     if user is not None:
@@ -412,7 +409,12 @@ def write_examples(
     for ex in examples:
         # Keep a stable id across re-seeds when the example carries one (so per-example identity
         # survives a redeploy); derive one from its content when absent.
-        ex_id = str(ex.get("id") or example_id(ex))
+        #
+        # Absent means absent, not falsy: an unquoted `id: 0` in YAML parses to an int, and
+        # `ex.get("id") or ...` would derive an id for an example that carries one. An empty string
+        # is treated as absent, since it names nothing.
+        authored = ex.get("id")
+        ex_id = str(authored) if authored is not None and str(authored) != "" else example_id(ex)
         if ex_id in seen:
             continue
         seen.add(ex_id)

--- a/tests/test_ace109_example_identity.py
+++ b/tests/test_ace109_example_identity.py
@@ -1,0 +1,230 @@
+"""A curated example keeps the same id across deploys, and the caller can see it (ACE-109).
+
+The `id` column existed and was worthless: absent an authored id the seed minted a uuid4, nothing
+wrote it back, so the next deploy minted a different one for the same example. Here the id is
+*derived* from the example's own content, which is stable by construction and needs no coordination.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+import model_store  # noqa: E402
+from store import Store  # noqa: E402
+
+QUESTION = "how many active assets"
+SQL = "SELECT count(*) FROM assets WHERE status = 'active'"
+
+
+def _store(tmp_path, name: str = "agami.db") -> Store:
+    s = Store.connect("sqlite://" + str(tmp_path / name))
+    s.run_migrations()
+    return s
+
+
+def _ids(store: Store, datasource: str = "main") -> list[str]:
+    rows = store.query(
+        "SELECT id FROM prompt_example WHERE datasource = ? ORDER BY id", (datasource,)
+    )
+    return [r["id"] for r in rows]
+
+
+# --- the derivation ---------------------------------------------------------------------------
+
+
+def test_the_id_is_pinned_to_its_construction():
+    """A golden constant, not a round-trip: the whole point of the id is that it is the same one
+    next release, so the test that matters is the one that fails when someone 'improves' the hash."""
+    assert model_store.example_id({"question": QUESTION, "sql": SQL}) == "88e825e75112"
+
+
+def test_each_part_is_nul_terminated_so_the_split_cannot_be_ambiguous():
+    """Joining instead of terminating would collapse these two onto one id."""
+    assert model_store.example_id({"question": "ab", "sql": "c"}) != model_store.example_id(
+        {"question": "a", "sql": "bc"}
+    )
+
+
+@pytest.mark.parametrize("key", ["question", "sql"])
+def test_editing_the_question_or_the_sql_moves_the_id(key):
+    base = {"question": QUESTION, "sql": SQL}
+    edited = {**base, key: base[key] + " -- reworked"}
+    assert model_store.example_id(edited) != model_store.example_id(base)
+
+
+@pytest.mark.parametrize("key", ["notes", "tables", "columns", "status", "metric", "source"])
+def test_metadata_edits_leave_the_id_alone(key):
+    """Curation churn — retagging, a note, a status flip — is not a different example."""
+    base = {"question": QUESTION, "sql": SQL}
+    assert model_store.example_id({**base, key: "anything at all"}) == model_store.example_id(base)
+
+
+def test_the_id_is_byte_exact_so_whitespace_is_a_difference():
+    """No strip, no case-fold: a normalizer is a second thing that can disagree."""
+    assert model_store.example_id({"question": QUESTION + " ", "sql": SQL}) != model_store.example_id(
+        {"question": QUESTION, "sql": SQL}
+    )
+
+
+def test_an_example_missing_its_sql_still_derives_an_id():
+    """Malformed items already reach the seed — `test_malformed_examples_file_is_skipped_not_fatal`
+    is the file-level guard, not an item-level one."""
+    assert len(model_store.example_id({"question": QUESTION})) == 12
+
+
+def test_the_id_is_twelve_hex_characters():
+    ex_id = model_store.example_id({"question": QUESTION, "sql": SQL})
+    assert len(ex_id) == 12 and all(c in "0123456789abcdef" for c in ex_id)
+
+
+# --- the seed ---------------------------------------------------------------------------------
+
+
+def test_two_databases_get_the_same_ids(tmp_path):
+    """The property the minted uuid4 could never have: seed the same library twice, get the same
+    identities — no shared state, no write-back, no coordination."""
+    examples = [
+        {"area": "sales", "question": f"question {i}", "sql": f"SELECT {i}"} for i in range(5)
+    ]
+    first, second = _store(tmp_path, "a.db"), _store(tmp_path, "b.db")
+    model_store.write_examples(first, "main", examples)
+    model_store.write_examples(second, "main", examples)
+    assert _ids(first) == _ids(second)
+    first.close()
+    second.close()
+
+
+def test_reseeding_the_same_library_keeps_every_id(tmp_path):
+    examples = [{"area": "sales", "question": QUESTION, "sql": SQL}]
+    s = _store(tmp_path)
+    model_store.write_examples(s, "main", examples)
+    before = _ids(s)
+    model_store.write_examples(s, "main", examples)
+    assert _ids(s) == before
+    s.close()
+
+
+def test_an_authored_id_wins_verbatim(tmp_path):
+    """The existing escape hatch is untouched — derivation is only the fallback."""
+    s = _store(tmp_path)
+    model_store.write_examples(
+        s, "main", [{"area": "sales", "id": "hand-written", "question": QUESTION, "sql": SQL}]
+    )
+    assert _ids(s) == ["hand-written"]
+    s.close()
+
+
+def test_one_example_in_two_areas_is_one_row_not_a_crash(tmp_path):
+    """`area` is not in the primary key and is deliberately not in the hash, so the same example
+    filed under two subject areas now collapses to one id. A bare INSERT would raise here and take
+    the whole deploy down; first-wins dedup is what makes that a no-op instead."""
+    s = _store(tmp_path)
+    model_store.write_examples(
+        s,
+        "main",
+        [
+            {"area": "sales", "question": QUESTION, "sql": SQL},
+            {"area": "assets", "question": QUESTION, "sql": SQL},
+        ],
+    )
+    rows = s.query("SELECT area FROM prompt_example WHERE datasource = ?", ("main",))
+    assert len(rows) == 1
+    assert rows[0]["area"] == "sales"  # first wins, so the surviving row is stable across deploys
+    s.close()
+
+
+def test_examples_that_differ_only_by_area_are_still_two_rows(tmp_path):
+    """The dedup keys on the id, not on carelessness — different content stays distinct."""
+    s = _store(tmp_path)
+    model_store.write_examples(
+        s,
+        "main",
+        [
+            {"area": "sales", "question": QUESTION, "sql": SQL},
+            {"area": "assets", "question": "how many regions", "sql": SQL},
+        ],
+    )
+    assert len(_ids(s)) == 2
+    s.close()
+
+
+# --- the read ---------------------------------------------------------------------------------
+
+
+def test_select_examples_returns_the_id_on_every_example(tmp_path):
+    s = _store(tmp_path)
+    model_store.write_examples(
+        s, "main", [{"area": "sales", "question": QUESTION, "sql": SQL}]
+    )
+    out = model_store.select_examples(s, "main")
+    assert out[0]["id"] == model_store.example_id({"question": QUESTION, "sql": SQL})
+    assert out[0]["question"] == QUESTION  # the rest of the doc still rides along
+    s.close()
+
+
+def test_example_by_id_round_trips_a_served_id(tmp_path):
+    """The derivation is one-way, so this is the only way a caller holding an id gets back to the
+    example it names."""
+    s = _store(tmp_path)
+    model_store.write_examples(
+        s, "main", [{"area": "sales", "question": QUESTION, "sql": SQL, "tables": ["assets"]}]
+    )
+    served = model_store.select_examples(s, "main")[0]
+    found = model_store.example_by_id(s, datasource="main", example_id=served["id"])
+    assert found == served
+    assert found["tables"] == ["assets"]  # the tagged tables a consumer checks the SQL against
+    s.close()
+
+
+def test_example_by_id_is_none_for_an_id_that_was_never_seeded(tmp_path):
+    s = _store(tmp_path)
+    model_store.write_examples(s, "main", [{"question": QUESTION, "sql": SQL}])
+    assert model_store.example_by_id(s, datasource="main", example_id="0" * 12) is None
+    s.close()
+
+
+def test_example_by_id_does_not_cross_datasource_or_org(tmp_path):
+    """Scoped like every other read in the module — an id is only an identity within its org and
+    datasource, and the same curated example imported elsewhere derives the same 12 characters."""
+    s = _store(tmp_path)
+    example = {"question": QUESTION, "sql": SQL}
+    model_store.write_examples(s, "other", [example])
+    model_store.write_examples(s, "main", [example], "another-org")
+    ex_id = model_store.example_id(example)
+
+    assert model_store.example_by_id(s, datasource="other", example_id=ex_id) is not None
+    assert model_store.example_by_id(s, datasource="main", example_id=ex_id) is None
+    assert (
+        model_store.example_by_id(s, org_id="another-org", datasource="main", example_id=ex_id)
+        is not None
+    )
+    s.close()
+
+
+def test_the_column_wins_over_an_id_inside_the_doc(tmp_path):
+    """`write_examples` writes the two in agreement, so only a row inserted behind its back can tell
+    them apart — and the column has to win, because it is the value `example_by_id` matches on. Both
+    reads must agree, or an id taken off one would not resolve through the other."""
+    s = _store(tmp_path)
+    s.execute(
+        "INSERT INTO prompt_example (org_id, datasource, area, id, question, doc) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            model_store.DEFAULT_ORG,
+            "main",
+            "sales",
+            "the-column",
+            QUESTION,
+            json.dumps({"id": "stale-in-the-doc", "question": QUESTION, "sql": SQL}),
+        ),
+    )
+    s.commit()
+
+    assert model_store.select_examples(s, "main")[0]["id"] == "the-column"
+    found = model_store.example_by_id(s, datasource="main", example_id="the-column")
+    assert found is not None and found["id"] == "the-column"
+    s.close()

--- a/tests/test_ace109_example_identity.py
+++ b/tests/test_ace109_example_identity.py
@@ -65,9 +65,9 @@ def test_metadata_edits_leave_the_id_alone(key):
 
 def test_the_id_is_byte_exact_so_whitespace_is_a_difference():
     """No strip, no case-fold: a normalizer is a second thing that can disagree."""
-    assert model_store.example_id({"question": QUESTION + " ", "sql": SQL}) != model_store.example_id(
-        {"question": QUESTION, "sql": SQL}
-    )
+    assert model_store.example_id(
+        {"question": QUESTION + " ", "sql": SQL}
+    ) != model_store.example_id({"question": QUESTION, "sql": SQL})
 
 
 def test_an_example_missing_its_sql_still_derives_an_id():
@@ -118,6 +118,30 @@ def test_an_authored_id_wins_verbatim(tmp_path):
     s.close()
 
 
+def test_an_authored_id_of_zero_still_wins(tmp_path):
+    """`0` is a legal id and a falsy one. YAML parses an unquoted `id: 0` as an int, so a truthiness
+    check reads it as absent and derives over it — and a numbered library starts at exactly this
+    value. The failure is silent: the example keeps working, under an id its author did not choose."""
+    s = _store(tmp_path)
+    model_store.write_examples(
+        s, "main", [{"area": "sales", "id": 0, "question": QUESTION, "sql": SQL}]
+    )
+    assert _ids(s) == ["0"]
+    s.close()
+
+
+@pytest.mark.parametrize("empty", [None, ""])
+def test_an_id_that_names_nothing_is_treated_as_absent(tmp_path, empty):
+    """The other half, and the reason the check is not simply `is not None`: a key present but empty
+    names no example, so derivation is the right answer rather than an id of ""."""
+    s = _store(tmp_path)
+    model_store.write_examples(
+        s, "main", [{"area": "sales", "id": empty, "question": QUESTION, "sql": SQL}]
+    )
+    assert _ids(s) == [model_store.example_id({"question": QUESTION, "sql": SQL})]
+    s.close()
+
+
 def test_one_example_in_two_areas_is_one_row_not_a_crash(tmp_path):
     """`area` is not in the primary key and is deliberately not in the hash, so the same example
     filed under two subject areas now collapses to one id. A bare INSERT would raise here and take
@@ -157,9 +181,7 @@ def test_examples_that_differ_only_by_area_are_still_two_rows(tmp_path):
 
 def test_select_examples_returns_the_id_on_every_example(tmp_path):
     s = _store(tmp_path)
-    model_store.write_examples(
-        s, "main", [{"area": "sales", "question": QUESTION, "sql": SQL}]
-    )
+    model_store.write_examples(s, "main", [{"area": "sales", "question": QUESTION, "sql": SQL}])
     out = model_store.select_examples(s, "main")
     assert out[0]["id"] == model_store.example_id({"question": QUESTION, "sql": SQL})
     assert out[0]["question"] == QUESTION  # the rest of the doc still rides along

--- a/tests/test_prompt_examples_serving.py
+++ b/tests/test_prompt_examples_serving.py
@@ -95,6 +95,29 @@ def test_the_area_parameter_is_advertised_so_a_client_can_send_it(tmp_path):
     assert "area" in schema["properties"]
 
 
+def test_every_served_example_carries_its_id(tmp_path, monkeypatch):
+    """The id column was never selected, so it reached nobody even when it held something. A caller
+    can now name the example it used rather than quoting it back (ACE-109).
+
+    Seeded under the org the tool will resolve to rather than the write default: on a machine that
+    has a deployment record, those differ, and the read would find nothing.
+    """
+    examples = [
+        {"area": "sales", "question": f"monthly revenue trend {i}", "sql": f"SELECT {i}"}
+        for i in range(3)
+    ]
+    url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(url)
+    s.run_migrations()
+    model_store.write_examples(s, "main", examples, tools.current_org_id())
+    s.close()
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    out = json.loads(tools.tool_get_prompt_examples({"datasource": "main", "query": "revenue"}))
+    assert out["examples"], "expected at least one match"
+    assert all(e["id"] == model_store.example_id(e) for e in out["examples"])
+
+
 # --- the local (file) path, which had no test at all -----------------------------------------
 
 


### PR DESCRIPTION
## Summary

`prompt_example` has an `id` column in its primary key and it was unusable three ways over: absent an
authored `id` the seed minted a `uuid4()`, nothing wrote it back so the next deploy minted a
different one for the same example, and the read selected `question, doc` — never the `id` column —
so no id reached the caller even when one held something.

The effect is that a curated example has no durable identity. Nothing can name one, count one, or
say whether the one returned yesterday is the one returned today. Three things already work around
its absence: `agami-save-correction` cannot tell a correction that created a new example from one
that should have replaced an existing one; ranking returns a subset that is not recordable, so
example-set behaviour is not reproducible across deploys; and the library only grows, because no two
observations of an example can be tied together.

This derives the id from the example's own content, returns it on the served path, and adds the
lookup that turns a one-way hash back into an example.

## Changes

- **`example_id(ex)`** — a 12-character SHA-256 prefix over `question` + `sql`, each part UTF-8
  encoded and NUL-**terminated**, copied from `snapshot.py::_hash_and_manifest` (what
  `compute_model_hash` uses). Terminating rather than joining is what keeps `("ab", "c")` and
  `("a", "bc")` distinct. Byte-exact — no strip, no case-fold — matching that same precedent.
- **`write_examples`** derives instead of minting. An authored `id` in the YAML still wins; the
  existing escape hatch and its comment are untouched. Derivation is the fallback for the case that
  is universal in practice.
- **`write_examples` dedups within the batch, first-wins.** `area` is deliberately not hashed — it is
  not carried in the example file, the deploy injects it from the subject-area directory name — so
  two examples sharing `question` and `sql` now collapse to one id. `area` is not in
  `PRIMARY KEY (org_id, datasource, id)` either, so without the dedup the second `INSERT` would raise
  and abort the whole deploy. The rows are deleted before the batch, so a within-call repeat is the
  only collision reachable.
- **`select_examples`** selects `id` and merges it into each returned dict, column-wins, before
  measuring against the char budget so the accounting reflects what is actually returned.
- **`example_by_id(store, *, org_id, datasource, example_id)`** — the derivation is one-way, so an id
  is inert without a lookup and there was none. Scoped by org and datasource like every other read in
  the module; `None` when the id was never seeded.

No schema change, no migration, no tool-schema change. The local file path is untouched: it returns
markdown-wrapped raw YAML rather than dicts, so an id there means parsing and re-rendering YAML in a
path that has no parser today.

### Two behaviour changes worth calling out

- An example authored under **two** subject-area directories previously seeded two rows and was
  served for both areas. Collapsed to one id it keeps the first area, and `select_examples` filters
  `area = ? OR area IS NULL`, so the second area's scoped query no longer finds it. Writing the
  survivor into the cross-area (`area IS NULL`) bucket would preserve both, but would also serve it
  to areas it was never filed under. Narrowing a rare deliberate duplicate beats polluting every
  unrelated few-shot set.
- Two examples carrying the **same authored** id used to raise an `IntegrityError` and take the
  deploy down; they now skip. That is a strict improvement, and it is noted in the comment.

## Checklist

- [x] Tests added — 24 new tests in `tests/test_ace109_example_identity.py` plus one in
      `tests/test_prompt_examples_serving.py`. **No existing test modified or removed** (`git diff
      -- tests/` is additions only), which is a stated success criterion.
- [x] The construction is pinned by a golden constant, not just a round-trip — the point of the id is
      that it is the same one next release, so the test that matters is the one that fails when
      someone changes the hash.
- [x] `uv run dev.py check` green — ruff lint + format, 4570 passed, gitleaks.
- [x] `uv run dev.py cover` — 100% diff coverage (18 lines).
- [x] Reviewed with the Agami panel (correctness/tests, security + runtime cost, structural rubric).
      Zero must-fix on the diff. Collision risk quantified: 3.7e-12 at the ~46-example scale, 1.8e-5
      at 100k.
- [x] Public-repo safe — no customer, dataset, or internal naming; fixtures are the repo's synthetic
      `sales`/`assets` areas.

Spec: ACE-109