### PR TITLE
An agent can say what it based a query on, and why

### DIFF
--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -209,6 +210,60 @@ def _utc(ts: str | None) -> str:
     return f'<time data-utc="{ui.esc(ts)}">{ui.esc(ts)}</time>'
 
 
+def _text(v: Any) -> str:
+    """A value from a self-reported JSON column as a string, or empty when it is not one.
+
+    `ui.esc` takes `str | None` and raises on anything else truthy, so this is what keeps a column
+    written by someone other than this process from reaching it."""
+    return v if isinstance(v, str) else ""
+
+
+def _basis_block(raw: Any) -> str:
+    """What the agent said it based this query on (020), rendered under the statement it explains.
+
+    Self-reported and attacker-influenceable exactly like the SQL and the question above, so every
+    part is escaped and the block says whose claim it is. A row written before the column existed, or
+    by a caller that sent nothing, renders nothing at all.
+
+    Unparseable JSON renders nothing rather than raising: this is one card in a page the operator
+    opened to read the rest of the log, and a malformed self-report is not worth losing that page.
+    """
+    if not raw:
+        return ""
+    try:
+        doc = json.loads(raw)
+    except (ValueError, TypeError):
+        return ""
+    if not isinstance(doc, dict):
+        return ""
+    entries = doc.get("entries")
+    if not isinstance(entries, list):
+        return ""
+    # Every value is re-checked for str-ness rather than trusted: `ui.esc` handles None but raises on
+    # any other non-string, and one such row would cost the operator the whole page (`_session_drawer`
+    # joins every card). The writer never emits one, but `basis` is a plain TEXT column and an
+    # embedder builds `ToolCallRecord` itself — not trusting the column is the point of this guard.
+    items = "".join(
+        f'<li><span class="pill" style="background:var(--chip);color:var(--ink)">'
+        f'{ui.esc(_text(e.get("kind")))}</span> {ui.esc(_text(e.get("ref")))}'
+        + (f' — {ui.esc(_text(e["why"]))}' if _text(e.get("why")) else "")
+        + "</li>"
+        for e in entries
+        if isinstance(e, dict)
+    )
+    cut = ' <span class="muted">· truncated</span>' if doc.get("truncated") else ""
+    if not items and not cut:
+        return ""
+    # A claim that was made and wholly rejected still shows its heading: on the one surface this
+    # feature exists for, "the agent said nothing" and "everything the agent said was rejected" must
+    # not look identical.
+    body = f'<ul style="margin:4px 0 0;padding-left:18px;font-size:13px">{items}</ul>' if items else ""
+    return (
+        f'<div class="muted" style="margin-top:6px;font-size:13px">basis · agent-reported{cut}</div>'
+        f"{body}"
+    )
+
+
 def _call_card(c: dict[str, Any]) -> str:
     """One call inside a turn. A **query** call (has `sql`) shows its agent-framing + SQL; a **non-query**
     call (list_datasources, get_datasource_schema, …) has no SQL, so it shows its tool name — so every call
@@ -239,7 +294,7 @@ def _call_card(c: dict[str, Any]) -> str:
     rows_bit = f" · {c['row_count']} rows" if c.get("row_count") is not None else ""
     return (
         '<div style="border-top:1px solid var(--line);padding:9px 0 11px">'
-        f"{head}{body}"
+        f"{head}{body}{_basis_block(c.get('basis'))}"
         f'<div class="muted" style="font-size:13px;margin-top:6px">{_utc(c["ts"])} · {ds} · '
         f"{lat} {_ok_pill(c['success'])}{rows_bit}</div></div>"
     )

--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -297,4 +297,11 @@ class ToolCallRecord(_Contract):
     # on the envelope the caller receives. `correlation_id` identifies the turn, which may run several
     # statements; this identifies the statement. NULL wherever none ran.
     audit_id: str | None = None
+    # What the agent says it based this query on (020): JSON `{"entries": [...], "truncated": bool}`,
+    # each entry a `kind` from a closed set, a `ref`, and a one-sentence `why`. Bounded by the writer
+    # (`tools.BASIS_MAX_ENTRIES` and the two length caps) — `truncated` says the stored value is not
+    # what was sent. Self-reported like `user_question`/`agent_query` above, so it is evidence of a
+    # claim and never a fact; nothing here checks `ref` against `sql`. NULL on every call that did
+    # not send one, which is the ordinary case.
+    basis: str | None = None
     org_id: str = "local"  # the tenant this call ran for; defaults to the single-tenant org

--- a/packages/agami-core/src/migrations/core/020_tool_calls_basis.sql
+++ b/packages/agami-core/src/migrations/core/020_tool_calls_basis.sql
@@ -1,0 +1,27 @@
+-- What the agent based this query on. The activity log already records what ran — the statement, the
+-- outcome, and two self-reported columns (`user_question`, `agent_query`) carrying the caller's own
+-- framing. What it has never recorded is the reasoning between the two: which curated example was
+-- mirrored, which table was chosen over a similar one, which metric definition was used, why a
+-- filter is there. So an operator can see that a query was wrong, but not where the reasoning went
+-- wrong.
+--
+-- ONE COLUMN, HOLDING JSON, because the shape is a list rather than a value: each entry is a `kind`
+-- from a closed set, a `ref` naming what was chosen, and a `why` that is one sentence. Eight named
+-- columns would be eight ALTERs, and a ninth kind would be a ninth; this way a new kind is a new
+-- enum value on the tool schema and no schema change at all here.
+--
+-- The stored value is an OBJECT, not a bare list — `{"entries": [...], "truncated": true|false}`.
+-- The writer caps the entry count and the length of `ref` and `why`, and a record that was cut has
+-- to say so, or a reader takes a truncated list for the whole claim. 015 recorded that flag as its
+-- own column (`query_executions.sql_truncated`); one column here means it rides inside the value.
+--
+-- SELF-REPORTED, LIKE ITS NEIGHBOURS. This is the model's account of its own reasoning, not
+-- something the server observed, so it is evidence of a claim and never a fact. Nothing in core
+-- scores it or checks `ref` against the SQL — a consumer holding the receipt can do that itself.
+--
+-- NULL IS THE ORDINARY CASE. The argument is optional and absent is normal: every client that has
+-- never heard of it keeps working, and its rows are byte-identical to today's but for this column.
+--
+-- PORTABLE: one nullable TEXT column added by ALTER — the only form SQLite and Postgres both accept
+-- without a table rebuild.
+ALTER TABLE tool_calls ADD COLUMN basis TEXT;

--- a/packages/agami-core/src/migrations/core/020_tool_calls_basis.sql
+++ b/packages/agami-core/src/migrations/core/020_tool_calls_basis.sql
@@ -8,7 +8,8 @@
 -- ONE COLUMN, HOLDING JSON, because the shape is a list rather than a value: each entry is a `kind`
 -- from a closed set, a `ref` naming what was chosen, and a `why` that is one sentence. Eight named
 -- columns would be eight ALTERs, and a ninth kind would be a ninth; this way a new kind is a new
--- enum value on the tool schema and no schema change at all here.
+-- value in the list the tool description advertises and in the set the boundary enforces, and no
+-- schema change at all here.
 --
 -- The stored value is an OBJECT, not a bare list — `{"entries": [...], "truncated": true|false}`.
 -- The writer caps the entry count and the length of `ref` and `why`, and a record that was cut has

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -490,8 +490,8 @@ class DbActivitySink:
         self._store.execute(
             "INSERT INTO tool_calls (id, ts, org_id, actor, tool_name, datasource, sql, row_count, "
             "execution_ms, success, error_kind, source, user_question, agent_query, thread_id, "
-            "correlation_id, refusal_detail, refusal_remediation, audit_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "correlation_id, refusal_detail, refusal_remediation, audit_id, basis) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 uuid4().hex,
                 record.ts,
@@ -519,6 +519,10 @@ class DbActivitySink:
                 # an older record shape writes NULL rather than raising. NULL is ordinary here too:
                 # those are NULL on every non-refusal, this on every call that ran no statement.
                 getattr(record, "audit_id", None),
+                # The agent's account of what it based the query on (020), already bounded and
+                # serialized by the writer. `getattr`-guarded like the three above, and NULL is
+                # ordinary here too: the argument is optional and most calls omit it.
+                getattr(record, "basis", None),
             ),
         )
         self._store.commit()
@@ -531,7 +535,7 @@ class DbActivitySink:
 _TOOL_CALL_COLS = (
     "id, ts, actor, tool_name, datasource, sql, row_count, execution_ms, success, error_kind, "
     "user_question, agent_query, thread_id, correlation_id, source, "
-    "refusal_detail, refusal_remediation"
+    "refusal_detail, refusal_remediation, basis"
 )
 
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -1964,6 +1964,79 @@ def _bounded_audit_sql(sql: str) -> tuple[str, bool]:
     return sql[:AUDIT_SQL_MAX_CHARS], True
 
 
+# What the agent may say it based a query on. A CLOSED set, enforced HERE and named in the tool
+# description as prose rather than declared as a schema `enum`. The MCP SDK validates arguments
+# against `inputSchema` before the handler runs, so an `enum` would not filter a bad value out of
+# the list — it would refuse the whole query over an optional note. An entry naming a kind we do not
+# know is dropped instead, and the row says the claim was not stored verbatim.
+BASIS_KINDS = frozenset(
+    {"example", "table", "join", "metric", "entity", "glossary", "filter", "date_range"}
+)
+
+# The list is caller-written and therefore caller-length. 20 is far above any honest use — a query
+# built on twenty distinct choices has more to explain than a log line can carry anyway — so this
+# bites only on a runaway, in the same spirit as `runtime._RECEIPT_MAX_REFS`.
+BASIS_MAX_ENTRIES = 20
+
+# `ref` is mostly a name — a table, a metric, an example id. But for `filter` and `date_range` it is
+# the PREDICATE, so it can carry a literal drawn from the customer's data, which is exactly the
+# disclosure `why` is bounded for. Same constraint, therefore: bounded here, and never treated as
+# safe to forward anywhere the SQL itself would not go.
+BASIS_REF_MAX_CHARS = 200
+
+# `why` is one short sentence by contract, and free text the model wrote can contain anything it
+# just read. Bounded well above a sentence, so a cut means something already went wrong.
+BASIS_WHY_MAX_CHARS = 300
+
+
+def _bounded_basis(raw: Any) -> str | None:
+    """The agent's stated basis as it will be stored, or None when it said nothing.
+
+    None rather than an empty envelope is what keeps a call that omits the argument byte-identical to
+    one made before the field existed — the column is simply NULL, as it is on every historical row.
+
+    `truncated` is ONE flag meaning "what is stored is not what was sent", set by a dropped entry, a
+    cut string and an over-cap list alike. Two flags would separate rejection from truncation, but a
+    reader only needs to know the record is not verbatim before quoting it — and a dropped entry that
+    set no flag would be a silent loss, which is the worse failure of the two.
+    """
+    if not isinstance(raw, list):
+        return None  # absent, or a caller sending something that was never a list
+    entries: list[dict[str, str]] = []
+    truncated = False
+    for item in raw:
+        if not isinstance(item, dict):
+            truncated = True  # rejected, and the row says the claim is not what was sent
+            continue
+        kind, ref, why = item.get("kind"), item.get("ref"), item.get("why")
+        # `kind` and `ref` are the entry's two required fields, so both are checked the same way and
+        # a failure of either drops the entry. The isinstance guards are not belt-and-braces: JSON
+        # gives us arbitrary types here, an array or object `kind` is UNHASHABLE, and testing it
+        # against a frozenset would raise TypeError out of the middle of building the audit record —
+        # turning a query that already succeeded into an error the caller sees.
+        if not isinstance(kind, str) or kind not in BASIS_KINDS:
+            truncated = True
+            continue
+        if not isinstance(ref, str) or not ref:
+            truncated = True
+            continue
+        if len(entries) >= BASIS_MAX_ENTRIES:
+            truncated = True
+            break  # nothing after this can change either value, so stop reading the caller's list
+        why = why if isinstance(why, str) else ""  # optional, unlike the two above
+        truncated = truncated or len(ref) > BASIS_REF_MAX_CHARS or len(why) > BASIS_WHY_MAX_CHARS
+        entries.append(
+            {
+                "kind": kind,
+                "ref": ref[:BASIS_REF_MAX_CHARS],
+                "why": why[:BASIS_WHY_MAX_CHARS],
+            }
+        )
+    if not entries and not truncated:
+        return None  # an empty list is the same claim as no list
+    return json.dumps({"entries": entries, "truncated": truncated})
+
+
 def _bounded_audit_detail(detail: str) -> str:
     """The refusal's detail as it will be stored (ACE-098).
 
@@ -2619,6 +2692,10 @@ def record_tool_call(
         "refusal_remediation": derived_refusal_remediation,
         "user_question": user_question if user_question is not None else args.get("user_question"),
         "agent_query": args.get("raw_query"),  # the existing arg is the agent's framing of the query
+        # The choices behind the query, bounded here rather than by the caller — a bound the caller
+        # applies is not a bound. Joins the two self-reported columns above: same provenance, same
+        # trust.
+        "basis": _bounded_basis(args.get("basis")),
         "thread_id": thread_id if thread_id is not None else args.get("thread_id"),
         "correlation_id": (  # the turn (one user question)
             correlation_id if correlation_id is not None else args.get("correlation_id")
@@ -2814,7 +2891,8 @@ TOOLS: dict[str, dict[str, Any]] = {
         "description": (
             "Fetch the curated few-shot NL→SQL examples for a datasource, grouped by subject area. "
             "Use before generating SQL to ground dialect and house style; match on the question, "
-            "then reuse the tagged tables/columns/SQL."
+            "then reuse the tagged tables/columns/SQL. On a served deployment each example carries "
+            "a stable `id` — cite it as a basis ref on execute_sql to say which one you followed."
         ),
         "inputSchema": {
             "type": "object",
@@ -2941,7 +3019,9 @@ TOOLS: dict[str, dict[str, Any]] = {
             "resolve what the aggregate reads (a `COUNT(*)`, an unqualified column, a CTE the walk "
             "does not enter), so do NOT report it as clean. Its sibling `findings` is a different "
             "question — whether the arithmetic is meaningful at all — and a number can be "
-            "un-multiplied and still meaningless."
+            "un-multiplied and still meaningless.\n"
+            "OPTIONALLY send `basis` — the choices behind this query, each with why. Recorded for "
+            "the admin activity log beside the statement; never checked against your SQL."
         ),
         "inputSchema": {
             "type": "object",
@@ -2972,6 +3052,22 @@ TOOLS: dict[str, dict[str, Any]] = {
                 },
                 "thread_id": _THREAD_ID_PROP,
                 "correlation_id": _CORRELATION_ID_PROP,
+                # Deliberately a bare array: no `items` schema, no `maxItems`. The MCP SDK validates
+                # every call against this schema BEFORE the handler runs, so any constraint here
+                # refuses the whole query rather than bounding the field — a 260-character `ref` is
+                # an ordinary IN-list predicate, and losing the user's answer over an advisory note
+                # is the opposite of what this field is for. `_bounded_basis` is the bound, which is
+                # also the only place a bound belongs: it truncates and records that it did.
+                # Validation is per-item and runs on the event loop, so an items schema also made a
+                # max-size body cost seconds of everyone else's latency.
+                "basis": {
+                    "type": "array",
+                    "description": "OPTIONAL. What you based this query on: objects of {kind, ref, "
+                    "why}. kind is one of example, table, join, metric, entity, glossary, filter, "
+                    "date_range; ref is what you chose (the example id, the table or metric name, "
+                    "the predicate); why is one short sentence, carrying no values from the data "
+                    "that the SQL does not. Over-long or unknown entries are trimmed, not refused.",
+                },
             },
             "required": ["sql"],
             "additionalProperties": False,

--- a/tests/test_ace042_no_filter_injection.py
+++ b/tests/test_ace042_no_filter_injection.py
@@ -274,9 +274,23 @@ def test_no_notice_leaks_a_spec_id_to_a_client():
                     m.Table.model_fields["default_filters"].description):
         assert not spec_id.search(surface), surface
 
+    # Every description at any depth, not just the top-level properties: a property whose `items`
+    # carry their own object schema puts descriptions a level down, and those ship to the client
+    # exactly like the rest. Sweeping only the top level meant the guard's reach stopped short of
+    # part of the surface it exists to protect.
+    def _descriptions(node):
+        if isinstance(node, dict):
+            if isinstance(node.get("description"), str):
+                yield node["description"]
+            for v in node.values():
+                yield from _descriptions(v)
+        elif isinstance(node, list):
+            for v in node:
+                yield from _descriptions(v)
+
     for spec in tools.TOOLS.values():
-        for prop in spec["inputSchema"].get("properties", {}).values():
-            assert not spec_id.search(prop.get("description", ""))
+        for description in _descriptions(spec["inputSchema"]):
+            assert not spec_id.search(description), description
 
 
 def test_no_shipped_markdown_surface_carries_a_spec_id():

--- a/tests/test_ace110_query_basis.py
+++ b/tests/test_ace110_query_basis.py
@@ -96,8 +96,8 @@ DECLARED_KINDS = [
 
 
 def test_every_declared_kind_is_accepted():
-    """The enum on the schema and the set enforced at the boundary have to be the same set, or a
-    compliant client sends something the boundary silently drops."""
+    """The kinds the description advertises and the set enforced at the boundary have to be the same
+    set, or a compliant client sends something the boundary silently drops."""
     entries = [{"kind": k, "ref": "x", "why": "y"} for k in DECLARED_KINDS]
     doc = _stored(tools._bounded_basis(entries))
     assert [e["kind"] for e in doc["entries"]] == DECLARED_KINDS
@@ -138,9 +138,11 @@ def test_a_payload_the_boundary_trims_is_accepted_by_the_schema():
 
 @pytest.mark.parametrize("bad", ["nonsense", "", None, "EXAMPLE", 7, True])
 def test_an_unknown_kind_is_dropped_at_the_boundary(bad):
-    """Criterion 3. The schema declares the enum, but nothing in this repo validates an incoming
-    payload against a tool's inputSchema — `enum` is honoured by the client — so a non-compliant
-    caller reaches this code path and the drop is what makes 'rejected rather than stored' true."""
+    """Criterion 3, and the drop is the whole of it. The MCP SDK validates arguments against
+    `inputSchema` before the handler runs, so a constraint declared there does not filter a bad entry
+    out of `basis` — it refuses the entire call, taking the answer with it. That is why the property
+    carries no `items` schema and the kinds are advertised as prose: enforcement belongs here, where
+    an unknown kind costs its own entry and nothing else."""
     doc = _stored(tools._bounded_basis([{"kind": bad, "ref": "x", "why": "y"}, ENTRY]))
     assert doc["entries"] == [ENTRY]
     assert doc["truncated"] is True  # dropped is not verbatim, and the row has to say so
@@ -192,7 +194,9 @@ def test_all_entries_invalid_still_records_the_attempt():
 
 
 def test_too_many_entries_are_capped_and_flagged():
-    over = [{"kind": "table", "ref": f"t{i}", "why": "w"} for i in range(tools.BASIS_MAX_ENTRIES + 3)]
+    over = [
+        {"kind": "table", "ref": f"t{i}", "why": "w"} for i in range(tools.BASIS_MAX_ENTRIES + 3)
+    ]
     doc = _stored(tools._bounded_basis(over))
     assert len(doc["entries"]) == tools.BASIS_MAX_ENTRIES
     assert doc["truncated"] is True
@@ -214,7 +218,9 @@ def test_a_long_ref_is_cut_and_flagged():
     """`ref` is bounded for the same reason `why` is: for `filter` and `date_range` it IS the
     predicate, so it can carry a literal out of the customer's data."""
     long_ref = "region = '" + "x" * (tools.BASIS_REF_MAX_CHARS + 50) + "'"
-    doc = _stored(tools._bounded_basis([{"kind": "filter", "ref": long_ref, "why": "asked for it"}]))
+    doc = _stored(
+        tools._bounded_basis([{"kind": "filter", "ref": long_ref, "why": "asked for it"}])
+    )
     assert len(doc["entries"][0]["ref"]) == tools.BASIS_REF_MAX_CHARS
     assert doc["truncated"] is True
 
@@ -319,9 +325,17 @@ def test_the_stored_basis_reaches_the_reader(db):
 
 def _card(basis_value):
     return admin._call_card(
-        {"sql": "SELECT 1", "agent_query": "count", "ts": "2026-08-17T00:00:00Z",
-         "datasource": "SALES_DATA", "execution_ms": 4, "success": 1, "row_count": 1,
-         "tool_name": "execute_sql", "basis": basis_value}
+        {
+            "sql": "SELECT 1",
+            "agent_query": "count",
+            "ts": "2026-08-17T00:00:00Z",
+            "datasource": "SALES_DATA",
+            "execution_ms": 4,
+            "success": 1,
+            "row_count": 1,
+            "tool_name": "execute_sql",
+            "basis": basis_value,
+        }
     )
 
 
@@ -338,9 +352,15 @@ def test_a_basis_lands_under_its_own_call_not_a_neighbour():
     """The criterion is 'under the RIGHT statement'. A turn runs several calls and only some carry a
     basis, so rendering one card per call is not enough — the block has to stay inside the card whose
     SQL it explains."""
-    with_basis = {"sql": "SELECT 1", "ts": "2026-08-17T00:00:00Z", "datasource": "SALES_DATA",
-                  "execution_ms": 4, "success": 1, "tool_name": "execute_sql",
-                  "basis": json.dumps({"entries": [ENTRY], "truncated": False})}
+    with_basis = {
+        "sql": "SELECT 1",
+        "ts": "2026-08-17T00:00:00Z",
+        "datasource": "SALES_DATA",
+        "execution_ms": 4,
+        "success": 1,
+        "tool_name": "execute_sql",
+        "basis": json.dumps({"entries": [ENTRY], "truncated": False}),
+    }
     without = {**with_basis, "sql": "SELECT 2", "basis": None}
     html = admin._call_card(without) + admin._call_card(with_basis)
     assert html.index("SELECT 2") < html.index("SELECT 1") < html.index("88e825e75112")
@@ -405,8 +425,16 @@ def test_the_rendered_basis_is_escaped():
     """Self-reported and attacker-influenceable, exactly like the SQL and the question beside it."""
     html = _card(
         json.dumps(
-            {"entries": [{"kind": "filter", "ref": "<script>alert(1)</script>",
-                          "why": 'a "quoted" & <b>bold</b> reason'}], "truncated": False}
+            {
+                "entries": [
+                    {
+                        "kind": "filter",
+                        "ref": "<script>alert(1)</script>",
+                        "why": 'a "quoted" & <b>bold</b> reason',
+                    }
+                ],
+                "truncated": False,
+            }
         )
     )
     assert "<script>" not in html

--- a/tests/test_ace110_query_basis.py
+++ b/tests/test_ace110_query_basis.py
@@ -1,0 +1,413 @@
+"""An agent can say what it based a query on, and why (ACE-110).
+
+The activity log has always recorded what ran, and two self-reported columns carrying the caller's
+framing of the question. What it never recorded is the reasoning in between — which example was
+mirrored, which table was chosen, why a filter is there. `basis` is that, bounded at the boundary and
+never adjudicated: core records the claim and leaves checking it to whoever holds the receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+PKG_SRC = Path(__file__).resolve().parent.parent / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+import admin  # noqa: E402
+import tools  # noqa: E402
+from store import Store  # noqa: E402
+
+ENTRY = {"kind": "example", "ref": "88e825e75112", "why": "closest match to the question"}
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    url = "sqlite://" + str(tmp_path / "calls.db")
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    s = Store.connect(url)
+    s.run_migrations()
+    s.close()
+    return url
+
+
+def _rows(url):
+    s = Store.connect(url)
+    rows = s.query("SELECT * FROM tool_calls ORDER BY ts")
+    s.close()
+    return rows
+
+
+def _record(basis=None, **extra):
+    args = {"datasource": "SALES_DATA", "sql": "SELECT 1", **extra}
+    if basis is not None:
+        args["basis"] = basis
+    tools.record_tool_call(
+        name="execute_sql",
+        arguments=args,
+        result_text='{"row_count": 1}',
+        execution_ms=4,
+        actor="jordan@example.com",
+    )
+
+
+def _stored(raw):
+    return json.loads(raw)
+
+
+# --- the bound ---------------------------------------------------------------------------------
+
+
+def test_no_basis_is_no_column():
+    """Criterion 1's half that lives in the writer: absent must be NULL, not an empty envelope, or a
+    call made by a client that never heard of the field stops matching one made before it existed."""
+    assert tools._bounded_basis(None) is None
+    assert tools._bounded_basis([]) is None
+
+
+@pytest.mark.parametrize("raw", ["a string", 7, {"kind": "table"}, True])
+def test_something_that_was_never_a_list_is_ignored(raw):
+    assert tools._bounded_basis(raw) is None
+
+
+def test_a_well_formed_entry_survives_verbatim():
+    doc = _stored(tools._bounded_basis([ENTRY]))
+    assert doc == {"entries": [ENTRY], "truncated": False}
+
+
+# Written out rather than derived from `tools.BASIS_KINDS`: a test that builds its expectation from
+# the constant it is checking asserts `X == X` and cannot fail. These eight are the contract.
+DECLARED_KINDS = [
+    "date_range",
+    "entity",
+    "example",
+    "filter",
+    "glossary",
+    "join",
+    "metric",
+    "table",
+]
+
+
+def test_every_declared_kind_is_accepted():
+    """The enum on the schema and the set enforced at the boundary have to be the same set, or a
+    compliant client sends something the boundary silently drops."""
+    entries = [{"kind": k, "ref": "x", "why": "y"} for k in DECLARED_KINDS]
+    doc = _stored(tools._bounded_basis(entries))
+    assert [e["kind"] for e in doc["entries"]] == DECLARED_KINDS
+    assert doc["truncated"] is False
+
+
+def test_the_advertised_kinds_and_the_enforced_set_agree():
+    """The kinds are prose on the property rather than a schema `enum`, so nothing but this test
+    holds the sentence the model reads and the set the boundary enforces to the same eight."""
+    described = tools.TOOLS["execute_sql"]["inputSchema"]["properties"]["basis"]["description"]
+    assert tools.BASIS_KINDS == set(DECLARED_KINDS)
+    for kind in DECLARED_KINDS:
+        assert kind in described, kind
+
+
+def test_the_basis_schema_constrains_nothing_the_sdk_could_refuse():
+    """The MCP SDK validates arguments against this schema BEFORE the handler runs, so every
+    constraint here is a whole-query refusal rather than a bound — and this field is optional and
+    advisory. `_bounded_basis` truncates instead, which is what the spec asks for. Anything but
+    `type` reappearing here is a regression that would make an over-long ref lose the user's answer.
+    """
+    prop = tools.TOOLS["execute_sql"]["inputSchema"]["properties"]["basis"]
+    assert set(prop) == {"type", "description"} and prop["type"] == "array"
+
+
+def test_a_payload_the_boundary_trims_is_accepted_by_the_schema():
+    """The two halves have to agree: what `_bounded_basis` is willing to trim, the schema must be
+    willing to accept, or the trim never runs."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = tools.TOOLS["execute_sql"]["inputSchema"]
+    for args in (
+        {"sql": "SELECT 1", "basis": [{"kind": "filter", "ref": "x" * 400, "why": "y" * 400}]},
+        {"sql": "SELECT 1", "basis": [{"kind": "table", "ref": "t"}] * 40},
+        {"sql": "SELECT 1", "basis": [{"kind": "made_up", "ref": "t", "extra": 1}]},
+    ):
+        jsonschema.validate(args, schema)  # raises if the schema would refuse instead of trim
+
+
+@pytest.mark.parametrize("bad", ["nonsense", "", None, "EXAMPLE", 7, True])
+def test_an_unknown_kind_is_dropped_at_the_boundary(bad):
+    """Criterion 3. The schema declares the enum, but nothing in this repo validates an incoming
+    payload against a tool's inputSchema — `enum` is honoured by the client — so a non-compliant
+    caller reaches this code path and the drop is what makes 'rejected rather than stored' true."""
+    doc = _stored(tools._bounded_basis([{"kind": bad, "ref": "x", "why": "y"}, ENTRY]))
+    assert doc["entries"] == [ENTRY]
+    assert doc["truncated"] is True  # dropped is not verbatim, and the row has to say so
+
+
+@pytest.mark.parametrize("unhashable", [["table"], {"a": 1}, [], {}])
+def test_an_unhashable_kind_is_rejected_rather_than_raising(unhashable):
+    """JSON hands us arbitrary types, and testing an array or object against a frozenset raises
+    `TypeError`. That raise would come from the middle of building the audit record — after the query
+    has already succeeded — and on the served path `record_tool_call` runs in an unwrapped `finally`,
+    so it would replace a good answer with an internal error the caller sees."""
+    doc = _stored(tools._bounded_basis([{"kind": unhashable, "ref": "x"}, ENTRY]))
+    assert doc["entries"] == [ENTRY] and doc["truncated"] is True
+
+
+@pytest.mark.parametrize("bad_ref", [None, "", 0, False, {"a": 1}, ["x"], 7])
+def test_an_entry_with_no_usable_ref_is_dropped_and_flagged(bad_ref):
+    """`ref` is required beside `kind`, so it is enforced the same way. Storing an entry whose ref
+    went missing as if it were verbatim would tell an operator the agent named something when it
+    did not — and a non-string ref would otherwise land in the column as a Python repr."""
+    doc = _stored(tools._bounded_basis([{"kind": "filter", "ref": bad_ref, "why": "y"}, ENTRY]))
+    assert doc["entries"] == [ENTRY] and doc["truncated"] is True
+
+
+@pytest.mark.parametrize("bad", ["a string", 7, None, ["nested"]])
+def test_an_entry_that_is_not_an_object_is_dropped(bad):
+    doc = _stored(tools._bounded_basis([bad, ENTRY]))
+    assert doc["entries"] == [ENTRY] and doc["truncated"] is True
+
+
+@pytest.mark.parametrize("no_why", [{}, {"why": None}, {"why": ""}, {"why": 7}, {"why": ["x"]}])
+def test_an_entry_with_no_usable_why_is_kept_with_an_empty_one(no_why):
+    """`why` is NOT in the schema's `required`, unlike `kind` and `ref` — a ref with no justification
+    is still a fact about what was chosen, so it is kept rather than dropped."""
+    doc = _stored(tools._bounded_basis([{"kind": "table", "ref": "orders", **no_why}]))
+    assert doc["entries"] == [{"kind": "table", "ref": "orders", "why": ""}]
+
+
+def test_extra_keys_on_an_entry_do_not_ride_along():
+    doc = _stored(tools._bounded_basis([{**ENTRY, "confidence": 0.9, "note": "x"}]))
+    assert doc["entries"] == [ENTRY]
+
+
+def test_all_entries_invalid_still_records_the_attempt():
+    """An empty list is the same claim as no list — but an empty list that USED to hold something is
+    not, and the flag is the only thing that distinguishes them."""
+    doc = _stored(tools._bounded_basis([{"kind": "nope", "ref": "x"}]))
+    assert doc == {"entries": [], "truncated": True}
+
+
+def test_too_many_entries_are_capped_and_flagged():
+    over = [{"kind": "table", "ref": f"t{i}", "why": "w"} for i in range(tools.BASIS_MAX_ENTRIES + 3)]
+    doc = _stored(tools._bounded_basis(over))
+    assert len(doc["entries"]) == tools.BASIS_MAX_ENTRIES
+    assert doc["truncated"] is True
+
+
+def test_exactly_at_the_cap_is_not_flagged():
+    at = [{"kind": "table", "ref": f"t{i}", "why": "w"} for i in range(tools.BASIS_MAX_ENTRIES)]
+    doc = _stored(tools._bounded_basis(at))
+    assert len(doc["entries"]) == tools.BASIS_MAX_ENTRIES and doc["truncated"] is False
+
+
+def test_a_long_why_is_cut_and_flagged():
+    doc = _stored(tools._bounded_basis([{**ENTRY, "why": "w" * (tools.BASIS_WHY_MAX_CHARS + 50)}]))
+    assert len(doc["entries"][0]["why"]) == tools.BASIS_WHY_MAX_CHARS
+    assert doc["truncated"] is True
+
+
+def test_a_long_ref_is_cut_and_flagged():
+    """`ref` is bounded for the same reason `why` is: for `filter` and `date_range` it IS the
+    predicate, so it can carry a literal out of the customer's data."""
+    long_ref = "region = '" + "x" * (tools.BASIS_REF_MAX_CHARS + 50) + "'"
+    doc = _stored(tools._bounded_basis([{"kind": "filter", "ref": long_ref, "why": "asked for it"}]))
+    assert len(doc["entries"][0]["ref"]) == tools.BASIS_REF_MAX_CHARS
+    assert doc["truncated"] is True
+
+
+# --- the surface -------------------------------------------------------------------------------
+
+
+def test_basis_is_optional_and_the_schema_stays_closed():
+    """Criterion 5. A client that has never heard of the field must be unaffected — which needs both
+    halves: not required, and still declared, or `additionalProperties: false` makes it unsendable."""
+    schema = tools.TOOLS["execute_sql"]["inputSchema"]
+    assert "basis" not in schema["required"]
+    assert "basis" in schema["properties"]
+    assert schema["additionalProperties"] is False
+
+
+def test_the_description_mentions_basis_once():
+    """Criterion 7. The tool description ships on every request, so a second mention is paid forever."""
+    assert tools.TOOLS["execute_sql"]["description"].count("basis") == 1
+
+
+def test_the_description_tells_the_agent_its_note_will_be_trimmed_not_refused():
+    """The model needs to know an over-long entry costs it the note, not the answer — otherwise the
+    safe move is to send nothing."""
+    described = tools.TOOLS["execute_sql"]["inputSchema"]["properties"]["basis"]["description"]
+    assert "not refused" in described
+
+
+def test_the_examples_tool_says_its_id_can_be_cited():
+    """The `id` ACE-109 puts on every served example is inert unless the agent knows it may name it."""
+    assert "basis" in tools.TOOLS["get_prompt_examples"]["description"]
+
+
+# --- end to end --------------------------------------------------------------------------------
+
+
+def test_a_call_without_basis_records_a_null_column(db):
+    """Criterion 1, end to end."""
+    _record(user_question="how many?", raw_query="count")
+    row = _rows(db)[0]
+    assert row["basis"] is None
+    assert row["sql"] == "SELECT 1" and row["user_question"] == "how many?"
+
+
+def test_sending_basis_perturbs_no_other_column(db):
+    """Criterion 1's real claim — *byte-identical but for the column*. Asserting three fields would
+    not catch a `basis` that quietly changed how anything else was derived, so this compares the two
+    rows whole and names the only keys allowed to differ."""
+    _record(user_question="how many?", raw_query="count")
+    _record(user_question="how many?", raw_query="count", basis=[ENTRY])
+    without, with_basis = _rows(db)
+    volatile = {"id", "ts", "basis"}
+    assert set(without) == set(with_basis)  # same columns, so the comparison below is total
+    assert {k: v for k, v in without.items() if k not in volatile} == {
+        k: v for k, v in with_basis.items() if k not in volatile
+    }
+    assert without["basis"] is None and with_basis["basis"] is not None
+
+
+def test_the_migration_applies_to_a_table_that_already_has_rows(tmp_path):
+    """Criterion 6. `ADD COLUMN` on a populated table is the case a deployment actually meets — an
+    empty-database migration run never exercises it, and the existing rows must survive reading back
+    with the new column NULL rather than the migration failing or rewriting them."""
+    url = "sqlite://" + str(tmp_path / "existing.db")
+    s = Store.connect(url)
+    s.run_migrations()
+    s.execute(
+        "INSERT INTO tool_calls (id, ts, org_id, tool_name, source, success) VALUES (?,?,?,?,?,?)",
+        ("row-1", "2026-08-17T00:00:00Z", "local", "execute_sql", "mcp", 1),
+    )
+    s.commit()
+    # Re-running is a no-op via the ledger; the assertion is that the pre-existing row is intact and
+    # simply carries NULL for the column that did not exist when it was written.
+    s.run_migrations()
+    row = s.query("SELECT id, basis FROM tool_calls WHERE id = ?", ("row-1",))[0]
+    s.close()
+    assert row["id"] == "row-1" and row["basis"] is None
+
+
+def test_basis_round_trips_onto_the_row(db):
+    """Criterion 2's write half."""
+    _record(basis=[ENTRY])
+    doc = _stored(_rows(db)[0]["basis"])
+    assert doc == {"entries": [ENTRY], "truncated": False}
+
+
+def test_the_stored_basis_reaches_the_reader(db):
+    """`_TOOL_CALL_COLS` is the SELECT list and is narrower than the INSERT — a column missing from
+    it is written on every row and read by nobody, so the view would render nothing forever."""
+    import model_store
+
+    _record(basis=[ENTRY], thread_id="t1")
+    s = Store.connect(db)
+    sessions = model_store.list_sessions(s)
+    s.close()
+    call = sessions[0]["turns"][0]["calls"][0]
+    assert _stored(call["basis"])["entries"] == [ENTRY]
+
+
+# --- the view ----------------------------------------------------------------------------------
+
+
+def _card(basis_value):
+    return admin._call_card(
+        {"sql": "SELECT 1", "agent_query": "count", "ts": "2026-08-17T00:00:00Z",
+         "datasource": "SALES_DATA", "execution_ms": 4, "success": 1, "row_count": 1,
+         "tool_name": "execute_sql", "basis": basis_value}
+    )
+
+
+def test_the_call_card_shows_the_basis_under_its_sql():
+    """Criterion 2's render half — under the statement it explains, so the reasoning sits next to the
+    SQL rather than in a separate pane."""
+    html = _card(json.dumps({"entries": [ENTRY], "truncated": False}))
+    assert "88e825e75112" in html and "closest match to the question" in html
+    assert html.index("SELECT 1") < html.index("88e825e75112")
+    assert "agent-reported" in html  # whose claim it is, like every other self-reported field
+
+
+def test_a_basis_lands_under_its_own_call_not_a_neighbour():
+    """The criterion is 'under the RIGHT statement'. A turn runs several calls and only some carry a
+    basis, so rendering one card per call is not enough — the block has to stay inside the card whose
+    SQL it explains."""
+    with_basis = {"sql": "SELECT 1", "ts": "2026-08-17T00:00:00Z", "datasource": "SALES_DATA",
+                  "execution_ms": 4, "success": 1, "tool_name": "execute_sql",
+                  "basis": json.dumps({"entries": [ENTRY], "truncated": False})}
+    without = {**with_basis, "sql": "SELECT 2", "basis": None}
+    html = admin._call_card(without) + admin._call_card(with_basis)
+    assert html.index("SELECT 2") < html.index("SELECT 1") < html.index("88e825e75112")
+    assert html.count("88e825e75112") == 1  # only the call that reported one
+
+
+def test_a_truncated_basis_says_so_in_the_view():
+    html = _card(json.dumps({"entries": [ENTRY], "truncated": True}))
+    assert "truncated" in html
+
+
+def test_a_card_with_no_basis_renders_nothing_extra():
+    assert "basis" not in _card(None)
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [
+        "not json",
+        "[]",
+        '{"no": "entries"}',
+        "",
+        '"a bare string"',
+        "7",
+        '{"entries": null}',
+        '{"entries": 5}',
+        '{"entries": "text"}',
+        '{"entries": [{"kind": 5, "ref": "x"}]}',
+        '{"entries": [{"kind": "table", "ref": 7}]}',
+        '{"entries": [{"kind": "table", "ref": "x", "why": 9}]}',
+        '{"entries": ["not an object"]}',
+    ],
+)
+def test_a_malformed_basis_does_not_take_the_page_down(junk):
+    """One card's bad self-report must not cost the operator the log they opened to read — and the
+    blast radius is the page, not the card: `_session_drawer` joins every card into one string.
+
+    The non-string inner values matter because `ui.esc` takes `str | None` and raises on anything
+    else truthy. `_bounded_basis` never writes one, but this column is plain TEXT on a self-hostable
+    schema and an embedder builds `ToolCallRecord` itself, so the renderer cannot assume its writer.
+    """
+    html = _card(junk)
+    assert "SELECT 1" in html  # the card still renders, which is the whole claim
+
+
+def test_a_wholly_rejected_basis_still_shows_that_a_claim_was_made():
+    """`_bounded_basis` stores `{"entries": [], "truncated": true}` when every entry was rejected, so
+    the audit log records the attempt. The view has to show it: on the one surface this feature
+    exists for, "the agent said nothing" and "everything the agent said was rejected" must not look
+    the same."""
+    html = _card(json.dumps({"entries": [], "truncated": True}))
+    assert "basis" in html and "truncated" in html
+
+
+def test_an_empty_unflagged_basis_renders_nothing():
+    """Not something the writer emits — it returns None for an empty claim — so there is nothing to
+    say and no heading to draw."""
+    assert "basis" not in _card(json.dumps({"entries": [], "truncated": False}))
+
+
+def test_the_rendered_basis_is_escaped():
+    """Self-reported and attacker-influenceable, exactly like the SQL and the question beside it."""
+    html = _card(
+        json.dumps(
+            {"entries": [{"kind": "filter", "ref": "<script>alert(1)</script>",
+                          "why": 'a "quoted" & <b>bold</b> reason'}], "truncated": False}
+        )
+    )
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html and "&amp;" in html


### PR DESCRIPTION
## Summary

The activity log records *what* ran — the statement, the outcome, and two self-reported columns
(`user_question`, `agent_query`) carrying the caller's framing of the question. What it has never
recorded is the reasoning in between: which curated example was mirrored, which table was chosen
over a similar one, which metric definition was used, why a filter is there. So an operator reading
the log can see that a query was wrong without seeing *where the reasoning went wrong*.

`execute_sql` gains one optional argument, `basis` — a list of `{kind, ref, why}` entries, one per
choice — recorded on `tool_calls` and rendered in the activity view under the statement it explains.
Core records the claim; it does not adjudicate it.

## Changes

- **`basis` on `execute_sql`** — a list of small uniform entries rather than eight named fields: the
  schema ships on every request so its size is a running cost, a ninth kind is one more name in a
  sentence rather than another schema change, and every entry splits into a `ref` that can be checked
  against the SQL and a `why` that cannot. Optional, absent is normal, and still declared —
  `additionalProperties: false` makes an undeclared argument unsendable.
- **A bare array, with the eight kinds as prose rather than a schema `enum`.** The MCP SDK registers
  the handler with `validate_input=True`, so anything constrained there refuses the **whole query**
  instead of bounding the field, and writes no `tool_calls` row at all. See below.
- **`_bounded_basis` is the only bound**, applied where the call is handled — a bound the caller
  applies is not a bound. Unknown `kind` or missing `ref` → the entry is dropped; `ref` and `why` are
  trimmed; the list is capped. `ref` is bounded like `why`, not only `why`, because for `filter` and
  `date_range` the `ref` *is* the predicate and can carry a literal out of the customer's data.
- **The stored value is an object**, `{"entries": [...], "truncated": bool}`, so one column carries
  both the entries and the fact that they were cut. `truncated` means only *what is stored is not
  what was sent* — a dropped entry and a trimmed string alike, because a drop that set no flag would
  be a silent loss in an audit log.
- **Migration `020`** — one nullable TEXT column, portable `ALTER`, no rebuild. `_TOOL_CALL_COLS` is
  the SELECT list and narrower than the INSERT, so it is updated too; a column missing from it is
  written on every row and read by nobody.
- **`admin._basis_block`** renders it under the SQL, escaped, and trusts nothing it reads: `basis` is
  plain TEXT and an embedder builds `ToolCallRecord` itself, so a non-string value would reach
  `ui.esc` and take out the whole activity page rather than one card.
- **`get_prompt_examples`** gains one sentence telling the agent its example `id` may be cited.

`ports.py` is untouched — `ActivitySink` declares only `record_query_execution`.

## The design changed under review, and it is the main thing to look at

The field was first built with a full item schema — `enum` on `kind`, `maxLength` on `ref`/`why`,
`maxItems`, `additionalProperties: false` — on the stated belief that nothing server-side validates a
payload against a tool's `inputSchema`. **That belief was wrong**, and it was wrong in the direction
that matters: `Server.call_tool(validate_input=True)` is the SDK default, so `jsonschema.validate`
runs on every call before the handler. Measured consequences of the original shape:

| payload | result |
|---|---|
| `ref` of 260 chars (an ordinary `IN`-list predicate) | **whole query refused**, no audit row |
| 21+ entries | **whole query refused** |
| any extra key on an entry | **whole query refused** |

That made success criterion 4 — *"truncated rather than refused"* — unmeetable on the served path,
and made `truncated` dead code there. Validation is also per-item and runs on the event loop:

| entries in a max-size body | with items schema | bare array |
|---|---|---|
| 100,000 | **2,210 ms** blocked worker | **3 ms** |

Dropping the item schema fixes the refusal, removes the stall, and returns ~90 tokens per request.
The cost is that the eight kinds are prose the model reads rather than an enum a client can validate
against.

## Tool schema cost — paid on every request

Measured with `cl100k_base`:

| | before | after | delta |
|---|---|---|---|
| `execute_sql` | 1,795 | 1,935 | **+140 (+7.8%)** |
| whole `tools/list` | 3,333 | 3,505 | **+172 (+5.2%)** |

Roughly ~130 for the `basis` property, ~40 for the sentence on `execute_sql`'s description, ~32 for
the one on `get_prompt_examples`.

## Checklist

- [x] Tests added — 71 in `tests/test_ace110_query_basis.py`. **No existing test weakened or
      removed.** One existing test was *strengthened*: `test_no_notice_leaks_a_spec_id_to_a_client`
      swept only top-level properties, and this diff is the first to put a description below that
      level, so its sweep now recurses.
- [x] `uv run dev.py check` green — ruff lint + format, full suite, gitleaks.
- [x] `uv run dev.py cover` — 100% diff coverage.
- [x] Reviewed with the Agami panel (correctness/tests, security + runtime cost, structural rubric).
      Three must-fix findings, all fixed and independently reproduced before and after: the schema
      refusal/stall above, a `TypeError` on an unhashable `kind` that escaped the audit-failure
      policy, and a renderer that raised on six shapes its docstring promised to tolerate.
- [x] Migration `020` is the next free number, portable, forward-only, no `IF NOT EXISTS`.
- [x] Public-repo safe — no customer, dataset or internal naming; fixtures are the repo's synthetic
      set.

## Known gap

A schema-rejected tool call writes no `tool_calls` row **on any tool** — the SDK validates before the
handler's `finally`. Pre-existing and not introduced here; this change now avoids adding to it by
constraining nothing at the schema.

Spec: ACE-110