### PR TITLE
release: 0.6.7 — a curated example keeps its id, and an agent can say what it based a query on

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.6.6",
+    "version": "0.6.7",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,56 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.6.7] — 2026-08-18
+
+### Added
+
+- **A curated example keeps the same id across deploys, and the caller can see it.** `prompt_example`
+  has had an `id` column in its primary key since the table existed, and it was unusable three times
+  over: an example with no `id` in its YAML got a minted uuid4, nothing wrote that back, so the next
+  deploy minted a different one for the same example — and the read selected `question, doc`, never
+  the `id`, so no identity reached a caller even where one existed. Across a real deployed model of
+  16 subject areas and 46 curated examples, not one carried an id.
+
+  So nothing could name an example, count one, or say whether the one returned yesterday is the one
+  returned today. `agami-save-correction` cannot tell a correction that created an example from one
+  that should have replaced it; ranking returns a subset and which subset is unrecordable; the library
+  only grows, because no two observations of an example can be tied together.
+
+  The id is now **derived from the example's own content** — `question` and `sql`, each NUL-terminated,
+  SHA-256, twelve hex characters, the construction `compute_model_hash` already uses. Derived rather
+  than minted, because a minted id changes every deploy; derived rather than authored, because
+  authoring gives the id two homes that can disagree and needs a pass over every deployment. An
+  authored `id` in the YAML still wins, which is the escape hatch for an example deliberately filed
+  under two subject areas — those otherwise resolve to one id, and the first now wins rather than the
+  second aborting the deploy.
+
+  `select_examples` returns it, and `example_by_id` reads one back, scoped by org and datasource like
+  every other read in the module. The derivation is one-way, so a consumer holding an id needs the
+  lookup for the id to be worth having.
+
+- **An agent can say what it based a query on, and why.** The activity log records what ran and two
+  self-reported columns carrying the caller's framing of the question. What it never recorded is the
+  reasoning in between: why that table, when the model declares three that look similar; why that
+  join, when it declares no relationship between those two tables; which curated example this
+  followed, or whether there was none. An operator could see that a query was wrong and not where the
+  reasoning went wrong — and a query against the wrong table is indistinguishable, in the log, from
+  one against the right table.
+
+  `execute_sql` takes an optional `basis`: a list of `{kind, ref, why}`, recorded on `tool_calls` and
+  rendered in the activity log beneath the statement it explains. Absent is the ordinary case, the
+  field is not `required`, and a client that has never heard of it is unaffected.
+
+  **The property is declared as a bare array, and that is a correctness constraint rather than a
+  simplification.** The MCP SDK validates arguments against `inputSchema` before the handler runs, so
+  a `maxLength`, `maxItems` or `enum` there does not trim a bad entry — it refuses the whole call and
+  takes the caller's answer with it. The kinds are advertised in the description and enforced at the
+  boundary, where an over-long `ref` or an unknown `kind` costs its own entry and nothing else. The
+  stored value says when it was cut, so a reader never takes a truncated list for the whole claim.
+
+  Self-reported, like its neighbours: core records the claim and adjudicates nothing. Whoever holds
+  the receipt can check `ref` against the SQL themselves.
+
 ## [0.6.6] — 2026-08-14
 
 ### Added

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.6.6"
+version = "0.6.7"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts 0.6.7 with the two changes merged since 0.6.6.

**ACE-109 — a curated example keeps the same id across deploys.** `prompt_example.id` has been in the primary key since the table existed and was unusable three ways over: minted per deploy when the YAML carried none, never written back, and never selected by the read. So nothing could name an example, count one, or tell whether the one returned yesterday is the one returned today. The id is now derived from `question` + `sql` — stable by construction, no coordination, no write access to a customer's artifacts — and `example_by_id` reads one back.

**ACE-110 — an agent can say what it based a query on.** An optional `basis` on `execute_sql`, recorded on `tool_calls` beside the two self-reported columns already there and rendered in the activity log under the statement it explains. The property is declared as a bare array deliberately: the MCP SDK validates arguments against `inputSchema` before the handler runs, so a constraint there refuses the whole call rather than trimming one entry. Kinds are advertised in the description and enforced at the boundary.

### Version

Four files, the same set as 0.6.6 (`f1a4a01`) — `marketplace.json` carries it twice.

**Patch, not minor.** 0.6.3 and 0.6.4 both shipped `### Added` sections as patches; this follows that. No compare link at the foot — that list stops at `[0.3.4]`.

### Verification

`pytest tests/` — **4,643 passed**, 12 skipped.

One local failure, `test_org_resolver_defaults_to_local`, is environmental and not from this branch: it fails identically on clean `main`, and passes with an empty `AGAMI_ARTIFACTS_DIR`. The resolver was reading an org from the developer's own artifacts directory, which CI does not have.