### PR TITLE
Eval command and suites

### DIFF
--- a/plugins/agami/scripts/run_golden_eval.py
+++ b/plugins/agami/scripts/run_golden_eval.py
@@ -26,6 +26,15 @@ Usage:
     python3 run_golden_eval.py --profile main --list
     python3 run_golden_eval.py --profile main --dataset orders --timeout-s 120
     python3 run_golden_eval.py --profile main --dataset orders --tag smoke --tag revenue
+    python3 run_golden_eval.py --profile main --dataset orders --rerun-failures
+
+**What a run sends outbound.** Generating a statement spawns the operator's own client with every
+tool switched off, and hands it the question, the organization, the datasource name and the tables
+and columns of the semantic model. It is handed neither the answer key, nor the dataset's location,
+nor any result row — generation finishes before anything is executed, so no row exists yet. That
+egress is the operator's own model provider and nothing else. It matters most in CI, where the
+model's vocabulary leaves a shared runner rather than one person's machine, and where the
+credential is whatever the environment supplies to the client.
 """
 
 from __future__ import annotations
@@ -493,6 +502,68 @@ def _pick(datasets: list[GoldenDataset], wanted: Optional[str]) -> Optional[Gold
     return None
 
 
+def _last_failures(profile: str, dataset_name: str) -> Optional[list[str]]:
+    """The item keys the most recent run of this dataset recorded as failures, or None if none ran.
+
+    Artifacts are keyed on the profile, not the dataset, so the newest file in the directory may
+    describe something else entirely — matching on the recorded `dataset` is what stops a re-run
+    executing another dataset's failures and reporting confidently about it. `*.json` and not `*`
+    because the report slice writes its HTML into this same directory.
+
+    An unreadable or unrecognisable artifact is skipped rather than fatal. These accumulate over
+    months and one truncated file, from a full disk or an interrupted write, must not make the
+    feature unusable for every run after it.
+    """
+    out = agami_paths.dashboard_dir("eval", profile)
+    if not out.is_dir():
+        return None
+    for path in sorted(out.glob("*.json"), reverse=True):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            if record["dataset"] != dataset_name:
+                continue
+            return [
+                item["item_key"] for item in record["items"] if item["section"] == "failure"
+            ]
+        except (OSError, ValueError, KeyError, TypeError):
+            continue
+    return None
+
+
+def _reselect(dataset: GoldenDataset, profile: str) -> Optional[GoldenDataset]:
+    """The dataset narrowed to what its last run failed, or None having said why not.
+
+    No previous run refuses rather than falling back to running everything: someone re-running a
+    failure list is asking a narrow question, and answering a wider one costs a model call per case
+    and buries the answer they wanted.
+    """
+    failures = _last_failures(profile, dataset.name)
+    if failures is None:
+        _stop(
+            f"no previous run of {dataset.name!r} to re-read on this profile — "
+            "run it once before re-running its failures"
+        )
+        return None
+    by_key = {item.item_key: item for item in dataset.test_cases}
+    selected = [by_key[key] for key in failures if key in by_key]
+    missing = len(failures) - len(selected)
+    if missing:
+        # Editing a case away between runs is ordinary; running fewer than the last run reported
+        # without saying so is not.
+        _warn(
+            f"{missing} of the last run's failures are no longer in {dataset.name!r} and were "
+            "skipped"
+        )
+    if not selected:
+        # Not a wrong selector — the last run genuinely had nothing to re-run — so this is a clean
+        # exit, and the sentence says which of the two it was so a reader is not left guessing.
+        _warn(
+            f"the last run of {dataset.name!r} recorded no failures, so this re-run had nothing "
+            "to do"
+        )
+    return dataset.model_copy(update={"test_cases": selected})
+
+
 def _select(dataset: GoldenDataset, tags: Optional[list[str]]) -> Optional[GoldenDataset]:
     """The dataset narrowed to the cases carrying one of `tags`, or None having said why not.
 
@@ -572,6 +643,11 @@ def _write_artifact(
 
     This lands under `local/`, which is gitignored per-user state, and the answer key it repeats is
     already on disk in the dataset file the run just read, so it adds no exposure.
+
+    The verdict fields are here because the score alone cannot say which cases failed: `passed`
+    folds `gated` into itself, so a gated-but-accurate case reads exactly like a pass, and a re-run
+    of the failures would silently skip it. Widening this record is additive on purpose — the report
+    slice reads the same file, so a field may be added but none may be reshaped or dropped.
     """
     joined = {
         "run_id": result.run_id,
@@ -588,6 +664,12 @@ def _write_artifact(
                 "expected_sql": keys[outcome.item_key],
                 "generated_sql": outcome.generated_sql,
                 "score": outcome.as_dict()["score"],
+                "confirmed": outcome.confirmed,
+                "passed": outcome.passed,
+                "gated": outcome.gated,
+                # The same classifier the terminal printed, so "re-run the failures" runs what a
+                # reader actually saw under that heading rather than a second opinion about it.
+                "section": _section(outcome),
             }
             for outcome in result.outcomes
         ],
@@ -690,11 +772,19 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--list", action="store_true", help="describe the profile's datasets and run nothing"
     )
-    parser.add_argument(
+    # Two ways of narrowing the same dataset, so naming both is a question with no answer rather
+    # than a combination worth defining.
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument(
         "--tag",
         action="append",
         help="run only the cases carrying this tag; repeatable, and a case carrying any of the "
         "tags given runs",
+    )
+    selection.add_argument(
+        "--rerun-failures",
+        action="store_true",
+        help="run only the cases the last run of this dataset recorded as failures",
     )
     parser.add_argument(
         "--timeout-s", type=float, default=120.0, help="how long one generation may take"
@@ -720,7 +810,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     # nothing. The selection is applied to the dataset here rather than threaded into the run:
     # `run_golden_dataset` takes a dataset, an environment and a generator, and widening that
     # signature with a notion of which cases to skip would make every caller of it carry one.
-    dataset = _select(dataset, args.tag)
+    dataset = (
+        _reselect(dataset, args.profile) if args.rerun_failures else _select(dataset, args.tag)
+    )
     if dataset is None:
         return _CANNOT_START
 

--- a/plugins/agami/scripts/run_golden_eval.py
+++ b/plugins/agami/scripts/run_golden_eval.py
@@ -536,16 +536,17 @@ def _last_failures(profile: str, dataset_name: str) -> Optional[list[str]]:
             if record["selection"] is not None:
                 continue
             summary = record["summary"]
-            if _verdict_of(
-                completed=summary["completed"],
-                total=summary["total"],
-                errored=summary["errored"],
-                gating_failures=summary["gating_failures"],
-            ) == _CANNOT_START:
+            if (
+                _verdict_of(
+                    completed=summary["completed"],
+                    total=summary["total"],
+                    errored=summary["errored"],
+                    gating_failures=summary["gating_failures"],
+                )
+                == _CANNOT_START
+            ):
                 continue
-            return [
-                item["item_key"] for item in record["items"] if item["section"] == "failure"
-            ]
+            return [item["item_key"] for item in record["items"] if item["section"] == "failure"]
         except (OSError, ValueError, KeyError, TypeError):
             continue
     return None
@@ -685,17 +686,16 @@ def _write_artifact(
         "summary": summary,
         "items": [
             {
-                "item_key": outcome.item_key,
                 # Indexed rather than defaulted: both dicts are built from the same `test_cases`
                 # the run was handed, and a key that stopped resolving should say so rather than
                 # write an artifact with an empty question in it.
                 "question": questions[outcome.item_key],
                 "expected_sql": keys[outcome.item_key],
-                # The runner's own record, rather than three of its keys re-spelled here: it
-                # already carries `confirmed`, `passed`, `gated` and the claim difference the
-                # report renders beside the two statements.
+                # The runner's own record, whole. It already carries `item_key`, `generated_sql`,
+                # `confirmed`, `passed`, `gated` and the claim difference the report renders beside
+                # the two statements — re-spelling any of them here is a second source of truth for
+                # a value that has one, and the copy is what goes stale.
                 **outcome.as_dict(),
-                "generated_sql": outcome.generated_sql,
                 # The same classifier the terminal printed, so "re-run the failures" runs what a
                 # reader actually saw under that heading rather than a second opinion about it.
                 "section": _section(outcome),
@@ -819,14 +819,14 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     # Two ways of narrowing the same dataset, so naming both is a question with no answer rather
     # than a combination worth defining.
-    selection = parser.add_mutually_exclusive_group()
-    selection.add_argument(
+    narrowing = parser.add_mutually_exclusive_group()
+    narrowing.add_argument(
         "--tag",
         action="append",
         help="run only the cases carrying this tag; repeatable, and a case carrying any of the "
         "tags given runs",
     )
-    selection.add_argument(
+    narrowing.add_argument(
         "--rerun-failures",
         action="store_true",
         help="run only the cases the last run of this dataset recorded as failures",
@@ -866,9 +866,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         # real one, so the evidence a later re-run needs would be gone.
         return 0
 
-    selection = (
-        "rerun" if args.rerun_failures else (",".join(args.tag) if args.tag else None)
-    )
+    selection = "rerun" if args.rerun_failures else (",".join(args.tag) if args.tag else None)
 
     # Reading the model and resolving its dialect are the three raises this path reaches, and
     # everything below them is total. None of them is relayed as a stack: a traceback prints the
@@ -924,7 +922,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     keys = {item.item_key: item.expected.sql or "" for item in dataset.test_cases}
     payload = _run_payload(result, questions)
     try:
-        payload["artifact"] = str(_write_artifact(result, questions, keys, payload["summary"], selection))
+        payload["artifact"] = str(
+            _write_artifact(result, questions, keys, payload["summary"], selection)
+        )
     except OSError as exc:
         # The run is already paid for — a model call and up to two warehouse queries per case — so
         # a directory it cannot write to costs the drill-down and nothing else. The verdicts print

--- a/plugins/agami/scripts/run_golden_eval.py
+++ b/plugins/agami/scripts/run_golden_eval.py
@@ -6,6 +6,11 @@ and no command of its own, so this is the wiring that lets a person — or a ski
 does three things nothing upstream does: it chooses the dataset, it renders the tables and columns
 the generator is given, and it decides what a verdict looks like on a terminal.
 
+**The exit code is the contract a pipeline gates on**: `0` every confirmed case passed, `1` a
+confirmed case failed, `2` no verdict could be produced — the preflight refused, the run stopped
+partway, or every generation errored. `2` reads as "go look at the harness", never as "the model
+regressed". See `_verdict`, whose ordering is the whole of that distinction.
+
 **Stdout carries verdicts and never SQL.** Neither the answer key nor the generated statement
 appears in the printed payload — nor the answer key's own column names, which two of the
 comparator's reasons are built out of — so a terminal that gets pasted into a chat window carries
@@ -74,10 +79,16 @@ except ImportError as exc:
 # the same order, so the two cannot disagree about what a run looks like.
 _SECTION_ORDER = ("failure", "error", "unscored", "unconfirmed", "pass")
 
-# Where a run's exit code is decided is a later slice's problem. This one exits 0 for any run that
-# reached the end of its wiring — a run with failures in it is a run that worked — and non-zero
-# only when it could not start.
+# What a run's exit code means, and the whole of what CI reads. `_CANNOT_START` is both "the
+# preflight refused" and "the run produced no verdict": to a pipeline those are the same event —
+# nothing was judged — and a second code for it would only be a second thing to configure.
+_FAILED = 1
 _CANNOT_START = 2
+
+# Marks the lines a caller is meant to strip — the refusals and the warnings, this helper talking
+# about itself. The run's own summary line carries no prefix, because that one is the thing to
+# keep.
+_PREFIX = "agami-eval:"
 
 
 def _section(outcome: Any) -> str:
@@ -482,8 +493,18 @@ def _pick(datasets: list[GoldenDataset], wanted: Optional[str]) -> Optional[Gold
 
 
 def _stop(reason: str) -> None:
-    """Say why the run cannot start. One prefix everywhere, so a caller can strip it."""
-    print(f"agami-eval: {reason}", file=sys.stderr)
+    """Say why the run cannot start."""
+    print(f"{_PREFIX} {reason}", file=sys.stderr)
+
+
+def _warn(reason: str) -> None:
+    """Say something about a run that still finished.
+
+    Same stream and same prefix as `_stop`, and a separate name for one reason: `_stop` is called
+    at six sites that all return `_CANNOT_START`, so a call reading `_stop(...)` where nothing
+    stops would misdescribe the control flow at every one of them.
+    """
+    print(f"{_PREFIX} {reason}", file=sys.stderr)
 
 
 def _section_counts(items: list[dict[str, Any]]) -> dict[str, int]:
@@ -583,6 +604,50 @@ def _run_payload(result: GoldenRunResult, questions: dict[str, str]) -> dict[str
     }
 
 
+def _verdict(result: GoldenRunResult) -> int:
+    """The run's exit code, so a pipeline can gate on it.
+
+    The ORDER of these checks is the substance, not an implementation detail. A broken pipeline
+    outranks a regression, so a run that stopped partway AND carries gating failures reports
+    `_CANNOT_START` rather than `_FAILED`: sending somebody to debug a model change against a run
+    that never happened is the expensive mistake this ordering exists to prevent.
+
+    A run in which EVERY generation errored is `_CANNOT_START` for the same reason — nothing was
+    scored, so it is neither a regression nor a passing suite. That rule is CATEGORICAL and not
+    proportional on purpose: any fraction here would be a pass-rate threshold, which a verdict
+    built on a confirmed answer key deliberately does not have.
+
+    `gating_failures` and never `failed`. `failed` counts every scored miss including the
+    unconfirmed ones, whose answer keys nobody has reviewed and which can therefore never gate;
+    resting the exit code on it would fail CI on an item no human has agreed to. Confirmed-only is
+    the contract's invariant, and this is the surface it is observable at.
+    """
+    if not result.completed:
+        return _CANNOT_START
+    if result.outcomes and result.errored == len(result.outcomes):
+        return _CANNOT_START
+    if result.gating_failures:
+        return _FAILED
+    return 0
+
+
+def _summary_line(result: GoldenRunResult, summary: dict[str, Any]) -> str:
+    """The one line a person reads a pipeline log against.
+
+    Built from `sections` rather than the runner's counters, for the reason `_section_counts`
+    gives: these are the rows that were printed, and `failed` is a different number. Word for word
+    the sentence the skill renders from the same payload, so a CI log and a chat report describe
+    one run in one wording instead of two.
+    """
+    sections = summary["sections"]
+    return (
+        f"Ran {result.dataset} on {result.profile}: "
+        f"{sections['failure']} failed, {sections['error']} errored, "
+        f"{sections['unscored']} unscored, {sections['unconfirmed']} unconfirmed, "
+        f"{sections['pass']} passed — run completed: {'yes' if summary['completed'] else 'no'}."
+    )
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Run a golden dataset and score every case.")
     parser.add_argument("--profile", required=True, help="the semantic-model profile to run")
@@ -675,7 +740,23 @@ def main(argv: Optional[list[str]] = None) -> int:
             f"({exc.__class__.__name__}: {exc.strerror or 'cannot be written'})"
         )
     print(json.dumps(payload, indent=2))
-    return 0
+
+    # Everything below prints AFTER the payload, and the exit code is computed last: a run costs a
+    # model call and up to two warehouse queries per case, so a verdict must never cost the
+    # verdicts. The summary goes to stderr because stdout is a JSON document — a human sentence
+    # there would break every caller that parses it — and stderr already carries the refusals, so a
+    # log has one place to look. It is unprefixed because it is the thing to keep rather than the
+    # thing to strip.
+    print(_summary_line(result, payload["summary"]), file=sys.stderr)
+    if not any(outcome.confirmed for outcome in result.outcomes):
+        # A green run that verified nothing is the one most easily mistaken for evidence, so it
+        # says so out loud. The exit code stays 0: the run worked, there was simply nothing in it
+        # that could gate.
+        _warn(
+            "this run gated on nothing — no case in it has a confirmed answer key, so a green "
+            "exit says only that the run worked"
+        )
+    return _verdict(result)
 
 
 if __name__ == "__main__":

--- a/plugins/agami/scripts/run_golden_eval.py
+++ b/plugins/agami/scripts/run_golden_eval.py
@@ -30,8 +30,11 @@ Usage:
 
 **What a run sends outbound.** Generating a statement spawns the operator's own client with every
 tool switched off, and hands it the question, the organization, the datasource name and the tables
-and columns of the semantic model. It is handed neither the answer key, nor the dataset's location,
-nor any result row — generation finishes before anything is executed, so no row exists yet. That
+and columns of the semantic model. It is handed neither the answer key nor any result row —
+generation finishes before anything is executed, so no row exists yet. It is not told where the
+dataset lives either, though that withholds a name rather than a capability: the child keeps `HOME`
+and is given the profile's name, and what actually stops it reading the answer key off disk is that
+it is started with no tools to read one with. That
 egress is the operator's own model provider and nothing else. It matters most in CI, where the
 model's vocabulary leaves a shared runner rather than one person's machine, and where the
 credential is whatever the environment supplies to the client.
@@ -503,16 +506,24 @@ def _pick(datasets: list[GoldenDataset], wanted: Optional[str]) -> Optional[Gold
 
 
 def _last_failures(profile: str, dataset_name: str) -> Optional[list[str]]:
-    """The item keys the most recent run of this dataset recorded as failures, or None if none ran.
+    """The item keys the most recent WHOLE, CONCLUDED run of this dataset recorded as failures.
+
+    Three things disqualify a record, and each of them was a false green before it did:
+
+    * **A run that produced no verdict.** An all-errored or half-finished run records no failures
+      because it scored nothing, not because nothing was wrong. Trusting its empty list makes the
+      next re-run exit `0` over a dataset with live regressions in it — the exact reading the `2`
+      branch exists to prevent, arrived at two invocations later.
+    * **A run that was itself a selection.** A `--tag` slice or an earlier re-run describes some of
+      the dataset, so its failure list is silently narrower than the truth and every re-run after it
+      inherits the narrowing.
+    * **A record this version cannot read**, including one written before the verdict fields were
+      added.
 
     Artifacts are keyed on the profile, not the dataset, so the newest file in the directory may
     describe something else entirely — matching on the recorded `dataset` is what stops a re-run
     executing another dataset's failures and reporting confidently about it. `*.json` and not `*`
     because the report slice writes its HTML into this same directory.
-
-    An unreadable or unrecognisable artifact is skipped rather than fatal. These accumulate over
-    months and one truncated file, from a full disk or an interrupted write, must not make the
-    feature unusable for every run after it.
     """
     out = agami_paths.dashboard_dir("eval", profile)
     if not out.is_dir():
@@ -521,6 +532,16 @@ def _last_failures(profile: str, dataset_name: str) -> Optional[list[str]]:
         try:
             record = json.loads(path.read_text(encoding="utf-8"))
             if record["dataset"] != dataset_name:
+                continue
+            if record["selection"] is not None:
+                continue
+            summary = record["summary"]
+            if _verdict_of(
+                completed=summary["completed"],
+                total=summary["total"],
+                errored=summary["errored"],
+                gating_failures=summary["gating_failures"],
+            ) == _CANNOT_START:
                 continue
             return [
                 item["item_key"] for item in record["items"] if item["section"] == "failure"
@@ -554,9 +575,11 @@ def _reselect(dataset: GoldenDataset, profile: str) -> Optional[GoldenDataset]:
             f"{missing} of the last run's failures are no longer in {dataset.name!r} and were "
             "skipped"
         )
-    if not selected:
+    if not selected and not missing:
         # Not a wrong selector — the last run genuinely had nothing to re-run — so this is a clean
-        # exit, and the sentence says which of the two it was so a reader is not left guessing.
+        # exit. Only claimed when nothing was skipped: saying "recorded no failures" right after
+        # saying some were skipped contradicts it, and a skill reads this sentence back as "the
+        # previous run was green".
         _warn(
             f"the last run of {dataset.name!r} recorded no failures, so this re-run had nothing "
             "to do"
@@ -586,12 +609,13 @@ def _select(dataset: GoldenDataset, tags: Optional[list[str]]) -> Optional[Golde
     selected = [item for item in dataset.test_cases if wanted.intersection(item.tags)]
     if not selected:
         present = sorted({tag for item in dataset.test_cases for tag in item.tags})
+        tags_shown = ", ".join(repr(tag) for tag in tags)
         names = (
             f"Tags present: {', '.join(present)}"
             if present
             else "No case in this dataset carries a tag at all."
         )
-        _stop(f"no case in {dataset.name!r} carries any of: {', '.join(tags)}. {names}")
+        _stop(f"no case in {dataset.name!r} carries any of: {tags_shown}. {names}")
         return None
     # A copy and not a mutation: the model forbids unknown fields and the caller's dataset is what
     # the reader handed back, so narrowing in place would edit the record every other reader sees.
@@ -633,6 +657,7 @@ def _write_artifact(
     questions: dict[str, str],
     keys: dict[str, str],
     summary: dict[str, Any],
+    selection: Optional[str],
 ) -> Path:
     """Join the run to the dataset it ran and persist both statements.
 
@@ -653,6 +678,10 @@ def _write_artifact(
         "run_id": result.run_id,
         "profile": result.profile,
         "dataset": result.dataset,
+        # What narrowed this run, or None for a whole one. A later re-run reads only whole runs:
+        # a slice's failure list is silently narrower than the truth, and inheriting it narrows
+        # every re-run after it.
+        "selection": selection,
         "summary": summary,
         "items": [
             {
@@ -662,11 +691,11 @@ def _write_artifact(
                 # write an artifact with an empty question in it.
                 "question": questions[outcome.item_key],
                 "expected_sql": keys[outcome.item_key],
+                # The runner's own record, rather than three of its keys re-spelled here: it
+                # already carries `confirmed`, `passed`, `gated` and the claim difference the
+                # report renders beside the two statements.
+                **outcome.as_dict(),
                 "generated_sql": outcome.generated_sql,
-                "score": outcome.as_dict()["score"],
-                "confirmed": outcome.confirmed,
-                "passed": outcome.passed,
-                "gated": outcome.gated,
                 # The same classifier the terminal printed, so "re-run the failures" runs what a
                 # reader actually saw under that heading rather than a second opinion about it.
                 "section": _section(outcome),
@@ -739,11 +768,27 @@ def _verdict(result: GoldenRunResult) -> int:
     resting the exit code on it would fail CI on an item no human has agreed to. Confirmed-only is
     the contract's invariant, and this is the surface it is observable at.
     """
-    if not result.completed:
+    return _verdict_of(
+        completed=result.completed,
+        total=len(result.outcomes),
+        errored=result.errored,
+        gating_failures=result.gating_failures,
+    )
+
+
+def _verdict_of(*, completed: bool, total: int, errored: int, gating_failures: int) -> int:
+    """The rule itself, over four numbers rather than a run.
+
+    A recorded run has to be judged by the same rule as a live one — `_last_failures` must know
+    whether the artifact it is about to trust produced a verdict at all — and an artifact carries
+    these four values and not a `GoldenRunResult`. One spelling, so the two can never drift into
+    disagreeing about what a green run was.
+    """
+    if not completed:
         return _CANNOT_START
-    if result.outcomes and result.errored == len(result.outcomes):
+    if total and errored == total:
         return _CANNOT_START
-    if result.gating_failures:
+    if gating_failures:
         return _FAILED
     return 0
 
@@ -815,6 +860,15 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     if dataset is None:
         return _CANNOT_START
+    if args.rerun_failures and not dataset.test_cases:
+        # Nothing to re-run is a clean exit, and it stops here rather than running: an empty run
+        # would write a 0-case artifact that becomes this dataset's newest record and shadows the
+        # real one, so the evidence a later re-run needs would be gone.
+        return 0
+
+    selection = (
+        "rerun" if args.rerun_failures else (",".join(args.tag) if args.tag else None)
+    )
 
     # Reading the model and resolving its dialect are the three raises this path reaches, and
     # everything below them is total. None of them is relayed as a stack: a traceback prints the
@@ -870,13 +924,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     keys = {item.item_key: item.expected.sql or "" for item in dataset.test_cases}
     payload = _run_payload(result, questions)
     try:
-        payload["artifact"] = str(_write_artifact(result, questions, keys, payload["summary"]))
+        payload["artifact"] = str(_write_artifact(result, questions, keys, payload["summary"], selection))
     except OSError as exc:
         # The run is already paid for — a model call and up to two warehouse queries per case — so
         # a directory it cannot write to costs the drill-down and nothing else. The verdicts print
         # either way. The path is not relayed, for the reason the preflight guards give.
         payload["artifact"] = ""
-        _stop(
+        _warn(
             "the verdicts are below, but this run's artifact could not be written "
             f"({exc.__class__.__name__}: {exc.strerror or 'cannot be written'})"
         )

--- a/plugins/agami/scripts/run_golden_eval.py
+++ b/plugins/agami/scripts/run_golden_eval.py
@@ -25,6 +25,7 @@ Usage:
 
     python3 run_golden_eval.py --profile main --list
     python3 run_golden_eval.py --profile main --dataset orders --timeout-s 120
+    python3 run_golden_eval.py --profile main --dataset orders --tag smoke --tag revenue
 """
 
 from __future__ import annotations
@@ -492,6 +493,40 @@ def _pick(datasets: list[GoldenDataset], wanted: Optional[str]) -> Optional[Gold
     return None
 
 
+def _select(dataset: GoldenDataset, tags: Optional[list[str]]) -> Optional[GoldenDataset]:
+    """The dataset narrowed to the cases carrying one of `tags`, or None having said why not.
+
+    OR and never AND: a tag names a slice its author wrote, so a suite is the union of the slices
+    asked for. Intersecting them would make every extra `--tag` narrow the run, which is the
+    opposite of what naming a second suite means.
+
+    Matching is CASE-SENSITIVE. `tags` is free text with no vocabulary and no normalization
+    anywhere it is read, so folding case here would invent one that no other reader of the dataset
+    applies — `Smoke` and `smoke` would select the same cases from this helper and different ones
+    from anything else looking at the same file.
+
+    A tag no case carries is a wrong selector rather than an empty result, so it refuses instead of
+    running zero cases green: a typo in a pipeline's arguments would otherwise pass forever. The
+    refusal names the tags that do exist, because that list is what the next invocation needs.
+    """
+    if not tags:
+        return dataset
+    wanted = set(tags)
+    selected = [item for item in dataset.test_cases if wanted.intersection(item.tags)]
+    if not selected:
+        present = sorted({tag for item in dataset.test_cases for tag in item.tags})
+        names = (
+            f"Tags present: {', '.join(present)}"
+            if present
+            else "No case in this dataset carries a tag at all."
+        )
+        _stop(f"no case in {dataset.name!r} carries any of: {', '.join(tags)}. {names}")
+        return None
+    # A copy and not a mutation: the model forbids unknown fields and the caller's dataset is what
+    # the reader handed back, so narrowing in place would edit the record every other reader sees.
+    return dataset.model_copy(update={"test_cases": selected})
+
+
 def _stop(reason: str) -> None:
     """Say why the run cannot start."""
     print(f"{_PREFIX} {reason}", file=sys.stderr)
@@ -656,6 +691,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--list", action="store_true", help="describe the profile's datasets and run nothing"
     )
     parser.add_argument(
+        "--tag",
+        action="append",
+        help="run only the cases carrying this tag; repeatable, and a case carrying any of the "
+        "tags given runs",
+    )
+    parser.add_argument(
         "--timeout-s", type=float, default=120.0, help="how long one generation may take"
     )
     parser.add_argument(
@@ -672,6 +713,14 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     datasets, findings = load_golden_datasets(args.profile)
     dataset = _pick(datasets, args.dataset)
+    if dataset is None:
+        return _CANNOT_START
+
+    # Before the model is read and long before the generator is reached, so a wrong selector costs
+    # nothing. The selection is applied to the dataset here rather than threaded into the run:
+    # `run_golden_dataset` takes a dataset, an environment and a generator, and widening that
+    # signature with a notion of which cases to skip would make every caller of it carry one.
+    dataset = _select(dataset, args.tag)
     if dataset is None:
         return _CANNOT_START
 

--- a/plugins/agami/skills/agami-eval/SKILL.md
+++ b/plugins/agami/skills/agami-eval/SKILL.md
@@ -68,6 +68,10 @@ A run costs one model call plus one query per case, so tell the user what they a
 
 `--timeout-s` bounds a single generation (default 120). Raise it only if items are coming back with *"the generator did not answer within the time this run allows"*.
 
+Two flags narrow the run, and naming both is refused because they are two ways of selecting from the same dataset. `--tag <name>` is repeatable and runs the cases carrying **any** of the tags given, matched exactly — `Smoke` and `smoke` are different tags. `--rerun-failures` runs only what this dataset's last run recorded under failures. Both are for the non-interactive path; reach for them here only if the user asks for a slice or a re-run by name.
+
+**The exit code is the contract, and you should read it before the payload.** `0` every confirmed case passed · `1` a confirmed case failed · `2` no verdict could be produced. A `2` is never a model regression — report it as a broken harness and do not open the failures table.
+
 **The script emits `items` already ordered** — failures, errors, unscored, unconfirmed, passes — and `summary.sections` counts the rows in each. Render them in the order received and use those counts; do not re-sort, re-group or recount.
 
 ---
@@ -187,5 +191,8 @@ End the turn.
 | `agami-eval: cannot read the semantic model…` / `…does not parse…` | The model is missing or broken, so the generator has no tables to write against. Route to `/agami-connect` to build or rebuild it. Nothing ran; this is not a failing eval, and don't try to repair the YAML from here. |
 | `agami-eval: the verdicts are below, but…could not be written` | The run finished and its JSON artifact did not land — usually a permissions problem on `<artifacts_dir>/local/eval/<profile>/`. Report the verdicts normally, and say there is no drill-down file for this run rather than pointing at an empty `artifact`. |
 | Every item says *"the generator command could not be started on this machine"* | The generator is the `claude` client and it is not on this PATH (or not on the PATH of whatever shell ran the script). Nothing was scored — report it as a broken run, not a red one. |
-| `completed: false` | The run stopped partway: the cases after the stop were never attempted and are absent from `items`. Say so on the summary line, and don't compare the counts to a previous run. |
+| `completed: false` | The run stopped partway: the cases after the stop were never attempted and are absent from `items`. Say so on the summary line, and don't compare the counts to a previous run. Exit code is `2`. |
+| `agami-eval: no previous run of … to re-read` | `--rerun-failures` with nothing to re-read. Run the dataset once first; it deliberately does not fall back to running everything. |
+| `agami-eval: the last run … recorded no failures` | Nothing to re-run, which is a clean `0`. Say the previous run was green rather than reporting an empty run as a result. |
+| `agami-eval: … no longer in <dataset> and were skipped` | Cases were edited out between the two runs. Report how many were skipped so the smaller count is explained. |
 | Credentials missing | The run fails at execution, not generation, so items come back scored-as-errors in bulk. Check `<artifacts_dir>/local/credentials` per Phase 0.2 and re-invoke `/agami-connect` if it's absent. |

--- a/tests/test_ah106_eval_skill.py
+++ b/tests/test_ah106_eval_skill.py
@@ -406,13 +406,16 @@ def test_listing_reads_no_credentials(artifacts, monkeypatch, capsys):
 
 def test_a_run_reports_every_item_and_the_summary_counts_them(artifacts, scripted, capsys):
     """Nothing is dropped between the dataset and the payload, and the summary describes exactly
-    the items that were printed."""
+    the items that were printed.
+
+    The dataset carries one confirmed miss, so the run exits `1` — the payload is the point here
+    and it prints in full either way, which is the reason the verdict is computed after it."""
     _write(artifacts, "mixed", MIXED_DATASET)
 
     code, payload, _ = _run(capsys, "--dataset", "mixed")
 
     sections = _sections(payload)
-    assert code == 0
+    assert code == 1
     assert payload["summary"]["total"] == len(payload["items"]) == 4
     assert payload["summary"]["passed"] == sections.count("pass")
     assert payload["summary"]["errored"] == sections.count("error")
@@ -647,6 +650,8 @@ def test_what_the_reader_dropped_reaches_the_findings(artifacts, scripted, capsy
 
 
 def test_a_single_dataset_needs_no_argument(artifacts, scripted, capsys):
+    """Also the exit-0 anchor: an all-pass run over one confirmed case is the only shape that
+    is green on every one of the verdict's checks."""
     _write(artifacts, "green", PASSING_DATASET)
 
     code, payload, _ = _run(capsys)
@@ -675,13 +680,17 @@ def test_naming_a_dataset_that_does_not_exist_lists_what_does(artifacts, scripte
 
 def test_a_dataset_with_no_cases_runs_and_reports_nothing(artifacts, scripted, capsys):
     """An author who created the file but has not written a case yet. The reader calls that a
-    dataset, so the run does too — an empty summary rather than a failure."""
+    dataset, so the run does too — an empty summary rather than a failure.
+
+    It exits `0` because the run worked, and it says on stderr that it gated on nothing, because a
+    green exit over zero confirmed cases is the one most easily mistaken for evidence."""
     _write(artifacts, "blank", {"description": "nothing yet"})
 
-    code, payload, _ = _run(capsys, "--dataset", "blank")
+    code, payload, err = _run(capsys, "--dataset", "blank")
 
     assert code == 0 and payload["items"] == []
     assert payload["summary"]["total"] == 0 and payload["summary"]["completed"] is True
+    assert "gated on nothing" in err
 
 
 def test_a_dataset_whose_only_case_is_unconfirmed_gates_on_nothing(artifacts, scripted, capsys):
@@ -719,7 +728,8 @@ def test_a_generator_that_raises_stops_the_run_and_the_payload_says_so(
     artifacts, monkeypatch, capsys
 ):
     """`completed: false` and the cases after the raise simply absent. A reader who only counted
-    failures would call this run clean."""
+    failures would call this run clean, which is why the exit code refuses to give a verdict at
+    all rather than reporting the fraction of the dataset it reached."""
 
     class _RaisesOnTheSecond:
         def __init__(self, schema: str, *, timeout_s: float) -> None:
@@ -736,7 +746,7 @@ def test_a_generator_that_raises_stops_the_run_and_the_payload_says_so(
 
     code, payload, _ = _run(capsys, "--dataset", "mixed")
 
-    assert code == 0
+    assert code == 2
     assert payload["summary"]["completed"] is False
     assert [item["item_key"] for item in payload["items"]] == ["orders-count"]
     assert payload["summary"]["total"] == 1
@@ -744,7 +754,8 @@ def test_a_generator_that_raises_stops_the_run_and_the_payload_says_so(
 
 def test_a_run_where_every_item_errors_is_not_green(artifacts, monkeypatch, capsys):
     """Zero gating failures, and nothing was answered. The counter is over items that were SCORED,
-    so `errored` is the only field that distinguishes this from a clean run."""
+    so `errored` is the only field that distinguishes this from a clean run — and the exit code
+    reads it, which is what keeps a runner with no `claude` on it from passing CI."""
 
     class _AnswersNothing:
         def __init__(self, schema: str, *, timeout_s: float) -> None:
@@ -756,8 +767,9 @@ def test_a_run_where_every_item_errors_is_not_green(artifacts, monkeypatch, caps
     monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _AnswersNothing)
     _write(artifacts, "mixed", MIXED_DATASET)
 
-    _, payload, _ = _run(capsys, "--dataset", "mixed")
+    code, payload, _ = _run(capsys, "--dataset", "mixed")
 
+    assert code == 2
     assert payload["summary"]["gating_failures"] == 0
     assert payload["summary"]["errored"] == 4 and payload["summary"]["completed"] is True
     assert _sections(payload) == ["error", "error", "error", "error"]
@@ -770,8 +782,9 @@ def test_a_run_where_every_item_errors_is_not_green(artifacts, monkeypatch, caps
 
 def test_the_artifact_write_failing_does_not_discard_the_run(artifacts, scripted, capsys):
     """A run costs a model call and two warehouse queries per case. A directory it cannot write to
-    loses the drill-down and nothing else — the verdicts still print, the exit code still says the
-    run reached the end of its wiring, and the path is not relayed onto stderr."""
+    loses the drill-down and nothing else — the verdicts still print, the exit code is still the
+    dataset's own (`0` here: one confirmed case, and it passed), and the path is not relayed onto
+    stderr. A missing artifact is not a broken run, so it does not become a `2`."""
     _write(artifacts, "green", PASSING_DATASET)
     out = agami_paths.dashboard_dir("eval", PROFILE, artifacts)
     out.mkdir(parents=True)

--- a/tests/test_ah110_eval_command.py
+++ b/tests/test_ah110_eval_command.py
@@ -93,6 +93,24 @@ ONE_FAILURE: dict[str, Any] = {"test_cases": [FAILING_ITEM, PASSING_ITEM]}
 ONLY_UNCONFIRMED: dict[str, Any] = {"test_cases": [UNCONFIRMED_ITEM]}
 
 
+def _tagged(item: dict[str, Any], *tags: str) -> dict[str, Any]:
+    """The same case, carrying tags. A copy, so the untagged datasets above stay untagged."""
+    return {**item, "tags": list(tags)}
+
+
+# The tags overlap on purpose: `smoke` and `revenue` both name the failing case, so a selection of
+# the two has a different size under OR (two cases) than under AND (one) — which is the only way a
+# test can tell the two readings apart. `draft` names the unconfirmed case alone, the selection
+# that runs correctly and can gate on nothing.
+TAGGED: dict[str, Any] = {
+    "test_cases": [
+        _tagged(PASSING_ITEM, "smoke"),
+        _tagged(FAILING_ITEM, "smoke", "revenue"),
+        _tagged(UNCONFIRMED_ITEM, "draft"),
+    ]
+}
+
+
 class _Scripted:
     """The shipped generator's stand-in, constructed the way the script constructs the real one."""
 
@@ -357,3 +375,104 @@ def test_a_failing_run_still_carries_neither_statement(artifacts, scripted, caps
     assert GENERATED_SENTINEL not in rendered
     # …and the stderr the same pipeline log carries is held to the same rule.
     assert GOLDEN_SENTINEL not in err and GENERATED_SENTINEL not in err
+
+
+# ---------------------------------------------------------------------------
+# Selecting a slice of a dataset by tag
+# ---------------------------------------------------------------------------
+
+def test_a_tag_runs_only_the_cases_carrying_it(artifacts, scripted, capsys):
+    """The selection is asserted on what the run actually contains rather than on a printed count:
+    a filter that narrowed nothing and a filter that narrowed correctly say the same thing in a
+    summary line, and differ only in which cases have verdicts."""
+    _write(artifacts, "suite", TAGGED)
+
+    _, payload, _ = _run(capsys, "--dataset", "suite", "--tag", "smoke")
+
+    assert len(payload["items"]) == 2
+    assert {item["item_key"] for item in payload["items"]} == {"orders-count", "customers-count"}
+
+
+def test_two_tags_run_their_union_and_not_their_intersection(artifacts, scripted, capsys):
+    """OR across tags: a suite is the union of the slices asked for. `smoke` and `revenue` overlap
+    on the failing case, so AND would run that one case alone — the count is what separates the two
+    readings, and the intersection is spelled out here so a future change to OR fails loudly."""
+    _write(artifacts, "suite", TAGGED)
+
+    _, payload, _ = _run(capsys, "--dataset", "suite", "--tag", "smoke", "--tag", "revenue")
+
+    keys = {item["item_key"] for item in payload["items"]}
+    assert keys == {"orders-count", "customers-count"}
+    # The case both tags name. Under AND this would be the whole run.
+    assert keys != {"customers-count"}
+
+
+def test_a_tag_no_case_carries_refuses_and_names_the_tags_that_exist(artifacts, scripted, capsys):
+    """A tag nothing carries is a wrong selector, not an empty result, so it is `2` and not a green
+    run over zero cases — a typo in CI would otherwise pass forever. The refusal names the tags the
+    dataset does have, because that list is the whole of what the next invocation needs."""
+    _write(artifacts, "suite", TAGGED)
+
+    code, payload, err = _run(capsys, "--dataset", "suite", "--tag", "smoek")
+
+    assert code == 2
+    assert payload == {}
+    assert "draft" in err and "revenue" in err and "smoke" in err
+
+
+def test_tag_matching_is_case_sensitive(artifacts, scripted, capsys):
+    """Tags are free text the dataset's author wrote, and nothing else that reads them folds case.
+    Matching loosely here would invent a vocabulary the file itself does not have."""
+    _write(artifacts, "suite", TAGGED)
+
+    code, _, _ = _run(capsys, "--dataset", "suite", "--tag", "Smoke")
+
+    assert code == 2
+
+
+def test_a_tag_selecting_only_unconfirmed_cases_is_green_and_says_it_gated_on_nothing(
+    artifacts, scripted, capsys
+):
+    """The confusing pair with the refusal above, and the reason it is tested next to it: this
+    selector was right and the run was fine — there was simply nothing in the slice that could
+    gate. A `2` here would tell CI the harness is broken when nothing is."""
+    _write(artifacts, "suite", TAGGED)
+
+    code, payload, err = _run(capsys, "--dataset", "suite", "--tag", "draft")
+
+    assert code == 0
+    assert [item["item_key"] for item in payload["items"]] == ["payments-count"]
+    assert "gated on nothing" in err
+
+
+def test_a_tag_selecting_a_confirmed_failure_still_exits_one(artifacts, scripted, capsys):
+    """Selecting a slice narrows what runs and changes nothing about how a verdict is reached."""
+    _write(artifacts, "suite", TAGGED)
+
+    code, payload, _ = _run(capsys, "--dataset", "suite", "--tag", "revenue")
+
+    assert code == 1
+    assert [item["item_key"] for item in payload["items"]] == ["customers-count"]
+
+
+def test_no_tag_runs_every_case(artifacts, scripted, capsys):
+    """The default is unchanged: a dataset whose cases carry tags runs whole when none is named."""
+    _write(artifacts, "suite", TAGGED)
+
+    _, payload, _ = _run(capsys, "--dataset", "suite")
+
+    assert len(payload["items"]) == 3
+
+
+def test_a_tag_against_a_dataset_with_no_tags_says_so(artifacts, scripted, capsys):
+    """The state every dataset starts in. There is no list of tags to name, so the refusal says
+    that in words rather than printing an empty one — "Tags present:" followed by nothing reads as
+    a broken message and tells the reader nothing about what to do next."""
+    _write(artifacts, "plain", ONE_FAILURE)
+
+    code, _, err = _run(capsys, "--dataset", "plain", "--tag", "smoke")
+
+    assert code == 2
+    assert "carries a tag at all" in err
+    # The list-shaped half of the refusal is the thing that would have rendered empty.
+    assert "Tags present" not in err

--- a/tests/test_ah110_eval_command.py
+++ b/tests/test_ah110_eval_command.py
@@ -196,6 +196,7 @@ def _run(capsys, *argv: str) -> tuple[int, dict[str, Any], str]:
 # The three verdicts
 # ---------------------------------------------------------------------------
 
+
 def test_a_run_whose_confirmed_cases_all_pass_is_green(artifacts, scripted, capsys):
     """And it stays green with a failing UNCONFIRMED case beside them.
 
@@ -310,6 +311,7 @@ def test_an_incomplete_run_with_failures_in_it_reports_the_broken_pipeline(
 # What a green run has to admit about itself
 # ---------------------------------------------------------------------------
 
+
 def test_a_run_with_nothing_confirmed_is_green_and_says_it_gated_on_nothing(
     artifacts, scripted, capsys
 ):
@@ -341,9 +343,8 @@ def test_a_run_with_a_confirmed_case_does_not_warn_about_gating(artifacts, scrip
 # The human line, and the stream it does not go on
 # ---------------------------------------------------------------------------
 
-def test_the_summary_line_goes_to_stderr_and_leaves_stdout_parseable(
-    artifacts, scripted, capsys
-):
+
+def test_the_summary_line_goes_to_stderr_and_leaves_stdout_parseable(artifacts, scripted, capsys):
     """A pipeline log needs one line a person can read the run against, and every caller of this
     helper parses stdout as a JSON document — so the sentence goes on stderr, where the prefixed
     refusals already are. `_run` parses stdout, so a line printed there fails this outright."""
@@ -384,6 +385,7 @@ def test_the_summary_line_says_when_the_run_did_not_complete(artifacts, monkeypa
 # The rule the payload exists to keep, at the surface that now gates
 # ---------------------------------------------------------------------------
 
+
 def test_a_failing_run_still_carries_neither_statement(artifacts, scripted, capsys):
     """Asserted on a FAILING case, because a passing one proves nothing: its `reason` is empty, and
     the two reasons built out of the answer key's own column names are only ever built on a
@@ -404,6 +406,7 @@ def test_a_failing_run_still_carries_neither_statement(artifacts, scripted, caps
 # ---------------------------------------------------------------------------
 # Selecting a slice of a dataset by tag
 # ---------------------------------------------------------------------------
+
 
 def test_a_tag_runs_only_the_cases_carrying_it(artifacts, scripted, capsys):
     """The selection is asserted on what the run actually contains rather than on a printed count:
@@ -505,6 +508,7 @@ def test_a_tag_against_a_dataset_with_no_tags_says_so(artifacts, scripted, capsy
 # ---------------------------------------------------------------------------
 # The artifact, and re-running what failed
 # ---------------------------------------------------------------------------
+
 
 def _artifacts_in(art: Path) -> list[Path]:
     return sorted((art / "local" / "eval" / PROFILE).glob("*.json"))
@@ -688,7 +692,10 @@ def test_a_rerun_carries_no_statement_on_stdout(artifacts, scripted, capsys):
 # A re-run may only trust a whole, concluded run
 # ---------------------------------------------------------------------------
 
-ERRORING_ITEM: dict[str, Any] = {
+# Named apart from the file's other erroring case on purpose: that one errors because the
+# generator refuses the question, this one because no generator was scripted for it at all, and
+# a re-run has to tell the sections apart rather than the reasons.
+UNSCRIPTED_ITEM: dict[str, Any] = {
     "id": "unscripted-count",
     "query": "A question no generator has an answer for",
     "expected": {"sql": "SELECT COUNT(*) AS n FROM products", "sql_confirmed": True},
@@ -696,9 +703,7 @@ ERRORING_ITEM: dict[str, Any] = {
 
 # One of each section a re-run must tell apart: a confirmed miss, an unconfirmed miss that can
 # never gate, and a case whose generation produced nothing at all.
-ONE_OF_EACH: dict[str, Any] = {
-    "test_cases": [FAILING_ITEM, UNCONFIRMED_ITEM, ERRORING_ITEM]
-}
+ONE_OF_EACH: dict[str, Any] = {"test_cases": [FAILING_ITEM, UNCONFIRMED_ITEM, UNSCRIPTED_ITEM]}
 
 
 def test_a_tagged_slice_does_not_become_the_datasets_failure_record(
@@ -767,9 +772,7 @@ def test_an_incomplete_run_is_not_read_as_a_failure_record(artifacts, capsys, mo
     assert "no previous run" in err
 
 
-def test_a_rerun_selects_the_failures_and_not_merely_what_did_not_pass(
-    artifacts, scripted, capsys
-):
+def test_a_rerun_selects_the_failures_and_not_merely_what_did_not_pass(artifacts, scripted, capsys):
     """`section` and not `passed`. An errored case did not pass and an unconfirmed miss did not
     pass, and neither is a failure — selecting on `passed` would re-run the whole dataset."""
     _write(artifacts, "each", ONE_OF_EACH)

--- a/tests/test_ah110_eval_command.py
+++ b/tests/test_ah110_eval_command.py
@@ -476,3 +476,178 @@ def test_a_tag_against_a_dataset_with_no_tags_says_so(artifacts, scripted, capsy
     assert "carries a tag at all" in err
     # The list-shaped half of the refusal is the thing that would have rendered empty.
     assert "Tags present" not in err
+
+
+# ---------------------------------------------------------------------------
+# The artifact, and re-running what failed
+# ---------------------------------------------------------------------------
+
+def _artifacts_in(art: Path) -> list[Path]:
+    return sorted((art / "local" / "eval" / PROFILE).glob("*.json"))
+
+
+def _artifact(art: Path) -> dict[str, Any]:
+    return json.loads(_artifacts_in(art)[-1].read_text(encoding="utf-8"))
+
+
+def test_the_artifact_records_the_verdict_and_still_records_the_statements(
+    artifacts, scripted, capsys
+):
+    """The four verdict fields are what makes a failure list recoverable, and they are ADDITIVE:
+    the report slice reads this same file, so nothing that was here before may go."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+
+    _run(capsys, "--dataset", "mixed")
+
+    item = _artifact(artifacts)["items"][0]
+    assert {"confirmed", "passed", "gated", "section"} <= set(item)
+    # Everything the record carried before the widening is still here.
+    assert {"item_key", "question", "expected_sql", "generated_sql", "score"} <= set(item)
+
+
+def test_the_recorded_section_is_the_one_the_terminal_printed(artifacts, scripted, capsys):
+    """A re-run selects on `section`, so the file and the screen must classify identically —
+    otherwise "re-run the failures" runs something the reader never saw under that heading."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+
+    _, payload, _ = _run(capsys, "--dataset", "mixed")
+
+    on_screen = {item["item_key"]: item["section"] for item in payload["items"]}
+    on_disk = {item["item_key"]: item["section"] for item in _artifact(artifacts)["items"]}
+    assert on_screen == on_disk
+
+
+def test_a_rerun_runs_exactly_what_the_last_run_recorded_as_failures(artifacts, scripted, capsys):
+    """Asserted against the artifact rather than a hard-coded list, so the test cannot agree with
+    a bug that mis-records and then mis-selects the same way."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+    first, _, _ = _run(capsys, "--dataset", "mixed")
+    assert first == 1
+    failed = [i["item_key"] for i in _artifact(artifacts)["items"] if i["section"] == "failure"]
+    assert failed, "the first run must have failed something for this to mean anything"
+
+    code, payload, _ = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    assert [item["item_key"] for item in payload["items"]] == failed
+    assert code == 1
+
+
+def test_a_rerun_with_no_previous_run_refuses(artifacts, scripted, capsys):
+    """It must not fall back to running everything: a narrow question answered widely costs a
+    model call per case and buries the answer that was asked for."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+
+    code, payload, err = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    assert code == 2
+    assert payload == {}
+    assert "no previous run" in err
+
+
+def test_a_rerun_after_a_clean_run_does_nothing_and_says_so(artifacts, scripted, capsys):
+    """Nothing to re-run is not a wrong selector, so it is a clean exit — but a silent one would
+    read exactly like a re-run that fixed everything."""
+    _write(artifacts, "clean", {"test_cases": [PASSING_ITEM]})
+    assert _run(capsys, "--dataset", "clean")[0] == 0
+
+    code, payload, err = _run(capsys, "--dataset", "clean", "--rerun-failures")
+
+    assert code == 0
+    assert payload["items"] == []
+    assert "recorded no failures" in err
+
+
+def test_a_rerun_reads_its_own_datasets_artifact_and_not_the_newest_one(
+    artifacts, scripted, capsys
+):
+    """The directory is keyed on the profile, so the newest file may describe another dataset.
+    Matching on the recorded name is what stops a re-run executing the wrong cases."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+    _run(capsys, "--dataset", "mixed")
+    mixed_failed = [
+        i["item_key"] for i in _artifact(artifacts)["items"] if i["section"] == "failure"
+    ]
+    # A later run of a different dataset, which is now the newest file in the directory.
+    _write(artifacts, "clean", {"test_cases": [PASSING_ITEM]})
+    _run(capsys, "--dataset", "clean")
+    assert _artifact(artifacts)["dataset"] == "clean"
+
+    _, payload, _ = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    assert [item["item_key"] for item in payload["items"]] == mixed_failed
+
+
+def test_a_rerun_ignores_a_report_beside_the_artifacts(artifacts, scripted, capsys):
+    """The report slice writes its HTML into this directory. Globbing `*` rather than `*.json`
+    would try to read one as a run and refuse."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+    _run(capsys, "--dataset", "mixed")
+    (artifacts / "local" / "eval" / PROFILE / "99999999T999999999999Z.html").write_text(
+        "<html>a report</html>", encoding="utf-8"
+    )
+
+    code, payload, _ = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    assert code == 1
+    assert payload["items"]
+
+
+def test_a_rerun_skips_an_artifact_it_cannot_read(artifacts, scripted, capsys):
+    """These accumulate for months; one truncated file from a full disk must not make the feature
+    unusable for every run after it."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+    _run(capsys, "--dataset", "mixed")
+    failed = [i["item_key"] for i in _artifact(artifacts)["items"] if i["section"] == "failure"]
+    (artifacts / "local" / "eval" / PROFILE / "99999999T999999999999Z.json").write_text(
+        "{ this is not json", encoding="utf-8"
+    )
+
+    code, payload, _ = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    assert code == 1
+    assert [item["item_key"] for item in payload["items"]] == failed
+
+
+def test_a_rerun_skips_a_failure_the_dataset_no_longer_has_and_says_how_many(
+    artifacts, scripted, capsys
+):
+    """Editing a case away between runs is ordinary. Running fewer cases than the last run
+    reported without saying so is not."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+    _run(capsys, "--dataset", "mixed")
+    # The failing case is edited out; only the passing one remains.
+    _write(artifacts, "mixed", {"test_cases": [PASSING_ITEM]})
+
+    code, payload, err = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    assert code == 0
+    assert payload["items"] == []
+    assert "no longer in" in err
+
+
+def test_naming_both_selections_is_refused(artifacts, scripted, capsys):
+    """Two ways of narrowing the same dataset — asking for both is a question with no answer."""
+    _write(artifacts, "tagged", TAGGED)
+
+    with pytest.raises(SystemExit) as raised:
+        run_golden_eval.main(
+            ["--profile", PROFILE, "--dataset", "tagged", "--tag", "smoke", "--rerun-failures"]
+        )
+
+    assert raised.value.code != 0
+    assert "not allowed with" in capsys.readouterr().err
+
+
+def test_a_rerun_carries_no_statement_on_stdout(artifacts, scripted, capsys):
+    """The no-SQL rule holds on the re-run path too, asserted on a FAILING re-run: a passing
+    case's reason is empty and would prove nothing."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+    _run(capsys, "--dataset", "mixed")
+
+    _, payload, err = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    rendered = json.dumps(payload)
+    assert GOLDEN_SENTINEL not in rendered
+    assert GENERATED_SENTINEL not in rendered
+    assert GOLDEN_SENTINEL not in err
+    assert GENERATED_SENTINEL not in err

--- a/tests/test_ah110_eval_command.py
+++ b/tests/test_ah110_eval_command.py
@@ -1,0 +1,359 @@
+"""The eval helper's exit contract: what a run's exit code says, and what it refuses to say.
+
+`run_golden_eval.py` printed verdicts and exited 0 for every run that reached the end of its
+wiring, which made it unusable as a gate — CI cannot tell a clean suite from one where the
+generator was never on the machine. This file pins the three answers it now gives (`0` green,
+`1` a confirmed regression, `2` no verdict at all) and, more importantly, the ORDER in which they
+are decided: a run that both stopped partway and has failures in it reports the broken pipeline,
+because sending somebody to debug a model change that never happened is the expensive mistake.
+
+The fixtures are the sibling file's: the shipped sample store, the real reader, chokepoint and
+comparator, and a scripted generator in place of the client — a run in CI must not spend a token,
+and a live model would make an exit-code assertion ambiguous between the contract and whatever
+statement the model happened to write.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+import yaml
+
+pytest.importorskip("pydantic")
+pytest.importorskip("sqlglot")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+SAMPLE_DIR = REPO_ROOT / "plugins" / "agami" / "samples" / "store"
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+sys.path.insert(0, str(SAMPLE_DIR))
+
+import build_sample  # noqa: E402
+import run_golden_eval  # noqa: E402
+from semantic_model import golden_run as gr  # noqa: E402
+
+PROFILE = "agami-example"
+
+# Planted in the two statements so the no-SQL rule can be asserted at the exit-code surface too.
+# Column aliases, because the comparator pairs by value and ignores names.
+GOLDEN_SENTINEL = "goldensentinelzzq"
+GENERATED_SENTINEL = "generatedsentinelzzq"
+
+Q_PASS = "How many orders have been placed?"
+Q_FAIL = "How many customers are on file?"
+Q_UNCONFIRMED = "How many payments have been taken?"
+
+GENERATED = {
+    Q_PASS: "SELECT COUNT(id) AS n FROM orders",
+    # A different number off the same table, so the miss is a real disagreement about rows rather
+    # than an accident of which table is larger.
+    Q_FAIL: f"SELECT COUNT(DISTINCT country) AS {GENERATED_SENTINEL} FROM customers",
+    Q_UNCONFIRMED: "SELECT COUNT(*) AS n FROM refunds",
+}
+
+PASSING_ITEM: dict[str, Any] = {
+    "id": "orders-count",
+    "query": Q_PASS,
+    "expected": {"sql": "SELECT COUNT(*) AS n FROM orders", "sql_confirmed": True},
+}
+
+# Confirmed and scored a miss, so it is the one thing a run may exit `1` on. Its answer key carries
+# the sentinel, because the reasons that name a column are only ever built on a disagreement.
+FAILING_ITEM: dict[str, Any] = {
+    "id": "customers-count",
+    "query": Q_FAIL,
+    "expected": {
+        "sql": f"SELECT COUNT(*) AS {GOLDEN_SENTINEL} FROM customers",
+        "sql_confirmed": True,
+    },
+}
+
+# Scores a miss and can never gate: nobody has confirmed its answer key.
+UNCONFIRMED_ITEM: dict[str, Any] = {
+    "id": "payments-count",
+    "query": Q_UNCONFIRMED,
+    "expected": {"sql": "SELECT COUNT(*) AS n FROM payments", "sql_confirmed": False},
+}
+
+# The shape the confirmed-only rule is invisible in until you look at the exit code: something
+# failed, and nothing that failed can gate.
+PASS_AND_UNCONFIRMED_MISS: dict[str, Any] = {"test_cases": [PASSING_ITEM, UNCONFIRMED_ITEM]}
+
+# The failing case FIRST, which is also what makes it usable for the ordering: a generator that
+# raises on its second question leaves a run that is both incomplete and carrying a gating failure.
+ONE_FAILURE: dict[str, Any] = {"test_cases": [FAILING_ITEM, PASSING_ITEM]}
+
+ONLY_UNCONFIRMED: dict[str, Any] = {"test_cases": [UNCONFIRMED_ITEM]}
+
+
+class _Scripted:
+    """The shipped generator's stand-in, constructed the way the script constructs the real one."""
+
+    def __init__(self, schema: str, *, timeout_s: float) -> None:
+        self.schema = schema
+        self.timeout_s = timeout_s
+
+    def generate(self, question: str, org: str, datasource: Optional[str]) -> gr.GeneratedSql:
+        sql = GENERATED.get(question)
+        if sql is None:
+            return gr.GeneratedSql(sql="", error="no statement was scripted for this question")
+        return gr.GeneratedSql(sql=sql, error=None)
+
+
+@pytest.fixture(scope="module")
+def warehouse(tmp_path_factory) -> Path:
+    """The shipped sample database, built once for the whole file."""
+    db = tmp_path_factory.mktemp("store") / "store.db"
+    build_sample.build(db, prefer_cli=False)
+    return db
+
+
+@pytest.fixture()
+def artifacts(tmp_path, monkeypatch, warehouse) -> Path:
+    """A profile wired the way the onboarding path wires one, with no datasets in it yet."""
+    art = tmp_path / "artifacts"
+    shutil.copytree(SAMPLE_DIR / "model", art / PROFILE)
+
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(art))
+    # The org-less form: this helper runs on one operator's machine and resolves to the
+    # single-tenant `local` org, the only org those vars are offered to.
+    monkeypatch.setenv("DATASOURCE_URL__AGAMI_EXAMPLE", f"sqlite:///{warehouse}")
+    for var in ("AGAMI_DB_URL", "APP_DATABASE_URL", "AGAMI_ORG_ID", "AGAMI_SQL_TIMEOUT_S"):
+        monkeypatch.delenv(var, raising=False)
+    return art
+
+
+@pytest.fixture()
+def scripted(monkeypatch) -> None:
+    """Answer every question from a table instead of spawning the operator's client."""
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Scripted)
+
+
+def _write(art: Path, name: str, dataset: dict[str, Any]) -> None:
+    golden = art / PROFILE / "golden_datasets"
+    golden.mkdir(exist_ok=True)
+    (golden / f"{name}.yaml").write_text(yaml.safe_dump(dataset), encoding="utf-8")
+
+
+def _run(capsys, *argv: str) -> tuple[int, dict[str, Any], str]:
+    """Invoke the helper and read back its exit code, its JSON and its stderr."""
+    code = run_golden_eval.main(["--profile", PROFILE, *argv])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out) if captured.out.strip() else {}
+    return code, payload, captured.err
+
+
+# ---------------------------------------------------------------------------
+# The three verdicts
+# ---------------------------------------------------------------------------
+
+def test_a_run_whose_confirmed_cases_all_pass_is_green(artifacts, scripted, capsys):
+    """And it stays green with a failing UNCONFIRMED case beside them.
+
+    This is the confirmed-only rule observed at the exit status rather than in a counter: the run
+    reports `failed: 1`, and the item behind that number has an answer key nobody has reviewed, so
+    gating on it would fail CI on something no human has agreed to."""
+    _write(artifacts, "mixed", PASS_AND_UNCONFIRMED_MISS)
+
+    code, payload, _ = _run(capsys, "--dataset", "mixed")
+
+    assert code == 0
+    assert payload["summary"]["failed"] == 1
+    assert payload["summary"]["gating_failures"] == 0
+
+
+def test_one_confirmed_failure_exits_one_and_names_the_item(artifacts, scripted, capsys):
+    """The regression verdict. The exit code is what CI reads; the item key is what a person needs
+    in order to act on it, so both are asserted at once."""
+    _write(artifacts, "regressed", ONE_FAILURE)
+
+    code, payload, _ = _run(capsys, "--dataset", "regressed")
+
+    assert code == 1
+    failures = [item for item in payload["items"] if item["section"] == "failure"]
+    assert [item["item_key"] for item in failures] == ["customers-count"]
+
+
+def test_a_run_that_stopped_partway_cannot_produce_a_verdict(artifacts, monkeypatch, capsys):
+    """`completed: false` means the cases after the stop were never attempted. The counts describe
+    a fraction of the dataset, so there is no verdict to give — not a green one and not a red one.
+
+    Everything the run DID reach passed, so nothing but `completed` distinguishes it from a clean
+    suite."""
+
+    class _RaisesOnTheSecond:
+        def __init__(self, schema: str, *, timeout_s: float) -> None:
+            self.answered = 0
+
+        def generate(self, question, org, datasource):
+            self.answered += 1
+            if self.answered > 1:
+                raise RuntimeError("the client fell over")
+            return gr.GeneratedSql(sql=GENERATED[Q_PASS], error=None)
+
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _RaisesOnTheSecond)
+    _write(artifacts, "stopped", {"test_cases": [PASSING_ITEM, FAILING_ITEM]})
+
+    code, payload, _ = _run(capsys, "--dataset", "stopped")
+
+    assert code == 2
+    assert payload["summary"]["completed"] is False
+    assert payload["summary"]["gating_failures"] == 0
+
+
+def test_a_run_where_every_generation_errored_cannot_produce_a_verdict(
+    artifacts, monkeypatch, capsys
+):
+    """The `claude` binary not being on the runner. Nothing was scored, so this is neither a
+    regression nor a passing suite — and the rule is categorical rather than proportional, because
+    any fraction here would be the pass-rate threshold this deliberately does not have."""
+
+    class _AnswersNothing:
+        def __init__(self, schema: str, *, timeout_s: float) -> None:
+            pass
+
+        def generate(self, question, org, datasource):
+            return gr.GeneratedSql(sql="", error="no statement was scripted for this question")
+
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _AnswersNothing)
+    _write(artifacts, "regressed", ONE_FAILURE)
+
+    code, payload, _ = _run(capsys, "--dataset", "regressed")
+
+    assert code == 2
+    total = payload["summary"]["total"]
+    assert payload["summary"]["errored"] == total > 0
+    assert payload["summary"]["gating_failures"] == 0
+
+
+def test_an_incomplete_run_with_failures_in_it_reports_the_broken_pipeline(
+    artifacts, monkeypatch, capsys
+):
+    """The ordering, and the whole reason the checks are in the order they are.
+
+    This run has a confirmed failure in it AND stopped partway, so both rules apply and only one
+    code can be returned. It is `2`: the failure is real but the run around it is not trustworthy,
+    and sending somebody to debug a model change against a run that never finished is the expensive
+    mistake this ordering exists to prevent."""
+
+    class _RaisesAfterTheFirst:
+        def __init__(self, schema: str, *, timeout_s: float) -> None:
+            self.answered = 0
+
+        def generate(self, question, org, datasource):
+            self.answered += 1
+            if self.answered > 1:
+                raise RuntimeError("the client fell over")
+            return gr.GeneratedSql(sql=GENERATED[Q_FAIL], error=None)
+
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _RaisesAfterTheFirst)
+    _write(artifacts, "half", ONE_FAILURE)
+
+    code, payload, _ = _run(capsys, "--dataset", "half")
+
+    # Both conditions really are present, or the ordering is not what is being asserted.
+    assert payload["summary"]["completed"] is False
+    assert payload["summary"]["gating_failures"] == 1
+    assert code == 2
+
+
+# ---------------------------------------------------------------------------
+# What a green run has to admit about itself
+# ---------------------------------------------------------------------------
+
+def test_a_run_with_nothing_confirmed_is_green_and_says_it_gated_on_nothing(
+    artifacts, scripted, capsys
+):
+    """The state most profiles are actually in. The run worked, so it exits `0` — but a green
+    status that verified nothing is the one that gets mistaken for evidence, so it has to say so
+    out loud rather than only in a counter nobody reads."""
+    _write(artifacts, "draft", ONLY_UNCONFIRMED)
+
+    code, _, err = _run(capsys, "--dataset", "draft")
+
+    assert code == 0
+    # The same prefix the refusals carry, so a log has one thing to grep and a caller one thing
+    # to strip.
+    warning = next(line for line in err.splitlines() if "gated on nothing" in line)
+    assert warning.startswith("agami-eval: ")
+
+
+def test_a_run_with_a_confirmed_case_does_not_warn_about_gating(artifacts, scripted, capsys):
+    """The other half of the warning: it fires on the absence of a confirmed case and not on every
+    run, or it is noise and a reader learns to skip the line."""
+    _write(artifacts, "regressed", ONE_FAILURE)
+
+    _, _, err = _run(capsys, "--dataset", "regressed")
+
+    assert "gated on nothing" not in err
+
+
+# ---------------------------------------------------------------------------
+# The human line, and the stream it does not go on
+# ---------------------------------------------------------------------------
+
+def test_the_summary_line_goes_to_stderr_and_leaves_stdout_parseable(
+    artifacts, scripted, capsys
+):
+    """A pipeline log needs one line a person can read the run against, and every caller of this
+    helper parses stdout as a JSON document — so the sentence goes on stderr, where the prefixed
+    refusals already are. `_run` parses stdout, so a line printed there fails this outright."""
+    _write(artifacts, "mixed", PASS_AND_UNCONFIRMED_MISS)
+
+    _, payload, err = _run(capsys, "--dataset", "mixed")
+
+    # `_run` parsed stdout as JSON to hand back `payload`, so a sentence printed there fails
+    # before this line is reached — and the counts are spelled out rather than read back off the
+    # payload, which would assert the line against itself.
+    assert payload["items"]
+    assert (
+        f"Ran mixed on {PROFILE}: 0 failed, 0 errored, 0 unscored, 1 unconfirmed, 1 passed "
+        "— run completed: yes."
+    ) in err
+
+
+def test_the_summary_line_says_when_the_run_did_not_complete(artifacts, monkeypatch, capsys):
+    """The one fact the counts cannot carry: a run that stopped reports numbers over the cases it
+    reached, and a reader comparing them to last week's needs to be told not to."""
+
+    class _RaisesImmediately:
+        def __init__(self, schema: str, *, timeout_s: float) -> None:
+            pass
+
+        def generate(self, question, org, datasource):
+            raise RuntimeError("the client fell over")
+
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _RaisesImmediately)
+    _write(artifacts, "stopped", ONE_FAILURE)
+
+    _, _, err = _run(capsys, "--dataset", "stopped")
+
+    assert "run completed: no." in err
+
+
+# ---------------------------------------------------------------------------
+# The rule the payload exists to keep, at the surface that now gates
+# ---------------------------------------------------------------------------
+
+def test_a_failing_run_still_carries_neither_statement(artifacts, scripted, capsys):
+    """Asserted on a FAILING case, because a passing one proves nothing: its `reason` is empty, and
+    the two reasons built out of the answer key's own column names are only ever built on a
+    disagreement. The exit code is now what a pipeline surfaces, so the payload behind it is the
+    thing most likely to be pasted into a chat window."""
+    _write(artifacts, "regressed", ONE_FAILURE)
+
+    code, payload, err = _run(capsys, "--dataset", "regressed")
+
+    rendered = json.dumps(payload)
+    assert code == 1 and any(item["section"] == "failure" for item in payload["items"])
+    assert GOLDEN_SENTINEL not in rendered
+    assert GENERATED_SENTINEL not in rendered
+    # …and the stderr the same pipeline log carries is held to the same rule.
+    assert GOLDEN_SENTINEL not in err and GENERATED_SENTINEL not in err

--- a/tests/test_ah110_eval_command.py
+++ b/tests/test_ah110_eval_command.py
@@ -48,13 +48,21 @@ GENERATED_SENTINEL = "generatedsentinelzzq"
 
 Q_PASS = "How many orders have been placed?"
 Q_FAIL = "How many customers are on file?"
+Q_FAIL_TOO = "How many products are listed?"
 Q_UNCONFIRMED = "How many payments have been taken?"
+# Deliberately absent from `GENERATED` below, which is what makes its case error.
+Q_ERRORS = "How many invoices were issued?"
+
+# The statement that makes the confirmed case miss, kept as a name so a test can put it back after
+# monkeypatching a passing answer over it.
+GENERATED_FAILING = f"SELECT COUNT(DISTINCT country) AS {GENERATED_SENTINEL} FROM customers"
 
 GENERATED = {
     Q_PASS: "SELECT COUNT(id) AS n FROM orders",
     # A different number off the same table, so the miss is a real disagreement about rows rather
     # than an accident of which table is larger.
-    Q_FAIL: f"SELECT COUNT(DISTINCT country) AS {GENERATED_SENTINEL} FROM customers",
+    Q_FAIL: GENERATED_FAILING,
+    Q_FAIL_TOO: "SELECT COUNT(DISTINCT category_id) AS n FROM products",
     Q_UNCONFIRMED: "SELECT COUNT(*) AS n FROM refunds",
 }
 
@@ -73,6 +81,22 @@ FAILING_ITEM: dict[str, Any] = {
         "sql": f"SELECT COUNT(*) AS {GOLDEN_SENTINEL} FROM customers",
         "sql_confirmed": True,
     },
+}
+
+# A second confirmed miss, so a run can record a failure LIST rather than a single failure — which
+# is the only shape in which "the list narrowed" is observable.
+SECOND_FAILING_ITEM: dict[str, Any] = {
+    "id": "products-count",
+    "query": Q_FAIL_TOO,
+    "expected": {"sql": "SELECT COUNT(*) AS n FROM products", "sql_confirmed": True},
+}
+
+# Confirmed, and its generation produces no statement at all. It is `passed: false` like a failure
+# and it is not one — nothing was scored.
+ERRORING_ITEM: dict[str, Any] = {
+    "id": "invoices-count",
+    "query": Q_ERRORS,
+    "expected": {"sql": "SELECT COUNT(*) AS n FROM invoices", "sql_confirmed": True},
 }
 
 # Scores a miss and can never gate: nobody has confirmed its answer key.
@@ -550,11 +574,15 @@ def test_a_rerun_after_a_clean_run_does_nothing_and_says_so(artifacts, scripted,
     _write(artifacts, "clean", {"test_cases": [PASSING_ITEM]})
     assert _run(capsys, "--dataset", "clean")[0] == 0
 
+    before = len(_artifacts_in(artifacts))
     code, payload, err = _run(capsys, "--dataset", "clean", "--rerun-failures")
 
     assert code == 0
-    assert payload["items"] == []
     assert "recorded no failures" in err
+    # Nothing ran, so nothing printed and nothing was written: a 0-case artifact would become this
+    # dataset's newest record and shadow the real one a later re-run needs.
+    assert payload == {}
+    assert len(_artifacts_in(artifacts)) == before
 
 
 def test_a_rerun_reads_its_own_datasets_artifact_and_not_the_newest_one(
@@ -621,8 +649,11 @@ def test_a_rerun_skips_a_failure_the_dataset_no_longer_has_and_says_how_many(
     code, payload, err = _run(capsys, "--dataset", "mixed", "--rerun-failures")
 
     assert code == 0
-    assert payload["items"] == []
+    assert payload == {}
     assert "no longer in" in err
+    # And it must NOT also claim the last run was clean — it recorded a failure, which was deleted.
+    # A skill reads that sentence back to the user as "the previous run was green".
+    assert "recorded no failures" not in err
 
 
 def test_naming_both_selections_is_refused(artifacts, scripted, capsys):
@@ -651,3 +682,116 @@ def test_a_rerun_carries_no_statement_on_stdout(artifacts, scripted, capsys):
     assert GENERATED_SENTINEL not in rendered
     assert GOLDEN_SENTINEL not in err
     assert GENERATED_SENTINEL not in err
+
+
+# ---------------------------------------------------------------------------
+# A re-run may only trust a whole, concluded run
+# ---------------------------------------------------------------------------
+
+ERRORING_ITEM: dict[str, Any] = {
+    "id": "unscripted-count",
+    "query": "A question no generator has an answer for",
+    "expected": {"sql": "SELECT COUNT(*) AS n FROM products", "sql_confirmed": True},
+}
+
+# One of each section a re-run must tell apart: a confirmed miss, an unconfirmed miss that can
+# never gate, and a case whose generation produced nothing at all.
+ONE_OF_EACH: dict[str, Any] = {
+    "test_cases": [FAILING_ITEM, UNCONFIRMED_ITEM, ERRORING_ITEM]
+}
+
+
+def test_a_tagged_slice_does_not_become_the_datasets_failure_record(
+    artifacts, scripted, capsys, monkeypatch
+):
+    """The false green this refusal exists for. A slice describes some of the dataset, so its
+    failure list is narrower than the truth — and inheriting it exits 0 over a live regression."""
+    _write(artifacts, "tagged", TAGGED)
+    assert _run(capsys, "--dataset", "tagged")[0] == 1
+    # The tagged case now passes, so a slice over it alone records no failures at all.
+    monkeypatch.setitem(GENERATED, Q_FAIL, "SELECT COUNT(*) AS n FROM customers")
+    assert _run(capsys, "--dataset", "tagged", "--tag", "revenue")[0] == 0
+    monkeypatch.setitem(GENERATED, Q_FAIL, GENERATED_FAILING)
+
+    code, payload, err = _run(capsys, "--dataset", "tagged", "--rerun-failures")
+
+    assert "recorded no failures" not in err
+    assert [item["item_key"] for item in payload["items"]] == ["customers-count"]
+    assert code == 1
+
+
+def test_a_run_that_produced_no_verdict_is_not_read_as_a_clean_one(artifacts, capsys, monkeypatch):
+    """An all-errored run records no failures because it scored nothing, not because nothing was
+    wrong. Trusting its empty list arrives at exactly the green the `2` branch refuses."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+
+    class _Silent(_Scripted):
+        def generate(self, question, org, datasource):
+            return gr.GeneratedSql(sql="", error="the generator did not answer")
+
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Silent)
+    assert _run(capsys, "--dataset", "mixed")[0] == 2
+
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Scripted)
+    code, payload, err = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    # No usable record exists, so it refuses rather than reporting a clean re-run.
+    assert code == 2
+    assert payload == {}
+    assert "no previous run" in err
+
+
+def test_an_incomplete_run_is_not_read_as_a_failure_record(artifacts, capsys, monkeypatch):
+    """Same rule for a run that stopped partway: its truncated list would narrow every re-run
+    after it."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+
+    class _Raises(_Scripted):
+        def __init__(self, schema, *, timeout_s):
+            super().__init__(schema, timeout_s=timeout_s)
+            self.asked = 0
+
+        def generate(self, question, org, datasource):
+            self.asked += 1
+            if self.asked > 1:
+                raise RuntimeError("the client fell over")
+            return super().generate(question, org, datasource)
+
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Raises)
+    assert _run(capsys, "--dataset", "mixed")[0] == 2
+
+    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Scripted)
+    code, _, err = _run(capsys, "--dataset", "mixed", "--rerun-failures")
+
+    assert code == 2
+    assert "no previous run" in err
+
+
+def test_a_rerun_selects_the_failures_and_not_merely_what_did_not_pass(
+    artifacts, scripted, capsys
+):
+    """`section` and not `passed`. An errored case did not pass and an unconfirmed miss did not
+    pass, and neither is a failure — selecting on `passed` would re-run the whole dataset."""
+    _write(artifacts, "each", ONE_OF_EACH)
+    first, payload, _ = _run(capsys, "--dataset", "each")
+    assert first == 1
+    sections = {item["section"] for item in payload["items"]}
+    assert {"failure", "error", "unconfirmed"} <= sections, sections
+
+    _, payload, _ = _run(capsys, "--dataset", "each", "--rerun-failures")
+
+    assert [item["item_key"] for item in payload["items"]] == ["customers-count"]
+
+
+def test_an_unreachable_datasource_cannot_produce_a_verdict(
+    artifacts, scripted, capsys, monkeypatch
+):
+    """The criterion this contract exists for. It reaches `2` by a different route than a
+    generation failure does — the statements are written, and then nothing can execute them."""
+    _write(artifacts, "mixed", ONE_FAILURE)
+    monkeypatch.delenv("DATASOURCE_URL__AGAMI_EXAMPLE")
+
+    code, payload, _ = _run(capsys, "--dataset", "mixed")
+
+    assert code == 2
+    assert payload["summary"]["errored"] == payload["summary"]["total"]


### PR DESCRIPTION
Spec: AH-110

> **Sixth in a stack**, on #241 (`AH-106-agami-eval-skill`), which it targets as its base. It extends
> that branch's script in place. Merge the stack in order and this retargets onto `main`. Review only
> this branch's four commits.

## Summary

The eval script ran a golden dataset, printed verdicts, and **always exited 0** — its own comment
called the exit code "a later slice's problem". A CI job could not gate on it. This adds the exit
contract, a tag selection, and re-running the last run's failures: *an entry point and a selection,
not behaviour*. No new scoring, no new generation, no new dataset reading.

## The exit contract

| | |
|---|---|
| `0` | every confirmed case passed |
| `1` | a confirmed case failed |
| `2` | no verdict could be produced |

`2` means *go look at the harness*, never *the model regressed*. It covers the preflight refusals, a
run that stopped partway, a run where **every** generation errored (the `claude`-binary-missing case),
and a selector that matched nothing.

**The ordering is the substance**: incomplete → all-errored → gating failures → `0`. A run that is
both incomplete *and* carries gating failures reports `2`, because sending someone to debug a model
change against a run that never happened is the expensive mistake. The all-errored rule is
**categorical** (`errored == total`) and never proportional — a fraction here would be a pass-rate
threshold, which the spec explicitly refuses.

The verdict reads **`gating_failures`, never `failed`**. `failed` counts every scored miss including
unconfirmed ones, whose answer keys nobody has reviewed; resting CI on it would fail a run over an
item no human has agreed to.

## Changes

- **`--tag`**, repeatable, **OR** across tags, **case-sensitive** (tags are free text with no
  vocabulary; folding case would invent one no other reader applies). A tag no case carries is a
  wrong selector and refuses with `2` naming the tags that exist. A tag selecting only *unconfirmed*
  cases exits `0` with a warning — it ran correctly and there was simply nothing that could gate.
- **`--rerun-failures`**, mutually exclusive with `--tag`. Reads the newest artifact for the dataset
  and re-runs the cases recorded under `section: "failure"`.
- **The artifact gained the verdict fields** — it carried a score per case but not a verdict, and
  `passed` folds `gated` into itself, so a gated-but-accurate case was indistinguishable from a pass
  and the failure list was not recoverable at all. The record now spreads `ItemOutcome.as_dict()`
  (which also carries the claim difference the report will need) plus `section` and `selection`.
  Additive, because the report slice reads this same file.
- A **stable summary line** on stderr for a pipeline log, and every refusal likewise — stdout stays a
  JSON document a caller can parse.

## Findings from review

Two passes ran over the diff. They converged independently on one root defect, with four different
reproductions between them.

**A re-run trusted any artifact for its dataset — a false green.** `_last_failures` never asked
whether the run it was reading had *finished*, had *produced a verdict at all*, or had covered the
*whole dataset*. Every run writes an artifact, including a `--tag` slice and a run that stopped
partway. Reproduced end to end:

```
full run    exit 1   recorded failures: ['a', 'b']
tag slice   exit 0   recorded failures: []      ← a narrowed run overwrote the record
rerun       exit 0                              ← 'b' still fails
```

An all-errored run (exit `2`) did the same, and a re-run that stopped partway narrowed the record
permanently. The `2` branch exists so a no-verdict run never reads green; two invocations later it
did — and the skill renders that sentence back to the user as *"the previous run was green"*. It now
skips a record that is a selection, or that would itself score `2`, sharing **one spelling** of the
verdict rule between the live path and the recorded one.

**An emptied re-run wrote a 0-case artifact** that became the dataset's newest record and shadowed
the real one, making the evidence a later re-run needs unreachable. It now returns before running.

**"recorded no failures" was printed even when failures existed but had been deleted**, contradicting
the line above it — and, again, the skill turns that into "the previous run was green".

**A surviving mutant:** changing the selection from `section == "failure"` to `not passed` left all 72
tests green. Every re-run test used a dataset whose only non-passing case was a confirmed failure, so
nothing pinned that an errored or unconfirmed-miss case stays *out* of a re-run — which is the entire
reason `section` was recorded. Now covered by a dataset carrying one of each.

**The spec's headline criterion had no test.** "An unreachable datasource exits `2` — the criterion
the spec exists for." The behaviour was correct but reached `2` by a different branch than the tested
generation-failure path, so nothing stood in for it.

**The egress disclosure overstated what is withheld.** It claimed the child is handed neither the
answer key, the dataset's location, nor any result row. The first and third hold; the second does
not — the child keeps `HOME` and is given the profile name, so both halves of the path are in its
hands. What actually withholds the answer key is being started with no tools to read one with. The
runner's own module is careful about exactly this and the new paragraph had dropped that care. An
inaccurate disclosure is worse than none.

Also fixed: the one `_stop` where nothing stops is now a `_warn`; an empty or whitespace-only tag
rendered invisibly in its refusal; a pre-widening artifact produced a false "no previous run" message.

**Verified clean by the passes:** no workflow file added (out of scope — it lands in another repo);
no threshold, ratio or tunable anywhere; no second script, verdict or presentation; no MCP tool or
`sm` subcommand; nothing written into `<profile>/`; and sentinels planted in both statements leaked
on **none** of the new paths, stdout or stderr.

## Decisions

Six are recorded in the spec's `## Decisions`, and its `[NEEDS DECISION]` on CI credentials is
resolved in place: the credential is an environment variable read by the generator, **documented as a
disclosed egress**. That needed no code — the variable is already on the generator child's env
allowlist — so what this slice adds is the disclosure itself, in the module docstring where an
operator reads it.

## Checklist

- [x] Spec referenced (`Spec: AH-110`)
- [x] Every spec success criterion implemented and covered by a test (10 of 10)
- [x] Full suite green
- [x] `ruff check` clean; gitleaks clean
- [x] No test weakened. Six pre-existing tests were re-aimed (exit 0 → the verdict their dataset now
      earns); two more were re-aimed because an emptied re-run no longer prints a payload.
- [x] No real customer, organization, table, or question names — fixtures use the shipped sample store
- [x] No spec ids in source, comments, or docs
- [x] Reviewed via the panel (correctness/tests, structural rubric, security/disclosure); all findings
      dispositioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
