### PR TITLE
Reopen a database connection the server has closed

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -622,7 +622,7 @@ def create_app(
                         _log.info("seeded the configured admin")  # not the email — no PII in logs
                     store.commit()
                 except Exception:  # noqa: BLE001 — a concurrent boot won the seed; not fatal
-                    store.conn.rollback()
+                    store.rollback()
                     _log.warning(
                         "admin seed skipped (already seeded or a concurrent boot won the race)"
                     )

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -59,6 +59,28 @@ def register_migration_overlay(path: Path) -> None:
         _MIGRATION_OVERLAYS.append(path)
 
 
+
+def _is_read(sql: str) -> bool:
+    """Whether a statement can be assumed to write nothing.
+
+    **Deliberately one keyword, and deliberately conservative.** This is not a SQL parser and must
+    not become one — the repo has exactly one of those and a second would be a second thing to keep
+    correct. It decides one thing: may a reconnect drop this statement without losing data?
+
+    Only a bare `SELECT` qualifies. `WITH` is excluded even though most CTEs are reads, because
+    Postgres allows a data-modifying statement inside one and a wrong answer here is silent. Anything
+    unrecognised counts as a write, so the failure direction is a refused reconnect rather than a
+    lost row.
+
+    The word boundary is not pedantry: a prefix match alone reads any identifier beginning with those
+    six letters as a query, and being wrong in that direction is the one direction that loses data.
+    """
+    head = sql.lstrip()
+    if head[:6].upper() != "SELECT":
+        return False
+    after = head[6:7]
+    return after == "" or not (after.isalnum() or after == "_")
+
 class Store:
     """A DB-API connection + its dialect, with portable execute/query helpers.
 
@@ -66,9 +88,15 @@ class Store:
     dicts on every backend (built from cursor.description), so callers never branch on the backend.
     """
 
-    def __init__(self, conn: Any, dialect: str) -> None:
+    def __init__(self, conn: Any, dialect: str, *, url: str = "") -> None:
         self.conn = conn
         self.dialect = dialect  # "sqlite" | "postgres"
+        # Kept so a connection the server reaped can be reopened — see `execute`. Empty for SQLite
+        # and for a hand-built Store, and an empty url simply means no reconnect is attempted.
+        self._url = url
+        # Whether a statement has run since the last commit or rollback. **This is what makes the
+        # reconnect safe**, and it is the whole reason this flag exists: see `_reconnected`.
+        self._mid_transaction = False
 
     # --- construction -------------------------------------------------------
 
@@ -85,7 +113,7 @@ class Store:
         if url.startswith(("postgresql://", "postgres://")):
             import psycopg2  # in the [server] extra; only needed for the Postgres backend
 
-            return cls(psycopg2.connect(url), "postgres")
+            return cls(psycopg2.connect(url), "postgres", url=url)
         raise ValueError(
             f"Unsupported AGAMI_DB_URL scheme: {url.split('://', 1)[0]!r} "
             "(expected sqlite:// or postgresql://)"
@@ -112,7 +140,57 @@ class Store:
         # Our SQL never contains a literal '?'; Postgres wants %s placeholders.
         return sql if self.dialect == "sqlite" else sql.replace("?", "%s")
 
+    def _dead_connection_errors(self) -> tuple:
+        """The exceptions that mean "this connection is gone", or nothing on SQLite.
+
+        Both are needed and they arrive at different moments. `OperationalError` is raised the first
+        time a statement meets a socket the server has closed — so it comes out of `cursor.execute`.
+        Every call after that gets `InterfaceError` from `conn.cursor()`, because the driver has by
+        then marked the connection closed. A deployment that handled only the second would recover
+        from every failure except the one that starts each outage.
+        """
+        if self.dialect != "postgres":
+            return ()
+        import psycopg2
+
+        return (psycopg2.InterfaceError, psycopg2.OperationalError)
+
+    def _reconnected(self) -> bool:
+        """Reopen the connection, unless doing so would be unsafe or impossible.
+
+        **Refuses mid-transaction, and that refusal is the point of this method.** Several callers
+        write two rows that must land together — a role change and its audit line, a credential and
+        the record of who set it. If the connection dies between the two statements, the first is
+        already lost, and silently reconnecting would let the second commit **alone**: an audit line
+        for a grant that never happened, which is precisely the property the audit line exists to
+        provide. A caller mid-transaction must see the failure and roll back.
+
+        Between statements there is nothing uncommitted to lose, which is the ordinary case — a read,
+        or the first statement of a unit of work — and that is where an hour-idle connection is
+        reaped in practice.
+        """
+        if self._mid_transaction or not self._url:
+            return False
+        import psycopg2
+
+        try:
+            self.conn = psycopg2.connect(self._url)
+        except Exception:  # noqa: BLE001
+            return False
+        return True
+
     def execute(self, sql: str, params: tuple = ()) -> Any:
+        try:
+            return self._execute_once(sql, params)
+        except self._dead_connection_errors():
+            # A connection idle long enough gets closed by the server, and nothing tells the process.
+            # Without this the instance is poisoned for as long as it lives: every request afterwards
+            # fails in milliseconds, having attempted no round trip at all.
+            if not self._reconnected():
+                raise
+        return self._execute_once(sql, params)
+
+    def _execute_once(self, sql: str, params: tuple = ()) -> Any:
         cur = self.conn.cursor()
         # **No params argument at all when there are none**, and that is not a tidy-up.
         # psycopg2 treats a non-None `params` as a request to interpolate, so it reads `%` in the SQL
@@ -128,6 +206,16 @@ class Store:
             cur.execute(self._adapt(sql), params)
         else:
             cur.execute(self._adapt(sql))
+        # **Only a write marks the transaction, and only after it has actually run.**
+        #
+        # What the guard in `_reconnected` protects is uncommitted *writes*: reconnecting after one
+        # would let a later statement commit without it. A read leaves nothing to lose, so it must
+        # not set the flag — and the difference is not cosmetic. The path this whole change exists
+        # for reads five tables in a row and never commits, because there is nothing to commit. If a
+        # read marked the transaction, that caller would reconnect once and then be refused for the
+        # life of the process: the fix would not fix the bug. A test pins exactly that.
+        if not _is_read(sql):
+            self._mid_transaction = True
         return cur
 
     def query(self, sql: str, params: tuple = ()) -> list[dict[str, Any]]:
@@ -137,9 +225,18 @@ class Store:
 
     def commit(self) -> None:
         self.conn.commit()
+        self._mid_transaction = False
+
+    def rollback(self) -> None:
+        """Abandon the open transaction. Callers reached past this into `store.conn.rollback()`
+        before it existed; going through here is what keeps the reconnect guard honest, because a
+        connection left marked mid-transaction never reconnects again."""
+        self.conn.rollback()
+        self._mid_transaction = False
 
     def close(self) -> None:
         self.conn.close()
+        self._mid_transaction = False
 
     # --- migrations ---------------------------------------------------------
 

--- a/packages/agami-core/src/store.py
+++ b/packages/agami-core/src/store.py
@@ -59,7 +59,6 @@ def register_migration_overlay(path: Path) -> None:
         _MIGRATION_OVERLAYS.append(path)
 
 
-
 def _is_read(sql: str) -> bool:
     """Whether a statement can be assumed to write nothing.
 
@@ -81,6 +80,7 @@ def _is_read(sql: str) -> bool:
     after = head[6:7]
     return after == "" or not (after.isalnum() or after == "_")
 
+
 class Store:
     """A DB-API connection + its dialect, with portable execute/query helpers.
 
@@ -94,9 +94,12 @@ class Store:
         # Kept so a connection the server reaped can be reopened — see `execute`. Empty for SQLite
         # and for a hand-built Store, and an empty url simply means no reconnect is attempted.
         self._url = url
-        # Whether a statement has run since the last commit or rollback. **This is what makes the
-        # reconnect safe**, and it is the whole reason this flag exists: see `_reconnected`.
+        # Whether an uncommitted WRITE is outstanding. **This is what makes the reconnect safe**,
+        # and it is the whole reason this flag exists: see `_reconnected`.
         self._mid_transaction = False
+        # Whether something holds state that belongs to this connection rather than to a transaction
+        # — today only the migration advisory lock. A new connection would not have it.
+        self._session_state_held = False
 
     # --- construction -------------------------------------------------------
 
@@ -141,19 +144,40 @@ class Store:
         return sql if self.dialect == "sqlite" else sql.replace("?", "%s")
 
     def _dead_connection_errors(self) -> tuple:
-        """The exceptions that mean "this connection is gone", or nothing on SQLite.
+        """The exceptions that *may* mean "this connection is gone", or nothing on SQLite.
 
         Both are needed and they arrive at different moments. `OperationalError` is raised the first
         time a statement meets a socket the server has closed — so it comes out of `cursor.execute`.
         Every call after that gets `InterfaceError` from `conn.cursor()`, because the driver has by
         then marked the connection closed. A deployment that handled only the second would recover
         from every failure except the one that starts each outage.
+
+        Catching them is not the same as acting on them — see `_is_dead`.
         """
         if self.dialect != "postgres":
             return ()
         import psycopg2
 
         return (psycopg2.InterfaceError, psycopg2.OperationalError)
+
+    def _is_dead(self, exc: Exception) -> bool:
+        """Whether that exception really means the connection is gone.
+
+        **`OperationalError` is a broad base class** — a cancelled query, a statement timeout, a full
+        disk all raise it, on a connection that is perfectly healthy. Retrying blindly on any of them
+        would re-run the statement, and for the first write of a transaction (where the guard below
+        correctly permits a reconnect) that means the row lands **twice**. A retry is only safe when
+        there is nothing left to retry *on*, so the driver's own view decides: psycopg2 sets
+        `conn.closed` non-zero once the connection is unusable.
+
+        `InterfaceError` needs no such test. It is raised by `conn.cursor()`, which the driver only
+        refuses when the connection is already closed.
+        """
+        import psycopg2
+
+        if isinstance(exc, psycopg2.InterfaceError):
+            return True
+        return bool(getattr(self.conn, "closed", 0))
 
     def _reconnected(self) -> bool:
         """Reopen the connection, unless doing so would be unsafe or impossible.
@@ -168,8 +192,13 @@ class Store:
         Between statements there is nothing uncommitted to lose, which is the ordinary case — a read,
         or the first statement of a unit of work — and that is where an hour-idle connection is
         reaped in practice.
+
+        **It also refuses while session-scoped state is held.** A Postgres advisory lock belongs to a
+        connection, not to a transaction, so reconnecting silently continues without it. During
+        migrations that would let two instances apply the same files at once — the exact thing the
+        lock exists to prevent, reintroduced by the mechanism meant to make things more reliable.
         """
-        if self._mid_transaction or not self._url:
+        if self._mid_transaction or self._session_state_held or not self._url:
             return False
         import psycopg2
 
@@ -182,7 +211,9 @@ class Store:
     def execute(self, sql: str, params: tuple = ()) -> Any:
         try:
             return self._execute_once(sql, params)
-        except self._dead_connection_errors():
+        except self._dead_connection_errors() as exc:
+            if not self._is_dead(exc):
+                raise
             # A connection idle long enough gets closed by the server, and nothing tells the process.
             # Without this the instance is poisoned for as long as it lives: every request afterwards
             # fails in milliseconds, having attempted no round trip at all.
@@ -291,6 +322,11 @@ class Store:
         locked = self.dialect == "postgres"
         if locked:
             self.execute("SELECT pg_advisory_lock(?)", (_MIGRATION_LOCK_KEY,))
+            # **No reconnect until this is released.** The lock belongs to the connection, not to a
+            # transaction, so a new connection would not hold it — and a reconnect part-way through
+            # would let a second instance apply the same files concurrently, which is the one thing
+            # this lock exists to stop.
+            self._session_state_held = True
         try:
             self.execute(
                 "CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT)"
@@ -316,15 +352,17 @@ class Store:
                 # back FIRST so the unlock can run; suppress cleanup errors here so the REAL migration error
                 # is what propagates (the lock also frees on connection close as a backstop).
                 with contextlib.suppress(Exception):
-                    self.conn.rollback()
+                    self.rollback()
                     self.execute("SELECT pg_advisory_unlock(?)", (_MIGRATION_LOCK_KEY,))
                     self.commit()
+                self._session_state_held = False
             raise
         if locked:
             # Success: release the lock and let an unexpected unlock failure SURFACE — silently holding the
             # lock would hang the next instance on pg_advisory_lock.
             self.execute("SELECT pg_advisory_unlock(?)", (_MIGRATION_LOCK_KEY,))
             self.commit()
+            self._session_state_held = False
         return ran
 
     def _run_script(self, sql: str) -> None:

--- a/tests/test_auto_migrate.py
+++ b/tests/test_auto_migrate.py
@@ -120,6 +120,15 @@ class _Recorder:
     def commit(self) -> None:
         pass
 
+    def rollback(self) -> None:
+        """`run_migrations` rolls back through `Store` rather than reaching into `store.conn`.
+
+        Changed when the reconnect guard landed: `Store.rollback` is what clears the flag saying an
+        uncommitted write is outstanding, and a rollback that bypassed it would leave the connection
+        marked mid-transaction forever, so it could never reconnect again.
+        """
+        self.conn.rollback()
+
     def _run_script(self, sql: str) -> None:
         if self._fail:
             raise RuntimeError("bad migration")

--- a/tests/test_store_reconnect.py
+++ b/tests/test_store_reconnect.py
@@ -1,0 +1,308 @@
+"""A connection the server has closed must be reopened — and never mid-transaction.
+
+**Why this exists.** `Store` opened one Postgres connection and held it for the life of the process.
+A deployment that sits idle for an hour has that connection reaped from the server side, and nothing
+told the process: `execute` called `conn.cursor()` with no liveness check and there was no reconnect
+path anywhere. The instance was then poisoned for as long as it lived, answering every request — not
+only the data-heavy ones — with a 500 in about three milliseconds, having attempted no round trip at
+all. Observed four times in four days on a pilot deployment, one to two hours each.
+
+**The two exceptions are not interchangeable.** `OperationalError` comes out of `cursor.execute` the
+first time a statement meets a closed socket; `InterfaceError` comes out of `conn.cursor()` on every
+call after that, once the driver has marked the connection closed. Handling only the second recovers
+from everything except the failure that begins each outage.
+
+**And the refusal matters as much as the retry.** Callers write two rows that must land together — a
+role change and its audit line. If the connection dies between them the first is already lost, and
+reconnecting silently would let the second commit alone: an audit line for a grant that never
+happened. So the reconnect is allowed between statements and refused inside a transaction.
+
+No database and no driver: `psycopg2` is stubbed, because the engine that fails is the one the suite
+does not run on, and a test that needed a real reaped connection would run nowhere.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from store import Store  # noqa: E402
+
+URL = "postgresql://someone@example.test/db"
+
+
+class _InterfaceError(Exception):
+    """Stands in for `psycopg2.InterfaceError` — the driver refusing a closed connection."""
+
+
+class _OperationalError(Exception):
+    """Stands in for `psycopg2.OperationalError` — the server closing it under a live statement."""
+
+
+class _Cursor:
+    def __init__(self, conn: _Conn) -> None:
+        self._conn = conn
+        self.description = [("ok",)]
+
+    def execute(self, sql, params=None):
+        if self._conn.die_on_execute:
+            self._conn.die_on_execute = False
+            self._conn.closed = True
+            raise _OperationalError("server closed the connection unexpectedly")
+        self._conn.statements.append(sql)
+
+    def fetchall(self):
+        return [(1,)]
+
+
+class _Conn:
+    """A connection that can be told to die once, either way it dies in production."""
+
+    def __init__(self, *, dead: bool = False, die_on_execute: bool = False) -> None:
+        self.closed = dead
+        self.die_on_execute = die_on_execute
+        self.statements: list[str] = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self):
+        if self.closed:
+            raise _InterfaceError("connection already closed")
+        return _Cursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def fake_psycopg2(monkeypatch):
+    """A stub driver, and a record of every reconnect attempted through it."""
+    opened: list[_Conn] = []
+    module = types.ModuleType("psycopg2")
+    module.InterfaceError = _InterfaceError
+    module.OperationalError = _OperationalError
+
+    def connect(url):
+        conn = _Conn()
+        opened.append(conn)
+        return conn
+
+    module.connect = connect
+    monkeypatch.setitem(sys.modules, "psycopg2", module)
+    return opened
+
+
+def _store(conn: _Conn, *, url: str = URL) -> Store:
+    return Store(conn, "postgres", url=url)
+
+
+# --- the connection comes back ------------------------------------------------------------------
+
+
+def test_a_connection_closed_by_the_server_is_reopened_and_the_statement_runs(fake_psycopg2):
+    """`InterfaceError` from `cursor()` — every request after the first failure of an outage."""
+    store = _store(_Conn(dead=True))
+
+    assert store.query("SELECT 1 AS ok") == [{"ok": 1}]
+    assert len(fake_psycopg2) == 1, "the connection was not reopened"
+
+
+def test_a_connection_that_dies_under_a_live_statement_is_reopened(fake_psycopg2):
+    """`OperationalError` from `execute()` — the failure that OPENS each outage. A fix that caught
+    only the other one would leave this unhandled, and this is the one that happens first."""
+    store = _store(_Conn(die_on_execute=True))
+
+    assert store.query("SELECT 1 AS ok") == [{"ok": 1}]
+    assert len(fake_psycopg2) == 1
+
+
+def test_the_statement_reaches_the_new_connection_not_the_dead_one(fake_psycopg2):
+    store = _store(_Conn(dead=True))
+    store.execute("SELECT 'after the reconnect'")
+
+    assert fake_psycopg2[0].statements == ["SELECT 'after the reconnect'"]
+
+
+def test_a_reconnect_is_attempted_once_not_in_a_loop(fake_psycopg2, monkeypatch):
+    """A provider that is genuinely down must surface as an error, not spin."""
+    module = sys.modules["psycopg2"]
+    monkeypatch.setattr(module, "connect", lambda url: _Conn(dead=True))
+    store = _store(_Conn(dead=True))
+
+    with pytest.raises(_InterfaceError):
+        store.execute("SELECT 1")
+
+
+def test_a_connection_that_cannot_be_reopened_raises_the_original_failure(fake_psycopg2, monkeypatch):
+    """The database being unreachable is a real error and must not be disguised as anything else."""
+    module = sys.modules["psycopg2"]
+
+    def refuse(url):
+        raise _OperationalError("could not connect to server")
+
+    monkeypatch.setattr(module, "connect", refuse)
+    store = _store(_Conn(dead=True))
+
+    with pytest.raises(_InterfaceError):
+        store.execute("SELECT 1")
+
+
+# --- and never mid-transaction --------------------------------------------------------------------
+
+
+def test_a_dead_connection_mid_transaction_refuses_rather_than_reconnecting(fake_psycopg2):
+    """**The property this whole guard exists for.**
+
+    Two rows that must land together: a role change and the audit line naming who granted it. The
+    first statement has run and is uncommitted; the connection then dies. Reconnecting here would
+    let the SECOND statement commit alone — an audit line for a grant that never happened, which is
+    exactly what the audit line exists to make impossible. The caller has to see the failure.
+    """
+    conn = _Conn()
+    store = _store(conn)
+    store.execute("UPDATE org_membership SET role = 'admin'")  # first half, uncommitted
+    conn.closed = True  # the server hangs up between the two
+
+    with pytest.raises(_InterfaceError):
+        store.execute("INSERT INTO role_change_audit VALUES ('...')")
+
+    assert fake_psycopg2 == [], "reconnected mid-transaction; the audit line would commit alone"
+
+
+def test_committing_ends_the_transaction_so_the_next_statement_may_reconnect(fake_psycopg2):
+    conn = _Conn()
+    store = _store(conn)
+    store.execute("INSERT INTO t VALUES (1)")
+    store.commit()
+    conn.closed = True
+
+    store.execute("SELECT 1")
+    assert len(fake_psycopg2) == 1
+
+
+def test_rolling_back_ends_it_too(fake_psycopg2):
+    """Otherwise a connection abandoned by a failed transaction could never reconnect again."""
+    conn = _Conn()
+    store = _store(conn)
+    store.execute("INSERT INTO t VALUES (1)")
+    store.rollback()
+    conn.closed = True
+
+    store.execute("SELECT 1")
+    assert len(fake_psycopg2) == 1
+    assert conn.rollbacks == 1
+
+
+def test_a_statement_that_died_does_not_leave_a_transaction_marked_open(fake_psycopg2):
+    """The `OperationalError` path: the statement never ran, so nothing is uncommitted, so the NEXT
+    call must still be free to reconnect. Marking the transaction before the statement succeeded
+    would wedge the store closed after one failure."""
+    store = _store(_Conn(die_on_execute=True))
+    store.execute("SELECT 1")  # dies, reconnects, succeeds
+    fake_psycopg2[0].closed = True
+
+    store.execute("SELECT 2")
+    assert len(fake_psycopg2) == 2
+
+
+# --- everything else is untouched -------------------------------------------------------------
+
+
+def test_sqlite_never_tries_to_reconnect(tmp_path):
+    """SQLite has no reaped-connection problem, and a Store built by hand has no url to reopen from.
+    Both must behave exactly as they did."""
+    store = Store.connect("sqlite://" + str(tmp_path / "plain.db"))
+    try:
+        store.execute("CREATE TABLE t (name TEXT)")
+        store.execute("INSERT INTO t (name) VALUES (?)", ("acme",))
+        store.commit()
+        assert store.query("SELECT name FROM t") == [{"name": "acme"}]
+    finally:
+        store.close()
+
+
+def test_a_store_with_no_url_raises_rather_than_reconnecting(fake_psycopg2):
+    """Nothing to reopen from, so the failure is the answer."""
+    store = _store(_Conn(dead=True), url="")
+
+    with pytest.raises(_InterfaceError):
+        store.execute("SELECT 1")
+    assert fake_psycopg2 == []
+
+
+# --- the case the fix exists for, which the first version of it did not handle -------------------
+
+
+def test_a_run_of_reads_that_never_commits_can_still_reconnect(fake_psycopg2):
+    """**This is the failing production path, and it nearly went unfixed.**
+
+    The piece that resolves a caller's org reads five tables in a row and never commits — there is
+    nothing to commit. An earlier version of this guard marked the transaction on *any* statement,
+    which meant that caller reconnected once and was then refused for the life of the process. The
+    fix would have shipped, looked right, and left the outage exactly where it was.
+
+    A read leaves nothing uncommitted, so it must not close the door behind it.
+    """
+    conn = _Conn()
+    store = _store(conn)
+    for table in ("org_membership", "organization", "super_admin", "org_role", "org_default"):
+        store.query(f"SELECT * FROM {table}")  # no commit, ever
+    conn.closed = True  # an hour later, the server hangs up
+
+    assert store.query("SELECT * FROM org_membership") == [{"ok": 1}]
+    assert len(fake_psycopg2) == 1, "a read-only caller could not reconnect"
+
+
+def test_an_uncommitted_write_still_closes_the_door(fake_psycopg2):
+    """The other half. Reads staying open must not weaken the guard for writes."""
+    conn = _Conn()
+    store = _store(conn)
+    store.query("SELECT * FROM org_membership")  # harmless
+    store.execute("UPDATE org_membership SET role = 'admin'")  # not harmless
+    conn.closed = True
+
+    with pytest.raises(_InterfaceError):
+        store.execute("INSERT INTO role_change_audit VALUES ('...')")
+    assert fake_psycopg2 == []
+
+
+@pytest.mark.parametrize(
+    "sql, is_read",
+    [
+        ("SELECT 1", True),
+        ("  select 1", True),
+        ("\n  SELECT\n  *\n  FROM t", True),
+        ("INSERT INTO t VALUES (1)", False),
+        ("UPDATE t SET a = 1", False),
+        ("DELETE FROM t", False),
+        ("CREATE TABLE t (a TEXT)", False),
+        # A CTE is usually a read and Postgres lets it write, so it is treated as a write. Being
+        # wrong in this direction costs a refused reconnect; the other direction costs a lost row.
+        ("WITH x AS (SELECT 1) SELECT * FROM x", False),
+        ("WITH x AS (INSERT INTO t VALUES (1) RETURNING *) SELECT * FROM x", False),
+        # A word boundary, not a prefix: an identifier that merely starts with those six letters
+        # is not a query, and reading it as one is the direction that loses data.
+        ("SELECTED", False),
+        ("SELECT_ALL()", False),
+        ("SELECT*FROM t", True),
+        ("SELECT(1)", True),
+    ],
+)
+def test_which_statements_count_as_reads(sql, is_read):
+    from store import _is_read
+
+    assert _is_read(sql) is is_read

--- a/tests/test_store_reconnect.py
+++ b/tests/test_store_reconnect.py
@@ -53,6 +53,8 @@ class _Cursor:
         self.description = [("ok",)]
 
     def execute(self, sql, params=None):
+        if self._conn.raise_on_execute is not None:
+            raise self._conn.raise_on_execute
         if self._conn.die_on_execute:
             self._conn.die_on_execute = False
             self._conn.closed = True
@@ -69,6 +71,8 @@ class _Conn:
     def __init__(self, *, dead: bool = False, die_on_execute: bool = False) -> None:
         self.closed = dead
         self.die_on_execute = die_on_execute
+        # A failure that leaves the connection HEALTHY — a timeout, a cancelled query.
+        self.raise_on_execute: Exception | None = None
         self.statements: list[str] = []
         self.commits = 0
         self.rollbacks = 0
@@ -147,7 +151,9 @@ def test_a_reconnect_is_attempted_once_not_in_a_loop(fake_psycopg2, monkeypatch)
         store.execute("SELECT 1")
 
 
-def test_a_connection_that_cannot_be_reopened_raises_the_original_failure(fake_psycopg2, monkeypatch):
+def test_a_connection_that_cannot_be_reopened_raises_the_original_failure(
+    fake_psycopg2, monkeypatch
+):
     """The database being unreachable is a real error and must not be disguised as anything else."""
     module = sys.modules["psycopg2"]
 
@@ -306,3 +312,55 @@ def test_which_statements_count_as_reads(sql, is_read):
     from store import _is_read
 
     assert _is_read(sql) is is_read
+
+
+# --- what Copilot found: three ways the retry was too eager -------------------------------------
+
+
+def test_an_operational_error_on_a_LIVE_connection_is_not_retried(fake_psycopg2):
+    """**`OperationalError` is a broad base class.** A cancelled query, a statement timeout and a
+    full disk all raise it on a connection that is perfectly healthy. Retrying blindly re-runs the
+    statement — and for the first write of a transaction, where the guard correctly allows a
+    reconnect, that lands the row twice. Only the driver's own `closed` flag decides.
+    """
+    conn = _Conn()
+    conn.raise_on_execute = _OperationalError("canceling statement due to statement timeout")
+
+    store = _store(conn)
+    with pytest.raises(_OperationalError, match="statement timeout"):
+        store.execute("INSERT INTO t VALUES (1)")
+
+    assert fake_psycopg2 == [], "reconnected on a healthy connection; the insert would run twice"
+
+
+def test_an_operational_error_that_did_close_the_connection_is_retried(fake_psycopg2):
+    """The other side of the same test: a real reap must still recover."""
+    store = _store(_Conn(die_on_execute=True))
+    assert store.query("SELECT 1 AS ok") == [{"ok": 1}]
+    assert len(fake_psycopg2) == 1
+
+
+def test_no_reconnect_while_the_migration_lock_is_held(fake_psycopg2):
+    """The advisory lock belongs to the connection, not to a transaction. Reconnecting part-way
+    through a migration would continue **without** it, letting a second instance apply the same
+    files at once — the exact thing the lock exists to prevent, reintroduced by the mechanism meant
+    to make things more reliable."""
+    conn = _Conn()
+    store = _store(conn)
+    store._session_state_held = True
+    conn.closed = True
+
+    with pytest.raises(_InterfaceError):
+        store.execute("SELECT 1")
+    assert fake_psycopg2 == []
+
+
+def test_releasing_the_lock_allows_reconnecting_again(fake_psycopg2):
+    conn = _Conn()
+    store = _store(conn)
+    store._session_state_held = True
+    store._session_state_held = False
+    conn.closed = True
+
+    store.execute("SELECT 1")
+    assert len(fake_psycopg2) == 1


### PR DESCRIPTION
## Summary

A deployment idle for about an hour has its Postgres connection reaped from the server side, and nothing tells the process. `Store` opened one connection at startup and held it for the life of the process; `execute` called `conn.cursor()` with no liveness check, and there was no reconnect path anywhere in the package.

The instance was then poisoned for as long as it lived — **every** request, not only the data-heavy ones, answered in ~3ms having attempted no round trip at all. The three milliseconds are the tell.

Observed on a downstream deployment **four times in four days**, one to two hours each, across two revisions. Thirty days of that service's error logs contain 123 application tracebacks and every one is this.

## What changed

`Store` keeps the URL it connected with (`connect` discarded it), and `execute` retries once on a dead connection.

**Both driver exceptions are handled, and they are not interchangeable.** `OperationalError` comes out of `cursor.execute` the first time a statement meets a closed socket; `InterfaceError` comes out of `conn.cursor()` on every call after that. A fix catching only the second recovers from everything except the failure that *begins* each outage — and the logs show every outage opening with the first.

**The retry refuses mid-transaction.** Callers write two rows that must land together — a role change and the audit line naming who granted it. If the connection dies between them the first is already lost, and reconnecting silently would let the second commit alone: an audit line for a grant that never happened, which is precisely what that line exists to make impossible.

`rollback()` moves onto `Store` rather than being reached past it via `store.conn`, because a connection left marked mid-transaction would never reconnect again.

## The part worth reviewing

**A read does not count as an open transaction, and that distinction is the difference between fixing this and appearing to.**

My first draft marked the transaction on any statement. The path this change exists for reads five tables in a row and never commits — there is nothing to commit — so it would have reconnected once and then been refused for the life of the process. It would have shipped, looked right, and left the outage exactly where it was. My own test caught it.

`_is_read` is deliberately one keyword and should stay that way — this is not a SQL parser and a second one would be a second thing to keep correct. `WITH` counts as a **write**, because Postgres allows a data-modifying statement inside a CTE and being wrong there is silent. The match requires a word boundary, so an identifier merely beginning with those six letters is not read as a query.

## Tests

26 tests, no database and no driver — `psycopg2` is stubbed, because the engine that fails is the one the suite does not run on, and a test needing a real reaped connection would run nowhere.

Both guards mutation-tested: removing the read/write distinction fails two tests, removing the mid-transaction refusal fails two others.

- `uv run dev.py check` — 4670 passed, ruff and gitleaks clean
- `uv run dev.py cover` — **100%** patch coverage

## Out of scope

Connection pooling, and keepalive parameters on the DSN. Both are reasonable next steps; neither is needed to end this class of failure, and the retry is the smallest change that does.