### PR TITLE
Let an existing password account move onto an identity provider

### DIFF
--- a/packages/agami-core/src/mcp_http.py
+++ b/packages/agami-core/src/mcp_http.py
@@ -487,6 +487,30 @@ def build_server(
     return server
 
 
+
+def _is_loopback(base: str) -> bool:
+    """Whether this is a local address, where plain http is safe and is the only thing that works.
+
+    **Not a relaxation of the TLS rule — the reason for that rule does not apply here.** It exists
+    because a browser drops a `Secure` cookie sent over http, which would silently break the admin
+    session. Browsers make a specific exception for loopback: `http://localhost` is a *secure
+    context* by the W3C definition, so `Secure` cookies are kept and everything the rule protects
+    still holds.
+
+    It is also the only thing that works. Identity providers permit a plain-http redirect **only**
+    on loopback, for exactly the same reason, so a developer signing in against a real provider from
+    their own machine has no https option to choose instead.
+
+    The host is parsed rather than matched as a prefix: `http://localhost.example.com` is somebody
+    else's domain, and `startswith("http://localhost")` would have said yes to it.
+    """
+    from urllib.parse import urlsplit
+
+    if not base.startswith("http://"):
+        return False
+    return urlsplit(base).hostname in ("localhost", "127.0.0.1", "::1")
+
+
 def create_app(
     extra_tools: dict | None = None,
     adapters: Adapters | None = None,
@@ -514,9 +538,10 @@ def create_app(
     # plain-http PUBLIC_BASE_URL would silently break the admin login (the browser drops a Secure
     # cookie), so fail fast with a clear message instead. (Set this to the public https URL even when
     # TLS terminates at a proxy — the browser↔proxy hop is what must be https.)
-    if not base.startswith("https://"):
+    if not base.startswith("https://") and not _is_loopback(base):
         raise RuntimeError(
-            "PUBLIC_BASE_URL must be https:// (OAuth + the Secure admin cookie need TLS)."
+            "PUBLIC_BASE_URL must be https:// (OAuth + the Secure admin cookie need TLS). "
+            "http://localhost is the one exception, for local development."
         )
     bootstrap_paths()
     adapters = adapters or default_adapters()

--- a/packages/agami-core/src/oauth_server.py
+++ b/packages/agami-core/src/oauth_server.py
@@ -285,12 +285,16 @@ def login_body_html(
     carried = {k: params.get(k, "") for k in _OAUTH_CONTEXT_KEYS}
     alert = f'<div class="alert error">{ui.esc(error)}</div>' if error else ""
     client = _client_label(params.get("redirect_uri", ""))
-    # Consent banner mirrors the web app: a quiet "Allow <client> to access your data". When the
+    # Consent banner mirrors the web app: a quiet "Allow <client> to connect to your data". When the
     # client isn't a recognised AI assistant we just show the logo (no banner) — no filler text.
+    #
+    # "connect to" rather than "access": what is being granted is a connection the person can see and
+    # remove, not a handover of the data itself. On a screen somebody reads in two seconds before
+    # deciding, the difference between those two readings is the whole decision.
     consent = (
         f'<div class="consent"><p class="small">Allow</p>'
         f'<p class="who">{ui.esc(client)}</p>'
-        f'<p class="small">to access your data</p></div>'
+        f'<p class="small">to connect to your data</p></div>'
         if client
         else ""
     )

--- a/packages/agami-core/src/user_store.py
+++ b/packages/agami-core/src/user_store.py
@@ -121,6 +121,66 @@ def claim_pending_oidc(store: Store, username: str, provider: str, subject: str)
     return cur.rowcount
 
 
+def migrate_password_user_to_oidc(store: Store, username: str, provider: str, subject: str) -> int:
+    """Move an existing PASSWORD account onto an identity provider, and take the password away.
+
+    **This is a migration, not a login.** `claim_pending_oidc` above adopts an account nobody has used
+    yet; this one takes over an account somebody has been signing into with a password for weeks, and
+    keeps everything attached to it — the row, the username, and therefore every conversation,
+    membership and audit line keyed on that address. Nothing is recreated, so nothing is orphaned.
+
+    **The password is cleared, and that is the point rather than tidiness.** Left in place, the
+    identity provider would not actually be in charge: revoke somebody in the directory and they
+    could still sign in with the password they chose months ago, with nothing to show for it. A
+    deployment that moves to single sign-on is saying the directory decides, and a surviving password
+    is a way around that decision.
+
+    **Guarded so it can never take an account belonging to another provider.** The WHERE matches only
+    an account bound to nobody or already bound to THIS provider, so a second identity provider
+    cannot claim a person by presenting the same address. As with `claim_pending_oidc` the caller must
+    re-read and confirm the binding is theirs rather than trusting the row count alone — a concurrent
+    claim is the case that makes the difference.
+
+    Deciding *whether* a deployment should adopt accounts this way is the caller's, not this
+    function's: it is safe only where the caller has already verified the token against a pinned
+    tenant and checked the address against that company's own domains. Returns the row count
+    (0 ⇒ nothing was adopted).
+    """
+    cur = store.execute(
+        "UPDATE users SET oidc_provider = ?, oidc_subject = ?, password_hash = NULL "
+        "WHERE username = ? AND (oidc_provider IS NULL OR oidc_provider = ?)",
+        (provider, subject, username, provider),
+    )
+    store.commit()
+    return cur.rowcount
+
+
+def set_user_names(store: Store, username: str, first_name: str, last_name: str) -> int:
+    """Fill in a person's display name from whatever their identity provider now says.
+
+    **A blank never erases what is there.** An identity provider that simply does not send a name is
+    silent, not authoritative — treating silence as an instruction to delete would wipe a name an
+    administrator typed in, on the next sign-in, with nothing to point at. So each half is written
+    only when a value arrives for it.
+
+    Returns the row count; 0 means nothing was supplied, or the account does not exist.
+    """
+    first_name, last_name = (first_name or "").strip(), (last_name or "").strip()
+    sets, params = [], []
+    if first_name:
+        sets.append("first_name = ?")
+        params.append(first_name)
+    if last_name:
+        sets.append("last_name = ?")
+        params.append(last_name)
+    if not sets:
+        return 0
+    params.append(username)
+    cur = store.execute(f"UPDATE users SET {', '.join(sets)} WHERE username = ?", tuple(params))  # noqa: S608
+    store.commit()
+    return cur.rowcount
+
+
 def claim_pending_password(store: Store, username: str, password: str) -> int:
     """A **pending** user sets their own password (a password deployment, via the admin setup link).
     Guarded so it fires ONLY while still pending — if an OIDC provider already bound (or a password was

--- a/tests/test_user_store_oidc_migration.py
+++ b/tests/test_user_store_oidc_migration.py
@@ -1,0 +1,224 @@
+"""Moving people who already have password accounts onto an identity provider.
+
+**The situation this exists for.** A deployment has been running on usernames and passwords; people
+have accounts, conversations, roles and an audit trail. It now moves to single sign-on. Those people
+must keep everything they have, and `claim_pending_oidc` cannot help — it fires only on an account
+nobody has used yet, so every existing person would be refused at sign-in.
+
+Two properties carry the weight here:
+
+  * **the row survives**, so everything keyed on that address survives with it; and
+  * **the password does not**, because a deployment that says the directory decides cannot leave a
+    way around the directory.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+
+from store import MIGRATIONS_DIR, Store  # noqa: E402
+from user_store import (  # noqa: E402
+    authenticate,
+    create_user,
+    get_user,
+    migrate_password_user_to_oidc,
+    set_user_names,
+)
+
+ADDRESS = "someone@example.com"
+THEIR_PASSWORD = "the-password-they-chose-in-july"
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = Store.connect("sqlite://" + str(tmp_path / "users.db"))
+    s.run_migrations(MIGRATIONS_DIR)
+    yield s
+    s.close()
+
+
+def _a_person_who_has_been_using_passwords(store, address: str = ADDRESS) -> None:
+    create_user(store, username=address, password=THEIR_PASSWORD, email=address, status="active")
+    store.commit()
+
+
+# --- the migration ------------------------------------------------------------------------------
+
+
+def test_an_existing_password_account_is_adopted_rather_than_refused(store):
+    _a_person_who_has_been_using_passwords(store)
+
+    assert migrate_password_user_to_oidc(store, ADDRESS, "microsoft", "subject-1") == 1
+
+    row = get_user(store, ADDRESS)
+    assert row["oidc_provider"] == "microsoft"
+    assert row["oidc_subject"] == "subject-1"
+
+
+def test_it_is_the_same_row_so_everything_keyed_on_it_survives(store):
+    """The whole reason for adopting rather than creating: conversations, memberships and audit lines
+    are keyed on the address, and a new account would orphan every one of them."""
+    _a_person_who_has_been_using_passwords(store)
+    before = get_user(store, ADDRESS)
+
+    migrate_password_user_to_oidc(store, ADDRESS, "microsoft", "subject-1")
+
+    after = get_user(store, ADDRESS)
+    assert after["id"] == before["id"]
+    assert after["username"] == before["username"]
+    assert after["created"] == before["created"]
+    assert len(store.query("SELECT * FROM users")) == 1
+
+
+def test_the_password_no_longer_works(store):
+    """**The point, not tidiness.** Left in place, revoking somebody in the directory would not stop
+    them signing in with the password they chose months ago, and nothing would show it."""
+    _a_person_who_has_been_using_passwords(store)
+    assert authenticate(store, ADDRESS, THEIR_PASSWORD) is not None  # it works beforehand
+
+    migrate_password_user_to_oidc(store, ADDRESS, "microsoft", "subject-1")
+
+    assert get_user(store, ADDRESS)["password_hash"] is None
+    assert authenticate(store, ADDRESS, THEIR_PASSWORD) is None
+
+
+def test_adopting_twice_is_harmless(store):
+    """Every sign-in runs this. It must be the same on the second one as on the first."""
+    _a_person_who_has_been_using_passwords(store)
+    migrate_password_user_to_oidc(store, ADDRESS, "microsoft", "subject-1")
+    assert migrate_password_user_to_oidc(store, ADDRESS, "microsoft", "subject-1") == 1
+    assert get_user(store, ADDRESS)["oidc_subject"] == "subject-1"
+
+
+# --- and what it must never do -------------------------------------------------------------------
+
+
+def test_an_account_bound_to_another_provider_is_not_taken(store):
+    """The guard. Without it, a second identity provider could claim somebody by presenting the same
+    address — which is the confusion `_resolve_oidc_user`'s provider binding exists to close."""
+    create_user(
+        store,
+        username=ADDRESS,
+        password=None,
+        email=ADDRESS,
+        status="active",
+        oidc_provider="google",
+        oidc_subject="google-subject",
+    )
+    store.commit()
+
+    assert migrate_password_user_to_oidc(store, ADDRESS, "microsoft", "subject-1") == 0
+
+    row = get_user(store, ADDRESS)
+    assert row["oidc_provider"] == "google"
+    assert row["oidc_subject"] == "google-subject"
+
+
+def test_an_account_that_does_not_exist_is_not_created(store):
+    assert migrate_password_user_to_oidc(store, "nobody@example.com", "microsoft", "s") == 0
+    assert store.query("SELECT * FROM users") == []
+
+
+def test_one_persons_migration_does_not_touch_another(store):
+    _a_person_who_has_been_using_passwords(store)
+    _a_person_who_has_been_using_passwords(store, "other@example.com")
+
+    migrate_password_user_to_oidc(store, ADDRESS, "microsoft", "subject-1")
+
+    other = get_user(store, "other@example.com")
+    assert other["oidc_provider"] is None
+    assert other["password_hash"] is not None
+
+
+# --- filling in the name --------------------------------------------------------------------------
+
+
+def test_a_name_is_filled_in_from_the_provider(store):
+    _a_person_who_has_been_using_passwords(store)
+    assert get_user(store, ADDRESS)["first_name"] is None
+
+    set_user_names(store, ADDRESS, "Ada", "Lovelace")
+
+    row = get_user(store, ADDRESS)
+    assert (row["first_name"], row["last_name"]) == ("Ada", "Lovelace")
+
+
+def test_a_provider_that_sends_nothing_does_not_erase_a_name(store):
+    """**Silence is not an instruction to delete.** A provider that simply omits a name would
+    otherwise wipe one an administrator typed in, on the next sign-in, with nothing to point at."""
+    _a_person_who_has_been_using_passwords(store)
+    set_user_names(store, ADDRESS, "Ada", "Lovelace")
+
+    assert set_user_names(store, ADDRESS, "", "") == 0
+
+    row = get_user(store, ADDRESS)
+    assert (row["first_name"], row["last_name"]) == ("Ada", "Lovelace")
+
+
+def test_half_a_name_updates_only_that_half(store):
+    _a_person_who_has_been_using_passwords(store)
+    set_user_names(store, ADDRESS, "Ada", "Lovelace")
+
+    set_user_names(store, ADDRESS, "Augusta", "")
+
+    row = get_user(store, ADDRESS)
+    assert (row["first_name"], row["last_name"]) == ("Augusta", "Lovelace")
+
+
+def test_a_corrected_name_replaces_the_old_one(store):
+    """The directory is authoritative when it speaks — that is what makes a name change there reach
+    the product without anybody retyping it."""
+    _a_person_who_has_been_using_passwords(store)
+    set_user_names(store, ADDRESS, "Ada", "Byron")
+
+    set_user_names(store, ADDRESS, "Ada", "Lovelace")
+
+    assert get_user(store, ADDRESS)["last_name"] == "Lovelace"
+
+
+def test_whitespace_is_not_a_name(store):
+    _a_person_who_has_been_using_passwords(store)
+    assert set_user_names(store, ADDRESS, "   ", "\t") == 0
+    assert get_user(store, ADDRESS)["first_name"] is None
+
+
+# --- and the one thing that made testing any of this locally impossible --------------------------
+
+
+@pytest.mark.parametrize(
+    "base, allowed",
+    [
+        ("https://agami.example.com", True),
+        ("https://localhost:5173", True),
+        # Loopback over plain http: a secure context by the browser's own definition, so a `Secure`
+        # cookie survives — and the only redirect an identity provider will accept from a laptop.
+        ("http://localhost:5173", True),
+        ("http://127.0.0.1:8080", True),
+        ("http://[::1]:8080", True),
+        # Everything else stays refused. The third of these is the one a prefix match would have let
+        # through: it is somebody else's domain that merely begins with the right letters.
+        ("http://agami.example.com", False),
+        ("http://192.168.1.10:8080", False),
+        ("http://localhost.example.com", False),
+        ("http://notlocalhost", False),
+    ],
+)
+def test_which_base_urls_may_be_plain_http(base, allowed):
+    """TLS is required because a browser drops a `Secure` cookie over http, which would break the
+    admin session silently. Loopback is exempt because the browser makes the same exception — not
+    because the rule is being relaxed."""
+    from mcp_http import _is_loopback
+
+    assert (base.startswith("https://") or _is_loopback(base)) is allowed
+    # ...and asked directly, because the `or` above short-circuits on every https case and would
+    # leave the answer for those untested. An https address is not loopback-over-http, whatever its
+    # host: `https://localhost` is allowed by the line above, not by this function.
+    assert _is_loopback(base) is (base.startswith("http://") and allowed)


### PR DESCRIPTION
## The problem, verified rather than reasoned about

A deployment running on usernames and passwords cannot switch to single sign-on. `_resolve_oidc_user` refuses an account not already bound to the provider, so an existing person resolves to `None`:

```
before: someone@example.com, no provider, has_password: True
SSO sign-in resolves to: None
=> REFUSED
```

**On the day it is switched on, everybody already using the product is locked out**, with their conversations orphaned behind an account nobody can reach.

## `migrate_password_user_to_oidc`

The row survives — same id, same address — so memberships, roles, conversations and the audit trail all follow.

**The password is cleared.** Left in place, the directory would not actually be in charge: revoke somebody there and they could still sign in with a password chosen months ago, with nothing to show for it.

**Guarded so it can never take an account bound to a different provider.** The identity-confusion guard has to survive the migration that relaxes the password case.

**Deciding *whether* to adopt is not this function's job**, and the docstring says so. It is safe only where the caller has already verified the token against a pinned tenant and checked the address against that company's domains. Core has neither of those facts; its consumer does.

## `set_user_names`

Fills in a display name from the provider. **A blank never erases what is there** — a provider that omits a name is silent, not authoritative, and treating silence as deletion would wipe a name an administrator typed in, on the next sign-in, with nothing to point at.

## Two smaller things, both from putting the flow in front of somebody

**`http://localhost` is allowed for `PUBLIC_BASE_URL`.** TLS is required because a browser drops a `Secure` cookie over http — and browsers make a specific exception for loopback, a secure context by their own definition, so nothing that rule protects is lost. It is also the only thing that *works*: identity providers permit a plain-http redirect only on loopback, so a developer signing in against a real provider from their machine has no https option to choose. The host is parsed rather than prefix-matched, because `http://localhost.example.com` is somebody else's domain.

**"Allow Claude to _connect to_ your data"**, not "access". What is granted is a connection the person can see and remove, not a handover of the data itself.

## Verification

- `uv run dev.py check` — full suite green
- `uv run dev.py cover` — **100%** patch coverage, including one line only reachable by calling the loopback check directly, since every https case short-circuits before it
- Proven end to end against a real tenant: an account with three conversation turns kept its id, lost its password, gained its provider and its name

## Consumer

`AgamiAI/agami#82` imports both functions and is blocked on this releasing as 0.6.9.