### PR TITLE
release: 0.6.9 — an existing password account can move onto an identity provider

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.6.8",
+    "version": "0.6.9",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ below corresponds to one such version.
   own machine had no https option to choose and could not run the server at all. The host is parsed
   rather than prefix-matched, because `http://localhost.example.com` is somebody else's domain.
 
-- The sign-in consent line now reads **"Allow <client> to connect to your data"** rather than "to
+- The sign-in consent line now reads **"Allow `<client>` to connect to your data"** rather than "to
   access your data". What is granted is a connection the person can see and remove, not a handover
   of the data itself, and on a screen read in two seconds before deciding that is the whole
   decision.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,48 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.6.9] — 2026-08-27
+
+### Added
+
+- **An existing password account can move onto an identity provider, keeping everything attached to
+  it.** A deployment running on usernames and passwords could not switch to single sign-on:
+  `_resolve_oidc_user` refuses an account not already bound to the provider, so on the day it was
+  turned on every person already using the product would be locked out, with their conversations
+  orphaned behind an account nobody could reach. Verified against a real account rather than
+  reasoned about — it came back `None`.
+
+  `migrate_password_user_to_oidc` keeps the row, so the id, the address and everything keyed on it
+  survive. **The password is cleared**, because left in place the directory would not actually be in
+  charge: revoking somebody there would not stop them signing in with a password they chose months
+  ago, and nothing would show it. Guarded so it can never take an account already bound to a
+  different provider — the identity-confusion guard has to survive the migration that relaxes the
+  password case.
+
+  Deciding *whether* to adopt is deliberately not this function's job. It is safe only where the
+  caller has already verified the token against a pinned tenant and checked the address against that
+  company's own domains; core has neither of those facts, and its consumer does.
+
+- **`set_user_names`** fills in a display name from whatever the provider now says, so a name
+  corrected in a directory reaches the product without anybody retyping it. A blank never erases
+  what is there: a provider that omits a name is silent rather than authoritative, and treating
+  silence as an instruction to delete would wipe a name an administrator typed in.
+
+### Changed
+
+- **`http://localhost` is accepted for `PUBLIC_BASE_URL`.** TLS is still required everywhere else,
+  for the reason it always was — a browser drops a `Secure` cookie over http. Browsers make a
+  specific exception for loopback, which is a secure context by their own definition, so nothing
+  that rule protects is lost. It is also the only thing that works: identity providers permit a
+  plain-http redirect only on loopback, so a developer signing in against a real provider from their
+  own machine had no https option to choose and could not run the server at all. The host is parsed
+  rather than prefix-matched, because `http://localhost.example.com` is somebody else's domain.
+
+- The sign-in consent line now reads **"Allow <client> to connect to your data"** rather than "to
+  access your data". What is granted is a connection the person can see and remove, not a handover
+  of the data itself, and on a screen read in two seconds before deciding that is the whole
+  decision.
+
 ## [0.6.8] — 2026-08-27
 
 ### Fixed

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.6.8"
+version = "0.6.9"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts #246 for release. `AgamiAI/agami#82` is blocked on it.

**Why a release so soon after 0.6.8:** that one was the database reconnect fix, cut this morning before any of this existed. The migration problem surfaced an hour later, when we checked whether people already using the product keep their accounts and history when single sign-on is switched on. They did not — every one of them would have been locked out.

## What's in it

- `migrate_password_user_to_oidc` — adopts an existing password account, keeping the row and clearing the password
- `set_user_names` — fills in a display name, never erasing one on a provider's silence
- `http://localhost` accepted for `PUBLIC_BASE_URL`, loopback only, host parsed not prefix-matched
- "Allow <client> to **connect to** your data"

Version bumped in all four places. Merging does not publish — the PyPI workflow fires on a published release whose tag matches.