### PR TITLE
Golden dataset authoring: import a question bank, save a verified answer

### DIFF
--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -17,13 +17,20 @@ through as `sql`, but nobody ran it, so an imported row is unverified by constru
 confirmed-only rule is what makes a green golden run mean something, and a spreadsheet column is
 not a person who looked at a result.
 
+**Every write goes through one funnel.** `_write_items` is it: both doors call it and AH-111's
+promotion will too, so the append-only rule — a change to an item that already exists renders the
+before and the after and stops for an explicit yes — is a property of the software rather than a
+rule each caller has to remember.
+
 Usage:
 
-    python3 golden_author.py parse --csv /path/to/question-bank.csv
+    python3 golden_author.py parse  --csv /path/to/question-bank.csv
+    python3 golden_author.py import --profile main --dataset orders --rows /path/to/parsed.json
 
 Stdout is always one JSON document; every refusal and every warning goes to stderr with the prefix
-below, so a caller can parse the one and strip the other. Stdlib only, plus `reconcile.parse_value`
-for the expected-value column.
+below, so a caller can parse the one and strip the other. The parse door is stdlib only, plus
+`reconcile.parse_value` for the expected-value column; the write doors go through AH-100's models,
+which is what the guarded import below is for.
 """
 
 from __future__ import annotations
@@ -40,7 +47,38 @@ from typing import Any, Optional
 # plugin ships in — the marketplace cache invokes these scripts by absolute path, where the
 # interpreter's own `sys.path[0]` is not something to rely on.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import reconcile  # noqa: E402
+
+# Three layouts reach this script and only one of them has `packages/` on disk: a dev checkout keeps
+# the source beside the plugin, a marketplace install ships `<version>/lib` and no checkout at all,
+# and a pip install has the library importable already. `_agami_lib` is the one helper that knows
+# all three, and every other runtime script in this directory calls it.
+import _agami_lib  # noqa: E402
+
+_agami_lib.ensure_importable()
+
+# A sibling script and stdlib-only, so it is imported plainly: it has none of the dependencies the
+# guard below exists for.
+import reconcile
+
+try:
+    import agami_paths
+    import yaml
+    from semantic_model.golden import (
+        GoldenDataset,
+        GoldenExpected,
+        GoldenItem,
+        load_golden_datasets,
+    )
+    from semantic_model.validator import ValidationResult
+except ImportError as exc:
+    # A fresh plugin install genuinely lacks these, and the traceback a bare ImportError prints
+    # names an internal module rather than the thing to install.
+    print(
+        "golden_author's write doors need agami-core and its model extra (pydantic, pyyaml): "
+        f"install `agami-core[model]` into this interpreter. ({exc})",
+        file=sys.stderr,
+    )
+    raise SystemExit(2) from exc
 
 # Marks the lines a caller is meant to strip — the refusals and the warnings, this helper talking
 # about itself.
@@ -244,6 +282,222 @@ def _parse(path: str) -> Optional[dict[str, Any]]:
     return payload
 
 
+# ---------------------------------------------------------------------------
+# The write core — one funnel, and the append-only rule lives in it
+# ---------------------------------------------------------------------------
+
+
+def _datasets_dir(profile: str) -> Path:
+    """Where a profile's datasets live.
+
+    The same path `run_golden_eval.py` names. A door that wrote somewhere the runner does not read
+    would produce a dataset nobody ever runs, and two spellings of this path would be two answers to
+    "where does one go".
+    """
+    return agami_paths.profile_dir(profile) / "golden_datasets"
+
+
+def _drop_empty(doc: dict[str, Any], *keys: str) -> None:
+    """Remove the named keys when they hold an empty list.
+
+    `exclude_none` does not drop `[]`, so a model dumped straight out writes `tags: []`,
+    `must_filter: []` and `tables_used: []` into every item — noise in a file a person reads and
+    diffs, and a shape nobody would ever author by hand.
+    """
+    for key in keys:
+        if doc.get(key) == []:
+            del doc[key]
+
+
+def _item_doc(item: GoldenItem) -> dict[str, Any]:
+    """One case as it goes on disk, and as the confirmation prompt shows it."""
+    doc = item.model_dump(mode="json", exclude_none=True)
+    _drop_empty(doc, "tags", "must_filter")
+    _drop_empty(doc["expected"], "tables_used")
+    if "recorded" in doc:
+        _drop_empty(doc["recorded"], "columns", "rows")
+    return doc
+
+
+def _dataset_doc(dataset: GoldenDataset) -> dict[str, Any]:
+    """A whole dataset file as it goes on disk.
+
+    `name` is excluded, and that is the one exclusion that is not cosmetic: the reader injects the
+    name from the filename and REFUSES a file that declares one, so dumping the model whole would
+    write a file this helper could never read back.
+    """
+    doc = dataset.model_dump(mode="json", exclude_none=True, exclude={"name", "test_cases"})
+    doc["test_cases"] = [_item_doc(item) for item in dataset.test_cases]
+    return doc
+
+
+def _our_faults(res: ValidationResult, stem: str) -> list[str]:
+    """The error findings this write is answerable for.
+
+    The reader validates the whole profile, so a neighbouring dataset that was already broken lands
+    in the same result. Rolling our write back because of it would restore a correct file and blame
+    a locator the person never touched, so only findings against this stem count.
+    """
+    prefix = f"{stem}.yaml"
+    return [
+        finding.message
+        for finding in res.findings
+        if finding.severity == "error" and (finding.locator or "").startswith(prefix)
+    ]
+
+
+def _rollback(path: Path, snapshot: Optional[bytes], created_dir: bool) -> None:
+    """Put the tree back exactly as it was before this write.
+
+    The original bytes rather than a re-dump of the parsed model: a file the person hand-wrote has
+    to come back with their formatting, on the path where nothing was supposed to change at all. A
+    file that is new goes away entirely, along with the directory if this write is what made it —
+    a half-created `golden_datasets/` holding a file the reader refuses is worse than no dataset,
+    because the next run reads it and reports a fault nobody meant to create.
+    """
+    if snapshot is not None:
+        path.write_bytes(snapshot)
+        return
+    path.unlink()
+    if created_dir and not any(path.parent.iterdir()):
+        path.parent.rmdir()
+
+
+def _write_items(
+    profile: str,
+    stem: str,
+    items: list[GoldenItem],
+    *,
+    confirm_replace: bool,
+    description: Optional[str] = None,
+) -> int:
+    """Merge `items` into a profile's dataset, print what happened, and return the exit code.
+
+    THE write path. Both doors call it and AH-111 will too, so the append-only rule is enforced
+    once rather than remembered by each caller. The order of the steps is the contract: nothing is
+    written until the person has agreed to every replacement, and nothing survives a re-read the
+    runner's own reader would refuse.
+    """
+    path = _datasets_dir(profile) / f"{stem}.yaml"
+    snapshot = path.read_bytes() if path.exists() else None
+    existing: list[GoldenItem] = []
+    fields: dict[str, Any] = {}
+
+    if snapshot is not None:
+        datasets, res = load_golden_datasets(profile)
+        prior = _our_faults(res, stem)
+        if prior:
+            # Merging into a file the reader cannot fully read would silently drop whatever it
+            # could not parse — this write deleting somebody's case to make room for its own.
+            _stop(
+                f"{stem}.yaml cannot be read as it stands, so nothing may be merged into it: "
+                f"{prior[0]}"
+            )
+            return _CANNOT_START
+        found = next(dataset for dataset in datasets if dataset.name == stem)
+        existing = list(found.test_cases)
+        fields = found.model_dump(exclude={"name", "test_cases"}, exclude_none=True)
+
+    by_id = {item.id: item for item in existing}
+    added = [item for item in items if item.id not in by_id]
+    replaced = [item for item in items if item.id in by_id]
+
+    if replaced and not confirm_replace:
+        # The before AND the after, because "this id already exists" is not enough for a person to
+        # decide with: an answer key is the thing being overwritten, and they have to see both.
+        print(
+            json.dumps(
+                {
+                    "dataset": stem,
+                    "path": str(path),
+                    "added": [item.id for item in added],
+                    "needs_confirmation": [
+                        {
+                            "id": item.id,
+                            "before": _item_doc(by_id[item.id]),
+                            "after": _item_doc(item),
+                        }
+                        for item in replaced
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return _NEEDS_CONFIRMATION
+
+    incoming = {item.id: item for item in items}
+    # A replacement lands in place: the id is the key results are already stored under, and moving
+    # a case to the end of the file would reorder a diff for no reason anyone asked for.
+    merged = [incoming.get(item.id, item) for item in existing] + added
+    if description is not None:
+        fields["description"] = description
+    doc = _dataset_doc(GoldenDataset(name=stem, test_cases=merged, **fields))
+
+    created_dir = not path.parent.exists()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # The canonical dump kwargs, the same ones `build.py` writes every other model file with.
+    path.write_text(
+        yaml.safe_dump(doc, sort_keys=False, allow_unicode=True, width=100), encoding="utf-8"
+    )
+
+    # Reading IS validating: `semantic_model.golden` ships no writer and no standalone `validate()`,
+    # so the only way to know the runner will accept this file is to hand it to the runner's reader.
+    _, res = load_golden_datasets(profile)
+    faults = _our_faults(res, stem)
+    if faults:
+        _rollback(path, snapshot, created_dir)
+        for fault in faults:
+            _stop(fault)
+        return _CANNOT_START
+
+    print(
+        json.dumps(
+            {
+                "dataset": stem,
+                "path": str(path),
+                "added": [item.id for item in added],
+                "replaced": [item.id for item in replaced],
+                "summary": {"added": len(added), "replaced": len(replaced)},
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _import(
+    profile: str,
+    stem: str,
+    rows_path: str,
+    *,
+    confirm_replace: bool,
+    description: Optional[str],
+) -> int:
+    """Turn a confirmed `parse` payload into items, every one of them unverified.
+
+    `expected.sql_confirmed` is False for every row without exception, including the rows whose
+    sheet carried a statement: nobody ran it, and an import that marked its own rows verified would
+    forge the gate the confirmed-only rule exists to be.
+
+    `expected_value` is dropped. AH-100's shape has no home for it, and parking it in
+    `validation_notes` would put a number nothing compares against into a field a reader would
+    reasonably read as an answer key.
+    """
+    payload = json.loads(Path(rows_path).expanduser().read_text(encoding="utf-8"))
+    items = [
+        GoldenItem(
+            id=row["id"],
+            query=row["query"],
+            expected=GoldenExpected(sql=row.get("sql"), sql_confirmed=False),
+            tags=row.get("tags") or [],
+        )
+        for row in payload["rows"]
+    ]
+    return _write_items(
+        profile, stem, items, confirm_replace=confirm_replace, description=description
+    )
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Author golden-dataset items from a spreadsheet.")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -251,13 +505,33 @@ def main(argv: Optional[list[str]] = None) -> int:
     parse_cmd = sub.add_parser("parse", help="Read a question-bank CSV and print what it holds.")
     parse_cmd.add_argument("--csv", required=True, help="the question bank to read")
 
+    import_cmd = sub.add_parser("import", help="Write confirmed parse rows as unverified items.")
+    import_cmd.add_argument("--profile", required=True, help="the profile whose dataset to write")
+    import_cmd.add_argument("--dataset", required=True, help="the dataset's filename stem")
+    import_cmd.add_argument("--rows", required=True, help="the confirmed `parse` payload")
+    import_cmd.add_argument(
+        "--confirm-replace",
+        action="store_true",
+        help="agree to overwrite the items whose id already exists",
+    )
+    import_cmd.add_argument("--description", help="the dataset's description")
+
     args = parser.parse_args(argv)
 
-    payload = _parse(args.csv)
-    if payload is None:
-        return _CANNOT_START
-    print(json.dumps(payload, indent=2))
-    return 0
+    if args.cmd == "parse":
+        payload = _parse(args.csv)
+        if payload is None:
+            return _CANNOT_START
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    return _import(
+        args.profile,
+        args.dataset,
+        args.rows,
+        confirm_replace=args.confirm_replace,
+        description=args.description,
+    )
 
 
 if __name__ == "__main__":

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -246,7 +246,11 @@ def _parse_rows(header: list[str], body: list[list[str]]) -> dict[str, Any]:
     # here would turn a clash they need to see into two rows that both look fine.
     derived: dict[str, int] = {}
 
-    for number, row in enumerate(body, start=1):
+    # From 2, not 1: `body` is everything after the header, and a header is mandatory, so the
+    # first data row is the sheet's second line. Numbering from 1 here would report a number one
+    # short of the row a person opens, which is worse than no number at all — they look at a line
+    # that holds a perfectly good question and cannot see what was wrong with it.
+    for number, row in enumerate(body, start=2):
         query = _cell(row, columns.get("query"))
         if not query:
             skipped.append({"row": number, "reason": "empty question"})
@@ -670,7 +674,10 @@ def _save(
             fields[key] = payload[key]
 
     return _write_items(
-        profile, stem, [GoldenItem(**fields)], confirm_replace=confirm_replace,
+        profile,
+        stem,
+        [GoldenItem(**fields)],
+        confirm_replace=confirm_replace,
         description=description,
     )
 

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -26,6 +26,7 @@ Usage:
 
     python3 golden_author.py parse  --csv /path/to/question-bank.csv
     python3 golden_author.py import --profile main --dataset orders --rows /path/to/parsed.json
+    python3 golden_author.py save   --profile main --dataset orders --item /path/to/item.json
 
 Stdout is always one JSON document; every refusal and every warning goes to stderr with the prefix
 below, so a caller can parse the one and strip the other. The parse door is stdlib only, plus
@@ -40,6 +41,7 @@ import csv
 import json
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -64,9 +66,12 @@ try:
     import agami_paths
     import yaml
     from semantic_model.golden import (
+        GoldenConfirmedBy,
         GoldenDataset,
         GoldenExpected,
         GoldenItem,
+        GoldenRecorded,
+        _lint_relativity,
         load_golden_datasets,
     )
     from semantic_model.validator import ValidationResult
@@ -346,6 +351,26 @@ def _our_faults(res: ValidationResult, stem: str) -> list[str]:
     ]
 
 
+def _relativity_fault(item: GoldenItem, stem: str) -> Optional[str]:
+    """AH-100's relativity lint, asked about one item before it is written.
+
+    Called, never restated. The rule is three regexes in `semantic_model.golden`, and a second copy
+    of them would drift — the failure the repo's "no second SQL parser" guardrail exists to prevent.
+
+    What running it here buys is the timing. The reader runs the same lint on every read, so a
+    question phrased against today with an answer key pinned to a fixed date would surface anyway —
+    as a finding at the next run, with the file already written and whoever reads it having to work
+    out that saving it was the mistake. Refused at the moment of saving, it is the one person who
+    can still fix it being told.
+
+    The lint only fires on an item that has a statement, so in practice this is a save-door rule;
+    it lives in the funnel anyway, so the import door inherits it for the sheets that carry SQL.
+    """
+    res = ValidationResult()
+    _lint_relativity(item, stem, res)
+    return res.errors[0] if res.errors else None
+
+
 def _rollback(path: Path, snapshot: Optional[bytes], created_dir: bool) -> None:
     """Put the tree back exactly as it was before this write.
 
@@ -425,6 +450,12 @@ def _write_items(
         )
         return _NEEDS_CONFIRMATION
 
+    for item in items:
+        fault = _relativity_fault(item, stem)
+        if fault:
+            _stop(fault)
+            return _CANNOT_START
+
     incoming = {item.id: item for item in items}
     # A replacement lands in place: the id is the key results are already stored under, and moving
     # a case to the end of the file would reorder a diff for no reason anyone asked for.
@@ -498,6 +529,75 @@ def _import(
     )
 
 
+def _save(
+    profile: str,
+    stem: str,
+    item_path: str,
+    *,
+    confirm_replace: bool,
+    description: Optional[str],
+) -> int:
+    """Write one answer somebody looked at and accepted.
+
+    The only door that can produce an item able to gate a run, and everything that makes it one is
+    written here: the statement, `sql_confirmed`, the receipt of what the answer looked like, and
+    how it was confirmed. AH-111 is a caller of this door, not a second write path.
+
+    `confirmed_by.method` is free text by AH-100's deliberate choice — a `Literal` would refuse
+    files for saying something reasonable — so the only check is that somebody said something. An
+    item with no method is the one refusal: an answer key whose provenance is blank cannot be
+    audited later, which is most of what a receipt is for.
+    """
+    payload = json.loads(Path(item_path).expanduser().read_text(encoding="utf-8"))
+    method = ((payload.get("confirmed_by") or {}).get("method") or "").strip()
+    if not method:
+        _stop(
+            "this item does not say how its answer was confirmed; set confirmed_by.method to how "
+            "the result was checked"
+        )
+        return _CANNOT_START
+
+    # Stamped here when the caller did not stamp it. AH-100 types both as optional, but a receipt
+    # that cannot say when it was taken is not much of a receipt.
+    now = datetime.now(timezone.utc).isoformat()
+    recorded = payload.get("recorded") or {}
+    fields: dict[str, Any] = {
+        "id": payload.get("id") or _slug(payload["query"]),
+        "query": payload["query"],
+        "expected": GoldenExpected(sql=payload["sql"], sql_confirmed=True),
+        "tags": payload.get("tags") or [],
+        "recorded": GoldenRecorded(
+            columns=recorded.get("columns") or [],
+            rows=recorded.get("rows") or [],
+            at=recorded.get("at") or now,
+        ),
+        "confirmed_by": GoldenConfirmedBy(
+            method=method, at=(payload.get("confirmed_by") or {}).get("at") or now
+        ),
+    }
+    if payload.get("match"):
+        # Omitted rather than defaulted, so how strictly a saved item compares stays AH-100's
+        # answer to that question and not a second one written down here.
+        fields["match"] = payload["match"]
+
+    return _write_items(
+        profile, stem, [GoldenItem(**fields)], confirm_replace=confirm_replace,
+        description=description,
+    )
+
+
+def _add_write_args(cmd: argparse.ArgumentParser) -> None:
+    """The flags both write doors take. They go through one funnel, so they take one set."""
+    cmd.add_argument("--profile", required=True, help="the profile whose dataset to write")
+    cmd.add_argument("--dataset", required=True, help="the dataset's filename stem")
+    cmd.add_argument(
+        "--confirm-replace",
+        action="store_true",
+        help="agree to overwrite the items whose id already exists",
+    )
+    cmd.add_argument("--description", help="the dataset's description")
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Author golden-dataset items from a spreadsheet.")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -506,15 +606,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     parse_cmd.add_argument("--csv", required=True, help="the question bank to read")
 
     import_cmd = sub.add_parser("import", help="Write confirmed parse rows as unverified items.")
-    import_cmd.add_argument("--profile", required=True, help="the profile whose dataset to write")
-    import_cmd.add_argument("--dataset", required=True, help="the dataset's filename stem")
     import_cmd.add_argument("--rows", required=True, help="the confirmed `parse` payload")
-    import_cmd.add_argument(
-        "--confirm-replace",
-        action="store_true",
-        help="agree to overwrite the items whose id already exists",
-    )
-    import_cmd.add_argument("--description", help="the dataset's description")
+    _add_write_args(import_cmd)
+
+    save_cmd = sub.add_parser("save", help="Write one confirmed answer, statement and receipt.")
+    save_cmd.add_argument("--item", required=True, help="the accepted answer, as JSON")
+    _add_write_args(save_cmd)
 
     args = parser.parse_args(argv)
 
@@ -525,10 +622,19 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(json.dumps(payload, indent=2))
         return 0
 
-    return _import(
+    if args.cmd == "import":
+        return _import(
+            args.profile,
+            args.dataset,
+            args.rows,
+            confirm_replace=args.confirm_replace,
+            description=args.description,
+        )
+
+    return _save(
         args.profile,
         args.dataset,
-        args.rows,
+        args.item,
         confirm_replace=args.confirm_replace,
         description=args.description,
     )

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Turn a spreadsheet of questions into golden-dataset rows, and print them for confirmation.
+
+The `agami-save-golden` skill has two doors and this helper is the deterministic half of the first
+one. An analyst's question bank lives in a spreadsheet; a golden dataset item is `id`, `query` and
+an answer key. Getting from one to the other is column matching, id derivation and number
+normalization — all of it decidable, and none of it something a model should be reading a file to
+do. What the skill keeps is the judgement: which sheet, and whether the parsed rows are right.
+
+**`parse` writes nothing.** That is the point of the verb rather than an accident of it. The
+contract says the rows are confirmed before anything is written, and the only way that is a fact
+about the software rather than a claim about how a skill behaves is for the reading step to have
+no write in it at all. The write door is a separate verb.
+
+**Nothing here confirms an answer key.** A sheet may carry a statement column and it is carried
+through as `sql`, but nobody ran it, so an imported row is unverified by construction — the
+confirmed-only rule is what makes a green golden run mean something, and a spreadsheet column is
+not a person who looked at a result.
+
+Usage:
+
+    python3 golden_author.py parse --csv /path/to/question-bank.csv
+
+Stdout is always one JSON document; every refusal and every warning goes to stderr with the prefix
+below, so a caller can parse the one and strip the other. Stdlib only, plus `reconcile.parse_value`
+for the expected-value column.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+# Sibling scripts are imported plainly, and this is what makes that work in every layout the
+# plugin ships in — the marketplace cache invokes these scripts by absolute path, where the
+# interpreter's own `sys.path[0]` is not something to rely on.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import reconcile  # noqa: E402
+
+# Marks the lines a caller is meant to strip — the refusals and the warnings, this helper talking
+# about itself.
+_PREFIX = "agami-save-golden:"
+
+# What an exit code means. `_NEEDS_CONFIRMATION` belongs to the write door: a change the person has
+# not agreed to yet is neither a success nor a breakage, and a pipeline that treats it as either
+# would be wrong in both directions.
+_NEEDS_CONFIRMATION = 1
+_CANNOT_START = 2
+
+# The column contract. Matching is EXACT against these alias sets after folding, and never fuzzy:
+# a header this contract does not know is the analyst's own note column, which is only safe to
+# ignore silently while no match can be approximate. `query` names the question and `query sql`
+# names the statement, which is exactly the kind of near-collision a fuzzy matcher gets wrong.
+_ALIASES: dict[str, frozenset[str]] = {
+    "query": frozenset({"question", "query", "nl", "nl question", "prompt", "ask"}),
+    "id": frozenset({"id", "key", "item id", "case id"}),
+    "expected_value": frozenset({"expected", "expected value", "answer", "value"}),
+    "sql": frozenset({"sql", "statement", "query sql", "expected sql"}),
+    "tags": frozenset({"tags", "tag", "labels"}),
+}
+
+# How long a derived id may be. An id is a filename-safe key a person reads in a diff and types
+# into a `--rerun` argument, and a whole question spelled out is neither.
+_MAX_SLUG = 60
+
+
+def _stop(reason: str) -> None:
+    """Say why the parse cannot start."""
+    print(f"{_PREFIX} {reason}", file=sys.stderr)
+
+
+def _warn(reason: str) -> None:
+    """Say something about a parse that still finished.
+
+    Same stream and prefix as `_stop`, and a separate name because a call reading `_stop(...)`
+    where nothing stops misdescribes the control flow at the call site.
+    """
+    print(f"{_PREFIX} {reason}", file=sys.stderr)
+
+
+def _fold(header: str) -> str:
+    """One header cell as the contract sees it.
+
+    Spreadsheets spell the same column `NL_Question`, `nl question` and ` Expected-Value `, and the
+    difference is typography rather than meaning. Underscores, hyphens and runs of whitespace all
+    fold to one space so that a single alias covers every spelling of it.
+    """
+    return re.sub(r"[\s_-]+", " ", header).strip().lower()
+
+
+def _slug(query: str) -> str:
+    """A deterministic id for a question that has none.
+
+    Deterministic is the whole requirement. `GoldenItem.item_key` is exactly the id, so the id IS
+    the append-only duplicate check: re-importing the same sheet has to derive the same ids and
+    land on the duplicate path, where sequential ids would append a second copy of every row under
+    fresh keys and the append-only rule would never fire on the import door at all.
+
+    Truncated at a `-` boundary rather than mid-word, because a person reads these in a diff and a
+    key ending in a half-word reads as corruption. A single word longer than the limit has no
+    boundary to trim back to and is cut where it falls.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", query.lower()).strip("-")
+    if len(slug) <= _MAX_SLUG:
+        return slug
+    head = slug[:_MAX_SLUG]
+    # Already on a boundary: the next character is the separator, so nothing is cut in half.
+    if slug[_MAX_SLUG] != "-":
+        head = head.rpartition("-")[0] or head
+    return head.strip("-")
+
+
+def _columns(header: list[str]) -> dict[str, int]:
+    """Which column holds which field, by index.
+
+    First match wins: a sheet with two columns folding to the same alias is one column and one
+    duplicate, and the person put the real one first.
+    """
+    found: dict[str, int] = {}
+    for index, cell in enumerate(header):
+        folded = _fold(cell)
+        for field, aliases in _ALIASES.items():
+            if folded in aliases and field not in found:
+                found[field] = index
+    return found
+
+
+def _cell(row: list[str], index: Optional[int]) -> str:
+    """One cell, for a column the sheet may not have and a row that may stop short of it.
+
+    A short row is ordinary — a spreadsheet exported with trailing empties trimmed — and it means
+    the cell is blank rather than that the file is malformed.
+    """
+    if index is None or index >= len(row):
+        return ""
+    return row[index].strip()
+
+
+def _read_rows(path: str) -> list[list[str]]:
+    """The CSV as rows, blank lines included.
+
+    Blank rows are kept because `skipped` reports a row number a person uses to find the row in
+    their own sheet, and dropping anything ahead of the numbering makes every number after it
+    point at the wrong line.
+    """
+    with Path(path).expanduser().open(newline="", encoding="utf-8-sig") as handle:
+        return list(csv.reader(handle))
+
+
+def _parse_rows(header: list[str], body: list[list[str]]) -> dict[str, Any]:
+    """The rows and the skips, in sheet order.
+
+    Every row is accounted for in exactly one of the two lists. A sheet that comes back shorter
+    than it went in, with nothing said about the difference, is how an import quietly loses a
+    question nobody notices is missing.
+    """
+    columns = _columns(header)
+    rows: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    # Derived ids only. An explicit id that repeats is a real duplicate in the person's own sheet,
+    # and the write door's append-only path is where that gets resolved — silently suffixing it
+    # here would turn a clash they need to see into two rows that both look fine.
+    derived: dict[str, int] = {}
+
+    for number, row in enumerate(body, start=1):
+        query = _cell(row, columns.get("query"))
+        if not query:
+            skipped.append({"row": number, "reason": "empty question"})
+            continue
+        item_id = _cell(row, columns.get("id"))
+        if not item_id:
+            slug = _slug(query)
+            if not slug:
+                skipped.append({"row": number, "reason": "question has no usable characters"})
+                continue
+            derived[slug] = derived.get(slug, 0) + 1
+            item_id = slug if derived[slug] == 1 else f"{slug}-{derived[slug]}"
+        statement = _cell(row, columns.get("sql"))
+        rows.append(
+            {
+                "id": item_id,
+                "query": query,
+                # Normalized through the reconcile parser rather than re-derived, so `$1.2M` means
+                # one thing across the plugin. Unreadable is `null` and not a refusal: this value
+                # is shown in the confirmation table and never becomes an answer key, so a cell
+                # nobody can read costs the person nothing.
+                "expected_value": reconcile.parse_value(_cell(row, columns.get("expected_value"))),
+                "sql": statement or None,
+                "tags": [
+                    tag.strip() for tag in _cell(row, columns.get("tags")).split(",") if tag.strip()
+                ],
+            }
+        )
+    return {
+        "columns": header,
+        "rows": rows,
+        "skipped": skipped,
+        "summary": {"parsed": len(rows), "skipped": len(skipped)},
+    }
+
+
+def _parse(path: str) -> Optional[dict[str, Any]]:
+    """The whole parse, or None having said on stderr why there is not one.
+
+    Both refusals are the same event: no column can be identified as the question. Never a fallback
+    to column 0 — a bank of ids or timestamps imported as questions produces items that fail every
+    run for a reason that looks exactly like a model regression and is not one. Each refusal names
+    the cells it actually read, because that list is the whole of what the person needs to rename a
+    column and re-invoke.
+
+    An alias match decides whether row 0 is the header, and `_looks_like_header` only chooses which
+    sentence to refuse with. That ordering is deliberate: the alias set is exact, so a cell folding
+    to `question` is a header and nothing else, whereas reconcile's heuristic reads the SECOND cell
+    and answers `False` for a one-column sheet — which is the shape a question bank most often has.
+    """
+    all_rows = _read_rows(path)
+    if not all_rows:
+        _stop("this file is empty — the sheet needs a header row naming its question column")
+        return None
+    header = all_rows[0]
+    if "query" not in _columns(header):
+        cells = ", ".join(repr(cell.strip()) for cell in header)
+        if reconcile._looks_like_header(header):
+            _stop(
+                f"no column here holds the question. Columns found: {cells}. Rename one of them "
+                "to 'question' (or 'query', 'nl question', 'prompt', 'ask')"
+            )
+        else:
+            _stop(
+                "this file has no header row, so no column can be identified as the question. Its "
+                f"first row reads: {cells}. Add a header naming one column 'question'"
+            )
+        return None
+    payload = _parse_rows(header, all_rows[1:])
+    if payload["skipped"]:
+        # The counts are in the payload, but a person reading a terminal sees the summary line, and
+        # a skip they never notice is a question missing from their dataset.
+        _warn(f"{len(payload['skipped'])} row(s) were skipped — see `skipped` in the payload")
+    return payload
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Author golden-dataset items from a spreadsheet.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    parse_cmd = sub.add_parser("parse", help="Read a question-bank CSV and print what it holds.")
+    parse_cmd.add_argument("--csv", required=True, help="the question bank to read")
+
+    args = parser.parse_args(argv)
+
+    payload = _parse(args.csv)
+    if payload is None:
+        return _CANNOT_START
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -65,13 +65,19 @@ import reconcile
 try:
     import agami_paths
     import yaml
+    from pydantic import ValidationError
+
+    # The module rather than its members for the two privates below: a rename of
+    # `golden._lint_relativity` imported by name would be an ImportError, caught by this same
+    # handler and reported as a missing dependency — diagnosing code drift as something to install.
+    # Referenced through the module, it surfaces at the call site as the AttributeError it is.
+    from semantic_model import golden
     from semantic_model.golden import (
         GoldenConfirmedBy,
         GoldenDataset,
         GoldenExpected,
         GoldenItem,
         GoldenRecorded,
-        _lint_relativity,
         load_golden_datasets,
     )
     from semantic_model.validator import ValidationResult
@@ -111,6 +117,20 @@ _ALIASES: dict[str, frozenset[str]] = {
 # into a `--rerun` argument, and a whole question spelled out is neither.
 _MAX_SLUG = 60
 
+# What `--profile` and `--dataset` may be. A whitelist rather than a hunt for `..`, because these
+# two strings are joined into a path this helper then TRUNCATES AND REWRITES: a stem that is not
+# plainly one name is not a stem written to the wrong place, it is a stem that destroys whatever
+# `<stem>.yaml` resolves onto — a sibling tenant's answer key, or the profile's own model file.
+# A leading dot is refused with the separators, which is what makes `..` itself unspellable.
+_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+# The one error code the reader raises that does not drop anything. `_lint_relativity` deliberately
+# keeps the item it reports (`semantic_model.golden` says so in as many words), so it is neither a
+# reason to refuse a merge into a file that already holds one — that file would otherwise be
+# unwritable forever, with Hard Rule 6 forbidding the hand edit out of it — nor a reason to roll
+# this write back. Incoming items are checked for it before the write instead.
+_KEPT_ITEM_CODE = "golden_relative_question_frozen_sql"
+
 
 def _stop(reason: str) -> None:
     """Say why the parse cannot start."""
@@ -124,6 +144,22 @@ def _warn(reason: str) -> None:
     where nothing stops misdescribes the control flow at the call site.
     """
     print(f"{_PREFIX} {reason}", file=sys.stderr)
+
+
+def _bad_name(kind: str, value: str) -> Optional[str]:
+    """Why `value` cannot be used as a `kind`, or None if it can."""
+    if not _NAME_RE.fullmatch(value):
+        return (
+            f"{value!r} is not a usable {kind} name — it has to be one name: a letter or digit "
+            "first, then letters, digits, dots, dashes or underscores, and no path separators"
+        )
+    # The stem IS the dataset's name — the reader takes it from the filename — so a typed extension
+    # would become part of what the dataset is called. `.yml` is the worse half: the reader refuses
+    # a real `.yml` file as misnamed, and a dataset *named* `orders.yml` would read back fine and
+    # contradict the only rule the directory has.
+    if value.lower().endswith((".yaml", ".yml")):
+        return f"{kind} {value!r} names the file rather than the {kind} — pass it without the extension"
+    return None
 
 
 def _fold(header: str) -> str:
@@ -205,8 +241,8 @@ def _parse_rows(header: list[str], body: list[list[str]]) -> dict[str, Any]:
     columns = _columns(header)
     rows: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
-    # Derived ids only. An explicit id that repeats is a real duplicate in the person's own sheet,
-    # and the write door's append-only path is where that gets resolved — silently suffixing it
+    # Derived ids only. An explicit id that repeats is a real duplicate in the person's own sheet
+    # and the write door refuses the whole batch over it, naming the id — silently suffixing it
     # here would turn a clash they need to see into two rows that both look fine.
     derived: dict[str, int] = {}
 
@@ -303,14 +339,15 @@ def _datasets_dir(profile: str) -> Path:
 
 
 def _drop_empty(doc: dict[str, Any], *keys: str) -> None:
-    """Remove the named keys when they hold an empty list.
+    """Remove the named keys when they hold an empty list or an empty string.
 
-    `exclude_none` does not drop `[]`, so a model dumped straight out writes `tags: []`,
-    `must_filter: []` and `tables_used: []` into every item — noise in a file a person reads and
-    diffs, and a shape nobody would ever author by hand.
+    `exclude_none` does not drop `[]` or `""`, so a model dumped straight out writes `tags: []`,
+    `must_filter: []`, `tables_used: []` and a blank `description:` — noise in a file a person reads
+    and diffs, and a shape nobody would ever author by hand. The reader defaults every one of them,
+    so writing them says nothing the file did not already say by omission.
     """
     for key in keys:
-        if doc.get(key) == []:
+        if key in doc and doc[key] in ([], ""):
             del doc[key]
 
 
@@ -332,6 +369,7 @@ def _dataset_doc(dataset: GoldenDataset) -> dict[str, Any]:
     write a file this helper could never read back.
     """
     doc = dataset.model_dump(mode="json", exclude_none=True, exclude={"name", "test_cases"})
+    _drop_empty(doc, "description")
     doc["test_cases"] = [_item_doc(item) for item in dataset.test_cases]
     return doc
 
@@ -341,13 +379,20 @@ def _our_faults(res: ValidationResult, stem: str) -> list[str]:
 
     The reader validates the whole profile, so a neighbouring dataset that was already broken lands
     in the same result. Rolling our write back because of it would restore a correct file and blame
-    a locator the person never touched, so only findings against this stem count.
+    a locator the person never touched, so only findings against this stem count — and `orders.yaml`
+    is a prefix of `orders.yaml.yaml`, which is a different dataset, so the match is the locator
+    exactly or the locator plus a case suffix rather than any string starting with it.
+
+    `_KEPT_ITEM_CODE` is excluded: the reader keeps that item, so the finding describes neither a
+    dropped case nor anything this write did.
     """
     prefix = f"{stem}.yaml"
     return [
         finding.message
         for finding in res.findings
-        if finding.severity == "error" and (finding.locator or "").startswith(prefix)
+        if finding.severity == "error"
+        and finding.code != _KEPT_ITEM_CODE
+        and (finding.locator == prefix or (finding.locator or "").startswith(f"{prefix}["))
     ]
 
 
@@ -367,7 +412,7 @@ def _relativity_fault(item: GoldenItem, stem: str) -> Optional[str]:
     it lives in the funnel anyway, so the import door inherits it for the sheets that carry SQL.
     """
     res = ValidationResult()
-    _lint_relativity(item, stem, res)
+    golden._lint_relativity(item, stem, res)
     return res.errors[0] if res.errors else None
 
 
@@ -399,11 +444,40 @@ def _write_items(
     """Merge `items` into a profile's dataset, print what happened, and return the exit code.
 
     THE write path. Both doors call it and AH-111 will too, so the append-only rule is enforced
-    once rather than remembered by each caller. The order of the steps is the contract: nothing is
-    written until the person has agreed to every replacement, and nothing survives a re-read the
-    runner's own reader would refuse.
+    once rather than remembered by each caller. The order of the steps is the contract: the names
+    are checked before any path is built from them, the batch is checked before any of it is
+    written, nothing is written until the person has agreed to every replacement, and nothing
+    survives a re-read the runner's own reader would refuse.
     """
-    path = _datasets_dir(profile) / f"{stem}.yaml"
+    for kind, value in (("profile", profile), ("dataset", stem)):
+        fault = _bad_name(kind, value)
+        if fault:
+            _stop(fault)
+            return _CANNOT_START
+
+    # One id, one item. Merging keys on the id, so a repeat is one question quietly overwriting
+    # another inside a single batch while `added`/`replaced` — counted off the raw list — report
+    # both. Refused here rather than left to the re-read, which would blame `<stem>.yaml` for a
+    # duplicate that is two rows of the person's own sheet and roll the whole import back over it.
+    seen: set[str] = set()
+    for item in items:
+        if item.id in seen:
+            _stop(
+                f"this batch carries the id {item.id!r} twice. An id is the key a result is stored "
+                "under, so each one may appear once — give the second one its own id and re-run"
+            )
+            return _CANNOT_START
+        seen.add(item.id)
+
+    gdir = _datasets_dir(profile)
+    path = gdir / f"{stem}.yaml"
+    # Belt and braces behind the name rule. The rule is what refuses a bad name with a sentence a
+    # person can act on; this is the invariant itself — the file this door writes is a direct child
+    # of the directory the runner reads — asserted against the paths that were actually built.
+    if path.resolve().parent != gdir.resolve():
+        _stop(f"{stem!r} does not name a file inside this profile's golden_datasets directory")
+        return _CANNOT_START
+
     snapshot = path.read_bytes() if path.exists() else None
     existing: list[GoldenItem] = []
     fields: dict[str, Any] = {}
@@ -413,15 +487,32 @@ def _write_items(
         prior = _our_faults(res, stem)
         if prior:
             # Merging into a file the reader cannot fully read would silently drop whatever it
-            # could not parse — this write deleting somebody's case to make room for its own.
+            # could not parse — this write deleting somebody's case to make room for its own. Only
+            # a fault that costs a case counts, which is why `_our_faults` excludes the one lint
+            # that keeps the item it reports.
             _stop(
                 f"{stem}.yaml cannot be read as it stands, so nothing may be merged into it: "
                 f"{prior[0]}"
             )
             return _CANNOT_START
-        found = next(dataset for dataset in datasets if dataset.name == stem)
+        found = next((dataset for dataset in datasets if dataset.name == stem), None)
+        if found is None:
+            # The file exists and the reader returned no dataset for it, so it was dropped whole
+            # for a reason `_our_faults` did not attribute to this stem. Refusing beats merging
+            # into an empty `existing` and overwriting the file with only the incoming items.
+            _stop(f"{stem}.yaml exists but the reader returned no dataset for it")
+            return _CANNOT_START
         existing = list(found.test_cases)
         fields = found.model_dump(exclude={"name", "test_cases"}, exclude_none=True)
+
+    # Before the append-only stop rather than after it: this refusal is unconditional, so asking
+    # the person to walk a before and an after and say yes, only to refuse the re-run anyway, is
+    # asking a question whose every answer is the same.
+    for item in items:
+        fault = _relativity_fault(item, stem)
+        if fault:
+            _stop(fault)
+            return _CANNOT_START
 
     by_id = {item.id: item for item in existing}
     added = [item for item in items if item.id not in by_id]
@@ -449,12 +540,6 @@ def _write_items(
             )
         )
         return _NEEDS_CONFIRMATION
-
-    for item in items:
-        fault = _relativity_fault(item, stem)
-        if fault:
-            _stop(fault)
-            return _CANNOT_START
 
     incoming = {item.id: item for item in items}
     # A replacement lands in place: the id is the key results are already stored under, and moving
@@ -575,10 +660,14 @@ def _save(
             method=method, at=(payload.get("confirmed_by") or {}).get("at") or now
         ),
     }
-    if payload.get("match"):
-        # Omitted rather than defaulted, so how strictly a saved item compares stays AH-100's
-        # answer to that question and not a second one written down here.
-        fields["match"] = payload["match"]
+    # Omitted rather than defaulted, so how strictly a saved item compares, what band it compares
+    # against and what gate the answer had to be reached through all stay AH-100's answers to those
+    # questions and not second ones written down here. All three are documented on the save door's
+    # payload, so a whitelist that forwarded only `match` dropped a `must_filter` the skill is told
+    # to carry forward on every replacement, and built a `bounded` item with no band to compare to.
+    for key in ("match", "bounds", "must_filter"):
+        if payload.get(key):
+            fields[key] = payload[key]
 
     return _write_items(
         profile, stem, [GoldenItem(**fields)], confirm_replace=confirm_replace,
@@ -598,23 +687,12 @@ def _add_write_args(cmd: argparse.ArgumentParser) -> None:
     cmd.add_argument("--description", help="the dataset's description")
 
 
-def main(argv: Optional[list[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description="Author golden-dataset items from a spreadsheet.")
-    sub = parser.add_subparsers(dest="cmd", required=True)
+def _dispatch(args: argparse.Namespace) -> int:
+    """Run the verb the arguments name.
 
-    parse_cmd = sub.add_parser("parse", help="Read a question-bank CSV and print what it holds.")
-    parse_cmd.add_argument("--csv", required=True, help="the question bank to read")
-
-    import_cmd = sub.add_parser("import", help="Write confirmed parse rows as unverified items.")
-    import_cmd.add_argument("--rows", required=True, help="the confirmed `parse` payload")
-    _add_write_args(import_cmd)
-
-    save_cmd = sub.add_parser("save", help="Write one confirmed answer, statement and receipt.")
-    save_cmd.add_argument("--item", required=True, help="the accepted answer, as JSON")
-    _add_write_args(save_cmd)
-
-    args = parser.parse_args(argv)
-
+    Every exit code this helper deliberately returns is decided here or below it; `main` wraps this
+    so that nothing else can invent one.
+    """
     if args.cmd == "parse":
         payload = _parse(args.csv)
         if payload is None:
@@ -638,6 +716,54 @@ def main(argv: Optional[list[str]] = None) -> int:
         confirm_replace=args.confirm_replace,
         description=args.description,
     )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Author golden-dataset items from a spreadsheet.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    parse_cmd = sub.add_parser("parse", help="Read a question-bank CSV and print what it holds.")
+    parse_cmd.add_argument("--csv", required=True, help="the question bank to read")
+
+    import_cmd = sub.add_parser("import", help="Write confirmed parse rows as unverified items.")
+    import_cmd.add_argument("--rows", required=True, help="the confirmed `parse` payload")
+    _add_write_args(import_cmd)
+
+    save_cmd = sub.add_parser("save", help="Write one confirmed answer, statement and receipt.")
+    save_cmd.add_argument("--item", required=True, help="the accepted answer, as JSON")
+    _add_write_args(save_cmd)
+
+    args = parser.parse_args(argv)
+
+    # Nothing gets out of here as a traceback. `1` is the skill's signal to render a
+    # `needs_confirmation` block and re-run with `--confirm-replace`, and an uncaught exception
+    # exits `1` too — so a crash would be read as a stop the person can agree to, and the answer to
+    # it would be a confirmed overwrite. Every unexpected failure becomes `2` and a stderr sentence.
+    try:
+        return _dispatch(args)
+    except FileNotFoundError as exc:
+        _stop(f"{exc.filename} does not exist")
+    except IsADirectoryError as exc:
+        _stop(f"{exc.filename} is a directory, not a file")
+    except json.JSONDecodeError as exc:
+        # Named separately from the catch-all because the fix is specific: this file is hand-built
+        # by the skill, and a truncated one is re-written rather than investigated.
+        _stop(f"this file is not readable JSON — {exc.msg} at line {exc.lineno}")
+    except (OSError, UnicodeDecodeError) as exc:
+        _stop(f"a file could not be read: {exc.__class__.__name__}")
+    except KeyError as exc:
+        _stop(f"the input is missing a required key: {exc}")
+    except ValidationError as exc:
+        # Through the digest, never the raw text: pydantic renders `input_value=`, which for these
+        # models is the answer key, the recorded result and the question — and this sentence goes
+        # to a terminal. The field and the reason are what a fix needs anyway.
+        _stop(f"this does not fit a golden case — {golden._validation_digest(exc)}")
+    except Exception as exc:
+        # Deliberately bare. A named list of what these doors can raise would be a list that goes
+        # stale, and the one thing that must never happen is a failure this helper did not name
+        # reaching the caller as the exit code that means "say yes to overwrite".
+        _stop(f"this could not be completed: {exc.__class__.__name__}")
+    return _CANNOT_START
 
 
 if __name__ == "__main__":

--- a/plugins/agami/shared/file-layout.md
+++ b/plugins/agami/shared/file-layout.md
@@ -37,7 +37,7 @@ Everything else in here is non-secret and team-useful. The default location is `
 | `<profile>/subject_areas/<area>/metrics/<slug>.yaml`, `entities/<slug>.yaml` | One metric / entity per file |
 | `<profile>/subject_areas/<area>/relationships.yaml` | In-area join edges (cardinality + trust block) |
 | `<profile>/prompt_examples/<area>/examples.yaml` | Per-area NL→SQL few-shot library |
-| `<profile>/golden_datasets/<name>.yaml` | The profile's golden datasets — each case a question, its answer key, and how strictly to compare. **User-authored**: a team writes and confirms these; no skill writes one today |
+| `<profile>/golden_datasets/<name>.yaml` | The profile's golden datasets — each case a question, its answer key, and how strictly to compare. **Written by `/agami-save-golden`** (or by hand): a bank of questions imports unconfirmed, and an answer somebody verified is saved confirmed with its receipt. Append-only — a write that would change an item already there stops and shows the before and the after. `/agami-eval` reads these and never writes one |
 | `<profile>/datasource.md` | Per-profile human narrative (the model-derived summary + glossary are assembled at read time, not stored here) |
 | `<profile>/.snapshots/<hash>/` | Pinned model snapshots — an answer reproduces against the hash it ran on |
 

--- a/plugins/agami/shared/golden-dataset-shape.md
+++ b/plugins/agami/shared/golden-dataset-shape.md
@@ -69,7 +69,7 @@ test_cases:
       chart_type: bar
       data_shape: category_value
       validation_notes: Counted at order grain, so nothing joins in to fan the count out.
-    match: values
+    match: exact
     must_filter: [status]
     recorded:
       columns: [channel, order_count]
@@ -117,7 +117,12 @@ Alongside `expected`, an item takes six optional fields:
 - `match` — how closely the run has to match the answer key, loosening left to
   right: `exact`, `values`, `shape`, `bounded`, `nonempty`. **Defaults to
   `exact`**, so an item that says nothing is held to the strictest reading. Any
-  other word is refused.
+  other word is refused. Loosen only for a reason the answer itself gives:
+  columns pair by value at every level, so differing names or order never call
+  for it. `values` forgives a floating-point tail **and an extra column**, which
+  makes it right for a result carrying a real float and wrong for a count — the
+  extra column it waves through is the most common way a generated statement is
+  wrong.
 - `bounds` — the band `match: bounded` is judged against: `min_rows` /
   `max_rows` on the number of rows, and `min_value` / `max_value` on a
   single-cell numeric answer. All four keys are optional but at least one has to

--- a/plugins/agami/shared/golden-dataset-shape.md
+++ b/plugins/agami/shared/golden-dataset-shape.md
@@ -160,9 +160,20 @@ wrong thing.
 
 ## How to write them
 
-Write the file by hand, one dataset per question area, and read it back before
-relying on it — the reader reports per-file and per-case, so one bad case costs
-one case rather than the suite:
+Two supported ways in, and both land the same shape.
+
+**`/agami-save-golden` is the skill that writes these.** It has two doors: a
+question bank (a CSV, or a table pasted into chat) imports as items written
+`sql_confirmed: false`, after the parsed rows have been shown and agreed to; and
+one question with the statement that answered it and the result somebody
+accepted saves as a confirmed item with its `recorded` receipt and its
+`confirmed_by`. It is append-only — a write that would change an item that
+already exists stops and shows the before and the after — and every write is
+re-read through the reader below before it is kept.
+
+**Or write the file by hand**, one dataset per question area, and read it back
+before relying on it — the reader reports per-file and per-case, so one bad case
+costs one case rather than the suite:
 
 ```bash
 python -c "from semantic_model.golden import load_golden_datasets; \

--- a/plugins/agami/shared/invocation-conventions.md
+++ b/plugins/agami/shared/invocation-conventions.md
@@ -1,6 +1,6 @@
 # Invocation conventions — read this BEFORE telling the user to invoke a skill
 
-agami ships eight skills, all prefixed `agami-` to avoid colliding with Claude Code's built-in slash commands (e.g. `/init`) and with other plugins:
+agami ships nine skills, all prefixed `agami-` to avoid colliding with Claude Code's built-in slash commands (e.g. `/init`) and with other plugins:
 
 | Skill | Slash command | Natural-language triggers (via `when_to_use`) |
 |---|---|---|
@@ -10,6 +10,7 @@ agami ships eight skills, all prefixed `agami-` to avoid colliding with Claude C
 | agami-save-correction | `/agami-save-correction` | "save this as a correction", "remember this", "use this SQL next time" |
 | agami-reconcile | `/agami-reconcile` | "reconcile against my dashboard", "verify these numbers against agami" |
 | agami-eval | `/agami-eval` | "run the evals", "run the golden dataset", "score the model against my golden questions", "did anything regress?", "how accurate is agami on my data?" |
+| agami-save-golden | `/agami-save-golden` | "save this as a golden question", "add this to the golden dataset", "import my question bank", "turn this spreadsheet into a golden dataset" |
 | agami-serve | `/agami-serve` | "set up agami for Claude Desktop", "use agami in the Claude app", "hook up the MCP server", "let me test what my end users would see" |
 | agami-deploy | `/agami-deploy` | "deploy agami", "self-host agami", "set up the agami server for my team", "host agami on a VM" (early access — in testing) |
 

--- a/plugins/agami/shared/plan-mode-check.md
+++ b/plugins/agami/shared/plan-mode-check.md
@@ -83,6 +83,12 @@ Stay-in-plan-mode → **refuse to proceed. Do not write a plan file. Do not call
 
 > I can't run an eval in plan mode — every case executes live SQL and the run writes a report. Switch to **Auto** or **Edit Automatically** mode (Shift+Tab to cycle) and re-invoke me with the dataset name.
 
+### `agami-save-golden`
+
+Stay-in-plan-mode → **refuse to proceed. Do not write a plan file. Do not call ExitPlanMode.** Both doors write: the import door writes the parsed rows into the profile's dataset, the save door writes one confirmed answer with its receipt, and a pasted table is written out as a CSV first — Write throughout, plus Bash for the helper itself. Surface ONLY this:
+
+> I can't save a golden item in plan mode — every door here writes to the model tree. Switch to **Auto** or **Edit Automatically** mode (Shift+Tab to cycle) and re-invoke me with the dataset name.
+
 ## When the system context is silent
 
 If neither signal 1 nor signal 2 confirms plan mode is active, **skip this phase silently** and go to Phase 0 of the skill. Don't pop a modal asking "are you in plan mode?" — that's noise for the 95% of users who aren't. The probe-on-Bash-failure path catches the rest naturally.

--- a/plugins/agami/skills/agami-save-golden/SKILL.md
+++ b/plugins/agami/skills/agami-save-golden/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: agami-save-golden
+description: "Writes golden-dataset items for a profile through two doors. The import door turns a question bank — a CSV, or a table pasted into chat — into items written unconfirmed, after the parsed rows have been shown and agreed to. The save door writes one question, the statement that answered it and the result the person accepted, as a confirmed item with its receipt. Every write goes through agami-core's writer, is re-read by the runner's own reader before it is kept, and is append-only: a write that would change an item that already exists stops and shows the before and the after. This skill writes only; it never runs or scores a dataset."
+when_to_use: "Use when the user says 'save this as a golden question', 'add this to the golden dataset', 'import my question bank', 'turn this spreadsheet into a golden dataset', 'this answer is correct — remember it as ground truth', or '/agami-save-golden <dataset>' — any ask to record a question, or a bank of questions, that the model should be scored against later. Requires agami-connect to have been run first (needs a profile with a semantic model). To RUN a dataset and see the verdicts, use `/agami-eval` instead: that skill reads and scores, this one writes and never runs or scores."
+argument-hint: "[dataset-name]"
+---
+
+# agami save-golden
+
+You are writing to the answer key. Goal: get a question — or a bank of them — into the profile's golden dataset in the state it has actually earned, and never in a better one. A dataset is what `/agami-eval` gates on, so an item that claims to be confirmed when nobody looked at a result turns the whole suite green on nothing.
+
+**This skill has two doors and they write different things.** Everything below is organized around them, because confusing them is the one failure that matters:
+
+| Door | Input | What it writes | Can it gate a run? |
+|---|---|---|---|
+| **Import** | A CSV of questions, or a table pasted into chat | Items with `sql_confirmed: false` | No |
+| **Save** | One question, the statement that answered it, the result the person accepted | One item with `sql_confirmed: true`, its statement and its receipt | Yes |
+
+An imported item **has no statement until somebody runs it and saves the answer through the save door.** That is the intended shape, not a gap to close: an import is a list of the questions this team cares about, and a question with no verified answer is an honest in-progress case that reports and cannot gate.
+
+**This skill never generates SQL for an imported question.** Not to be helpful, not "as a starting point", not even marked as a draft. Filling one in would fabricate ground truth, which is the one thing an answer key may not contain — the answer key is what everything else is measured against, so a statement nobody verified corrupts every future verdict rather than just one item. If the user wants an imported question answered, run it (`/agami-query`), let them look at the result, and come back through the save door with what they accepted.
+
+Spec for the deterministic half: [`scripts/golden_author.py`](../../scripts/golden_author.py) (column matching, id derivation, the append-only funnel and the write-then-re-read gate). The file shape is [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md)'s.
+
+## Conversation style
+
+- **One question per turn.** This is a tool, not a tutorial. At most two sentences of prose between phases.
+- **Show before you write.** Nothing reaches disk that the user has not seen rendered first — parsed rows as a table, a replacement as a before and an after.
+- **Never volunteer SQL for a question that has none.** See the rule above; it is the reason this skill exists in the shape it does.
+
+---
+
+## Phase −1: Plan-mode check
+
+Run the detection + ask logic from [`shared/plan-mode-check.md`](../../shared/plan-mode-check.md). agami-save-golden needs Write (the pasted-table CSV, the item JSON) and Bash (the helper) — both are blocked in plan mode.
+
+**If plan mode is active and the user picks `Stay in plan mode` (or this skill is invoked under an active plan-mode context):** refuse and end the turn. **DO NOT write a plan file. DO NOT call `ExitPlanMode`.** Refusal text (verbatim):
+
+> I can't save a golden item in plan mode — every door here writes to the model tree. Switch to **Auto** or **Edit Automatically** mode (Shift+Tab to cycle) and re-invoke me with the dataset name.
+
+If plan mode is not active, skip this phase silently and go to Phase 0.
+
+---
+
+## Phase 0: Preflight
+
+1. **Plan-mode check** — Phase −1 above. Do it first; a refusal halfway through a parse is a confusing partial state.
+2. **Model present** — `<artifacts_dir>/<profile>/datasource.yaml` must exist. If not, invoke `/agami-connect`. A dataset belongs to a profile, and a profile with no model has nothing to be scored against.
+3. **See what exists** — `ls <artifacts_dir>/<profile>/golden_datasets/`. It writes nothing, and it is how you find out whether this is a new dataset or an existing one you are appending to. A missing directory is ordinary: the first write creates it.
+4. **Which dataset** — the one named in `$ARGUMENTS`, the only one that exists, or ask with `AskUserQuestion` listing what is there plus "a new one". The name is the **filename stem** (`orders` → `orders.yaml`); the file never declares its own name and the writer never puts one in.
+
+**Never glob for a dataset outside this profile.** [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md) is the authority on every field and it carries the hard rule verbatim: **never read another profile** to learn the file shape. A golden dataset is the business definitions and the answer key in one file, so a glob across `<artifacts_dir>` returns another customer's questions together with the SQL that correctly answers them — a tenant-data leak in a hosted deployment and a lift of somebody's business definitions even locally. The reference has every field; a sibling profile never is the reference.
+
+---
+
+## Phase 1: Which door
+
+Route on what the user brought, and say which door you are opening:
+
+- **A file path, a spreadsheet, a pasted table, "here are our questions"** → the import door (Phase 2).
+- **A question plus a statement plus a result they just accepted** → the save door (Phase 3).
+- **Both** ("import these, and the first one I've already checked") → import first, then the save door for the one they verified. The save door replaces the imported item by id, which is the append-only path in Phase 4 and is exactly right here — say so and confirm it rather than treating it as a surprise.
+
+---
+
+## Phase 2: The import door
+
+### 2a — Get a CSV
+
+The parser reads **one format**, and that is deliberate: one parser is one place where a column can be misread.
+
+- **A `.csv` path** — use it as given.
+- **A `.xlsx` / `.xls` path** — refuse and say how to get past it. Do not try to read it, and do not guess at its contents:
+
+  > I can't read `.xlsx` directly. Open it in Excel (or Numbers / Google Sheets) and **Save As → CSV UTF-8**, then re-invoke me with the `.csv` path.
+
+- **A table pasted into chat** — write it out as a CSV with the **Write tool** and then parse that file. One parser, one code path, and the file is also the thing the user can fix and re-run. Per [`shared/invocation-conventions.md`](../../shared/invocation-conventions.md): **never a heredoc, never `python3 -c`, never a shell variable** — quoting mangles the commas and quotes that are the whole point of a CSV. Write it to `/tmp/agami-golden-pasted-<ts>.csv` and tell the user where it went.
+
+The sheet needs a header row with a **question column** — `question`, `query`, `nl question`, `prompt` or `ask` (case, underscores and hyphens all fold). Optional columns: `id`, `expected` / `expected value` / `answer`, `sql` / `statement`, `tags`. A header the contract does not know is left alone — matching is exact, never fuzzy, so an analyst's note column costs nothing.
+
+### 2b — Parse (this writes nothing)
+
+```bash
+python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" parse \
+  --csv <path-to-csv> \
+  > /tmp/agami-golden-parse-<ts>.json
+```
+
+Then `Read` the file. `parse` is inert **by construction** — it has no write in it at all, which is what makes "the rows are confirmed before anything is written" a fact about the software rather than a promise about how you behave.
+
+The payload carries `columns` (the header as found), `rows`, `skipped` (each with its row number in the user's own sheet and why) and `summary`. Exit `2` means no column could be identified as the question; the stderr line names every header it read, which is the whole of what the user needs to rename one and re-invoke.
+
+### 2c — Render the rows and get an explicit yes
+
+**Show the rows as a markdown table.** Not a count, not a summary — the rows:
+
+```markdown
+| id | Question | Expected | SQL in the sheet? | Tags |
+|---|---|---|---|---|
+| how-many-orders-have-been-placed | How many orders have been placed? | 1,329 | — | orders, smoke |
+| revenue-by-channel-2024 | What was revenue by channel in 2024? | — | yes (unverified) | revenue |
+```
+
+Ids are derived from the question when the sheet has none, so they are stable across re-imports — say that, because it is why re-running the same sheet lands on the duplicate path instead of doubling the dataset.
+
+If `skipped` is non-empty, list every skipped row with its number and reason **before** asking. A question missing from a dataset is one nobody notices is missing.
+
+Then ask, plainly: *"Import these `<N>` questions into `<dataset>`? They'll be written unconfirmed — none of them can gate a run until someone verifies an answer."* **Wait for an explicit yes.** Never skip this and never infer it from the user having handed you the file.
+
+### 2d — Import
+
+Pass the **same parse payload** to `--rows` — the file you just showed them, not a re-derivation of it:
+
+```bash
+python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" import \
+  --profile <profile> --dataset <dataset> \
+  --rows /tmp/agami-golden-parse-<ts>.json \
+  > /tmp/agami-golden-import-<ts>.json
+```
+
+`--description "<prose>"` sets the dataset's description, and is worth passing on a new dataset. Every row is written `sql_confirmed: false` — including the rows whose sheet carried a statement, which is carried through as `expected.sql` but claims nothing. Nobody ran it.
+
+Read the exit code before the payload (Phase 4). On `0`, report `summary.added` and where the file is, then say what is still missing: *"`<N>` questions are in `<dataset>`. None can gate a run yet — ask one of them, and say 'save this as a golden question' when the answer is right."*
+
+---
+
+## Phase 3: The save door
+
+This is the only door that can produce an item able to gate a run, and it needs three things the user has actually got:
+
+1. **The question**, as a user would ask it.
+2. **The statement** that answered it — the SQL that ran, not one you are writing now.
+3. **The result they accepted**, and how they checked it.
+
+If any of the three is missing, say which one and stop. Most often this skill is invoked straight after `/agami-query` returned a result the user is happy with, and all three are in the conversation already; take them from there rather than asking again.
+
+Write the item with the **Write tool** as JSON — the same rule as any JSON file this plugin passes to a script, and for the same reason ([`shared/invocation-conventions.md`](../../shared/invocation-conventions.md)):
+
+```json
+{
+  "query": "How many paid orders came through each channel in 2024?",
+  "sql": "SELECT channel, COUNT(*) AS order_count FROM orders WHERE status = 'paid' AND placed_at >= '2024-01-01' AND placed_at < '2025-01-01' GROUP BY channel",
+  "recorded": { "columns": ["channel", "order_count"], "rows": [["web", 812], ["mobile", 517]] },
+  "confirmed_by": { "method": "read on screen and accepted by the analyst who asked" },
+  "tags": ["orders"],
+  "match": "values"
+}
+```
+
+- `id` is optional — derived from the question when absent, the same way the import door derives it, so saving an answer to an imported question lands on that item rather than beside it.
+- `recorded` is the **receipt**: what the answer looked like on the day. It is never the comparison target; a run is judged against `expected`. Take the columns and rows from the result the user just looked at.
+- `confirmed_by.method` is free text and is **required** — an answer key whose provenance is blank cannot be audited later, and the script refuses without it. Say how it was checked ("read on screen and accepted", "cross-checked against the finance close"), not who in a way that names a person.
+- `match` is optional and defaults to `exact`. Reach for `values` when column order or naming shouldn't matter, or `bounded` with `bounds` for an answer that legitimately moves — see [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md).
+- `must_filter` gates *how* the answer was reached. Add it when the question only means what it says with a filter in place (`must_filter: [status]`).
+
+```bash
+python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
+  --profile <profile> --dataset <dataset> \
+  --item /tmp/agami-golden-item-<ts>.json \
+  > /tmp/agami-golden-save-<ts>.json
+```
+
+**A relative question over a frozen answer key is refused here**, with exit `2`: *"how many orders in the last 7 days?"* names a window that slides forward and SQL pinned to a fixed date does not. Either anchor the statement to the current date (`CURRENT_DATE - INTERVAL '7 days'`, the dialect's spelling) or rewrite the question to name the window it means (`…in Q1 2024?`), then re-invoke. Do not save it and plan to fix it later — the whole point of refusing at save time is that the one person who can still fix it is here.
+
+---
+
+## Phase 4: Exit codes, and the append-only stop
+
+**Read the exit code before the payload.** Both write doors share it:
+
+- **`0`** — written. Report `added` / `replaced` and the path.
+- **`1`** — **needs confirmation.** Nothing was written. Not a failure and not a success; a pipeline that treated it as either would be wrong in both directions.
+- **`2`** — cannot start. The stderr line (prefix `agami-save-golden:`) says why. Nothing was written, or a failed write was rolled back to the bytes that were there before.
+
+On `1`, the payload carries `needs_confirmation`: a list of `{id, before, after}`. **Render both sides** — a markdown table or two fenced blocks per id, the existing item and the one that would take its place. "This id already exists" is not enough for anyone to decide with: the thing being overwritten is an answer key, and they have to see what they would lose.
+
+**A replacement is wholesale** — the item that is written is the item you sent, so anything the existing one carries and yours does not (its `tags`, a `must_filter`, a `match`) is gone. Read the `before` and carry forward what still applies before you ask; that is also what the user is agreeing to when they look at the two sides.
+
+Then ask, and only after an explicit yes re-run the **same command with `--confirm-replace` appended**:
+
+```bash
+python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
+  --profile <profile> --dataset <dataset> \
+  --item /tmp/agami-golden-item-<ts>.json --confirm-replace \
+  > /tmp/agami-golden-save-<ts>.json
+```
+
+**Never pass `--confirm-replace` pre-emptively.** Not on the first attempt, not because a re-import "is probably the same sheet", not to save a round trip. The flag means one thing — a person saw the before and the after and said yes — and passing it before that has happened makes the stop decorative. If the user says no, say the file is untouched and stop; it is byte-identical, not merely equivalent.
+
+---
+
+## Hard rules
+
+1. **Never generate SQL for an imported question.** No drafts, no "here's a starting point", no filling in a blank `expected.sql` to make a dataset look finished. Ground truth that nobody verified is worse than a gap, because a gap reports itself and a fabrication does not. Run the question and come back through the save door.
+2. **Never write `sql_confirmed: true` for an answer nobody looked at.** The save door is the only route to it, and the only thing behind that door is a person who read a result and accepted it. A statement that "looks right" is not one.
+3. **Never skip the confirmation step.** The parse is shown as a table and agreed to before the import runs; a replacement is shown as a before and an after and agreed to before `--confirm-replace` is passed. Both are the point of the two-step, not a formality in front of it.
+4. **Never read another profile.** Not to learn the file shape, not to copy a case, not to see "how other people tag these". [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md) is the authority and it has every field; a glob across profiles returns another tenant's questions together with the SQL that answers them.
+5. **Never run or score a dataset from here.** No `/agami-eval`, no executing the statement to "check it first". This skill writes. If the user wants a verdict, hand them off: *"Say 'run the evals' to score `<dataset>`."*
+6. **Never edit a dataset YAML by hand.** Every write goes through `golden_author.py`, which re-reads the file with the runner's own reader and rolls back if it would not read clean. A hand edit skips that gate, and the fault surfaces at the next run against the file rather than at the moment it was made.
+
+---
+
+## Error handling cheat sheet
+
+| Symptom | Action |
+|---|---|
+| Exit `0` | Written. Report `added` / `replaced` and the path. After an import, say plainly that nothing can gate yet. |
+| Exit `1` with `needs_confirmation` | Nothing was written. Render the before and the after for every id, ask, and re-run with `--confirm-replace` only on an explicit yes. On a no, say the file is untouched and stop. |
+| Exit `2` | Cannot start. Read the `agami-save-golden:` line on stderr — it names the cause. Nothing was written; a rolled-back write left the previous bytes exactly as they were. |
+| `agami-save-golden: this file is empty` / `no column here holds the question` / `this file has no header row` | The sheet's question column can't be identified. The refusal lists every header it read — quote it back, ask which column holds the question, and have them rename it (or add a header row) and re-invoke. Never guess at column 0: a bank of ids imported as questions fails every future run in a way that looks exactly like a model regression. |
+| `agami-save-golden: N row(s) were skipped` on a successful parse | A warning, not a stop. List every entry in `skipped` with its row number and reason before asking for the import — a question silently missing from a dataset is the failure this line exists to prevent. |
+| A `.xlsx` / `.xls` path | Refuse with the Save As → CSV UTF-8 instruction (Phase 2a). Do not attempt to read it and do not reconstruct its contents from memory. |
+| `agami-save-golden: this item does not say how its answer was confirmed` | `confirmed_by.method` was blank. Ask how the result was checked and re-write the item JSON — provenance is most of what a receipt is for. |
+| `agami-save-golden: <name>.yaml cannot be read as it stands` | The existing dataset has a fault, so nothing may be merged into it — a merge into a file the reader can't fully read would drop whatever it couldn't parse. Report the finding, point at [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md), and let the user fix the named case first. |
+| A relative question refused at save time | The window slides and the SQL doesn't. Anchor the statement to the current date, or rewrite the question to name its window, then re-invoke. Don't save it "for now". |
+| `golden_author's write doors need agami-core and its model extra` | The plugin's interpreter is missing `agami-core[model]`. Route to `/agami-connect`, which sets the environment up; nothing was written. |

--- a/plugins/agami/skills/agami-save-golden/SKILL.md
+++ b/plugins/agami/skills/agami-save-golden/SKILL.md
@@ -144,15 +144,14 @@ Write the item with the **Write tool** as JSON — the same rule as any JSON fil
   "sql": "SELECT channel, COUNT(*) AS order_count FROM orders WHERE status = 'paid' AND placed_at >= '2024-01-01' AND placed_at < '2025-01-01' GROUP BY channel",
   "recorded": { "columns": ["channel", "order_count"], "rows": [["web", 812], ["mobile", 517]] },
   "confirmed_by": { "method": "read on screen and accepted by the analyst who asked" },
-  "tags": ["orders"],
-  "match": "values"
+  "tags": ["orders"]
 }
 ```
 
 - `id` is optional — derived from the question when absent, the same way the import door derives it, so saving an answer to an imported question lands on that item rather than beside it.
 - `recorded` is the **receipt**: what the answer looked like on the day. It is never the comparison target; a run is judged against `expected`. Take the columns and rows from the result the user just looked at.
 - `confirmed_by.method` is free text and is **required** — an answer key whose provenance is blank cannot be audited later, and the script refuses without it. Say how it was checked ("read on screen and accepted", "cross-checked against the finance close"), not who in a way that names a person.
-- `match` is optional and defaults to `exact`. Reach for `values` when column order or naming shouldn't matter, or `bounded` **with** a `bounds` block for an answer that legitimately moves — see [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md). `bounded` with no band is refused with exit `2`: a level with nothing to consult would keep passing forever.
+- `match` is optional and **defaults to `exact`, which is almost always the right answer**. Column pairing is by value at every level — neither a column's name nor its position is ever consulted — so "the names or the order might differ" is never a reason to loosen. `values` forgives exactly two things: a floating-point tail, and an extra column the question did not ask for. Reach for it when the answer carries a real float, and **not for a count or a result whose columns the question already names** — over-answering is the most common way a generated statement is wrong, and `values` is the level that forgives it. `bounded` takes a `bounds` block, for an answer that legitimately moves — see [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md). `bounded` with no band is refused with exit `2`: a level with nothing to consult would keep passing forever.
 - `must_filter` gates *how* the answer was reached. Add it when the question only means what it says with a filter in place (`must_filter: [status]`).
 
 `match`, `bounds` and `must_filter` all reach the written item exactly as sent — which is why a replacement has to repeat whatever the existing item carried (Phase 4).

--- a/plugins/agami/skills/agami-save-golden/SKILL.md
+++ b/plugins/agami/skills/agami-save-golden/SKILL.md
@@ -47,7 +47,7 @@ If plan mode is not active, skip this phase silently and go to Phase 0.
 1. **Plan-mode check** — Phase −1 above. Do it first; a refusal halfway through a parse is a confusing partial state.
 2. **Model present** — `<artifacts_dir>/<profile>/datasource.yaml` must exist. If not, invoke `/agami-connect`. A dataset belongs to a profile, and a profile with no model has nothing to be scored against.
 3. **See what exists** — `ls <artifacts_dir>/<profile>/golden_datasets/`. It writes nothing, and it is how you find out whether this is a new dataset or an existing one you are appending to. A missing directory is ordinary: the first write creates it.
-4. **Which dataset** — the one named in `$ARGUMENTS`, the only one that exists, or ask with `AskUserQuestion` listing what is there plus "a new one". The name is the **filename stem** (`orders` → `orders.yaml`); the file never declares its own name and the writer never puts one in.
+4. **Which dataset** — the one named in `$ARGUMENTS`, the only one that exists, or ask with `AskUserQuestion` listing what is there plus "a new one". The name is the **filename stem** (`orders` → `orders.yaml`); the file never declares its own name and the writer never puts one in. A stem is **one plain name** — letters, digits, dots, dashes and underscores, nothing else. `--profile` is held to the same rule. Both are joined straight into the path the writer truncates and rewrites, so anything with a separator or a `..` in it is refused with exit `2` before a single byte is read; never "helpfully" pass a path where a name is asked for.
 
 **Never glob for a dataset outside this profile.** [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md) is the authority on every field and it carries the hard rule verbatim: **never read another profile** to learn the file shape. A golden dataset is the business definitions and the answer key in one file, so a glob across `<artifacts_dir>` returns another customer's questions together with the SQL that correctly answers them — a tenant-data leak in a hosted deployment and a lift of somebody's business definitions even locally. The reference has every field; a sibling profile never is the reference.
 
@@ -105,6 +105,8 @@ Ids are derived from the question when the sheet has none, so they are stable ac
 
 If `skipped` is non-empty, list every skipped row with its number and reason **before** asking. A question missing from a dataset is one nobody notices is missing.
 
+Derived ids are unique by construction, but a sheet with its **own `id` column** can repeat one. The import refuses the whole batch and names the id, because an id is the key a result is stored under and the second row would otherwise overwrite the first inside one write. The table you just rendered is where to spot it — ask the user which row keeps the id.
+
 Then ask, plainly: *"Import these `<N>` questions into `<dataset>`? They'll be written unconfirmed — none of them can gate a run until someone verifies an answer."* **Wait for an explicit yes.** Never skip this and never infer it from the user having handed you the file.
 
 ### 2d — Import
@@ -150,8 +152,10 @@ Write the item with the **Write tool** as JSON — the same rule as any JSON fil
 - `id` is optional — derived from the question when absent, the same way the import door derives it, so saving an answer to an imported question lands on that item rather than beside it.
 - `recorded` is the **receipt**: what the answer looked like on the day. It is never the comparison target; a run is judged against `expected`. Take the columns and rows from the result the user just looked at.
 - `confirmed_by.method` is free text and is **required** — an answer key whose provenance is blank cannot be audited later, and the script refuses without it. Say how it was checked ("read on screen and accepted", "cross-checked against the finance close"), not who in a way that names a person.
-- `match` is optional and defaults to `exact`. Reach for `values` when column order or naming shouldn't matter, or `bounded` with `bounds` for an answer that legitimately moves — see [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md).
+- `match` is optional and defaults to `exact`. Reach for `values` when column order or naming shouldn't matter, or `bounded` **with** a `bounds` block for an answer that legitimately moves — see [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md). `bounded` with no band is refused with exit `2`: a level with nothing to consult would keep passing forever.
 - `must_filter` gates *how* the answer was reached. Add it when the question only means what it says with a filter in place (`must_filter: [status]`).
+
+`match`, `bounds` and `must_filter` all reach the written item exactly as sent — which is why a replacement has to repeat whatever the existing item carried (Phase 4).
 
 ```bash
 python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
@@ -169,7 +173,7 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
 **Read the exit code before the payload.** Both write doors share it:
 
 - **`0`** — written. Report `added` / `replaced` and the path.
-- **`1`** — **needs confirmation.** Nothing was written. Not a failure and not a success; a pipeline that treated it as either would be wrong in both directions.
+- **`1`** — **needs confirmation.** Nothing was written. Not a failure and not a success; a pipeline that treated it as either would be wrong in both directions. **This is the only thing that produces `1`** — every other outcome, expected or not, is `2` with a sentence on stderr — so a `1` always carries a `needs_confirmation` payload and is never a crash. If you ever see `1` with no such payload, stop and report it rather than re-running with `--confirm-replace`.
 - **`2`** — cannot start. The stderr line (prefix `agami-save-golden:`) says why. Nothing was written, or a failed write was rolled back to the bytes that were there before.
 
 On `1`, the payload carries `needs_confirmation`: a list of `{id, before, after}`. **Render both sides** — a markdown table or two fenced blocks per id, the existing item and the one that would take its place. "This id already exists" is not enough for anyone to decide with: the thing being overwritten is an answer key, and they have to see what they would lose.
@@ -211,6 +215,11 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
 | `agami-save-golden: N row(s) were skipped` on a successful parse | A warning, not a stop. List every entry in `skipped` with its row number and reason before asking for the import — a question silently missing from a dataset is the failure this line exists to prevent. |
 | A `.xlsx` / `.xls` path | Refuse with the Save As → CSV UTF-8 instruction (Phase 2a). Do not attempt to read it and do not reconstruct its contents from memory. |
 | `agami-save-golden: this item does not say how its answer was confirmed` | `confirmed_by.method` was blank. Ask how the result was checked and re-write the item JSON — provenance is most of what a receipt is for. |
-| `agami-save-golden: <name>.yaml cannot be read as it stands` | The existing dataset has a fault, so nothing may be merged into it — a merge into a file the reader can't fully read would drop whatever it couldn't parse. Report the finding, point at [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md), and let the user fix the named case first. |
+| `agami-save-golden: '<name>' is not a usable dataset name` / `profile name` | The stem or the profile was a path, not a name. Ask for the plain name (`orders`, not `orders/2024` or `../orders`) and re-invoke. Nothing was read and nothing was written. |
+| `agami-save-golden: dataset '<name>' names the file rather than the dataset` | The extension was typed too. The stem *is* the dataset's name, so pass `orders`, not `orders.yaml`. Re-invoke; nothing was written. |
+| `agami-save-golden: this batch carries the id '<id>' twice` | The sheet's own `id` column repeats a key, so two questions would land under one. Nothing was written. Show the user the two rows and ask which keeps the id. |
+| `agami-save-golden: this does not fit a golden case — …` | The item JSON is a shape the dataset reader refuses — most often `match: bounded` with no `bounds` block, or a `sql: null` on a save. The sentence names the field and the reason (never the value). Fix the item JSON and re-run. |
+| `agami-save-golden: <path> does not exist` / `this file is not readable JSON` | The `--csv` / `--rows` / `--item` path is wrong or the file you wrote is truncated. Re-write it with the Write tool and re-run; nothing was written. |
+| `agami-save-golden: <name>.yaml cannot be read as it stands` | The existing dataset has a fault that costs it a case, so nothing may be merged into it — a merge into a file the reader can't fully read would drop whatever it couldn't parse. Report the finding, point at [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md), and let the user fix the named case first. (A dataset that merely *reports* a relative question over a frozen answer key is not this: that finding drops nothing, and writing to the dataset still works.) |
 | A relative question refused at save time | The window slides and the SQL doesn't. Anchor the statement to the current date, or rewrite the question to name its window, then re-invoke. Don't save it "for now". |
 | `golden_author's write doors need agami-core and its model extra` | The plugin's interpreter is missing `agami-core[model]`. Route to `/agami-connect`, which sets the environment up; nothing was written. |

--- a/tests/test_ah109_save_golden_skill.py
+++ b/tests/test_ah109_save_golden_skill.py
@@ -1,0 +1,111 @@
+"""The save-golden skill's prose, and the shared docs that route to it.
+
+Everything here asserts on Markdown rather than on code, for the reason `test_ah106_eval_skill.py`
+gives about its own doc section: these behaviors have no code-level equivalent. The helper cannot
+make the model render the parsed rows before importing them, refuse to invent SQL for a question
+that has none, or decline to glob a neighbouring profile for a file shape — the skill is the only
+place those live, so "the skill says X" is the only decidable check there is.
+
+The one exception is the last test, which asserts on code precisely because it can: the answer key
+must not be reachable from the MCP surface, and that is a fact about `tools.py`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "plugins" / "agami" / "skills"
+SHARED = REPO_ROOT / "plugins" / "agami" / "shared"
+
+SKILL = (SKILLS_DIR / "agami-save-golden" / "SKILL.md").read_text(encoding="utf-8")
+FRONTMATTER = SKILL.split("---")[1]
+CONVENTIONS = (SHARED / "invocation-conventions.md").read_text(encoding="utf-8")
+FILE_LAYOUT = (SHARED / "file-layout.md").read_text(encoding="utf-8")
+PLAN_MODE = (SHARED / "plan-mode-check.md").read_text(encoding="utf-8")
+
+
+def test_the_skill_carries_the_four_frontmatter_keys():
+    """The house shape. `argument-hint` is the one a new skill forgets, and without it the dataset
+    name has nowhere to arrive from."""
+    assert SKILL.startswith("---\n")  # frontmatter at the top, not prose
+    assert "name: agami-save-golden" in FRONTMATTER
+    assert "description:" in FRONTMATTER
+    assert "when_to_use:" in FRONTMATTER
+    assert 'argument-hint: "[dataset-name]"' in FRONTMATTER
+
+
+def test_the_skill_refuses_in_plan_mode():
+    """SC-9. Every door here writes to the model tree, so none of them can proceed read-only.
+
+    The refusal has to be the literal sentence rather than any refusal, because the shared doc and
+    the skill both carry it and a drift between the two is how a skill starts refusing with wording
+    nobody wrote."""
+    assert "shared/plan-mode-check.md" in SKILL  # the shared detection logic
+    assert "I can't save a golden item in plan mode" in SKILL  # …and the sentence it ends on
+    assert "DO NOT call `ExitPlanMode`" in SKILL  # …without leaving a plan file behind
+
+
+def test_the_skill_carries_the_shared_shape_hard_rule():
+    """A golden dataset is the business definitions AND the answer key in one file, so a glob for a
+    sibling's returns another tenant's questions together with the SQL that answers them. The
+    authoring skill is exactly where that temptation lands, so it carries the rule rather than only
+    linking to it."""
+    assert "shared/golden-dataset-shape.md" in SKILL
+    assert "never read another profile" in SKILL
+
+
+def test_the_skill_never_offers_to_generate_sql_for_an_imported_question():
+    """The prohibition this skill exists around. An imported question has no verified answer, and
+    filling one in would put a statement nobody ran into the thing every future verdict is measured
+    against — a fabrication that, unlike a gap, does not report itself."""
+    assert "never generates SQL for an imported question" in SKILL
+    assert "fabricate ground truth" in SKILL
+    # …and again as a hard rule, because a reason stated once in prose is a reason skimmed past.
+    assert "Never generate SQL for an imported question" in SKILL
+
+
+def test_the_routing_triggers_are_the_skills_own():
+    """The table header says the triggers come from `when_to_use`, so a phrase in the row that the
+    frontmatter does not carry routes nothing — it reads as a trigger and is not one."""
+    row = next(
+        line for line in CONVENTIONS.splitlines() if line.startswith("| agami-save-golden |")
+    )
+    quoted = re.findall(r'"([^"]+)"', row)
+
+    assert quoted, "the agami-save-golden row no longer quotes any trigger phrase"
+    for phrase in quoted:
+        assert phrase in FRONTMATTER
+
+
+def test_plan_mode_check_documents_this_skill():
+    """The shared doc is the single source of the detection + ask logic, and its per-skill section
+    is what a reader consults to see what a given skill does when the user stays in plan mode. A
+    skill absent from it has no documented stay-in-plan-mode behavior at all."""
+    assert "### `agami-save-golden`" in PLAN_MODE
+    assert "I can't save a golden item in plan mode" in PLAN_MODE
+
+
+def test_file_layout_no_longer_says_no_skill_writes_one():
+    """The layout doc said no skill writes a golden dataset, which this slice makes false.
+
+    Asserted here rather than left to `test_file_layout_documents_the_golden_dataset_path`, which
+    only checks for the substring "golden_datasets" and stays green while the sentence beside it
+    tells a reader the opposite of the truth."""
+    assert "no skill writes one today" not in FILE_LAYOUT
+    assert "/agami-save-golden" in FILE_LAYOUT
+    assert "golden_datasets" in FILE_LAYOUT
+
+
+def test_the_author_script_registers_no_mcp_tool():
+    """REQ-006. The answer key is never reachable from the MCP surface.
+
+    A hosted server's tool surface is the one place a remote caller can reach, and a tool that
+    authored golden items would let one write the thing its own model is scored against. Authoring
+    is a local, human-confirmed flow behind a skill; asserting the script's name appears nowhere in
+    `tools.py` is what keeps a future registration from being a quiet one."""
+    tools = (REPO_ROOT / "packages" / "agami-core" / "src" / "tools.py").read_text(
+        encoding="utf-8"
+    )
+    assert "golden_author" not in tools

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -324,7 +324,6 @@ def test_the_written_file_never_declares_its_own_name(tmp_path, monkeypatch, cap
     _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row()])))
     doc = yaml.safe_load(_dataset_file(tmp_path).read_text(encoding="utf-8"))
     assert "name" not in doc
-    assert doc["description"] == ""
 
 
 def test_re_importing_the_same_sheet_asks_before_it_doubles_anything(tmp_path, monkeypatch, capsys):
@@ -571,3 +570,405 @@ def test_a_relative_question_anchored_on_the_current_date_saves(tmp_path, monkey
     )
     assert code == 0
     assert _items(tmp_path)[0].expected.sql == ANCHORED_SQL
+
+
+# --- the names the doors are handed, and the tree they may not leave ---
+#
+# `--profile` and `--dataset` are joined straight into a filesystem path this helper then WRITES,
+# so they are the one pair of inputs where being wrong is destructive rather than merely useless.
+# Every test here asserts the neighbour is untouched as well as the refusal, because a refusal that
+# still landed the file would pass a test that only read the exit code.
+
+
+def _neighbour(tmp_path) -> Path:
+    """A model file beside the datasets dir, standing in for whatever the profile already holds."""
+    path = tmp_path / PROFILE / "datasource.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("datasource: store\n", encoding="utf-8")
+    return path
+
+
+def test_a_dataset_name_that_climbs_out_of_the_profile_is_refused(tmp_path, monkeypatch, capsys):
+    """A stem is one filename, so a stem that walks up out of the profile is not a stem.
+
+    The escape is the whole finding: `../../other/golden_datasets/stolen` writes an answer key into
+    a sibling profile, which in a hosted deployment is another tenant's tree. Refused on the name,
+    before any path is built from it.
+    """
+    rows = _rows_file(tmp_path, [_row()])
+    stem = "../../othertenant/golden_datasets/stolen"
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _import_argv(rows, stem))
+    assert code == 2
+    assert "dataset" in err
+    assert not (tmp_path / "othertenant").exists()
+
+
+def test_a_profile_name_that_climbs_out_of_the_artifacts_dir_is_refused(
+    tmp_path, monkeypatch, capsys
+):
+    """The other half of the join. A profile is a directory name under the artifacts dir, and one
+    that climbs above it leaves the tree agami owns entirely."""
+    rows = _rows_file(tmp_path, [_row()])
+    code, _, err = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        ["import", "--profile", "../outside", "--dataset", "orders", "--rows", rows],
+    )
+    assert code == 2
+    assert "profile" in err
+    assert not (tmp_path.parent / "outside").exists()
+
+
+def test_a_dataset_name_carrying_a_separator_is_refused(tmp_path, monkeypatch, capsys):
+    """`sub/nested` needs no `..` to break the contract, which is why the rule is a whitelist.
+
+    The reader globs `*.yaml` in one directory and never recurses, so a file written a level down is
+    one the re-read cannot see: `_our_faults` finds nothing, and the write reports itself validated
+    when nothing validated it.
+    """
+    rows = _rows_file(tmp_path, [_row()])
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _import_argv(rows, "sub/nested"))
+    assert code == 2
+    assert "dataset" in err
+    assert not (tmp_path / PROFILE / "golden_datasets" / "sub").exists()
+
+
+def test_a_dataset_name_carrying_its_own_extension_is_refused(tmp_path, monkeypatch, capsys):
+    """`--dataset orders.yaml` reads as helpful and writes `orders.yaml.yaml`.
+
+    The stem is the dataset's name, and the reader takes that name from the filename stem — so the
+    extension the author typed becomes part of what their dataset is called. `orders.yml` is the
+    worse half: the reader refuses a real `.yml` file as misnamed, so a dataset called `orders.yml`
+    reads back fine and contradicts the one rule the directory has.
+    """
+    rows = _rows_file(tmp_path, [_row()])
+    for stem in ("orders.yaml", "orders.yml", "ORDERS.YML"):
+        code, _, err = _run(tmp_path, monkeypatch, capsys, _import_argv(rows, stem))
+        assert code == 2, stem
+        assert "without the extension" in err, stem
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+
+def test_a_traversing_dataset_name_never_touches_the_file_it_names(tmp_path, monkeypatch, capsys):
+    """The destructive direction, and the reason the check runs before any I/O.
+
+    `../datasource` resolves onto the profile's own semantic model, and this door truncates and
+    rewrites whatever `<stem>.yaml` names — so an unchecked stem does not merely write in the wrong
+    place, it destroys the file already there and reports success.
+    """
+    neighbour = _neighbour(tmp_path)
+    before = neighbour.read_bytes()
+    rows = _rows_file(tmp_path, [_row()])
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _import_argv(rows, "../datasource"))
+    assert code == 2
+    assert neighbour.read_bytes() == before
+
+
+def test_an_ordinary_stem_with_dots_and_dashes_still_writes(tmp_path, monkeypatch, capsys):
+    """The control. The rule refuses separators and parent hops, not the names people use."""
+    rows = _rows_file(tmp_path, [_row()])
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _import_argv(rows, "orders.v2-smoke"))
+    assert code == 0
+    assert [item.query for item in _items(tmp_path, "orders.v2-smoke")] == [QUERY]
+
+
+# --- exit 1 means one thing, so nothing unexpected may produce it ---
+#
+# The skill reads the exit code before the payload and `1` tells it to render a `needs_confirmation`
+# block and re-run with `--confirm-replace`. An uncaught exception exiting 1 therefore escalates a
+# crash into a confirmed-overwrite attempt, which is why every one of these asserts on the code
+# rather than only on the message.
+
+
+def _json_file(tmp_path, name: str, body) -> str:
+    path = tmp_path / name
+    path.write_text(body if isinstance(body, str) else json.dumps(body), encoding="utf-8")
+    return str(path)
+
+
+def test_an_item_missing_its_statement_refuses_rather_than_crashing(tmp_path, monkeypatch, capsys):
+    """A save-door item with no `sql` key: ordinary input, and a `KeyError` before the fix."""
+    item = _json_file(
+        tmp_path, "item.json", {"query": QUERY, "confirmed_by": {"method": METHOD}}
+    )
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _save_argv(item))
+    assert code == 2
+    assert golden_author._PREFIX in err
+    assert "sql" in err
+    assert "Traceback" not in err
+
+
+def test_an_item_whose_statement_is_null_refuses_without_echoing_the_item(
+    tmp_path, monkeypatch, capsys
+):
+    """`sql: null` builds a confirmed case with no answer key, which pydantic refuses.
+
+    The value must not travel with the refusal: pydantic's own text carries `input_value=`, which
+    for this model is the answer key and the recorded result — the exact thing
+    `golden._validation_digest` exists to strip before a finding is forwarded anywhere.
+    """
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path, sql=None)))
+    assert code == 2
+    assert "input_value" not in err
+    assert QUERY not in err
+    assert "order_count" not in err
+    assert "Traceback" not in err
+
+
+def test_a_malformed_item_file_refuses_with_its_own_sentence(tmp_path, monkeypatch, capsys):
+    """A truncated or hand-mangled JSON file is a caller mistake, not a crash."""
+    item = _json_file(tmp_path, "item.json", '{"query": "How many orders?",')
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _save_argv(item))
+    assert code == 2
+    assert "JSON" in err
+    assert "Traceback" not in err
+
+
+def test_a_missing_input_file_refuses_with_its_own_sentence(tmp_path, monkeypatch, capsys):
+    """The commonest mistake of all — a path that is not there — and the least useful traceback."""
+    missing = str(tmp_path / "not-here.csv")
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    code = golden_author.main(["parse", "--csv", missing])
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "not-here.csv" in err
+    assert "Traceback" not in err
+
+
+# --- a dataset that already holds a relative/frozen case is not a dataset nobody may write to ---
+
+
+def _with_frozen_case(tmp_path, stem: str = "orders") -> Path:
+    """A hand-written dataset holding one item the relativity lint reports and does not drop.
+
+    Hand-authoring is a supported path, and the lint deliberately keeps the item — so this file is
+    readable, complete, and reports a finding forever. A guard that treated any finding as a reason
+    to refuse a merge would make it a dataset nobody can ever add to again.
+    """
+    path = _dataset_file(tmp_path, stem)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "test_cases": [
+                    {
+                        "id": "stale-window",
+                        "query": RELATIVE,
+                        "expected": {"sql": FROZEN_SQL, "sql_confirmed": True},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _cases(tmp_path, stem: str = "orders"):
+    """The dataset's cases without asserting the read was clean — for the files that report one."""
+    datasets, _ = load_golden_datasets(PROFILE, tmp_path)
+    return next(d.test_cases for d in datasets if d.name == stem)
+
+
+def test_a_dataset_holding_a_frozen_case_still_accepts_a_save(tmp_path, monkeypatch, capsys):
+    """The deadlock. The lint keeps the item, so its finding is permanent — and a pre-read guard
+    that refused on it would refuse every future write to this dataset, with Hard Rule 6 forbidding
+    the hand edit that is the only way out."""
+    _with_frozen_case(tmp_path)
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+    assert code == 0, err
+    assert [item.id for item in _cases(tmp_path)] == [
+        "stale-window",
+        "how-many-orders-have-been-placed",
+    ]
+
+
+def test_a_dataset_holding_a_frozen_case_still_accepts_an_import(tmp_path, monkeypatch, capsys):
+    """The same deadlock through the other door, because the guard is in the shared funnel."""
+    _with_frozen_case(tmp_path)
+    code, _, err = _run(
+        tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row(REVENUE)]))
+    )
+    assert code == 0, err
+    assert len(_cases(tmp_path)) == 2
+
+
+def test_a_dataset_the_reader_would_drop_a_case_from_refuses_the_merge(
+    tmp_path, monkeypatch, capsys
+):
+    """The guard's real job, which the fix above must not remove.
+
+    A case the reader cannot parse is a case it DROPS, so merging into this file would rewrite it
+    without the dropped case — this write deleting somebody else's question to make room for its
+    own. Refused, and the file is left exactly as it was.
+    """
+    path = _dataset_file(tmp_path, "orders")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # `sql_confirmed` is the one field with no default, so this case cannot be read at all.
+    path.write_text(
+        yaml.safe_dump({"test_cases": [{"id": "stale", "query": QUERY, "expected": {}}]}),
+        encoding="utf-8",
+    )
+    before = path.read_bytes()
+
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+    assert code == 2
+    assert "cannot be read as it stands" in err
+    assert path.read_bytes() == before
+
+
+def test_a_frozen_item_over_an_existing_id_is_refused_before_the_confirmation_walk(
+    tmp_path, monkeypatch, capsys
+):
+    """The relativity refusal is unconditional, so asking about the replacement first is asking a
+    question whose every answer is refused. It comes before the append-only stop."""
+    rows = _rows_file(tmp_path, [_row(RELATIVE)])
+    assert _run(tmp_path, monkeypatch, capsys, _import_argv(rows))[0] == 0
+    code, payload, err = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        _save_argv(_item_file(tmp_path, query=RELATIVE, sql=FROZEN_SQL)),
+    )
+    assert code == 2
+    assert payload is None
+    assert "moves with time" in err
+
+
+# --- one id, one item: a duplicate inside a single write is refused, never merged away ---
+
+
+def _dup_rows(tmp_path) -> str:
+    """A sheet whose own `id` column repeats — two different questions under one key."""
+    return _rows_file(tmp_path, [_row(QUERY, id="q1"), _row(REVENUE, id="q1")])
+
+
+def test_two_rows_sharing_an_id_are_refused_against_the_sheet_not_the_file(
+    tmp_path, monkeypatch, capsys
+):
+    """A repeated `id` column value is a clash in the person's own sheet, and has to read as one.
+
+    Left to the re-read, the fault arrives as `orders.yaml[q1]: this id was already used in this
+    file` and the WHOLE import is rolled back — 200 good rows lost, blamed on a file the person did
+    not write, for a duplicate that is two rows of their spreadsheet.
+    """
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _import_argv(_dup_rows(tmp_path)))
+    assert code == 2
+    assert "q1" in err
+    assert "already used in this file" not in err
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+
+def test_a_duplicated_id_never_reports_more_items_than_it_wrote(tmp_path, monkeypatch, capsys):
+    """The payload is what the skill reports to the person, so it may not overcount the file.
+
+    `added` / `replaced` are counted off the raw list while the merge keys on the id, so with
+    `--confirm-replace` the duplicate lands: exit 0, `replaced: [q1, q1]`, and one item on disk with
+    the first row's question gone and nothing said about it.
+    """
+    assert _run(
+        tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row(QUERY, id="q1")]))
+    )[0] == 0
+    code, payload, err = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        _import_argv(_dup_rows(tmp_path), "orders", "--confirm-replace"),
+    )
+    assert code == 2, payload
+    assert "q1" in err
+    assert [item.query for item in _items(tmp_path)] == [QUERY]
+
+
+# --- the fields the item JSON documents, carried rather than dropped ---
+
+
+def test_a_must_filter_survives_the_save(tmp_path, monkeypatch, capsys):
+    """`must_filter` gates HOW the answer was reached, and the skill tells the model to carry it
+    forward on a replacement — so a door that dropped it would lose the gate on every save-over,
+    silently and at exit 0."""
+    code, _, _ = _run(
+        tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path, must_filter=["status"]))
+    )
+    assert code == 0
+    assert _items(tmp_path)[0].must_filter == ["status"]
+
+
+def test_a_bounded_item_saves_with_its_band(tmp_path, monkeypatch, capsys):
+    """`bounds` is the other half of `match: bounded`, and AH-100 refuses either half alone."""
+    code, _, err = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        _save_argv(_item_file(tmp_path, match="bounded", bounds={"min_rows": 1})),
+    )
+    assert code == 0, err
+    item = _items(tmp_path)[0]
+    assert item.match == "bounded"
+    assert item.bounds.min_rows == 1
+
+
+def test_a_bounded_item_with_no_band_is_refused_not_crashed(tmp_path, monkeypatch, capsys):
+    """A band nothing consults and a level with nothing to consult both keep passing, so AH-100
+    refuses the shape — and that refusal has to reach the person as a sentence, not a traceback."""
+    code, _, err = _run(
+        tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path, match="bounded"))
+    )
+    assert code == 2
+    assert "bounds" in err
+    assert "Traceback" not in err
+
+
+# --- the small ones ---
+
+
+def test_a_neighbour_named_after_this_stem_does_not_roll_our_write_back(
+    tmp_path, monkeypatch, capsys
+):
+    """`orders.yaml.yaml` is a different dataset whose locator starts with `orders.yaml`.
+
+    Prefix matching would attribute its findings to this write and roll back a correct file, which
+    is the same misattribution `_our_faults` exists to prevent for any other neighbour.
+    """
+    gdir = tmp_path / PROFILE / "golden_datasets"
+    gdir.mkdir(parents=True)
+    (gdir / "orders.yaml.yaml").write_text(
+        yaml.safe_dump({"test_cases": [{"id": "stale", "query": QUERY, "expected": {}}]}),
+        encoding="utf-8",
+    )
+    code, _, err = _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row()])))
+    assert code == 0, err
+    assert _dataset_file(tmp_path).exists()
+
+
+def test_a_dataset_written_without_a_description_carries_no_empty_one(
+    tmp_path, monkeypatch, capsys
+):
+    """`description: ''` as line 1 is exactly the noise `_drop_empty` exists to keep out of a file
+    a person reads and diffs — the reader defaults it, so writing it says nothing."""
+    _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row()])))
+    doc = yaml.safe_load(_dataset_file(tmp_path).read_text(encoding="utf-8"))
+    assert "description" not in doc
+
+
+def test_an_item_with_no_confirmation_method_is_refused(tmp_path, monkeypatch, capsys):
+    """An answer key whose provenance is blank cannot be audited later, which is most of what a
+    receipt is for. Blank rather than absent: a whitespace method is the likelier mistake."""
+    code, _, err = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        _save_argv(_item_file(tmp_path, confirmed_by={"method": "  "})),
+    )
+    assert code == 2
+    assert "confirmed_by.method" in err
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+
+def test_an_empty_sheet_refuses_and_says_what_is_missing(tmp_path, monkeypatch, capsys):
+    """A zero-byte CSV has no header row, so there is no column contract to match at all."""
+    code, payload, err = _parse(tmp_path, monkeypatch, capsys, "")
+    assert code == 2
+    assert payload is None
+    assert "empty" in err

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -1,0 +1,219 @@
+"""The parse door of the golden-authoring helper: what it reads, what it refuses, and what it
+does NOT do.
+
+`golden_author.py parse` is the step between a spreadsheet and a dataset, and it is deliberately
+inert: it reads a CSV, matches its header against a column contract, derives an id per row, and
+prints what it found. **It writes nothing.** That is the spec's third success criterion, and
+`test_parse_writes_nothing` is the whole of it — "the rows are confirmed before anything is
+written" is only a decidable claim if the parse itself cannot write, which is a property of the
+code rather than a promise about how a skill drives it.
+
+The refusals matter as much as the happy path. A question bank whose question column cannot be
+identified is a sheet somebody laid out differently, not a sheet whose first column is the
+question — guessing column 0 would import a bank of ids or timestamps as questions and every one
+of them would read back as a model failure later. So the refusal names every header it actually
+found, which is the only thing the person needs in order to fix it.
+
+Every fixture is a question over the shipped sample store database, so nothing here names a real
+dataset, table or question.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import golden_author  # noqa: E402
+
+PROFILE = "demo"
+
+QUERY = "How many orders have been placed?"
+SQL = "SELECT COUNT(*) AS order_count FROM orders"
+
+
+def _csv(tmp_path, body: str) -> str:
+    path = tmp_path / "questions.csv"
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+def _parse(tmp_path, monkeypatch, capsys, body: str):
+    """Run the parse verb over `body` and return (exit code, stdout payload, stderr)."""
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    code = golden_author.main(["parse", "--csv", _csv(tmp_path, body)])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out) if captured.out.strip() else None
+    return code, payload, captured.err
+
+
+# --- the point of the slice ---
+
+
+def test_parse_writes_nothing(tmp_path, monkeypatch, capsys):
+    """SC-3. A successful parse leaves the model tree exactly as it found it.
+
+    The confirmation step this slice exists to enable is only real if the parse cannot write, so
+    this asserts the absence of the directory a write would have to create rather than the absence
+    of a particular file.
+    """
+    code, payload, _ = _parse(tmp_path, monkeypatch, capsys, f"question,sql\n{QUERY},{SQL}\n")
+    assert code == 0
+    assert payload["summary"] == {"parsed": 1, "skipped": 0}
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+
+# --- the refusals ---
+
+
+def test_an_unmatched_question_column_refuses_and_names_the_headers(tmp_path, monkeypatch, capsys):
+    """SC-4. A sheet with no recognisable question column stops, and says what it saw.
+
+    Never a fallback to column 0: a bank of ids imported as questions produces items that fail
+    every run for a reason that looks like a model regression and is not one. Naming the headers is
+    what lets the person rename one and re-invoke.
+    """
+    code, payload, err = _parse(
+        tmp_path, monkeypatch, capsys, "ticket ref,owner,notes\nT-1,analyst,check this\n"
+    )
+    assert code == 2
+    assert payload is None
+    for header in ("ticket ref", "owner", "notes"):
+        assert header in err
+
+
+def test_a_file_with_no_header_row_refuses_and_names_its_first_row(tmp_path, monkeypatch, capsys):
+    """A headerless sheet cannot have a column contract, so it is the same refusal.
+
+    The first row is data, and importing it as a header would silently drop a real question as
+    well as mis-key every column below it.
+    """
+    code, payload, err = _parse(
+        tmp_path, monkeypatch, capsys, f"{QUERY},42\nHow many customers?,7\n"
+    )
+    assert code == 2
+    assert payload is None
+    assert "header" in err.lower()
+    assert QUERY in err
+
+
+# --- the per-row rules ---
+
+
+def test_an_empty_question_is_skipped_and_counted(tmp_path, monkeypatch, capsys):
+    """SC-5. A blank question is reported as skipped, never dropped.
+
+    A sheet that comes back one row shorter than it went in, with nothing said about it, is how an
+    import quietly loses a question nobody notices is missing.
+    """
+    code, payload, _ = _parse(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        f"question\n{QUERY}\n   \nHow many customers are on file?\n",
+    )
+    assert code == 0
+    assert payload["summary"] == {"parsed": 2, "skipped": 1}
+    assert payload["skipped"] == [{"row": 2, "reason": "empty question"}]
+    assert [row["query"] for row in payload["rows"]] == [QUERY, "How many customers are on file?"]
+
+
+def test_a_question_of_only_punctuation_is_skipped_and_counted(tmp_path, monkeypatch, capsys):
+    """A question that slugs to nothing has no id, so it is skipped for a stated reason.
+
+    Writing it under an empty id would collide with the next one like it, and the append-only
+    duplicate path would then fire on two rows that have nothing to do with each other.
+    """
+    code, payload, _ = _parse(tmp_path, monkeypatch, capsys, f"question\n???\n{QUERY}\n")
+    assert code == 0
+    assert payload["summary"] == {"parsed": 1, "skipped": 1}
+    assert payload["skipped"] == [{"row": 1, "reason": "question has no usable characters"}]
+
+
+def test_two_questions_that_slug_alike_get_distinct_ids(tmp_path, monkeypatch, capsys):
+    """Different questions that derive the same slug must not collide inside one parse.
+
+    `GoldenItem.item_key` is exactly the id, so two rows sharing one would be a duplicate on the
+    write path — and the person would be asked to resolve a clash between two questions they can
+    both legitimately keep.
+    """
+    code, payload, _ = _parse(
+        tmp_path, monkeypatch, capsys, "question\nHow many orders?\nHow many orders!\n"
+    )
+    assert code == 0
+    assert [row["id"] for row in payload["rows"]] == ["how-many-orders", "how-many-orders-2"]
+
+
+def test_an_explicit_id_column_wins_over_the_derived_slug(tmp_path, monkeypatch, capsys):
+    """A sheet that already keys its rows keeps its own keys.
+
+    The slug exists so re-importing an unkeyed sheet is idempotent; a sheet with an id column
+    already has that property, and overriding it would break the person's own cross-reference.
+    """
+    code, payload, _ = _parse(tmp_path, monkeypatch, capsys, f"id,question\norders-count,{QUERY}\n")
+    assert code == 0
+    assert [row["id"] for row in payload["rows"]] == ["orders-count"]
+
+
+def test_header_aliases_fold_case_and_underscores(tmp_path, monkeypatch, capsys):
+    """`NL_Question` is the same column as `nl question`, and a spreadsheet writes either.
+
+    Folding is exact-match against a named alias set, not fuzzy matching: a header this contract
+    does not know is an analyst's own note column and is ignored, which is only safe while a match
+    is never approximate.
+    """
+    code, payload, _ = _parse(
+        tmp_path, monkeypatch, capsys, f"NL_Question, Expected-Value \n{QUERY},7\n"
+    )
+    assert code == 0
+    assert payload["columns"] == ["NL_Question", " Expected-Value "]
+    assert payload["rows"][0]["query"] == QUERY
+    assert payload["rows"][0]["expected_value"] == 7.0
+
+
+def test_expected_values_are_normalized_and_an_unparseable_one_is_null(
+    tmp_path, monkeypatch, capsys
+):
+    """The expected column goes through `reconcile.parse_value`, dashboard spellings and all.
+
+    Reusing the reconcile parser rather than re-deriving number parsing is the decision under test:
+    a second definition of what `$1.2M` means is a second answer to the same question. A cell it
+    cannot read is `null` rather than a refusal — this value is shown in the confirmation table and
+    never becomes an answer key, so an unreadable one costs the person nothing.
+    """
+    code, payload, _ = _parse(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        f"question,expected\n{QUERY},$1.2M\nWhat is our total revenue?,about a dozen\n",
+    )
+    assert code == 0
+    assert [row["expected_value"] for row in payload["rows"]] == [1200000.0, None]
+
+
+def test_a_statement_column_is_carried_without_claiming_confirmation(tmp_path, monkeypatch, capsys):
+    """A sheet may already hold SQL, and carrying it must not read as verification.
+
+    Nobody ran that statement here, so nothing in this payload may say it was confirmed: the
+    confirmed-only rule is what makes a golden run's green mean something, and a spreadsheet
+    column is not a person who looked at a result.
+    """
+    code, payload, _ = _parse(tmp_path, monkeypatch, capsys, f"question,statement\n{QUERY},{SQL}\n")
+    assert code == 0
+    assert payload["rows"][0]["sql"] == SQL
+    assert "confirm" not in json.dumps(payload).lower()
+
+
+def test_tags_split_on_commas(tmp_path, monkeypatch, capsys):
+    """A tag cell is a list a person typed into one box, and empties are noise rather than tags."""
+    code, payload, _ = _parse(
+        tmp_path, monkeypatch, capsys, f'question,tags\n{QUERY},"smoke, revenue,,"\n'
+    )
+    assert code == 0
+    assert payload["rows"][0]["tags"] == ["smoke", "revenue"]

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -128,7 +128,8 @@ def test_an_empty_question_is_skipped_and_counted(tmp_path, monkeypatch, capsys)
     )
     assert code == 0
     assert payload["summary"] == {"parsed": 2, "skipped": 1}
-    assert payload["skipped"] == [{"row": 2, "reason": "empty question"}]
+    # Sheet row 3: the header is row 1 and the blank sits under the first question.
+    assert payload["skipped"] == [{"row": 3, "reason": "empty question"}]
     assert [row["query"] for row in payload["rows"]] == [QUERY, "How many customers are on file?"]
 
 
@@ -141,7 +142,8 @@ def test_a_question_of_only_punctuation_is_skipped_and_counted(tmp_path, monkeyp
     code, payload, _ = _parse(tmp_path, monkeypatch, capsys, f"question\n???\n{QUERY}\n")
     assert code == 0
     assert payload["summary"] == {"parsed": 1, "skipped": 1}
-    assert payload["skipped"] == [{"row": 1, "reason": "question has no usable characters"}]
+    # Sheet row 2 — the first line under the header.
+    assert payload["skipped"] == [{"row": 2, "reason": "question has no usable characters"}]
 
 
 def test_two_questions_that_slug_alike_get_distinct_ids(tmp_path, monkeypatch, capsys):
@@ -435,9 +437,7 @@ def test_a_failed_reread_on_a_new_dataset_leaves_nothing_behind(tmp_path, monkey
 METHOD = "read on screen and accepted"
 RELATIVE = "How many orders were placed in the last 7 days?"
 FROZEN_SQL = "SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= '2026-01-01'"
-ANCHORED_SQL = (
-    "SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= CURRENT_DATE - 7"
-)
+ANCHORED_SQL = "SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= CURRENT_DATE - 7"
 
 
 def _item_file(tmp_path, **kw) -> str:
@@ -520,7 +520,10 @@ def test_a_duplicate_save_confirmed_replaces_the_item_in_place(tmp_path, monkeyp
     assert _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, rows)))[0] == 0
 
     code, payload, _ = _run(
-        tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path), "orders", "--confirm-replace")
+        tmp_path,
+        monkeypatch,
+        capsys,
+        _save_argv(_item_file(tmp_path), "orders", "--confirm-replace"),
     )
     assert code == 0
     assert payload["replaced"] == ["how-many-orders-have-been-placed"]
@@ -689,9 +692,7 @@ def _json_file(tmp_path, name: str, body) -> str:
 
 def test_an_item_missing_its_statement_refuses_rather_than_crashing(tmp_path, monkeypatch, capsys):
     """A save-door item with no `sql` key: ordinary input, and a `KeyError` before the fix."""
-    item = _json_file(
-        tmp_path, "item.json", {"query": QUERY, "confirmed_by": {"method": METHOD}}
-    )
+    item = _json_file(tmp_path, "item.json", {"query": QUERY, "confirmed_by": {"method": METHOD}})
     code, _, err = _run(tmp_path, monkeypatch, capsys, _save_argv(item))
     assert code == 2
     assert golden_author._PREFIX in err
@@ -867,9 +868,15 @@ def test_a_duplicated_id_never_reports_more_items_than_it_wrote(tmp_path, monkey
     `--confirm-replace` the duplicate lands: exit 0, `replaced: [q1, q1]`, and one item on disk with
     the first row's question gone and nothing said about it.
     """
-    assert _run(
-        tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row(QUERY, id="q1")]))
-    )[0] == 0
+    assert (
+        _run(
+            tmp_path,
+            monkeypatch,
+            capsys,
+            _import_argv(_rows_file(tmp_path, [_row(QUERY, id="q1")])),
+        )[0]
+        == 0
+    )
     code, payload, err = _run(
         tmp_path,
         monkeypatch,

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -425,3 +425,149 @@ def test_a_failed_reread_on_a_new_dataset_leaves_nothing_behind(tmp_path, monkey
     code, _, _ = _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row()])))
     assert code == 2
     assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+
+# --- the save door, and the lint it is refused by ---
+#
+# The second door is the only one that can produce an item able to gate a run, because it is the
+# only one behind which a person looked at a result. It writes through the same funnel as the
+# import door, so everything asserted above holds here too and is not re-asserted.
+
+METHOD = "read on screen and accepted"
+RELATIVE = "How many orders were placed in the last 7 days?"
+FROZEN_SQL = "SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= '2026-01-01'"
+ANCHORED_SQL = (
+    "SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= CURRENT_DATE - 7"
+)
+
+
+def _item_file(tmp_path, **kw) -> str:
+    """One answer somebody accepted, in the shape AH-111 will send."""
+    payload = {
+        "id": None,
+        "query": QUERY,
+        "sql": SQL,
+        "match": None,
+        "tags": None,
+        "recorded": {"columns": ["order_count"], "rows": [[42]]},
+        "confirmed_by": {"method": METHOD},
+    }
+    payload.update(kw)
+    path = tmp_path / "item.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+def _save_argv(item_path: str, stem: str = "orders", *extra: str) -> list[str]:
+    return ["save", "--profile", PROFILE, "--dataset", stem, "--item", item_path, *extra]
+
+
+def test_a_saved_answer_carries_its_statement_and_receipt(tmp_path, monkeypatch, capsys):
+    """SC-6. The one door that can produce an item able to gate a run.
+
+    All four parts have to survive the round trip together: without the statement there is nothing
+    to compare, without `sql_confirmed` the runner will not let the case gate, and without the
+    receipt a reviewer months later cannot see what the answer looked like on the day somebody
+    accepted it. `confirmed_by.method` is carried verbatim — AH-100 types it as free text on
+    purpose, so nothing here narrows it to a vocabulary.
+    """
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+    assert code == 0
+    item = _items(tmp_path)[0]
+    assert item.id == "how-many-orders-have-been-placed"
+    assert item.expected.sql_confirmed is True
+    assert item.expected.sql == SQL
+    assert item.recorded.columns == ["order_count"] and item.recorded.rows == [[42]]
+    assert item.confirmed_by.method == METHOD
+    # Both stamps are set here rather than left None: a receipt that cannot say when it was taken
+    # is not much of a receipt.
+    assert item.recorded.at and item.confirmed_by.at
+    assert item.match == "exact"
+
+
+def test_a_duplicate_save_declined_leaves_the_file_byte_identical(tmp_path, monkeypatch, capsys):
+    """SC-7, the decline direction. An answer key that can be overwritten in passing is not one.
+
+    This is the whole of the append-only objection: the risk was never that the door exists, but
+    that it would make a failing item easy to replace. So the person is shown the statement that is
+    there and the statement that would take its place, and until they say yes the file is not
+    touched at all — byte-identical, not merely equivalent.
+    """
+    _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+    before = _dataset_file(tmp_path).read_bytes()
+
+    replacement = _item_file(
+        tmp_path, sql=REVENUE_SQL, recorded={"columns": ["revenue"], "rows": [[1234.56]]}
+    )
+    code, payload, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(replacement))
+    assert code == 1
+    assert _dataset_file(tmp_path).read_bytes() == before
+
+    entry = payload["needs_confirmation"][0]
+    assert entry["id"] == "how-many-orders-have-been-placed"
+    assert entry["before"]["expected"]["sql"] == SQL
+    assert entry["after"]["expected"]["sql"] == REVENUE_SQL
+
+
+def test_a_duplicate_save_confirmed_replaces_the_item_in_place(tmp_path, monkeypatch, capsys):
+    """SC-7, the accept direction. The yes replaces one item and disturbs nothing else.
+
+    In place rather than appended: the id is the key every stored result is already filed under,
+    and moving the case to the end of the file would reorder a diff nobody asked to reorder. Its
+    siblings staying unconfirmed is the other half — a confirmation is about one answer, and a
+    door that promoted the whole file would be the forged gate again by another route.
+    """
+    rows = [_row(REVENUE), _row(), _row("How many customers are on file?")]
+    assert _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, rows)))[0] == 0
+
+    code, payload, _ = _run(
+        tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path), "orders", "--confirm-replace")
+    )
+    assert code == 0
+    assert payload["replaced"] == ["how-many-orders-have-been-placed"]
+    assert payload["added"] == []
+
+    items = _items(tmp_path)
+    assert [item.id for item in items] == [
+        "what-is-our-total-revenue",
+        "how-many-orders-have-been-placed",
+        "how-many-customers-are-on-file",
+    ]
+    assert items[1].expected.sql == SQL
+    assert [item.expected.sql_confirmed for item in items] == [False, True, False]
+
+
+def test_a_relative_question_with_frozen_sql_is_refused_at_save_time(tmp_path, monkeypatch, capsys):
+    """SC-8. A question that moves with time and an answer key that does not is refused now.
+
+    The lint is AH-100's, called rather than restated — a second copy of those three regexes would
+    drift, and this is exactly the "no second parser" failure the repo guards against. The point of
+    running it here is the timing: the reader would report this at the next run, by which time the
+    dataset is written and whoever reads the finding has to work out that saving it was the mistake.
+    """
+    code, _, err = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        _save_argv(_item_file(tmp_path, query=RELATIVE, sql=FROZEN_SQL)),
+    )
+    assert code == 2
+    assert "moves with time" in err
+    # Nothing was written, not even the directory — the refusal is before the write, not a rollback.
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+
+def test_a_relative_question_anchored_on_the_current_date_saves(tmp_path, monkeypatch, capsys):
+    """The control for the refusal above: the lint objects to the pinning, not to the question.
+
+    Without this, a pre-check that refused every question phrased against today would pass the test
+    beside it while making the save door useless for the commonest question there is.
+    """
+    code, _, _ = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        _save_argv(_item_file(tmp_path, query=RELATIVE, sql=ANCHORED_SQL)),
+    )
+    assert code == 0
+    assert _items(tmp_path)[0].expected.sql == ANCHORED_SQL

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -24,6 +24,12 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
+# The write doors go through AH-100's models, so the whole module needs the optional model extra
+# even though the parse door is stdlib-only.
+pytest.importorskip("pydantic")
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
 if str(PKG_SRC) not in sys.path:
@@ -31,6 +37,8 @@ if str(PKG_SRC) not in sys.path:
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
 import golden_author  # noqa: E402
+import yaml  # noqa: E402
+from semantic_model.golden import load_golden_datasets  # noqa: E402
 
 PROFILE = "demo"
 
@@ -217,3 +225,203 @@ def test_tags_split_on_commas(tmp_path, monkeypatch, capsys):
     )
     assert code == 0
     assert payload["rows"][0]["tags"] == ["smoke", "revenue"]
+
+
+# --- the write core, and the import door on top of it ---
+#
+# Every write in this helper — both doors, and AH-111's promotion later — goes through one funnel,
+# so the append-only rule and the write-then-re-read gate are asserted once here and inherited.
+# The reader is the only validator there is (`semantic_model.golden` ships no writer and no
+# standalone `validate()`), which is why every one of these tests ends by reading the file back
+# rather than by inspecting the YAML it just wrote.
+
+REVENUE = "What is our total revenue?"
+REVENUE_SQL = "SELECT ROUND(SUM(total_amount), 2) AS revenue FROM orders"
+
+
+def _run(tmp_path, monkeypatch, capsys, argv: list[str]):
+    """Run any verb and return (exit code, stdout payload, stderr)."""
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    code = golden_author.main(argv)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out) if captured.out.strip() else None
+    return code, payload, captured.err
+
+
+def _row(query: str = QUERY, **kw) -> dict:
+    """One row of the `parse` payload, keyed the way the parse door keys it."""
+    return {
+        "id": golden_author._slug(query),
+        "query": query,
+        "expected_value": None,
+        "sql": None,
+        "tags": [],
+        **kw,
+    }
+
+
+def _rows_file(tmp_path, rows: list[dict]) -> str:
+    """The `parse` payload as the skill hands it back after the person has confirmed it."""
+    path = tmp_path / "parsed.json"
+    path.write_text(json.dumps({"rows": rows}), encoding="utf-8")
+    return str(path)
+
+
+def _import_argv(rows_path: str, stem: str = "orders", *extra: str) -> list[str]:
+    return ["import", "--profile", PROFILE, "--dataset", stem, "--rows", rows_path, *extra]
+
+
+def _dataset_file(tmp_path, stem: str = "orders") -> Path:
+    return tmp_path / PROFILE / "golden_datasets" / f"{stem}.yaml"
+
+
+def _items(tmp_path, stem: str = "orders"):
+    """The dataset's cases as the runner would see them, asserting the read was clean."""
+    datasets, res = load_golden_datasets(PROFILE, tmp_path)
+    assert res.ok, res.errors
+    return next(d.test_cases for d in datasets if d.name == stem)
+
+
+def test_imported_items_read_back_through_the_reader(tmp_path, monkeypatch, capsys):
+    """SC-1. A sheet of questions becomes items the runner can read, in sheet order.
+
+    Reading them back through `load_golden_datasets` rather than through the YAML is the whole
+    assertion: the writer's only claim to correctness is that the reader the runner uses accepts
+    what it wrote, so a test that inspected the dump would be checking the writer against itself.
+    """
+    rows = [_row(), _row(REVENUE)]
+    code, payload, _ = _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, rows)))
+    assert code == 0
+    assert payload["added"] == ["how-many-orders-have-been-placed", "what-is-our-total-revenue"]
+    assert payload["replaced"] == []
+    assert payload["summary"] == {"added": 2, "replaced": 0}
+    assert [item.query for item in _items(tmp_path)] == [QUERY, REVENUE]
+
+
+def test_an_import_never_marks_its_own_rows_confirmed(tmp_path, monkeypatch, capsys):
+    """SC-2. Not one imported row is confirmed — least of all the row that came with SQL.
+
+    A sheet's statement column is carried, because throwing it away would lose work; but nobody
+    ran it, and an import that marked its own rows verified would forge the gate the confirmed-only
+    rule exists to be. The row with a statement is in this fixture precisely because it is the one
+    a writer would be tempted to promote.
+    """
+    rows = [_row(), _row(REVENUE, sql=REVENUE_SQL)]
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, rows)))
+    assert code == 0
+    items = _items(tmp_path)
+    assert [item.expected.sql_confirmed for item in items] == [False, False]
+    assert items[1].expected.sql == REVENUE_SQL
+
+
+def test_the_written_file_never_declares_its_own_name(tmp_path, monkeypatch, capsys):
+    """The dataset's name is its filename, and a file that says so again is refused by the reader.
+
+    `load_golden_datasets` rejects a `name:` key outright (`golden_invalid_dataset`), so a dumper
+    that serialized the model whole would write a file it could never read back. The reader would
+    catch it, but only after the write — this pins the shape at the point it is produced.
+    """
+    _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row()])))
+    doc = yaml.safe_load(_dataset_file(tmp_path).read_text(encoding="utf-8"))
+    assert "name" not in doc
+    assert doc["description"] == ""
+
+
+def test_re_importing_the_same_sheet_asks_before_it_doubles_anything(tmp_path, monkeypatch, capsys):
+    """The determinism of the derived id is what makes a second import a duplicate, not a doubling.
+
+    This is the payoff of `_slug`: sequential ids would land the same questions under fresh keys,
+    the append-only rule would never fire on the import door, and a dataset would silently grow a
+    second copy of every question each time somebody re-ran the sheet.
+    """
+    argv = _import_argv(_rows_file(tmp_path, [_row()]))
+    assert _run(tmp_path, monkeypatch, capsys, argv)[0] == 0
+    code, payload, _ = _run(tmp_path, monkeypatch, capsys, argv)
+    assert code == 1
+    assert [entry["id"] for entry in payload["needs_confirmation"]] == [
+        "how-many-orders-have-been-placed"
+    ]
+    assert len(_items(tmp_path)) == 1
+
+
+def test_a_broken_dataset_elsewhere_neither_blocks_the_write_nor_gets_repaired(
+    tmp_path, monkeypatch, capsys
+):
+    """A correct write must not be rolled back by somebody else's already-broken file.
+
+    The re-read validates the whole profile, so an unrelated dataset that was already failing would
+    otherwise fail our write too — rolling back a correct file and reporting a fault at a locator
+    the person did not touch. The other half matters as much: the broken file is left exactly as it
+    was, because quietly rewriting a neighbour is not this door's business either.
+    """
+    gdir = tmp_path / PROFILE / "golden_datasets"
+    gdir.mkdir(parents=True)
+    broken = gdir / "legacy.yaml"
+    # `sql_confirmed` is the one field with no default, so this case cannot be read at all.
+    broken.write_text(
+        yaml.safe_dump({"test_cases": [{"id": "stale", "query": QUERY, "expected": {}}]}),
+        encoding="utf-8",
+    )
+    before = broken.read_bytes()
+
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row()])))
+    assert code == 0
+    assert _dataset_file(tmp_path).exists()
+    assert broken.read_bytes() == before
+
+    datasets, res = load_golden_datasets(PROFILE, tmp_path)
+    assert [d.name for d in datasets] == ["legacy", "orders"]
+    assert [f.locator for f in res.findings] == ["legacy.yaml[stale]"]
+
+
+def _break_the_reread(monkeypatch, stem: str, marker: str) -> None:
+    """Make the re-read report an error for `stem` once `marker` reaches disk.
+
+    There is no input this door can construct that the reader then refuses — the writer builds
+    `GoldenItem`s, so pydantic has already accepted everything by the time it is dumped. That is
+    the design working, and it also means the rollback has no natural fixture: the only way to
+    exercise it is to fail the re-read on purpose.
+    """
+    real = golden_author.load_golden_datasets
+
+    def fake(profile, art=None):
+        datasets, res = real(profile, art)
+        path = golden_author._datasets_dir(profile) / f"{stem}.yaml"
+        if path.exists() and marker in path.read_text(encoding="utf-8"):
+            locator = f"{stem}.yaml[{marker}]"
+            res.error("golden_invalid_case", f"{locator}: injected by the test", locator=locator)
+        return datasets, res
+
+    monkeypatch.setattr(golden_author, "load_golden_datasets", fake)
+
+
+def test_a_failed_reread_restores_the_previous_bytes(tmp_path, monkeypatch, capsys):
+    """A write the reader rejects leaves the dataset byte-identical to what it was.
+
+    Byte-identical rather than merely equivalent: a rollback that re-dumped the parsed model would
+    silently reformat a file the person may have hand-written, which is a change nobody asked for
+    on the path where nothing was supposed to change at all.
+    """
+    assert _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row()])))[0] == 0
+    before = _dataset_file(tmp_path).read_bytes()
+
+    _break_the_reread(monkeypatch, "orders", "what-is-our-total-revenue")
+    code, _, err = _run(
+        tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row(REVENUE)]))
+    )
+    assert code == 2
+    assert _dataset_file(tmp_path).read_bytes() == before
+    assert "injected by the test" in err
+
+
+def test_a_failed_reread_on_a_new_dataset_leaves_nothing_behind(tmp_path, monkeypatch, capsys):
+    """The first write to a profile creates the directory too, so the rollback has to unmake both.
+
+    A half-created `golden_datasets/` holding a file the reader refused is worse than no dataset:
+    the next run reads it, reports the fault, and the person has to work out that nothing they did
+    ever succeeded.
+    """
+    _break_the_reread(monkeypatch, "orders", "how-many-orders-have-been-placed")
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _import_argv(_rows_file(tmp_path, [_row()])))
+    assert code == 2
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()

--- a/tests/test_golden_authoring_e2e.py
+++ b/tests/test_golden_authoring_e2e.py
@@ -1,0 +1,172 @@
+"""Both doors, end to end, over one dataset — the flow the feature contract describes.
+
+The unit file beside this one pins each door's own behavior; what it cannot show is the shape a
+profile is actually left in after a team uses this feature, because that shape is the two doors
+interleaved. A question bank arrives, every question lands unconfirmed, somebody asks one of them,
+looks at the answer and saves it — and the dataset the runner then reads holds both kinds at once.
+That last read is the assertion that matters: the writer's only claim to correctness is that
+AH-100's reader, the one `/agami-eval` uses, accepts what it wrote.
+
+The script is driven in-process (`golden_author.main`) rather than through a subprocess so that a
+failure surfaces as a traceback in the code under test rather than as a non-zero exit code. Nothing
+is stubbed: the real column contract, the real writer, the real reader.
+
+Every question is synthetic, over the shipped sample `store` database (orders / customers /
+channels), so nothing here names a real dataset, table or question.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
+if str(PKG_SRC) not in sys.path:
+    sys.path.insert(0, str(PKG_SRC))
+sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
+
+import golden_author  # noqa: E402
+from semantic_model.golden import load_golden_datasets  # noqa: E402
+
+PROFILE = "demo"
+DATASET = "orders"
+
+# The question bank as an analyst hands it over: one column of questions, one note column the
+# contract does not know (and must leave alone), and one row that already carries a tag.
+QUESTION_BANK = """NL_Question,Owner note,tags
+How many orders have been placed?,the headline number,"orders,smoke"
+How many paid orders came through each channel in 2024?,split by channel,orders
+How many customers have placed at least one order?,,customers
+"""
+
+PAID_BY_CHANNEL = "How many paid orders came through each channel in 2024?"
+PAID_BY_CHANNEL_SQL = (
+    "SELECT channel, COUNT(*) AS order_count FROM orders "
+    "WHERE status = 'paid' AND placed_at >= '2024-01-01' AND placed_at < '2025-01-01' "
+    "GROUP BY channel"
+)
+METHOD = "read on screen and accepted by the analyst who asked"
+
+
+def _run(tmp_path, monkeypatch, capsys, argv: list[str]):
+    """Run one verb the way the skill runs it, and return (exit code, stdout payload)."""
+    monkeypatch.setenv("AGAMI_ARTIFACTS_DIR", str(tmp_path))
+    code = golden_author.main(argv)
+    captured = capsys.readouterr()
+    return code, (json.loads(captured.out) if captured.out.strip() else None)
+
+
+def _write(tmp_path, name: str, body: str) -> str:
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+def test_a_question_bank_imports_unconfirmed_and_one_verified_answer_confirms_it(
+    tmp_path, monkeypatch, capsys
+):
+    """The whole feature in one flow: import, then save, then read the result back.
+
+    The three acceptance points of the contract are asserted in the order a team meets them, and
+    the middle one is deliberately a save against a question the import already created — that is
+    the ordinary path (you import the bank, then work through it), and it is also the path that
+    goes through the append-only stop, so the two-step confirmation is exercised as part of the
+    flow rather than as a special case.
+    """
+    # --- 1. the import door: a sheet becomes items, and not one of them is confirmed ---
+    parse_code, parsed = _run(
+        tmp_path, monkeypatch, capsys, ["parse", "--csv", _write(tmp_path, "bank.csv", QUESTION_BANK)]
+    )
+    assert parse_code == 0
+    assert parsed["summary"] == {"parsed": 3, "skipped": 0}
+    # The parse is inert by construction; nothing exists to be read back yet.
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+    rows_file = _write(tmp_path, "parsed.json", json.dumps(parsed))
+    import_code, imported = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        ["import", "--profile", PROFILE, "--dataset", DATASET, "--rows", rows_file,
+         "--description", "Order-volume questions over the sample store database."],
+    )
+    assert import_code == 0
+    assert imported["summary"] == {"added": 3, "replaced": 0}
+
+    datasets, res = load_golden_datasets(PROFILE, tmp_path)
+    items = {item.id: item for item in next(d.test_cases for d in datasets if d.name == DATASET)}
+    assert len(items) == 3
+    # Every one of them, without exception. An import writes the questions a team cares about; it
+    # does not write answers, and a row that claimed to be confirmed would gate a run on nothing.
+    assert not any(item.expected.sql_confirmed for item in items.values())
+    assert not any(item.expected.sql for item in items.values())
+
+    # --- 2. the save door: one answer somebody looked at, against a question already imported ---
+    target = golden_author._slug(PAID_BY_CHANNEL)
+    assert target in items  # the derived id is what makes this a save INTO the bank, not beside it
+
+    item_file = _write(
+        tmp_path,
+        "item.json",
+        json.dumps(
+            {
+                "query": PAID_BY_CHANNEL,
+                "sql": PAID_BY_CHANNEL_SQL,
+                "match": "values",
+                # Carried explicitly. A replacement is wholesale — the item written is the item
+                # sent — so the tag the sheet supplied survives only because the save repeats it.
+                "tags": ["orders"],
+                "recorded": {
+                    "columns": ["channel", "order_count"],
+                    "rows": [["web", 812], ["mobile", 517]],
+                },
+                "confirmed_by": {"method": METHOD},
+            }
+        ),
+    )
+    save_argv = ["save", "--profile", PROFILE, "--dataset", DATASET, "--item", item_file]
+
+    # The item exists already, so the append-only rule fires first: the person is shown what is
+    # there and what would take its place, and nothing is written until they say yes.
+    stop_code, stop = _run(tmp_path, monkeypatch, capsys, save_argv)
+    assert stop_code == 1
+    (pending,) = stop["needs_confirmation"]
+    assert pending["id"] == target
+    assert pending["before"]["expected"]["sql_confirmed"] is False
+    assert pending["after"]["expected"]["sql"] == PAID_BY_CHANNEL_SQL
+
+    saved_code, saved = _run(tmp_path, monkeypatch, capsys, [*save_argv, "--confirm-replace"])
+    assert saved_code == 0
+    assert saved["summary"] == {"added": 0, "replaced": 1}
+
+    # --- 3. imported and saved together, read back through the reader the runner uses ---
+    datasets, res = load_golden_datasets(PROFILE, tmp_path)
+    assert res.ok, res.errors
+    assert not [f for f in res.findings if (f.locator or "").startswith(f"{DATASET}.yaml")]
+
+    dataset = next(d for d in datasets if d.name == DATASET)
+    assert dataset.description == "Order-volume questions over the sample store database."
+    # The replacement landed in place rather than at the end: the id is the key results already
+    # hang off, so a save must not reorder the file it merged into.
+    assert [item.id for item in dataset.test_cases] == [item_id for item_id in items]
+
+    confirmed = next(item for item in dataset.test_cases if item.id == target)
+    assert confirmed.expected.sql_confirmed is True
+    assert confirmed.expected.sql == PAID_BY_CHANNEL_SQL
+    assert confirmed.match == "values"
+    assert confirmed.tags == ["orders"]
+    # The receipt: what the answer looked like on the day, and how it was vouched for.
+    assert confirmed.recorded.columns == ["channel", "order_count"]
+    assert confirmed.recorded.rows == [["web", 812], ["mobile", 517]]
+    assert confirmed.confirmed_by.method == METHOD
+    assert confirmed.recorded.at and confirmed.confirmed_by.at
+
+    # …and the other two are untouched: still questions with no answer, still unable to gate.
+    others = [item for item in dataset.test_cases if item.id != target]
+    assert [item.expected.sql_confirmed for item in others] == [False, False]


### PR DESCRIPTION
Spec: AH-109

## Summary

A golden dataset that has to be hand-written stays empty, and an empty dataset gates nothing. This adds two doors into one, and keeps them apart on purpose.

- **The import door** turns a CSV question bank into items written `sql_confirmed: false`. Volume arrives here, and it gates nothing.
- **The save door** turns one answer a person just accepted into an item written `sql_confirmed: true`, with the statement that produced it and the result as its receipt.

A spreadsheet holds questions, not the statement that answers them, so an import that marked its own rows verified would forge the gate — the suite would fail on its own errors and teach people to ignore it. Keeping the doors separate is what makes the confirmed-only rule mean anything.

Everything is append-only: a write that would change an existing item renders the before and the after and stops for an explicit yes. Every write funnels through one function, so the rule holds for both doors — and for AH-111, which calls the save door rather than writing its own way in.

## Changes

- **`plugins/agami/scripts/golden_author.py`** — three verbs. `parse` reads a CSV against a column contract and prints a preview, writing nothing. `import` and `save` go through `_write_items`, which snapshots the file's bytes, merges, dumps, and re-reads through the runner's own reader, rolling back if that re-read refuses. There is no separate validator in the library — reading *is* validating — so this is how a write proves itself.
- **`plugins/agami/skills/agami-save-golden/SKILL.md`** — the ninth skill. Refuses in plan mode; refuses an `.xlsx` with the Save As → CSV instruction the other skills already use; never generates SQL for an imported question, because an imported item has no statement until someone runs it and saves the answer.
- **Shared docs** — a row in `invocation-conventions.md` (and its count), the `golden_datasets` row in `file-layout.md`, which claimed no skill wrote one, a `plan-mode-check.md` subsection, and a pointer in `golden-dataset-shape.md`. Its HARD RULE against reading a sibling profile is untouched and carried into the skill: a golden dataset is the business definitions and the answer key in one file, so a glob across profiles returns another tenant's questions together with the SQL that answers them.
- **Tests** — 47 across the script and the end-to-end flow, plus 8 on the skill's prose.

## Decisions taken during the build

- **CSV only in v1.** `openpyxl` is not available — the package declares no dependencies and the plugin ships without a pip install — and `agami-connect` and `agami-query` already answer an `.xlsx` with "save it as CSV". The success criterion asking for byte-identical CSV and `.xlsx` output went with it: with no `.xlsx` path it was unprovable.
- **An imported row's id is a deterministic slug of its question**, with an explicit `id` column winning. The id *is* the duplicate check, so deriving it from the question makes re-importing the same sheet idempotent; sequential ids would append a second copy under fresh keys and the append-only rule would never fire.
- **An imported expected value is shown and then dropped.** It is normalized and rendered so the parse can be checked, but there is nowhere in the shape to put a scalar expectation, and writing it would put an unverified number where the answer key goes.
- **Exit `1` means "needs confirmation" and nothing else.** The skill answers a `1` by re-running with `--confirm-replace`, so every unexpected failure reports `2`.

## Review findings fixed before this PR

Three review passes ran against the diff; two independently reproduced the first item.

- **A dataset name could write outside the dataset it named.** The stem and profile were joined into a path this door truncates and rewrites, so `--dataset ../datasource` replaced the profile's own model file at exit `0` — invisible to the append-only check and to the re-read gate, because the reader globs one directory and never saw the file to object to it. Both are now one plain name, checked before any I/O, with a containment assert behind it.
- **Every uncaught exception exited `1`** — the code the skill reads as "an item would change, re-run with `--confirm-replace`" — so a missing key or a truncated file was escalated into a confirmed overwrite. A refused case now also reports the field and the reason without the value it choked on.
- **A batch carrying one id twice** dropped a question and reported both as written.
- **`must_filter` and `bounds`** were documented on the item and discarded, so a gate the author asked for silently did not exist and a bounded case could not be saved at all.
- **A relative question over a frozen answer key** made a dataset that already held one unwritable forever, with only the hand edit the skill forbids to get out. Incoming items are still refused for it before the write.
- **A spec id in shipped markdown** broke an existing test. A SKILL.md is the prompt, loaded verbatim, so the id meant nothing at runtime — the reference now names the reader.

## Checklist

- [x] Spec linked (`AH-109`), and the change stays inside its scope
- [x] Every success criterion has a passing test; each was also exercised by hand against the real script
- [x] `ruff check` clean; gitleaks clean; no vendored-lib drift
- [x] No existing test weakened or deleted — `git diff origin/main -- tests/` is additive except the spec-id fix
- [x] Public-repo safe: synthetic fixtures over the sample `store` database, no customer names, no credentials
- [x] No network egress (the new script is auto-enrolled in `test_privacy_no_network.py`)
- [x] No MCP tool and no REST route — the answer key stays off the MCP surface
- [ ] **Suite is not fully green**: 39 tests fail, identically on `main` at `0d8fe75` (`test_admin_model`, `test_admin_activity`, `test_cloud_neutral_config`, `test_model_deploy`, `test_model_store_roundtrip`, `test_prompt_examples_serving`, `test_ace110_query_basis`). This branch adds none of them and fixes none; they want their own bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
