### PR TITLE
Promotion from a reconcile run: keep the answers the run already proved

### DIFF
--- a/plugins/agami/scripts/reconcile.py
+++ b/plugins/agami/scripts/reconcile.py
@@ -8,6 +8,7 @@ this helper handles the deterministic parts:
 - CSV parsing (header / no-header, common dialects)
 - Number-string parsing ($4.2M, ₹2.16Cr, "47,238,221.00", "42%", etc.)
 - Diff logic with tolerance
+- The tolerance band around an observed number, in a golden item's own bounds keys
 
 Stdlib only.
 
@@ -18,6 +19,9 @@ Usage:
 
     # Diff two numbers (expected vs actual) with optional tolerance:
     python3 reconcile.py diff --expected 47238221 --actual 47200000 --tolerance 0.01
+
+    # Band an observed number, ready to paste as a golden item's `bounds`:
+    python3 reconcile.py band --value 47238221 --tolerance 0.01
 """
 
 from __future__ import annotations
@@ -235,6 +239,31 @@ def diff(
     }
 
 
+# --- Band -----------------------------------------------------------------
+
+def band(value: float, *, tolerance: float = 0.01) -> dict:
+    """The band a single observed number is allowed to land in, as `GoldenBounds` keys.
+
+    `tolerance` is fractional (0.01 = ±1%), the same shape and default `diff` uses. The four
+    keys are exactly the ones `semantic_model.golden.GoldenBounds` accepts, so a caller pastes
+    the output into an item and does no arithmetic of its own.
+
+    Returns:
+      {"min_rows": 1, "max_rows": 1, "min_value": <float>, "max_value": <float>}
+    """
+    low, high = value * (1 - tolerance), value * (1 + tolerance)
+    # A negative observation inverts the two — and GoldenBounds refuses a floor above its
+    # ceiling, so the band would be rejected rather than merely read oddly. A zero value falls
+    # out of this as a zero band, which matches diff's rule that a zero expected is only ever
+    # matched exactly: there is no relative tolerance around nothing.
+    return {
+        "min_rows": 1,
+        "max_rows": 1,
+        "min_value": min(low, high),
+        "max_value": max(low, high),
+    }
+
+
 # --- CLI ------------------------------------------------------------------
 
 def main(argv: list[str] | None = None) -> int:
@@ -249,6 +278,10 @@ def main(argv: list[str] | None = None) -> int:
     p_diff.add_argument("--actual", required=True)
     p_diff.add_argument("--tolerance", type=float, default=0.01)
 
+    p_band = sub.add_parser("band", help="Band an observed number for a golden item's bounds.")
+    p_band.add_argument("--value", required=True)
+    p_band.add_argument("--tolerance", type=float, default=0.01)
+
     args = p.parse_args(argv)
 
     if args.cmd == "parse":
@@ -261,6 +294,10 @@ def main(argv: list[str] | None = None) -> int:
         a = parse_value(args.actual)
         result = diff(e, a, tolerance=args.tolerance)
         print(json.dumps(result, indent=2))
+        return 0
+
+    if args.cmd == "band":
+        print(json.dumps(band(parse_value(args.value), tolerance=args.tolerance), indent=2))
         return 0
 
     return 2

--- a/plugins/agami/scripts/reconcile.py
+++ b/plugins/agami/scripts/reconcile.py
@@ -297,7 +297,18 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.cmd == "band":
-        print(json.dumps(band(parse_value(args.value), tolerance=args.tolerance), indent=2))
+        value = parse_value(args.value)
+        if value is None:
+            # Refused rather than crashed, and specifically not with exit 1: the band feeds a
+            # golden item, and 1 on that path is the save door's "needs confirmation" — a
+            # traceback landing on it would read as a stop somebody could say yes to.
+            print(
+                f"reconcile band: could not read a number from --value {args.value!r}; "
+                "pass the observed value as it was recorded.",
+                file=sys.stderr,
+            )
+            return 2
+        print(json.dumps(band(value, tolerance=args.tolerance), indent=2))
         return 0
 
     return 2

--- a/plugins/agami/scripts/reconcile.py
+++ b/plugins/agami/scripts/reconcile.py
@@ -19,6 +19,7 @@ Usage:
 
     # Diff two numbers (expected vs actual) with optional tolerance:
     python3 reconcile.py diff --expected 47238221 --actual 47200000 --tolerance 0.01
+    #   (--tolerance also takes a percentage: `--tolerance 1%` is the same band)
 
     # Band an observed number, ready to paste as a golden item's `bounds`:
     python3 reconcile.py band --value 47238221 --tolerance 0.01
@@ -42,18 +43,18 @@ CURRENCY_SYMBOLS = ("$", "€", "£", "¥", "₹", "₩", "₽", "₿")
 # Magnitude suffixes. Indian numbering (Lakh / Crore) is included because
 # dashboards from Indian deployments commonly use it.
 SUFFIXES: dict[str, float] = {
-    "k":  1_000,
-    "K":  1_000,
-    "m":  1_000_000,
-    "M":  1_000_000,
-    "b":  1_000_000_000,
-    "B":  1_000_000_000,
+    "k": 1_000,
+    "K": 1_000,
+    "m": 1_000_000,
+    "M": 1_000_000,
+    "b": 1_000_000_000,
+    "B": 1_000_000_000,
     "bn": 1_000_000_000,
     "Bn": 1_000_000_000,
     "BN": 1_000_000_000,
-    "L":  100_000,         # Lakh
-    "l":  100_000,
-    "Cr": 10_000_000,      # Crore
+    "L": 100_000,  # Lakh
+    "l": 100_000,
+    "Cr": 10_000_000,  # Crore
     "cr": 10_000_000,
     "CR": 10_000_000,
 }
@@ -102,22 +103,24 @@ def parse_value(s: Any) -> float | None:
     # Strip leading currency symbols + ISO codes (USD / INR / EUR / etc.).
     for sym in CURRENCY_SYMBOLS:
         if raw.startswith(sym):
-            raw = raw[len(sym):].strip()
+            raw = raw[len(sym) :].strip()
             break
     iso = re.match(r"^[A-Z]{3}\s+", raw)
     if iso:
-        raw = raw[iso.end():].strip()
+        raw = raw[iso.end() :].strip()
 
     # Look for a magnitude suffix (longest-match: handle "Cr" before "C").
     suffix_multiplier = 1.0
     sorted_suffixes = sorted(SUFFIXES.keys(), key=len, reverse=True)
     for suf in sorted_suffixes:
         if raw.endswith(suf) and len(raw) > len(suf):
-            head = raw[:-len(suf)].strip()
+            head = raw[: -len(suf)].strip()
             # Only treat as a suffix if what's before is a clean number.
-            if re.fullmatch(r"-?\d+(\.\d+)?(\s*[,\s]\s*\d{3})*", head) or \
-               re.fullmatch(r"-?\d+(?:[,_]\d{3})*(?:\.\d+)?", head) or \
-               re.fullmatch(r"-?\d+(?:\.\d+)?", head):
+            if (
+                re.fullmatch(r"-?\d+(\.\d+)?(\s*[,\s]\s*\d{3})*", head)
+                or re.fullmatch(r"-?\d+(?:[,_]\d{3})*(?:\.\d+)?", head)
+                or re.fullmatch(r"-?\d+(?:\.\d+)?", head)
+            ):
                 raw = head
                 suffix_multiplier = SUFFIXES[suf]
                 break
@@ -141,6 +144,7 @@ def parse_value(s: Any) -> float | None:
 
 
 # --- CSV parsing ----------------------------------------------------------
+
 
 # Heuristic header detection. The first cell is the label and is *always*
 # non-numeric (the metric name). The second cell is the value: if it parses
@@ -188,16 +192,19 @@ def parse_csv(path: str) -> list[dict]:
         extras = [c.strip() for c in r[2:] if c.strip()]
         if extras:
             label = f"{label} ({', '.join(extras)})"
-        rows.append({
-            "label": label,
-            "expected_value": parse_value(raw_value),
-            "raw_value": raw_value,
-        })
+        rows.append(
+            {
+                "label": label,
+                "expected_value": parse_value(raw_value),
+                "raw_value": raw_value,
+            }
+        )
 
     return rows
 
 
 # --- Diff -----------------------------------------------------------------
+
 
 def diff(
     expected: float | None,
@@ -216,11 +223,9 @@ def diff(
       }
     """
     if expected is None:
-        return {"match": False, "delta": None, "delta_pct": None,
-                "reason": "missing_expected"}
+        return {"match": False, "delta": None, "delta_pct": None, "reason": "missing_expected"}
     if actual is None:
-        return {"match": False, "delta": None, "delta_pct": None,
-                "reason": "missing_actual"}
+        return {"match": False, "delta": None, "delta_pct": None, "reason": "missing_actual"}
 
     delta = actual - expected
     delta_pct: float | None = None
@@ -229,7 +234,7 @@ def diff(
         match = abs(delta_pct) <= tolerance
     else:
         # Expected is exactly 0 — exact match required (no relative tolerance possible).
-        match = (actual == 0)
+        match = actual == 0
 
     return {
         "match": match,
@@ -240,6 +245,7 @@ def diff(
 
 
 # --- Band -----------------------------------------------------------------
+
 
 def band(value: float, *, tolerance: float = 0.01) -> dict:
     """The band a single observed number is allowed to land in, as `GoldenBounds` keys.
@@ -266,6 +272,7 @@ def band(value: float, *, tolerance: float = 0.01) -> dict:
 
 # --- CLI ------------------------------------------------------------------
 
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description="Reconciliation helper for agami-reconcile.")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -273,14 +280,19 @@ def main(argv: list[str] | None = None) -> int:
     p_parse = sub.add_parser("parse", help="Parse a reconciliation CSV.")
     p_parse.add_argument("--csv", required=True)
 
+    # `--tolerance` is read the way every other number on this CLI is read, rather than by
+    # argparse's float: the skill's own prose says a tolerance out loud as `±1%` in a dozen places
+    # and then tells the caller to pass the run's tolerance, so `1%` is the form that actually
+    # arrives. `parse_value` folds it to 0.01 and leaves 0.01 alone, so the decimal form every
+    # existing caller passes is untouched.
     p_diff = sub.add_parser("diff", help="Diff two numbers.")
     p_diff.add_argument("--expected", required=True)
     p_diff.add_argument("--actual", required=True)
-    p_diff.add_argument("--tolerance", type=float, default=0.01)
+    p_diff.add_argument("--tolerance", default="0.01")
 
     p_band = sub.add_parser("band", help="Band an observed number for a golden item's bounds.")
     p_band.add_argument("--value", required=True)
-    p_band.add_argument("--tolerance", type=float, default=0.01)
+    p_band.add_argument("--tolerance", default="0.01")
 
     args = p.parse_args(argv)
 
@@ -289,10 +301,23 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(rows, indent=2))
         return 0
 
+    if args.cmd in ("diff", "band"):
+        # Refused rather than defaulted. A tolerance nobody can read is not a reason to fall back
+        # to ±1%: the caller asked for a band of some other width, and silently returning the
+        # default one would answer a question they did not ask.
+        tolerance = parse_value(args.tolerance)
+        if tolerance is None or tolerance < 0:
+            print(
+                f"reconcile {args.cmd}: could not read a tolerance from --tolerance "
+                f"{args.tolerance!r}; pass a fraction (0.01) or a percentage (1%).",
+                file=sys.stderr,
+            )
+            return 2
+
     if args.cmd == "diff":
         e = parse_value(args.expected)
         a = parse_value(args.actual)
-        result = diff(e, a, tolerance=args.tolerance)
+        result = diff(e, a, tolerance=tolerance)
         print(json.dumps(result, indent=2))
         return 0
 
@@ -308,7 +333,7 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 2
-        print(json.dumps(band(value, tolerance=args.tolerance), indent=2))
+        print(json.dumps(band(value, tolerance=tolerance), indent=2))
         return 0
 
     return 2

--- a/plugins/agami/shared/invocation-conventions.md
+++ b/plugins/agami/shared/invocation-conventions.md
@@ -8,7 +8,7 @@ agami ships nine skills, all prefixed `agami-` to avoid colliding with Claude Co
 | agami-query | `/agami-query` | any data question — "how many", "show me", "top N", "trend over time", etc. |
 | agami-model | `/agami-model` | "open the model explorer", "show me the model", "exclude a table", "remove this column" — AND review/sign-off: "open the review dashboard", "review my model", "sign off the metrics", "approve N", "walk the review queue" (its Review tab absorbed the former `/agami-review`) |
 | agami-save-correction | `/agami-save-correction` | "save this as a correction", "remember this", "use this SQL next time" |
-| agami-reconcile | `/agami-reconcile` | "reconcile against my dashboard", "verify these numbers against agami" |
+| agami-reconcile | `/agami-reconcile` | "reconcile against this dashboard", "do these numbers match?", "validate against my Tableau export" — and after a run: "keep these as golden questions", "promote these to a golden dataset" |
 | agami-eval | `/agami-eval` | "run the evals", "run the golden dataset", "score the model against my golden questions", "did anything regress?", "how accurate is agami on my data?" |
 | agami-save-golden | `/agami-save-golden` | "save this as a golden question", "add this to the golden dataset", "import my question bank", "turn this spreadsheet into a golden dataset" |
 | agami-serve | `/agami-serve` | "set up agami for Claude Desktop", "use agami in the Claude app", "hook up the MCP server", "let me test what my end users would see" |

--- a/plugins/agami/skills/agami-reconcile/SKILL.md
+++ b/plugins/agami/skills/agami-reconcile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agami-reconcile
 description: "Reconciles known (label, expected_value) numbers from an existing dashboard against agami's answers. Input can be a SCREENSHOT of a Metabase / Power BI / Tableau / Looker dashboard (Claude's vision extracts the pairs), a CSV, or numbers pasted inline — the user doesn't need to know which; they can just ask. For each pair, the skill generates a matching NL question, runs it through the active profile's semantic model, diffs actual vs expected, and surfaces matches in green and mismatches in red with drill-down receipts. The strongest onboarding demo for a skeptical data engineer — either we agree with their numbers (trust earned via evidence) or we surface a real definitional disagreement (trust earned via transparency)."
-when_to_use: "Use when the user says 'reconcile against this dashboard', 'do these numbers match?', 'validate against my Tableau export', '/agami-reconcile <csv>', drops a screenshot of a BI dashboard (Metabase/Power BI/Tableau/Looker/spreadsheet) and asks agami to reproduce the numbers, or pastes a CSV / table of known numbers. Requires agami-connect to have been run first (need a semantic model + examples library). A high-leverage validation surface for a skeptical data team — reproduce their dashboard numbers, or surface the definitional gap."
+when_to_use: "Use when the user says 'reconcile against this dashboard', 'do these numbers match?', 'validate against my Tableau export', '/agami-reconcile <csv>', drops a screenshot of a BI dashboard (Metabase/Power BI/Tableau/Looker/spreadsheet) and asks agami to reproduce the numbers, or pastes a CSV / table of known numbers. Also use after a run, when the user says 'keep these as golden questions' or 'promote these to a golden dataset' — the rows that agreed become an answer key later runs are scored against. Requires agami-connect to have been run first (need a semantic model + examples library). A high-leverage validation surface for a skeptical data team — reproduce their dashboard numbers, or surface the definitional gap."
 argument-hint: "<screenshot | path-to-csv | pasted numbers>"
 ---
 
@@ -196,7 +196,97 @@ This is where the trust win lands. The DE doesn't have to chase the disagreement
 
 Don't dump every match's drill-down — they're not interesting. The matches build the case; the mismatches drive the conversation.
 
-### 3e — Closing prompt
+### 3e — Offer promotion
+
+The rows that agreed are the most reusable thing this run produced: a question, the statement that answered it, and a number the user's own dashboard already vouches for. That is what a golden dataset is made of — the answer key `/agami-eval` replays later to catch a regression — so offer to keep them.
+
+**Make the offer once, here, after the summary. Never per row.** A per-row prompt turns a twelve-number reconcile into twelve interruptions and buries the mismatches, which are the point of the run.
+
+> Ten of these agreed. Want to keep them as golden questions? I'll write each one with the statement that produced it and a ±1% band around the number, so a later run tells you if any of them drifts.
+
+**Only rows whose `status` is `match` are offered.** That is the run's own tolerance — `reconcile.diff` decided it back in Phase 2c, and it is the only notion of agreement this skill has, so nothing here re-judges a number. One predicate drops `mismatch`, `error`, `missing_expected` and `missing_actual` together. **A row with no statement is never offered**: an error row carries `sql: null` (Phase 2d), so there is nothing to replay and nothing worth promoting.
+
+**If no row agreed, make no offer at all** — not an empty one, not "there's nothing to promote here". A run where nothing matched is having a different conversation (Phase 3b), and an offer with nothing in it interrupts it.
+
+**Every agreeing row starts selected.** The person reviewed each row's agreement as it landed; asking them to opt each one back in asks the same question twice. They can deselect any row, and **they can edit any question before it is written** — a later run regenerates SQL from the question, so the wording *is* the item.
+
+**Show the statement and the result, not just the number.** Per row: the question (editable), the statement that answered it, and the recorded result. What they are accepting is that this statement answers this question — that is what gets replayed — and a row accepted on its number alone is a row nobody checked the meaning of.
+
+**Declining writes nothing.** No dataset is created, no file is touched, and the run ends exactly where Phase 3f leaves it. Say that when you ask, and say it again if they decline.
+
+#### A question asked relative to today
+
+The save door refuses a question asked over a window that slides when its statement is pinned to fixed dates — exit `2`, nothing written. That is the **common** case here, not the exotic one: Phase 2a's own example turns `Mean order size last 30 days` into *"What's the average order size over the last 30 days?"*, and the statement that answered it names the thirty days that were current when it ran.
+
+Two things get past the refusal and **only one of them is right**:
+
+- **Ask which window the question means, and rewrite the question to name it.** *"'The last 30 days' was 2–31 August 2026 when this ran — save it as '…in August 2026'?"* The statement stays exactly as it ran, the question finally names the window it always meant, and the item stays true for as long as it exists.
+- **Never re-anchor the statement to `CURRENT_DATE`.** It clears the lint and it is a **trap**: the band was recorded around today's value of a window that slides, so next month the same question asks about different days, returns a different number, and fails against a band nobody moved. That is a false alarm on the one surface whose whole job is to be believed.
+
+So the offer edits the **question**, with the person's answer to "which window?". It never edits the SQL.
+
+#### What gets written, per kept row
+
+Write the item with the **Write tool** — never a heredoc, never `python3 -c`, per [`shared/invocation-conventions.md`](../../shared/invocation-conventions.md) — to `/tmp/agami-golden-item-<ts>.json`:
+
+```json
+{
+  "query": "What was total revenue in Q3 2025?",
+  "sql": "<the row's `sql`, verbatim>",
+  "match": "bounded",
+  "bounds": {"min_rows": 1, "max_rows": 1, "min_value": 3851100.0, "max_value": 3928900.0},
+  "recorded": {"columns": ["total_revenue"], "rows": [[3890000]]},
+  "tags": ["reconciled"],
+  "confirmed_by": {"method": "reconciled against the finance dashboard on 2026-08-31; agreed within ±1%"}
+}
+```
+
+- **`id` is omitted on purpose.** The save door derives it from the question, exactly as the import door does, so a promotion lands **on** an already-imported question of the same wording rather than beside it as a second copy.
+- `sql` and `recorded` come from the row record (Phase 2d) as they stand. Neither is rebuilt here — the record kept them so that nobody would have to.
+- `match: "bounded"` because a reconciled number is one that legitimately moves. `bounded` with no band is refused (exit `2`), which is why the band below is not optional.
+- **`bounds` comes from the helper, never from arithmetic written in prose:**
+
+  ```bash
+  python3 "$AGAMI_PLUGIN_ROOT/scripts/reconcile.py" band \
+    --value "<the row's actual>" --tolerance 0.01
+  ```
+
+  Pass the same tolerance the run diffed with. The four keys it prints *are* the `bounds` block — paste them in unchanged.
+
+Then call the save door. It is the only writer of a golden dataset anywhere in the plugin, and this skill does not become a second one:
+
+```bash
+python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
+  --profile <profile> --dataset <stem> \
+  --item /tmp/agami-golden-item-<ts>.json \
+  > /tmp/agami-golden-save-<ts>.json
+```
+
+`<stem>` is the dataset's **filename stem** — one plain name (`reconciled`), never a path and never `reconciled.yaml`. Ask which dataset once, for the whole batch.
+
+#### `confirmed_by.method` — two shapes, kept apart
+
+The method line is what somebody consults a year later to find out where this item's authority came from, so the two ways a number reaches a dataset from here read differently on purpose. Each names **the source, the date and the tolerance**:
+
+- **Agreed** — the row matched and the person accepted the offer:
+
+  > `reconciled against <source> on <date>; agreed within ±<tolerance>`
+
+- **Resolved** — the row did *not* match, and the person judged agami right anyway:
+
+  > `reconciled against <source> on <date>; disagreed beyond ±<tolerance>, resolved in agami's favour by the analyst`
+
+`<source>` is what the numbers came from, as the user described it ("the finance dashboard", "the Q3 export"); `<date>` is the day the run happened.
+
+**The resolution path is not part of the offer.** A disagreeing row is not offered and cannot be written by accepting the offer — the selection has no room for one. If the person opens a mismatch, decides their dashboard is wrong and agami is right, they have to say so explicitly, as its own step, and it writes with the *resolved* method above. **That friction is deliberate**: promoting a mismatch writes an answer key that contradicts the number the team currently believes, and that should cost a sentence rather than a checkbox.
+
+#### If the item already exists
+
+Exit `1`, a `needs_confirmation` payload, and **nothing written**. Render the `before` AND the `after` for every id — the item on disk and the one that would take its place — ask, and only on an explicit yes re-run the **same command with `--confirm-replace` appended**. **Never pass `--confirm-replace` pre-emptively**: the flag means one thing, that a person saw both sides and said yes, and passing it before that has happened makes the stop decorative.
+
+A replacement is wholesale — the item sent is the item written — so read the `before` and carry forward whatever it holds that still applies (its `tags`, a `must_filter`) into the item JSON before you re-run. On a no, say the file is untouched and stop.
+
+### 3f — Closing prompt
 
 ```
 Re-run with `tolerance=5%` to see softer matches, or open any drill-down to find the definitional gap.
@@ -206,6 +296,7 @@ End the turn. The user typically:
 - Opens a mismatch's drill-down, finds the definitional gap, says *"the dashboard is gross-of-refunds; can we update the metric?"* — chain into `/agami-save-correction` to update the metric definition.
 - Asks `tolerance=5%` to widen the matches.
 - Asks for a different CSV.
+- Takes the promotion offer from Phase 3e, and the rows that agreed become a golden dataset later runs are scored against.
 
 ---
 
@@ -213,8 +304,8 @@ End the turn. The user typically:
 
 1. **No automatic question generation for ambiguous labels.** If the label is too short or too vague (e.g., `Total`, `Number`, `Value`), surface to the user: *"Row 5's label is just 'Total' — too ambiguous to translate to a question. Skipping. Add more context to the CSV (e.g., `Total Revenue Q3` instead of `Total`) and re-run."* Don't guess.
 2. **Receipt is non-optional.** Every per-row run MUST produce a chart-template HTML report with the trust receipt — that's what the drill-down link points at, and it's what makes mismatches actionable. If the underlying query path can't produce a receipt (legacy pre-trust-layer model), refuse with: *"This profile pre-dates the trust-layer launch. Re-run `/agami-connect` to enable receipts, then retry."*
-3. **Don't write to the semantic model from this skill.** Reconcile reads + diffs; it never mutates. If a definitional disagreement surfaces and the user wants to update the metric, route them through `/agami-save-correction`.
-4. **CSV stays local.** Don't upload, don't summarize-and-send. The reconcile run produces local artifacts (`/tmp/agami-reconcile-results-*.jsonl` + the per-query chart HTML) and nothing leaves the machine.
+3. **Don't write to the semantic model from this skill.** Reconcile reads + diffs; it never mutates a metric, a join, a column or any other part of the model. If a definitional disagreement surfaces and the user wants to update the metric, route them through `/agami-save-correction`. **The one write this skill can make is Phase 3e's promotion, and it is not a model write:** a golden dataset is the answer key that *tests* the model, not the model itself. It goes through `golden_author.py save` — that door and nothing else, never a hand-edited YAML — only for rows this run scored as agreeing, and only after the user has said yes to the offer.
+4. **CSV stays local.** Don't upload, don't summarize-and-send. The reconcile run produces local artifacts (the per-query chart HTML, and `/tmp/agami-reconcile-results-*.jsonl`, which now carries the statement behind every row as well as its numbers) and nothing leaves the machine. A promoted row stays local too: the save door writes into the profile's own `golden_datasets/` directory on this machine.
 
 ---
 
@@ -229,6 +320,10 @@ End the turn. The user typically:
 | User pastes inline CSV instead of a path | Accept it. Write to `/tmp/agami-reconcile-pasted-<ts>.csv` and proceed. |
 | Screenshot is blurry / a value is cut off / can't read a tile | Don't guess the number. Extract what's legible, and tell the user which tiles you skipped: "Couldn't read 'Pipeline value' clearly — re-snip it or type that one in." |
 | User says "reconcile my dashboard" but attaches nothing | Ask for the screenshot (or CSV / pasted numbers) per Phase 0.4 — don't proceed without the expected numbers. |
+| A promotion exits `0` | Written. Report `added` / `replaced` and the path, and say the dataset can be run with "run the evals". |
+| A promotion exits `1` with `needs_confirmation` | Nothing was written. Render the `before` and the `after` for every id, carry forward the `tags` / `must_filter` the `before` holds, ask, and re-run with `--confirm-replace` only on an explicit yes. On a no, the file is untouched. |
+| A promotion exits `2` | Cannot start. The `agami-save-golden:` line on stderr names the cause. Nothing was written; a rolled-back write left the previous bytes exactly as they were. |
+| A promotion exits `2` saying the question moves with time and the answer key doesn't | **Rename the question, don't re-anchor the statement.** Ask which window it meant, rewrite the question to name it ("…in August 2026"), and re-run with the SQL exactly as it ran. Anchoring the SQL to `CURRENT_DATE` clears the lint and bands a sliding window around one day's value — a false alarm at the next run. |
 
 ---
 

--- a/plugins/agami/skills/agami-reconcile/SKILL.md
+++ b/plugins/agami/skills/agami-reconcile/SKILL.md
@@ -23,7 +23,7 @@ Spec for the deterministic helpers: [`scripts/reconcile.py`](../../scripts/recon
 
 - **Tight loops.** This skill is a tool, not a tutorial. One question per turn, max two sentences of prose between phases.
 - **Surface mismatches loud.** A reconcile run with 9/12 matches and 3 mismatches is a SUCCESSFUL run — the mismatches are the value. Lead with what didn't match.
-- **Don't paste raw SQL in chat.** The receipt has it. Same hard rule as agami-query.
+- **Don't paste raw SQL in chat.** The receipt has it. Same hard rule as agami-query — with one exception, Phase 3e's promotion offer, where the statement is shown because it is the thing being accepted into an answer key and cannot be hidden behind a receipt link at the moment somebody agrees to replay it.
 
 ---
 
@@ -202,9 +202,11 @@ The rows that agreed are the most reusable thing this run produced: a question, 
 
 **Make the offer once, here, after the summary. Never per row.** A per-row prompt turns a twelve-number reconcile into twelve interruptions and buries the mismatches, which are the point of the run.
 
-> Ten of these agreed. Want to keep them as golden questions? I'll write each one with the statement that produced it and a ±1% band around the number, so a later run tells you if any of them drifts.
+> Ten of these agreed. Want to keep them as golden questions? I'll write each one with the statement that produced it and a ±<the run's tolerance> band around the number, so a later run tells you if any of them drifts.
 
-**Only rows whose `status` is `match` are offered.** That is the run's own tolerance — `reconcile.diff` decided it back in Phase 2c, and it is the only notion of agreement this skill has, so nothing here re-judges a number. One predicate drops `mismatch`, `error`, `missing_expected` and `missing_actual` together. **A row with no statement is never offered**: an error row carries `sql: null` (Phase 2d), so there is nothing to replay and nothing worth promoting.
+**Only rows whose `status` is `match` are offered.** That is the run's own tolerance — `reconcile.diff` decided it back in Phase 2c, and it is the only notion of agreement this skill has, so nothing here re-judges a number. One predicate drops `mismatch` and `error` together, and with them the `missing_expected` and `missing_actual` rows — those are `reconcile.diff`'s own reasons rather than a row status, and a row that could not be diffed never reached `match` either. **A row with no statement is never offered**: an error row carries `sql: null` (Phase 2d), so there is nothing to replay and nothing worth promoting.
+
+**Only a single-cell result is offered.** A row whose `recorded` carries more than one column has no single number to band, and a `bounded` item over a wider result is scored on its row count alone — it would pass forever without ever checking the number it was promoted for.
 
 **If no row agreed, make no offer at all** — not an empty one, not "there's nothing to promote here". A run where nothing matched is having a different conversation (Phase 3b), and an offer with nothing in it interrupts it.
 
@@ -225,6 +227,8 @@ Two things get past the refusal and **only one of them is right**:
 
 So the offer edits the **question**, with the person's answer to "which window?". It never edits the SQL.
 
+**Ask which window it means in the offer, before anything is written** — not after the refusal lands. A batch is written one row at a time (below), so a refusal on the seventh row arrives with six items already on disk: **items already written stay written, and nothing is rolled back**. The cheat sheet's exit-`2` row is the fallback for a question that slips through, not the plan.
+
 #### What gets written, per kept row
 
 Write the item with the **Write tool** — never a heredoc, never `python3 -c`, per [`shared/invocation-conventions.md`](../../shared/invocation-conventions.md) — to `/tmp/agami-golden-item-<ts>.json`:
@@ -237,7 +241,7 @@ Write the item with the **Write tool** — never a heredoc, never `python3 -c`, 
   "bounds": {"min_rows": 1, "max_rows": 1, "min_value": 3851100.0, "max_value": 3928900.0},
   "recorded": {"columns": ["total_revenue"], "rows": [[3890000]]},
   "tags": ["reconciled"],
-  "confirmed_by": {"method": "reconciled against the finance dashboard on 2026-08-31; agreed within ±1%"}
+  "confirmed_by": {"method": "reconciled against the finance dashboard on 2026-08-31; agreed within ±<the run's tolerance>"}
 }
 ```
 
@@ -248,7 +252,7 @@ Write the item with the **Write tool** — never a heredoc, never `python3 -c`, 
 
   ```bash
   python3 "$AGAMI_PLUGIN_ROOT/scripts/reconcile.py" band \
-    --value "<the row's actual>" --tolerance 0.01
+    --value "<the row's actual>" --tolerance <the run's tolerance>
   ```
 
   Pass the same tolerance the run diffed with. The four keys it prints *are* the `bounds` block — paste them in unchanged.
@@ -263,6 +267,8 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
 ```
 
 `<stem>` is the dataset's **filename stem** — one plain name (`reconciled`), never a path and never `reconciled.yaml`. Ask which dataset once, for the whole batch.
+
+**One call per kept row.** The door takes one item, not an array — ten kept rows are ten runs of that command, each with its own item file. The dataset is asked once; the writing is a loop.
 
 #### `confirmed_by.method` — two shapes, kept apart
 
@@ -304,7 +310,7 @@ End the turn. The user typically:
 
 1. **No automatic question generation for ambiguous labels.** If the label is too short or too vague (e.g., `Total`, `Number`, `Value`), surface to the user: *"Row 5's label is just 'Total' — too ambiguous to translate to a question. Skipping. Add more context to the CSV (e.g., `Total Revenue Q3` instead of `Total`) and re-run."* Don't guess.
 2. **Receipt is non-optional.** Every per-row run MUST produce a chart-template HTML report with the trust receipt — that's what the drill-down link points at, and it's what makes mismatches actionable. If the underlying query path can't produce a receipt (legacy pre-trust-layer model), refuse with: *"This profile pre-dates the trust-layer launch. Re-run `/agami-connect` to enable receipts, then retry."*
-3. **Don't write to the semantic model from this skill.** Reconcile reads + diffs; it never mutates a metric, a join, a column or any other part of the model. If a definitional disagreement surfaces and the user wants to update the metric, route them through `/agami-save-correction`. **The one write this skill can make is Phase 3e's promotion, and it is not a model write:** a golden dataset is the answer key that *tests* the model, not the model itself. It goes through `golden_author.py save` — that door and nothing else, never a hand-edited YAML — only for rows this run scored as agreeing, and only after the user has said yes to the offer.
+3. **Don't write to the semantic model from this skill.** Reconcile reads + diffs; it never mutates a metric, a join, a column or any other part of the model. If a definitional disagreement surfaces and the user wants to update the metric, route them through `/agami-save-correction`. **The one write this skill can make is Phase 3e's promotion, and it is not a model write:** a golden dataset is the answer key that *tests* the model, not the model itself. It goes through `golden_author.py save` — that door and nothing else, never a hand-edited YAML — by exactly two routes, with the person's yes in front of either: a row this run scored as agreeing, accepted through Phase 3e's offer, or a row it scored as a mismatch that the person has explicitly resolved in agami's favour.
 4. **CSV stays local.** Don't upload, don't summarize-and-send. The reconcile run produces local artifacts (the per-query chart HTML, and `/tmp/agami-reconcile-results-*.jsonl`, which now carries the statement behind every row as well as its numbers) and nothing leaves the machine. A promoted row stays local too: the save door writes into the profile's own `golden_datasets/` directory on this machine.
 
 ---
@@ -336,4 +342,4 @@ The screenshot is an **image of numbers**, and a misread expected value reads ex
 ## Roadmap (not in v1)
 
 - **Tableau / Looker / Mode export parsing** — parse `.twb` / `.twbx` / JSON exports directly (today a screenshot of any of them already works via the vision branch).
-- **Recurring reconcile runs** — wire into `agami test` so the golden-test suite includes reconciliation against a pinned dashboard.
+- **Recurring reconcile runs** — re-run a reconcile against a pinned dashboard on a schedule, rather than by asking each time.

--- a/plugins/agami/skills/agami-reconcile/SKILL.md
+++ b/plugins/agami/skills/agami-reconcile/SKILL.md
@@ -99,6 +99,8 @@ Invoke the same SQL-generation + execution path agami-query uses (Phases 2 + 3 o
 - The full chart-template HTML report (so the user can drill in for mismatches)
 - The trust receipt (with confidence, signed-off-by, etc.)
 
+The SQL you capture here is the one that lands in the row record (Phase 2d) — keep it verbatim. It is the only place the statement survives the run: the chart report at `report_path` is HTML, and nothing re-derives the statement from it afterwards.
+
 If the SQL fails OR the result isn't a single scalar (e.g., the LLM-generated question returned a multi-row table), capture an error: `Could not extract a single scalar from the result.` These rows show up as `error` status in the report.
 
 ### 2c — Diff
@@ -128,11 +130,17 @@ Per row:
   "match":        true | false,
   "status":       "match" | "mismatch" | "error",
   "report_path":  "<artifacts_dir>/local/charts/<profile>/<ts>.html",  // the full chart report for this query
+  "sql":          "<the statement that produced actual, or null on an error row>",
+  "recorded":     {"columns": ["<column name>"], "rows": [[<value>]]},  // what the query actually returned
   "error":        "<message if status=error, else null>"
 }
 ```
 
-Append all records to `/tmp/agami-reconcile-results-<ts>.jsonl` so the user can inspect later.
+`sql` is the statement captured in Phase 2b, written down verbatim. `recorded` is the result it returned, shaped as `columns` + `rows` — the same two keys the golden-dataset receipt uses — so whoever picks this row up later forwards it as-is instead of rebuilding it from a number and guessing at a column name.
+
+**On a `status: "error"` row both `sql` and `recorded` are `null`.** There is no statement to keep: either none was generated, or the one that was didn't produce a scalar anyone read. An error row therefore carries nothing a later reader could mistake for a verified answer.
+
+Append all records to `/tmp/agami-reconcile-results-<ts>.jsonl` so the user can inspect later. The two keys are additive — a reader that only knows the older shape keeps working.
 
 ---
 

--- a/tests/test_ah111_reconcile_promotion_skill.py
+++ b/tests/test_ah111_reconcile_promotion_skill.py
@@ -1,0 +1,263 @@
+"""AH-111 — the reconcile skill's promotion offer, and the phases it must not have disturbed.
+
+Everything here asserts on Markdown, for the reason `test_ah109_save_golden_skill.py` gives about
+its own: the helpers cannot make the model offer the agreeing rows once instead of twelve times,
+decline to promote a row that has no statement, or rewrite a question rather than re-anchoring its
+SQL. The skill is the only place those live, so "the skill says X" is the only decidable check
+there is.
+
+This is also the first file to pin `agami-reconcile`'s prose at all, which is why the last test
+here is a regression pin rather than a claim about the new behaviour: `agami-reconcile` is a
+shipped skill and the strongest onboarding demo in the product, so a slice that adds an offer after
+the summary has to leave everything up to the summary reading exactly as it did.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "plugins" / "agami" / "skills"
+SHARED = REPO_ROOT / "plugins" / "agami" / "shared"
+
+SKILL = (SKILLS_DIR / "agami-reconcile" / "SKILL.md").read_text(encoding="utf-8")
+FRONTMATTER = SKILL.split("---")[1]
+WHEN_TO_USE = re.search(r"^when_to_use: \"(.*)\"$", FRONTMATTER, re.MULTILINE).group(1)
+CONVENTIONS = (SHARED / "invocation-conventions.md").read_text(encoding="utf-8")
+
+# The offer's own section, bounded by the heading that follows it. Several assertions below are
+# about what the offer does NOT say, and those are only meaningful over the section rather than
+# over a file that also documents the mismatch conversation.
+OFFER = SKILL.split("### 3e — Offer promotion")[1].split("### 3f — Closing prompt")[0]
+
+
+def test_the_skill_carries_the_four_frontmatter_keys():
+    """The house shape, and the frontmatter is where the new routing triggers have to land: a
+    trigger phrase that is only in the conventions table routes nothing."""
+    assert SKILL.startswith("---\n")
+    assert "name: agami-reconcile" in FRONTMATTER
+    assert "description:" in FRONTMATTER
+    assert "when_to_use:" in FRONTMATTER
+    assert 'argument-hint: "<screenshot | path-to-csv | pasted numbers>"' in FRONTMATTER
+
+
+def test_the_offer_is_made_once_after_the_summary_and_only_for_agreeing_rows():
+    """The offer's two structural rules. Once and after, because a per-row prompt buries the
+    mismatches that are the run's actual value; and only the rows the run itself scored as
+    agreeing, because `reconcile.diff`'s verdict is the only notion of agreement in this tree."""
+    assert "### 3e — Offer promotion" in SKILL
+    # Between the matches summary and the closing prompt, in that order.
+    assert (
+        SKILL.index("### 3d — Matches summary")
+        < SKILL.index("### 3e — Offer promotion")
+        < SKILL.index("### 3f — Closing prompt")
+    )
+    assert "Make the offer once, here, after the summary. Never per row." in OFFER
+    assert "Only rows whose `status` is `match` are offered." in OFFER
+    assert "`reconcile.diff`" in OFFER
+    # One predicate, naming every status it drops — including the two only `diff` knows about.
+    for dropped in ("`mismatch`", "`error`", "`missing_expected`", "`missing_actual`"):
+        assert dropped in OFFER
+
+
+def test_the_agreeing_rows_start_selected_and_the_statement_is_shown():
+    """The person already reviewed each row's agreement during the run, so re-confirming every one
+    asks the same question twice. What they have not yet accepted is the STATEMENT — that is what a
+    later run replays — so the offer shows it rather than the number alone."""
+    assert "Every agreeing row starts selected." in OFFER
+    assert "they can edit any question before it is written" in OFFER
+    assert "Show the statement and the result, not just the number." in OFFER
+
+
+def test_a_run_with_no_agreeing_rows_makes_no_offer():
+    """An empty offer interrupts the conversation an all-mismatch run is actually having."""
+    assert "If no row agreed, make no offer at all" in OFFER
+    assert "not an empty one" in OFFER
+
+
+def test_an_error_row_is_never_offered_and_the_prose_says_why():
+    """The reason is the point: an error row has no statement to replay, so there is nothing a
+    promotion could write that a later run could score."""
+    assert "A row with no statement is never offered" in OFFER
+    assert "`sql: null`" in OFFER
+
+
+def test_a_disagreeing_row_is_not_offered_and_needs_the_explicit_resolution_step():
+    """Promoting a mismatch writes an answer key that contradicts the number the team currently
+    believes. That is a legitimate thing to do and it should cost a sentence, not a checkbox."""
+    assert "The resolution path is not part of the offer." in OFFER
+    assert "cannot be written by accepting the offer" in OFFER
+    assert "friction is deliberate" in OFFER
+
+
+def test_declining_writes_nothing():
+    """The regression bar for this whole slice: a declined offer leaves a run looking exactly as it
+    looked before there was an offer at all."""
+    assert "**Declining writes nothing.**" in OFFER
+    assert "No dataset is created, no file is touched" in OFFER
+
+
+def test_the_relativity_guidance_renames_the_question_and_never_reanchors_the_sql():
+    """The trap. Both ways past the lint save; only one of them stays true.
+
+    Anchoring the statement to `CURRENT_DATE` clears the refusal and bands a window that slides
+    around one day's value, so the item drifts out of its own band and fails a later run as a false
+    alarm — on the surface whose whole job is to be believed. Every mention of `CURRENT_DATE` in the
+    skill therefore has to be a prohibition, which is what the sweep below checks.
+    """
+    assert "Never re-anchor the statement to `CURRENT_DATE`." in OFFER
+    assert "rewrite the question to name it" in OFFER
+    assert "It never edits the SQL." in OFFER
+    # And again in the cheat sheet, where somebody lands holding an exit 2.
+    assert "**Rename the question, don't re-anchor the statement.**" in SKILL
+
+    forbidding = ("Never", "never", "don't", "trap")
+    offenders = [
+        line
+        for line in SKILL.splitlines()
+        if "CURRENT_DATE" in line and not any(word in line for word in forbidding)
+    ]
+    assert not offenders, f"CURRENT_DATE offered rather than refused: {offenders}"
+
+
+def test_the_promotion_writes_through_the_save_door_and_nothing_else():
+    """One writer. The item is built with the Write tool and handed to the save door with the flags
+    that door actually takes; `id` is omitted so the door derives it from the question, which is
+    what makes a promotion land ON an already-imported question rather than beside it."""
+    assert 'python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save' in OFFER
+    for flag in ("--profile", "--dataset", "--item"):
+        assert flag in OFFER
+    assert "never a heredoc, never `python3 -c`" in OFFER
+    assert "**`id` is omitted on purpose.**" in OFFER
+    assert "rather than beside it" in OFFER
+
+
+def test_the_band_comes_from_the_band_verb_and_not_from_prose_arithmetic():
+    """A band computed in prose is a band nobody can reproduce, and this one is the thing a later
+    run is scored against. `match: bounded` with no band is refused outright, so the two travel
+    together."""
+    assert 'python3 "$AGAMI_PLUGIN_ROOT/scripts/reconcile.py" band' in OFFER
+    assert "--value" in OFFER and "--tolerance" in OFFER
+    assert "never from arithmetic written in prose" in OFFER
+    assert '"match": "bounded"' in OFFER
+
+
+def test_the_two_confirmed_by_method_shapes_are_documented_and_distinguishable():
+    """A reader a year later has to be able to tell an agreement from a resolution, so the two
+    method lines differ in words rather than only in tone — and each names the source, the date and
+    the tolerance, which is the whole of what makes the claim auditable."""
+    agreed = "reconciled against <source> on <date>; agreed within ±<tolerance>"
+    resolved = (
+        "reconciled against <source> on <date>; disagreed beyond ±<tolerance>, "
+        "resolved in agami's favour by the analyst"
+    )
+    assert agreed in OFFER
+    assert resolved in OFFER
+    assert agreed != resolved
+    for shape in (agreed, resolved):
+        assert "<source>" in shape and "<date>" in shape and "±<tolerance>" in shape
+
+
+def test_confirm_replace_is_never_preemptive_and_the_before_and_after_come_first():
+    """Exit 1 is the append-only stop, and the flag means one thing: a person saw both sides and
+    said yes. A replacement is wholesale, so whatever the `before` carries has to be carried
+    forward or it is gone."""
+    assert "Render the `before` AND the `after` for every id" in OFFER
+    assert "Never pass `--confirm-replace` pre-emptively" in OFFER
+    assert OFFER.index("Render the `before`") < OFFER.index("--confirm-replace` pre-emptively")
+    assert "carry forward whatever it holds that still applies" in OFFER
+    assert "On a no, say the file is untouched and stop." in OFFER
+
+
+def test_the_cheat_sheet_carries_the_save_doors_exit_codes():
+    """The cheat sheet is where somebody lands holding a non-zero exit, and `1` is the one that
+    must not be read as a failure or as a success."""
+    assert "| A promotion exits `0` |" in SKILL
+    assert "| A promotion exits `1` with `needs_confirmation` |" in SKILL
+    assert "| A promotion exits `2` |" in SKILL
+
+
+def test_hard_rule_3_still_forbids_mutating_the_semantic_model():
+    """The highest-regression edit in the slice. The carve-out is for the answer key that TESTS the
+    model, and it must not have loosened the rule it is carved out of: no metric, join or column is
+    ever mutated from here, and a definitional disagreement still routes to the correction skill."""
+    rule = SKILL.split("3. **Don't write to the semantic model from this skill.**")[1].split(
+        "\n4. "
+    )[0]
+    assert "never mutates a metric, a join, a column" in rule
+    assert "/agami-save-correction" in rule
+    # …and the carve-out is exactly one door, with the user's yes in front of it.
+    assert "golden_author.py save" in rule
+    assert "after the user has said yes" in rule
+
+
+def test_the_hard_rules_are_not_renumbered():
+    """The screenshot section cross-references rule #4 by number, so renumbering the list silently
+    re-points that reference at a different rule."""
+    assert "Hard rule #4" in SKILL
+    assert "4. **CSV stays local.**" in SKILL
+    assert "5. **" not in SKILL.split("## Hard rules")[1].split("---")[0]
+    # Rule 4's artifact list now says the jsonl carries statements, so "stays local" still covers
+    # everything the run wrote down.
+    assert "carries the statement behind every row" in SKILL
+
+
+def test_the_routing_triggers_are_the_skills_own():
+    """The conventions table header says the triggers come from `when_to_use`, so a phrase in the
+    row that the frontmatter does not carry reads as a trigger and routes nothing.
+
+    This row carried two such phrases before this slice ("reconcile against my dashboard", which
+    the skill spells with *this*, and "verify these numbers against agami", which the skill never
+    said at all). Correcting them is why this test exists here rather than only beside the skill it
+    was first written for.
+    """
+    row = next(line for line in CONVENTIONS.splitlines() if line.startswith("| agami-reconcile |"))
+    quoted = re.findall(r'"([^"]+)"', row)
+
+    assert quoted, "the agami-reconcile row no longer quotes any trigger phrase"
+    for phrase in quoted:
+        assert phrase in WHEN_TO_USE, phrase
+
+
+def test_the_promotion_triggers_reach_both_surfaces():
+    """A user who has just watched ten numbers agree says "keep these as golden questions", and
+    that has to route here rather than nowhere."""
+    for phrase in ("keep these as golden questions", "promote these to a golden dataset"):
+        assert phrase in WHEN_TO_USE
+        assert phrase in CONVENTIONS
+
+
+def test_phases_3a_to_3d_read_exactly_as_they_did():
+    """The regression pin. Reconciliation itself is untouched by this slice, and the way a run
+    presents itself up to the matches summary is the shipped demo — so each phase's heading and the
+    line it opens on are asserted verbatim, in order.
+    """
+    opening = [
+        ("### 3a — Summary line first", "```"),
+        (
+            "### 3b — Mismatches table (lead with what didn't match)",
+            "Render the mismatches as a markdown table BEFORE the matches:",
+        ),
+        ("### 3c — Errors block (if any)", "```markdown"),
+        ("### 3d — Matches summary (last, compact)", "```markdown"),
+    ]
+    lines = SKILL.splitlines()
+    positions = []
+    for heading, first in opening:
+        assert heading in lines, heading
+        index = lines.index(heading)
+        positions.append(index)
+        # The blank line, then the line the phase opens on.
+        assert lines[index + 1] == ""
+        assert lines[index + 2] == first, (heading, lines[index + 2])
+    assert positions == sorted(positions)
+
+    # The lines each phase is recognised by, none of which this slice had any business touching.
+    assert "Reconciled <N> numbers: <M> match (within ±1%), <K> mismatch, <E> error." in SKILL
+    assert "This is where the trust win lands." in SKILL
+    assert "Could not extract a single scalar — the question returned 47 rows." in SKILL
+    assert (
+        "Don't dump every match's drill-down — they're not interesting. The matches build the "
+        "case; the mismatches drive the conversation." in SKILL
+    )

--- a/tests/test_ah111_reconcile_promotion_skill.py
+++ b/tests/test_ah111_reconcile_promotion_skill.py
@@ -31,6 +31,9 @@ CONVENTIONS = (SHARED / "invocation-conventions.md").read_text(encoding="utf-8")
 # over a file that also documents the mismatch conversation.
 OFFER = SKILL.split("### 3e — Offer promotion")[1].split("### 3f — Closing prompt")[0]
 
+# Slice 1's own product: the record a row is written down as, which is what Phase 3e later reads.
+RECORD = SKILL.split("### 2d — Build the row record")[1].split("## Phase 3: Present")[0]
+
 
 def test_the_skill_carries_the_four_frontmatter_keys():
     """The house shape, and the frontmatter is where the new routing triggers have to land: a
@@ -40,6 +43,45 @@ def test_the_skill_carries_the_four_frontmatter_keys():
     assert "description:" in FRONTMATTER
     assert "when_to_use:" in FRONTMATTER
     assert 'argument-hint: "<screenshot | path-to-csv | pasted numbers>"' in FRONTMATTER
+
+
+def test_the_row_record_keeps_the_statement_and_the_result_beside_the_number():
+    """Slice 1's whole product, asserted on the RECORD rather than on anything rendered from it.
+
+    The record is what Phase 3e reads to build an item, so a promotion that FORWARDS the statement
+    and the receipt instead of rebuilding them is only possible if the record carried both. And the
+    keys a reader already knows have to still be there beside them: the run writes this shape to a
+    jsonl a person opens later, and the two new keys are additive or they are a break.
+    """
+    assert '"sql":' in RECORD
+    assert '"recorded":' in RECORD
+    # `recorded` is shaped like the golden receipt — the two keys a promotion hands straight on.
+    recorded = next(line for line in RECORD.splitlines() if line.strip().startswith('"recorded":'))
+    assert '"columns"' in recorded and '"rows"' in recorded
+    # An error row carries neither, so nothing on it can be mistaken for a verified answer.
+    assert '**On a `status: "error"` row both `sql` and `recorded` are `null`.**' in RECORD
+
+    for key in (
+        "label", "question", "expected", "actual", "delta_pct",
+        "match", "status", "report_path", "error",
+    ):
+        assert f'"{key}":' in RECORD, key
+
+
+def test_sql_stays_out_of_the_narration_except_where_it_is_the_thing_being_accepted():
+    """Both halves of the shipped rule.
+
+    The rule itself still stands — agami-query spells out what it forbids, and this skill defers to
+    it. The offer is named as its one exception because what the person is accepting there is the
+    STATEMENT: a receipt link is not where you read something you are about to agree to replay.
+    """
+    style = SKILL.split("## Conversation style")[1].split("\n---")[0]
+    assert "**Don't paste raw SQL in chat.**" in style
+    assert "Same hard rule as agami-query" in style
+    assert "with one exception, Phase 3e's promotion offer" in style
+    assert "the thing being accepted into an answer key" in style
+    # One exception in the whole skill, and it is that one.
+    assert SKILL.count("exception") == 1
 
 
 def test_the_offer_is_made_once_after_the_summary_and_only_for_agreeing_rows():
@@ -68,6 +110,27 @@ def test_the_agreeing_rows_start_selected_and_the_statement_is_shown():
     assert "Every agreeing row starts selected." in OFFER
     assert "they can edit any question before it is written" in OFFER
     assert "Show the statement and the result, not just the number." in OFFER
+
+
+def test_only_a_single_cell_result_is_offered():
+    """A value band judges one number. Handed a wider result the comparator finds no single cell,
+    skips the value band and scores the item on its row count alone — so a two-column row promoted
+    here writes an answer key that passes forever without checking the number it was promoted for.
+    """
+    assert "**Only a single-cell result is offered.**" in OFFER
+    assert "more than one column" in OFFER
+    assert "scored on its row count alone" in OFFER
+
+
+def test_the_offer_carries_the_runs_own_tolerance_and_never_a_hardcoded_one():
+    """The offer is told to pass the tolerance the run diffed with, so every literal in the section
+    has to be that placeholder. A hardcoded ±1% in the sentence said out loud, in the provenance
+    line or in the band command makes a `tolerance=5%` run offer a band it did not agree on."""
+    assert "±<the run's tolerance> band around the number" in OFFER
+    assert "agreed within ±<the run's tolerance>" in OFFER
+    assert "--tolerance <the run's tolerance>" in OFFER
+    assert "0.01" not in OFFER
+    assert "±1%" not in OFFER
 
 
 def test_a_run_with_no_agreeing_rows_makes_no_offer():
@@ -112,13 +175,34 @@ def test_the_relativity_guidance_renames_the_question_and_never_reanchors_the_sq
     # And again in the cheat sheet, where somebody lands holding an exit 2.
     assert "**Rename the question, don't re-anchor the statement.**" in SKILL
 
-    forbidding = ("Never", "never", "don't", "trap")
-    offenders = [
-        line
-        for line in SKILL.splitlines()
-        if "CURRENT_DATE" in line and not any(word in line for word in forbidding)
-    ]
-    assert not offenders, f"CURRENT_DATE offered rather than refused: {offenders}"
+    # The skill mentions `CURRENT_DATE` in exactly two places and both are these lines, verbatim.
+    # A looser sweep — any line carrying a forbidding word somewhere on it — would wave through
+    # "never rewrite the question, anchor to CURRENT_DATE", which is the instruction being banned.
+    permitted = {
+        "- **Never re-anchor the statement to `CURRENT_DATE`.** It clears the lint and it is a "
+        "**trap**: the band was recorded around today's value of a window that slides, so next "
+        "month the same question asks about different days, returns a different number, and fails "
+        "against a band nobody moved. That is a false alarm on the one surface whose whole job is "
+        "to be believed.",
+        "| A promotion exits `2` saying the question moves with time and the answer key doesn't | "
+        "**Rename the question, don't re-anchor the statement.** Ask which window it meant, "
+        'rewrite the question to name it ("…in August 2026"), and re-run with the SQL exactly as '
+        "it ran. Anchoring the SQL to `CURRENT_DATE` clears the lint and bands a sliding window "
+        "around one day's value — a false alarm at the next run. |",
+    }
+    mentions = {line for line in SKILL.splitlines() if "CURRENT_DATE" in line}
+    assert mentions == permitted, f"CURRENT_DATE said in a way this test has not read: {mentions}"
+
+
+def test_the_window_is_settled_in_the_offer_and_a_late_refusal_rolls_nothing_back():
+    """Which window a relative question meant is asked BEFORE anything is written, not in reaction
+    to the refusal — because a batch is one call per row, so a refusal on the seventh row lands
+    with six items already on disk. Saying that out loud is the point: nothing is rolled back, and
+    a model that believed otherwise would go looking for an undo that does not exist."""
+    assert "**Ask which window it means in the offer, before anything is written**" in OFFER
+    assert "**items already written stay written, and nothing is rolled back**" in OFFER
+    # The cheat-sheet row stays, demoted to the fallback it is.
+    assert "is the fallback for a question that slips through, not the plan" in OFFER
 
 
 def test_the_promotion_writes_through_the_save_door_and_nothing_else():
@@ -131,6 +215,11 @@ def test_the_promotion_writes_through_the_save_door_and_nothing_else():
     assert "never a heredoc, never `python3 -c`" in OFFER
     assert "**`id` is omitted on purpose.**" in OFFER
     assert "rather than beside it" in OFFER
+    # And it is called once per row. The door reads `payload["query"]` — an array handed to it is
+    # a TypeError nobody catches, and "ask which dataset once" reads like one call if nothing says
+    # otherwise.
+    assert "**One call per kept row.**" in OFFER
+    assert "one item, not an array" in OFFER
 
 
 def test_the_band_comes_from_the_band_verb_and_not_from_prose_arithmetic():
@@ -187,9 +276,22 @@ def test_hard_rule_3_still_forbids_mutating_the_semantic_model():
     )[0]
     assert "never mutates a metric, a join, a column" in rule
     assert "/agami-save-correction" in rule
-    # …and the carve-out is exactly one door, with the user's yes in front of it.
+    # …and the carve-out is exactly one door, with the person's yes in front of it. It names BOTH
+    # routes: a hard rule is the most authoritative prose in a skill, so one that named only the
+    # offer would have a model refuse the resolution write the rest of Phase 3e requires.
     assert "golden_author.py save" in rule
-    assert "after the user has said yes" in rule
+    assert "with the person's yes in front of either" in rule
+    assert "a row this run scored as agreeing" in rule
+    assert "resolved in agami's favour" in rule
+
+
+def test_the_roadmap_no_longer_promises_the_half_this_slice_shipped():
+    """Promotion put reconciled numbers into the golden suite. What is still ahead is the recurring
+    run against a pinned dashboard, and that is all the entry may now claim."""
+    roadmap = SKILL.split("## Roadmap (not in v1)")[1]
+    assert "**Recurring reconcile runs**" in roadmap
+    assert "golden-test suite" not in roadmap
+    assert "agami test" not in roadmap
 
 
 def test_the_hard_rules_are_not_renumbered():

--- a/tests/test_golden_authoring_e2e.py
+++ b/tests/test_golden_authoring_e2e.py
@@ -7,6 +7,11 @@ looks at the answer and saves it — and the dataset the runner then reads holds
 That last read is the assertion that matters: the writer's only claim to correctness is that
 AH-100's reader, the one `/agami-eval` uses, accepts what it wrote.
 
+AH-111 adds a third way in and no third writer: a reconcile run's agreeing rows are promoted
+through this same save door. Those tests go further than a read-back — they hand the written item
+to the comparator `/agami-eval` scores with, because a promoted row whose band its own recorded
+result falls outside of would fail the next run as a false alarm on the day it was written.
+
 The script is driven in-process (`golden_author.main`) rather than through a subprocess so that a
 failure surfaces as a traceback in the code under test rather than as a non-zero exit code. Nothing
 is stubbed: the real column contract, the real writer, the real reader.
@@ -24,6 +29,8 @@ from pathlib import Path
 import pytest
 
 pytest.importorskip("pydantic")
+# The comparator parses the answer key's statement to find out whether the author ordered the rows.
+pytest.importorskip("sqlglot")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PKG_SRC = REPO_ROOT / "packages" / "agami-core" / "src"
@@ -32,6 +39,9 @@ if str(PKG_SRC) not in sys.path:
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
 import golden_author  # noqa: E402
+import reconcile  # noqa: E402
+from execute_sql import ExecResult  # noqa: E402
+from semantic_model.comparator import compare_result_sets  # noqa: E402
 from semantic_model.golden import load_golden_datasets  # noqa: E402
 
 PROFILE = "demo"
@@ -170,3 +180,205 @@ def test_a_question_bank_imports_unconfirmed_and_one_verified_answer_confirms_it
     # …and the other two are untouched: still questions with no answer, still unable to gate.
     others = [item for item in dataset.test_cases if item.id != target]
     assert [item.expected.sql_confirmed for item in others] == [False, False]
+
+
+# --- the promotion door: a reconcile run's agreeing rows, written through the same save ---------
+
+# The dataset a promotion lands in. Separate from the imported bank on purpose: the rows a
+# reconcile run agreed on are their own body of evidence, and the two are only forced together
+# when a promoted question happens to be one somebody already imported.
+RECONCILED = "reconciled"
+
+Q3_REVENUE = "What was total revenue in Q3 2025?"
+Q3_REVENUE_SQL = (
+    "SELECT SUM(o.amount) AS total_revenue FROM orders o "
+    "WHERE o.placed_at >= '2025-07-01' AND o.placed_at < '2025-10-01'"
+)
+Q3_ACTUAL = 3890000.0
+TOLERANCE = 0.01
+
+# The two provenance shapes the skill documents. They differ in words rather than only in tone,
+# because a reader a year from now has to be able to tell "the dashboard agreed" from "the
+# dashboard disagreed and a person overruled it".
+AGREED_METHOD = "reconciled against the finance dashboard on 2026-08-31; agreed within ±1%"
+RESOLVED_METHOD = (
+    "reconciled against the finance dashboard on 2026-08-31; disagreed beyond ±1%, "
+    "resolved in agami's favour by the analyst"
+)
+
+
+def _promotion_item(
+    query: str, sql: str, actual: float, method: str, column: str = "total_revenue"
+) -> dict:
+    """One kept row as the skill writes it out — `id` omitted, band from the helper.
+
+    The band goes through `reconcile.band` rather than being written out here for the same reason
+    the skill is told to call it: two spellings of ±1% is two answers to what the run's tolerance
+    meant, and this one would be the one nobody runs.
+    """
+    return {
+        "query": query,
+        "sql": sql,
+        "match": "bounded",
+        "bounds": reconcile.band(actual, tolerance=TOLERANCE),
+        "recorded": {"columns": [column], "rows": [[actual]]},
+        "tags": ["reconciled"],
+        "confirmed_by": {"method": method},
+    }
+
+
+def test_an_agreeing_row_promotes_and_scores_on_its_own_next_run(tmp_path, monkeypatch, capsys):
+    """The promotion end to end, ending on the check that matters most.
+
+    A read-back only proves the file parses. What a promotion actually claims is that this item can
+    gate a run, so the last step hands the written `match` and `bounds` to the comparator
+    `/agami-eval` scores with, over the very result the band was drawn around. An item that scored
+    anything but a clean pass there would fail its next run as a false alarm on the day it was
+    written — which is exactly the trap the skill's relativity guidance exists to avoid, reached by
+    a different road.
+    """
+    item_file = _write(
+        tmp_path,
+        "promotion.json",
+        json.dumps(_promotion_item(Q3_REVENUE, Q3_REVENUE_SQL, Q3_ACTUAL, AGREED_METHOD)),
+    )
+    code, saved = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        ["save", "--profile", PROFILE, "--dataset", RECONCILED, "--item", item_file],
+    )
+    assert code == 0
+    assert saved["summary"] == {"added": 1, "replaced": 0}
+
+    datasets, res = load_golden_datasets(PROFILE, tmp_path)
+    assert res.ok, res.errors
+    (promoted,) = next(d.test_cases for d in datasets if d.name == RECONCILED)
+
+    # It came through the save door, so it is confirmed and it carries the statement it verified.
+    assert promoted.expected.sql_confirmed is True
+    assert promoted.expected.sql == Q3_REVENUE_SQL
+    # A reconciled number legitimately moves, so it is banded rather than pinned.
+    assert promoted.match == "bounded"
+    assert promoted.bounds.min_value < Q3_ACTUAL < promoted.bounds.max_value
+    # The receipt is the run's own recorded result, forwarded rather than rebuilt from a number.
+    assert promoted.recorded.columns == ["total_revenue"]
+    assert promoted.recorded.rows == [[Q3_ACTUAL]]
+    assert promoted.tags == ["reconciled"]
+    # Provenance names the source, the day and the tolerance — the whole of what makes the claim
+    # auditable later.
+    for part in ("the finance dashboard", "2026-08-31", "±1%"):
+        assert part in promoted.confirmed_by.method
+
+    # …and it passes its own next run.
+    result = ExecResult(columns=list(promoted.recorded.columns), rows=[(Q3_ACTUAL,)])
+    score = compare_result_sets(
+        result,
+        result,
+        match=promoted.match,
+        bounds=promoted.bounds,
+        golden_sql=promoted.expected.sql,
+    )
+    assert score.status == "scored"
+    assert score.accuracy == 1.0
+
+    # A promotion writes the answer key and nothing else. The examples library is a different
+    # skill's business, and a reconcile run that quietly taught the model would be one.
+    assert not (tmp_path / PROFILE / "prompt_examples").exists()
+
+
+def test_a_relative_question_is_refused_until_it_names_the_window_it_meant(
+    tmp_path, monkeypatch, capsys
+):
+    """The common case, not the exotic one: the skill's own question generator produces "over the
+    last 30 days" from a label reading `Mean order size last 30 days`, and the statement that
+    answered it names the thirty days that were current when it ran.
+
+    The fix is the question, never the SQL. Anchoring the statement to `CURRENT_DATE` would also
+    clear the lint and would band a sliding window around one day's value; the edit asserted here
+    leaves the statement exactly as it ran, and the derived id follows the new wording — which is
+    the thing that makes the edit real rather than cosmetic.
+    """
+    relative = "What's the average order size over the last 30 days?"
+    named = "What's the average order size in August 2026?"
+    sql = (
+        "SELECT AVG(o.amount) AS avg_order_size FROM orders o "
+        "WHERE o.placed_at >= '2026-08-01' AND o.placed_at < '2026-09-01'"
+    )
+    item = _promotion_item(relative, sql, 84.5, AGREED_METHOD, column="avg_order_size")
+
+    refused_file = _write(tmp_path, "relative.json", json.dumps(item))
+    argv = ["save", "--profile", PROFILE, "--dataset", RECONCILED, "--item", refused_file]
+    code, payload = _run(tmp_path, monkeypatch, capsys, argv)
+    assert code == 2
+    assert payload is None
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+    edited_file = _write(tmp_path, "named.json", json.dumps({**item, "query": named}))
+    code, saved = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        ["save", "--profile", PROFILE, "--dataset", RECONCILED, "--item", edited_file],
+    )
+    assert code == 0
+
+    datasets, res = load_golden_datasets(PROFILE, tmp_path)
+    assert res.ok, res.errors
+    (promoted,) = next(d.test_cases for d in datasets if d.name == RECONCILED)
+    # The edited question is what was written, its id was derived from the edit, and the statement
+    # is byte-for-byte the one that ran.
+    assert promoted.query == named
+    assert promoted.id == golden_author._slug(named)
+    assert promoted.id != golden_author._slug(relative)
+    assert promoted.expected.sql == sql
+
+
+def test_a_promotion_onto_an_existing_question_stops_until_it_is_confirmed(
+    tmp_path, monkeypatch, capsys
+):
+    """The append-only stop, reached the way a promotion reaches it.
+
+    The second write here is the resolution path — the same question, now vouched for as a
+    disagreement a person overruled — which is exactly the case where seeing the `before` matters:
+    the item being replaced says the dashboard agreed, and the one replacing it says it did not.
+    """
+    argv = ["save", "--profile", PROFILE, "--dataset", RECONCILED, "--item"]
+    first = _write(
+        tmp_path,
+        "agreed.json",
+        json.dumps(_promotion_item(Q3_REVENUE, Q3_REVENUE_SQL, Q3_ACTUAL, AGREED_METHOD)),
+    )
+    assert _run(tmp_path, monkeypatch, capsys, [*argv, first])[0] == 0
+
+    second = _write(
+        tmp_path,
+        "resolved.json",
+        json.dumps(_promotion_item(Q3_REVENUE, Q3_REVENUE_SQL, Q3_ACTUAL, RESOLVED_METHOD)),
+    )
+    stop_code, stop = _run(tmp_path, monkeypatch, capsys, [*argv, second])
+    assert stop_code == 1
+    (pending,) = stop["needs_confirmation"]
+    assert pending["id"] == golden_author._slug(Q3_REVENUE)
+    # Both sides, and the two provenance shapes are what tells them apart.
+    assert pending["before"]["confirmed_by"]["method"] == AGREED_METHOD
+    assert pending["after"]["confirmed_by"]["method"] == RESOLVED_METHOD
+    assert AGREED_METHOD != RESOLVED_METHOD
+
+    # Nothing was written by the stop: the file on disk still says the dashboard agreed.
+    datasets, _ = load_golden_datasets(PROFILE, tmp_path)
+    (still,) = next(d.test_cases for d in datasets if d.name == RECONCILED)
+    assert still.confirmed_by.method == AGREED_METHOD
+
+    replaced_code, replaced = _run(
+        tmp_path, monkeypatch, capsys, [*argv, second, "--confirm-replace"]
+    )
+    assert replaced_code == 0
+    assert replaced["summary"] == {"added": 0, "replaced": 1}
+
+    datasets, res = load_golden_datasets(PROFILE, tmp_path)
+    assert res.ok, res.errors
+    (resolved,) = next(d.test_cases for d in datasets if d.name == RECONCILED)
+    assert resolved.confirmed_by.method == RESOLVED_METHOD
+    # The tag survived only because the item repeated it — a replacement is wholesale.
+    assert resolved.tags == ["reconciled"]

--- a/tests/test_golden_authoring_e2e.py
+++ b/tests/test_golden_authoring_e2e.py
@@ -351,11 +351,11 @@ def test_a_promotion_onto_an_existing_question_stops_until_it_is_confirmed(
     )
     assert _run(tmp_path, monkeypatch, capsys, [*argv, first])[0] == 0
 
-    second = _write(
-        tmp_path,
-        "resolved.json",
-        json.dumps(_promotion_item(Q3_REVENUE, Q3_REVENUE_SQL, Q3_ACTUAL, RESOLVED_METHOD)),
-    )
+    # The tag is deliberately NOT repeated on the replacement. A replacement is wholesale — the
+    # item sent is the item written — and an item that repeated it could not show that.
+    resolution = _promotion_item(Q3_REVENUE, Q3_REVENUE_SQL, Q3_ACTUAL, RESOLVED_METHOD)
+    del resolution["tags"]
+    second = _write(tmp_path, "resolved.json", json.dumps(resolution))
     stop_code, stop = _run(tmp_path, monkeypatch, capsys, [*argv, second])
     assert stop_code == 1
     (pending,) = stop["needs_confirmation"]
@@ -380,5 +380,71 @@ def test_a_promotion_onto_an_existing_question_stops_until_it_is_confirmed(
     assert res.ok, res.errors
     (resolved,) = next(d.test_cases for d in datasets if d.name == RECONCILED)
     assert resolved.confirmed_by.method == RESOLVED_METHOD
-    # The tag survived only because the item repeated it — a replacement is wholesale.
-    assert resolved.tags == ["reconciled"]
+    # …and the tag the first item carried is GONE, because the second one did not repeat it. This
+    # is why the skill is told to read the `before` and carry forward what still applies: a
+    # replacement that forgets a key does not merge it, it drops it.
+    assert resolved.tags == []
+
+
+# The keys `_save` actually reads off a promotion payload. A documented key outside this set is a
+# key the door drops in silence, which is the drift the test below exists to catch.
+_KEYS_THE_DOOR_READS = {
+    "id", "query", "sql", "match", "bounds", "must_filter", "recorded", "tags", "confirmed_by",
+}
+
+RECONCILE_SKILL = (
+    REPO_ROOT / "plugins" / "agami" / "skills" / "agami-reconcile" / "SKILL.md"
+).read_text(encoding="utf-8")
+
+
+def _documented_promotion_item() -> dict:
+    """The skill's own item block, with the two placeholders filled the way a run fills them."""
+    section = RECONCILE_SKILL.split("#### What gets written, per kept row")[1]
+    item = json.loads(section.split("```json")[1].split("```")[0])
+    item["sql"] = Q3_REVENUE_SQL
+    item["confirmed_by"]["method"] = item["confirmed_by"]["method"].replace(
+        "<the run's tolerance>", "1%"
+    )
+    return item
+
+
+def test_the_item_the_skill_documents_is_the_item_the_save_door_reads(
+    tmp_path, monkeypatch, capsys
+):
+    """The skill's JSON block, run through the real door instead of re-typed beside it.
+
+    Every other test in this file builds the promotion payload by hand, which means the shape the
+    skill tells a model to write and the shape `_save` reads could drift apart without one of them
+    failing. This is the only place the two are the same bytes.
+    """
+    item = _documented_promotion_item()
+    assert set(item) <= _KEYS_THE_DOOR_READS, set(item) - _KEYS_THE_DOOR_READS
+    # The band in the block is the helper's own output, not arithmetic somebody wrote in prose.
+    assert item["bounds"] == reconcile.band(item["recorded"]["rows"][0][0], tolerance=TOLERANCE)
+
+    code, saved = _run(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        ["save", "--profile", PROFILE, "--dataset", RECONCILED, "--item",
+         _write(tmp_path, "documented.json", json.dumps(item))],
+    )
+    assert code == 0
+    assert saved["summary"] == {"added": 1, "replaced": 0}
+
+    datasets, res = load_golden_datasets(PROFILE, tmp_path)
+    assert res.ok, res.errors
+    (promoted,) = next(d.test_cases for d in datasets if d.name == RECONCILED)
+
+    # Each documented key arrived where the door puts it — `id` derived from the question the
+    # block carries, which is what makes the omission in the block deliberate rather than lossy.
+    assert promoted.id == golden_author._slug(item["query"])
+    assert promoted.query == item["query"]
+    assert promoted.expected.sql == item["sql"]
+    assert promoted.expected.sql_confirmed is True
+    assert promoted.match == item["match"]
+    assert promoted.bounds.model_dump(exclude_none=True) == item["bounds"]
+    assert promoted.recorded.columns == item["recorded"]["columns"]
+    assert promoted.recorded.rows == [list(row) for row in item["recorded"]["rows"]]
+    assert promoted.tags == item["tags"]
+    assert promoted.confirmed_by.method == item["confirmed_by"]["method"]

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -24,6 +24,7 @@ from reconcile import band, diff, parse_csv, parse_value  # noqa: E402
 
 # --- parse_value ---------------------------------------------------------
 
+
 class TestParseValue:
     def test_plain_int(self):
         assert parse_value("47238221") == 47238221.0
@@ -108,6 +109,7 @@ class TestParseValue:
 
 # --- diff ----------------------------------------------------------------
 
+
 class TestDiff:
     def test_exact_match(self):
         r = diff(100.0, 100.0)
@@ -158,6 +160,7 @@ class TestDiff:
 
 
 # --- band ----------------------------------------------------------------
+
 
 class TestBand:
     def test_default_tolerance_positive_value(self):
@@ -213,6 +216,7 @@ def test_band_output_is_accepted_by_the_bounds_model():
 
 # --- the band verb, at the CLI -------------------------------------------
 
+
 class TestBandCli:
     """`parse_value` returns None for anything it cannot read, and `band` takes a float. The verb
     is what stands between them, and the exit code it refuses with is the whole point: on this
@@ -237,7 +241,46 @@ class TestBandCli:
             assert "reconcile band:" in capsys.readouterr().err
 
 
+class TestToleranceIsReadTheWayTheSkillWritesIt:
+    """The skill says a tolerance out loud as `±1%` a dozen times and then tells the caller to pass
+    the run's tolerance, so `1%` is the form that actually arrives at the flag. Both verbs read it
+    through `parse_value`, the same reader every other number on this CLI goes through, so the two
+    spellings are one tolerance and the decimal every existing caller passes is untouched.
+    """
+
+    def test_a_percentage_and_its_fraction_are_the_same_band(self, capsys):
+        assert reconcile.main(["band", "--value", "1000", "--tolerance", "1%"]) == 0
+        percent = capsys.readouterr().out
+        assert reconcile.main(["band", "--value", "1000", "--tolerance", "0.01"]) == 0
+
+        assert percent == capsys.readouterr().out
+
+    def test_diff_reads_a_percentage_too(self, capsys):
+        assert (
+            reconcile.main(["diff", "--expected", "1000", "--actual", "1005", "--tolerance", "1%"])
+            == 0
+        )
+        assert '"match": true' in capsys.readouterr().out
+
+    def test_an_unreadable_tolerance_is_refused_rather_than_defaulted(self, capsys):
+        """Falling back to ±1% would answer a question the caller did not ask: they named a band of
+        some other width, and a silent default returns the wrong one under the right name."""
+        for verb in (["band", "--value", "1000"], ["diff", "--expected", "1", "--actual", "1"]):
+            code = reconcile.main([*verb, "--tolerance", "wide-ish"])
+            assert code == 2
+            captured = capsys.readouterr()
+            assert captured.out == ""
+            assert "could not read a tolerance" in captured.err
+
+    def test_a_negative_tolerance_is_refused_rather_than_silently_absolute(self, capsys):
+        """`band` sorts its two ends, so a negative tolerance used to produce the same band as its
+        positive twin — a typo answered with a plausible number instead of a refusal."""
+        assert reconcile.main(["band", "--value", "1000", "--tolerance", "-0.5"]) == 2
+        assert "could not read a tolerance" in capsys.readouterr().err
+
+
 # --- parse_csv -----------------------------------------------------------
+
 
 class TestParseCsv:
     def test_simple_two_column_with_header(self):

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -5,6 +5,7 @@ Covers the deterministic parts of the reconciliation harness:
 - Number-string parsing (currency, magnitudes, percentages, accounting parens)
 - CSV parsing (header detection, multi-column labels)
 - Diff with tolerance
+- The band a promoted observation is allowed to land in (AH-111)
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
-from reconcile import diff, parse_csv, parse_value  # noqa: E402
+from reconcile import band, diff, parse_csv, parse_value  # noqa: E402
 
 # --- parse_value ---------------------------------------------------------
 
@@ -153,6 +154,60 @@ class TestDiff:
         r = diff(100.0, None)
         assert r["match"] is False
         assert r["reason"] == "missing_actual"
+
+
+# --- band ----------------------------------------------------------------
+
+class TestBand:
+    def test_default_tolerance_positive_value(self):
+        # ±1%, the same default diff rides on.
+        b = band(100.0)
+        assert pytest.approx(b["min_value"], abs=1e-9) == 99.0
+        assert pytest.approx(b["max_value"], abs=1e-9) == 101.0
+
+    def test_custom_tolerance(self):
+        b = band(100.0, tolerance=0.05)
+        assert pytest.approx(b["min_value"], abs=1e-9) == 95.0
+        assert pytest.approx(b["max_value"], abs=1e-9) == 105.0
+
+    def test_zero_value_is_a_zero_band(self):
+        # Mirrors diff's rule that a zero expected requires exact equality — a relative
+        # tolerance around zero bounds nothing.
+        b = band(0.0)
+        assert b["min_value"] == 0.0
+        assert b["max_value"] == 0.0
+
+    def test_negative_value_keeps_the_floor_below_the_ceiling(self):
+        # Multiplying by 1-tol / 1+tol inverts the order for a negative observation, and
+        # GoldenBounds refuses a floor above its ceiling.
+        b = band(-100.0)
+        assert b["min_value"] <= b["max_value"]
+        assert pytest.approx(b["min_value"], abs=1e-9) == -101.0
+        assert pytest.approx(b["max_value"], abs=1e-9) == -99.0
+
+    def test_value_parsed_from_a_string(self):
+        b = band(parse_value("$1.2M"))
+        assert pytest.approx(b["min_value"], abs=1e-3) == 1_188_000.0
+        assert pytest.approx(b["max_value"], abs=1e-3) == 1_212_000.0
+
+    def test_emits_exactly_the_four_bounds_keys(self):
+        b = band(100.0)
+        assert set(b) == {"min_rows", "max_rows", "min_value", "max_value"}
+        # A reconciled number is one cell, so the row band is pinned at exactly one row.
+        assert b["min_rows"] == 1
+        assert b["max_rows"] == 1
+
+
+def test_band_output_is_accepted_by_the_bounds_model():
+    # The point of the four keys is that a caller pastes them into an item with no arithmetic
+    # of its own, so the model itself is the assertion. pydantic isn't otherwise needed here.
+    pytest.importorskip("pydantic")
+    from semantic_model.golden import GoldenBounds
+
+    for value in (100.0, 0.0, -100.0):
+        bounds = GoldenBounds(**band(value))
+        assert bounds.min_rows == 1
+        assert bounds.min_value <= bounds.max_value
 
 
 # --- parse_csv -----------------------------------------------------------

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -19,6 +19,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "plugins" / "agami" / "scripts"))
 
+import reconcile  # noqa: E402
 from reconcile import band, diff, parse_csv, parse_value  # noqa: E402
 
 # --- parse_value ---------------------------------------------------------
@@ -208,6 +209,32 @@ def test_band_output_is_accepted_by_the_bounds_model():
         bounds = GoldenBounds(**band(value))
         assert bounds.min_rows == 1
         assert bounds.min_value <= bounds.max_value
+
+
+# --- the band verb, at the CLI -------------------------------------------
+
+class TestBandCli:
+    """`parse_value` returns None for anything it cannot read, and `band` takes a float. The verb
+    is what stands between them, and the exit code it refuses with is the whole point: on this
+    path exit `1` is the save door's `needs_confirmation`, so a value nobody could read has to
+    come back as `2` — cannot start — rather than as a traceback landing on whatever code it likes.
+    """
+
+    def test_a_readable_value_bands_and_exits_zero(self, capsys):
+        assert reconcile.main(["band", "--value", "$4.2M", "--tolerance", "0.01"]) == 0
+        assert '"min_value"' in capsys.readouterr().out
+
+    def test_an_unreadable_value_is_refused_and_not_crashed(self, capsys):
+        code = reconcile.main(["band", "--value", "n/a"])
+        assert code == 2
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "could not read a number from --value" in captured.err
+
+    def test_the_sentinels_the_parser_knows_are_all_refused_the_same_way(self, capsys):
+        for value in ("n/a", "—", "", "not a number"):
+            assert reconcile.main(["band", "--value", value]) == 2
+            assert "reconcile band:" in capsys.readouterr().err
 
 
 # --- parse_csv -----------------------------------------------------------


### PR DESCRIPTION
Spec: AH-111

> **Stacked on #248.** Base branch is `AH-109-golden-dataset-authoring`, not `main`, because the save door this calls is not on `main` yet and the contract forbids a second writer. **Merge #248 first**, then this retargets to `main`. Review `git diff 496b40d`.

## Summary

A reconcile run that matched nine of twelve numbers has already produced nine verified answers — a person read each one and accepted it — and then throws them away. The statement that produced each number lives only inside the chart HTML at `report_path`; the row record never held it. The cheapest source of confirmed golden items in the product was the one place nothing was kept.

Now the row record keeps the statement and the result, and after the run's summary the rows that agreed are offered once for promotion into a golden dataset. It writes through the save door and nothing else.

## Changes

- **`agami-reconcile/SKILL.md`** — the Phase 2d row record gains `sql` and `recorded` (additive; every existing key stays). A new Phase 3e offers the agreeing rows, all selected by default, showing each statement and its result; the old closing prompt becomes 3f. Only `status == "match"` rows are eligible — one predicate, and an error row carries no statement to keep. Declining writes nothing.
- **`reconcile.py`** — a `band` verb turning an observed value and the run's tolerance into the bounds block, so a promoted item is `bounded` rather than `exact`. The band is arithmetic, and arithmetic written in prose is the class of bug this script exists to remove.
- **Hard rule 3** — amended in place, not replaced. Still forbids mutating a metric, a join or a column, still routes those to `/agami-save-correction`; carves out the golden write as the answer key that *tests* the model, through one door, by two named routes, with a yes in front of either.

## Decisions taken during the build

- **The band is centred on the observed value, not the expected one.** A bounded item is judged against its band alone, so this makes "passes its own next run" a property of the arithmetic rather than a hope. Verified: the promoted item scores 1.0 on replay and anywhere inside its band, 0.0 on a 7% drift.
- **A promotion edits the question; it never re-anchors the statement.** The relativity lint refuses a question asked relative to today over frozen dates, and this skill's own example is "the last 30 days" — so the refusal is the common case. Anchoring the SQL on `CURRENT_DATE` passes the lint and is a trap: the band was drawn around today's value of a window that slides, so the item drifts out of its own band and fails later as a false alarm. Naming the window keeps the answer true. Every mention of `CURRENT_DATE` in the skill is now a prohibition, and a test asserts that.
- **Agreement is `status == "match"` at the run's own tolerance** — the only notion of agreement in the tree. There is no second one.
- **The conventions row's routing triggers were wrong.** It quoted "reconcile against my dashboard" and "verify these numbers against agami"; the skill says *this* dashboard, and the second phrase appears nowhere in it. The table claims triggers come from `when_to_use`, so both routed nothing. Corrected, and now pinned by the first test ever to assert this skill's prose.

## Review findings fixed before this PR

Two passes ran against the diff.

- **The offer contradicted a shipped rule about pasting SQL in chat**, inherited from `agami-query`. The offer breaks it by design — the person accepts the statement, not the number — so the exception is now written into the rule itself, and a test pins that it is the only one.
- **Hard rule 3's first carve-out was too narrow to permit the resolution write** the same file requires. A hard rule is the most authoritative prose in a skill, so a model reading it would have refused a write the spec puts in scope.
- **Retention had no test at all** — the row record's two new keys were the first commit's entire product and nothing asserted them.
- **`band` crashed on an unreadable value**, exiting 1 — the code the save door uses for "needs confirmation". It refuses with 2 now.
- Nine smaller corrections: statuses that cannot occur named in the eligibility prose, a hardcoded ±1% in a run whose tolerance is configurable, a batch of ten rows that read as one call to a door that takes one item, and a roadmap still promising the half this shipped.

## Checklist

- [x] Spec linked (`AH-111`), and the change stays inside its scope
- [x] Every success criterion has a passing test; the promotion was also exercised by hand end to end
- [x] **Reconciliation itself is unchanged** — phases 3a–3d are byte-identical and pinned by a verbatim regression test; `TestDiff` untouched
- [x] `ruff check` clean; gitleaks clean
- [x] No existing test weakened — two assertions updated deliberately, both named in the review section above
- [x] Public-repo safe: synthetic fixtures, no customer names, no credentials, no spec ids in shipped markdown
- [x] No network egress; no MCP tool and no REST route
- [ ] **Suite is not fully green**: 39 tests fail, identically on `main` at `0d8fe75` and on this branch's base. This work adds none and fixes none; they want their own bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
