### PR TITLE
ci: a PR that changes what we ship must say so in CHANGELOG.md

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,48 @@
+name: Changelog
+
+# A PR that changes what we ship must say so in CHANGELOG.md. Written after 0.7.0, where 90 commits
+# landed with an empty [Unreleased] section and a minor release — two new skills, four new library
+# modules, a new CI exit contract — reached the cut with no notes at all.
+#
+# The decision lives in dev/changelog_gate.py so it is unit-tested (tests/test_changelog_gate.py)
+# rather than asserted in YAML; this workflow only supplies the changed paths.
+#
+# SEPARATE from ci.yml on purpose. The waiver is a label, and a label change only re-runs a workflow
+# that subscribes to `labeled` — but subscribing ci.yml to label events would re-run the whole test
+# matrix and both safety-corpus legs every time anyone touches any label. This job takes seconds, so
+# it can afford the extra triggers that make the waiver actually work.
+
+on:
+  pull_request:
+    # `labeled` / `unlabeled` are the point: without them, applying `no-changelog` queues no new run
+    # and the red check stands forever. Re-running from the UI does not help either — it replays the
+    # original event payload, in which the label is still absent — so the documented escape hatch
+    # would have had no way to clear the gate short of an empty commit.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    name: changelog entry
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # need the base commit to diff against
+
+      - name: changed files must include CHANGELOG.md
+        # `shell: bash` is load-bearing, not style. A bare `run:` uses `bash -e {0}` WITHOUT
+        # pipefail, so a pipeline's status is the last command's alone: if `git diff` failed, python
+        # would read empty stdin, print "nothing shipped changed" and exit 0 — the gate going green
+        # having checked nothing, while its own message claimed otherwise. An explicit shell is what
+        # lets `set -o pipefail` apply.
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Three dots: compare against the MERGE BASE, so files main changed under us aren't
+          # attributed to this PR. `origin/<base>` is fetched by the full-depth checkout above.
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            | python3 dev/changelog_gate.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,31 @@ permissions:
   contents: read
 
 jobs:
+  # A PR that changes what we ship must say so in CHANGELOG.md. Written after 0.7.0, where 90
+  # commits landed with an empty [Unreleased] section and a minor release — two new skills, four new
+  # library modules — arrived with no notes at all. The decision lives in dev/changelog_gate.py so
+  # it is unit-tested rather than asserted in YAML; this job only supplies the changed paths.
+  #
+  # PR-only: a push to main has no base to diff against, and the gate has already run on the PR
+  # that produced that commit.
+  changelog:
+    name: changelog entry
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'no-changelog')
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # need the base commit to diff against
+
+      # Three dots: compare against the MERGE BASE, so files main changed under us aren't
+      # attributed to this PR. `origin/<base>` is fetched by the full-depth checkout above.
+      - name: changed files must include CHANGELOG.md
+        run: |
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            | python3 dev/changelog_gate.py
+
   lint-and-test:
     name: lint + test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -29,13 +54,13 @@ jobs:
       # Lint + import sorting — blocking. Rules come from pyproject.toml.
       # packages/ holds the agami-core library.
       - name: ruff check
-        run: uvx ruff@0.15.19 check plugins packages tests
+        run: uvx ruff@0.15.19 check plugins packages tests dev.py dev
 
       # Format check is informational for now: the tree has a large unformatted
       # backlog (~74 files). Flip `continue-on-error` off after a dedicated
       # `ruff format` pass makes the tree clean.
       - name: ruff format --check (informational)
-        run: uvx ruff@0.15.19 format --check plugins packages tests
+        run: uvx ruff@0.15.19 format --check plugins packages tests dev.py dev
         continue-on-error: true
 
       # Coverage is ENFORCED, not just reported. Measured 2026-07-29 at 85.66% on every leg of this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,31 +13,6 @@ permissions:
   contents: read
 
 jobs:
-  # A PR that changes what we ship must say so in CHANGELOG.md. Written after 0.7.0, where 90
-  # commits landed with an empty [Unreleased] section and a minor release — two new skills, four new
-  # library modules — arrived with no notes at all. The decision lives in dev/changelog_gate.py so
-  # it is unit-tested rather than asserted in YAML; this job only supplies the changed paths.
-  #
-  # PR-only: a push to main has no base to diff against, and the gate has already run on the PR
-  # that produced that commit.
-  changelog:
-    name: changelog entry
-    runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request' &&
-      !contains(github.event.pull_request.labels.*.name, 'no-changelog')
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0 # need the base commit to diff against
-
-      # Three dots: compare against the MERGE BASE, so files main changed under us aren't
-      # attributed to this PR. `origin/<base>` is fetched by the full-depth checkout above.
-      - name: changed files must include CHANGELOG.md
-        run: |
-          git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-            | python3 dev/changelog_gate.py
-
   lint-and-test:
     name: lint + test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,24 @@ release is cut with a `v<version>` tag matching `packages/agami-core/pyproject.t
 
 Record notable user-visible changes in [`CHANGELOG.md`](CHANGELOG.md) (Keep a Changelog format) under the version that ships them.
 
+### CI requires a changelog entry — write it in the PR that ships the change
+
+A PR that touches `plugins/` or `packages/` must also touch `CHANGELOG.md`, or the **changelog
+entry** check fails. Add your entry under `## [Unreleased]`; the release PR later renames that
+heading to the version.
+
+Tests, docs, `dev/` tooling and workflows are **not** gated — none of them reach a user's machine on
+an install. If a shipped change genuinely has nothing user-visible to say (an internal refactor, a
+comment, a docstring typo), apply the **`no-changelog`** label to the PR and the check passes.
+
+The rule exists because of what 0.7.0 cost: 90 commits landed between v0.6.9 and v0.7.0 with an
+empty `[Unreleased]` section, so a minor release — two new skills, four new library modules, a new
+CI exit contract — reached the cut with no notes at all. Reconstructing them from nine merged PRs
+was slow, and worse, it was wrong in a way writing-at-the-time wouldn't have been: the notes shipped
+a CLI flag that does not exist, because a summary written weeks later describes what someone
+remembers building rather than what shipped. You are the only person who will ever have the context
+to write your entry correctly, and that moment is the PR.
+
 ## A community Discord will land soon
 
 Once it's live, the link will appear here and in [`agami-connect/SKILL.md`](plugins/agami/skills/agami-connect/SKILL.md).

--- a/dev.py
+++ b/dev.py
@@ -30,7 +30,9 @@ RUFF = ["uvx", "ruff@0.15.19"]
 # The suite imports the agami-core library, so install it editable with the [model]
 # extra (pydantic/pyyaml/sqlglot). DB drivers are omitted on purpose — those tests skip without a DB.
 TEST_DEPS = ["--with", "pytest-cov", "--with-editable", "packages/agami-core[model,server]"]
-TARGETS = ["plugins", "packages", "tests", "dev.py"]
+# `dev/` is here because it holds gate logic CI executes (changelog_gate.py), not just local
+# helpers — code the build depends on should be linted like the code it guards.
+TARGETS = ["plugins", "packages", "tests", "dev.py", "dev"]
 
 _ROOT = Path(__file__).resolve().parent
 # The plugin's runtime scripts import a small stdlib-only slice of the agami-core library. The

--- a/dev/changelog_gate.py
+++ b/dev/changelog_gate.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Fail a PR that changes what we ship without saying so in CHANGELOG.md.
+
+The gate exists because of what 0.7.0 cost. Ninety commits landed between v0.6.9 and v0.7.0 and not
+one carried a changelog entry, so a minor release — two new skills, four new library modules, a new
+CI exit contract — arrived with an EMPTY `[Unreleased]` section and no notes at all. Nothing told a
+user that `/agami-eval` or `/agami-save-golden` existed. Reconstructing that from nine merged PRs at
+release time is both slow and worse: the PR bodies were excellent and the release notes still came
+out with a flag that does not exist in them, because a summary written weeks later describes what
+someone remembers building rather than what shipped.
+
+Writing the entry in the PR that ships the change is the only time the author has the context to
+write it correctly, and this gate is what makes that the path of least resistance.
+
+Stdlib only, and a pure function underneath the CLI: CI hands it the changed paths on stdin, and
+`tests/test_changelog_gate.py` calls `unreleased_paths` directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+
+CHANGELOG = "CHANGELOG.md"
+
+# What "we ship" means, as prefixes. `plugins/` is the marketplace plugin — skills, scripts, shared
+# templates — and `packages/` is the pip-installable library. A change under either reaches a user's
+# machine on the next install; everything else in the tree (tests, docs, dev tooling, workflows)
+# does not, and is deliberately NOT gated. Keeping the watched set this narrow is what stops the
+# gate becoming noise a contributor learns to bypass on reflex.
+SHIPPED_PREFIXES = ("plugins/", "packages/")
+
+# The label that waives the gate. Deliberately a label rather than a magic string in the title or
+# body: a label is a separate, visible act that survives a force-push and shows up in the PR's
+# timeline, so waiving is auditable rather than invisible.
+WAIVER_LABEL = "no-changelog"
+
+
+def _is_test(path: str) -> bool:
+    """Tests ship to nobody. `tests/` is the repo's suite; `/tests/` catches a package's own."""
+    return path.startswith("tests/") or "/tests/" in path
+
+
+def unreleased_paths(paths: Iterable[str]) -> list[str]:
+    """The changed paths that reach a user with no changelog entry to explain them.
+
+    Empty means the gate passes — either nothing shipped changed, or CHANGELOG.md moved with it.
+    Returns the offending paths (sorted) rather than a bool so the CI failure can name them; being
+    told *which* file tripped the gate is the difference between fixing it and re-running it.
+    """
+    paths = list(paths)
+    if CHANGELOG in paths:
+        return []
+    return sorted(p for p in paths if p.startswith(SHIPPED_PREFIXES) and not _is_test(p))
+
+
+def main() -> int:
+    changed = [line.strip() for line in sys.stdin if line.strip()]
+    offenders = unreleased_paths(changed)
+    if not offenders:
+        print("✓ changelog gate: nothing shipped changed, or CHANGELOG.md moved with it")
+        return 0
+
+    shown = offenders[:20]
+    print("✗ changelog gate: these change what we ship, but CHANGELOG.md was not touched:\n")
+    for p in shown:
+        print(f"    {p}")
+    if len(offenders) > len(shown):
+        print(f"    … and {len(offenders) - len(shown)} more")
+    print(
+        f"\nAdd an entry under ## [Unreleased] in {CHANGELOG} describing the user-visible change.\n"
+        f"If there genuinely isn't one — an internal refactor, a comment, a typo in a docstring —\n"
+        f"apply the `{WAIVER_LABEL}` label to the PR and this check will pass."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_changelog_gate.py
+++ b/tests/test_changelog_gate.py
@@ -1,0 +1,137 @@
+"""The changelog gate: a PR that changes what we ship must say so in CHANGELOG.md.
+
+The gate's whole value is being narrow enough that nobody learns to waive it on reflex, so these
+tests pin both directions — what it catches AND what it deliberately lets through. A gate that
+fired on a test-only change would be waived by habit within a week, and then the release it exists
+to protect would ship with no notes anyway.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GATE = REPO / "dev" / "changelog_gate.py"
+
+sys.path.insert(0, str(REPO / "dev"))
+
+from changelog_gate import CHANGELOG, unreleased_paths  # noqa: E402
+
+# --- what it catches -------------------------------------------------------------------------
+
+
+def test_a_plugin_change_without_a_changelog_entry_is_caught():
+    assert unreleased_paths(["plugins/agami/skills/agami-eval/SKILL.md"]) == [
+        "plugins/agami/skills/agami-eval/SKILL.md"
+    ]
+
+
+def test_a_library_change_without_a_changelog_entry_is_caught():
+    assert unreleased_paths(["packages/agami-core/src/semantic_model/golden.py"]) == [
+        "packages/agami-core/src/semantic_model/golden.py"
+    ]
+
+
+def test_a_dependency_change_is_caught():
+    # A cap or a new dep changes what a user's install resolves to, so it is user-visible even
+    # though no line of our own code moved.
+    assert unreleased_paths(["packages/agami-core/pyproject.toml"]) == [
+        "packages/agami-core/pyproject.toml"
+    ]
+
+
+def test_every_offender_is_reported_not_just_the_first():
+    # The failure names what tripped it; reporting one of five would send the author round again.
+    paths = [
+        "packages/agami-core/src/tools.py",
+        "plugins/agami/scripts/sm",
+        "tests/test_tools.py",
+        "docs/self-hosting.md",
+    ]
+    assert unreleased_paths(paths) == [
+        "packages/agami-core/src/tools.py",
+        "plugins/agami/scripts/sm",
+    ]
+
+
+def test_the_real_070_diff_would_have_been_caught():
+    # The case the gate was written for: 0.7.0's shipped surface, with CHANGELOG.md absent.
+    paths = [
+        "packages/agami-core/src/semantic_model/comparator.py",
+        "packages/agami-core/src/semantic_model/golden_run.py",
+        "plugins/agami/scripts/run_golden_eval.py",
+        "plugins/agami/skills/agami-save-golden/SKILL.md",
+    ]
+    assert len(unreleased_paths(paths)) == 4
+
+
+# --- what it deliberately lets through -------------------------------------------------------
+
+
+def test_a_changelog_entry_satisfies_the_gate():
+    assert unreleased_paths(["plugins/agami/scripts/sm", CHANGELOG]) == []
+
+
+def test_a_test_only_change_is_not_gated():
+    assert unreleased_paths(["tests/test_tools.py"]) == []
+
+
+def test_a_packages_own_tests_dir_is_not_gated():
+    # A package that grows its own tests/ must not trip a gate meant for shipped code.
+    assert unreleased_paths(["packages/agami-core/tests/test_internal.py"]) == []
+
+
+def test_docs_ci_and_dev_tooling_are_not_gated():
+    # None of these reach a user's machine on an install, so gating them would be the noise that
+    # teaches people to waive the label without reading.
+    assert (
+        unreleased_paths(
+            [
+                "docs/self-hosting.md",
+                "README.md",
+                "CONTRIBUTING.md",
+                ".github/workflows/ci.yml",
+                "dev.py",
+                "dev/changelog_gate.py",
+            ]
+        )
+        == []
+    )
+
+
+def test_an_empty_diff_passes():
+    assert unreleased_paths([]) == []
+
+
+# --- the CLI ---------------------------------------------------------------------------------
+
+
+def _run(paths: list[str]):
+    return subprocess.run(
+        [sys.executable, str(GATE)],
+        input="\n".join(paths),
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_exits_1_and_names_the_offender():
+    r = _run(["plugins/agami/scripts/sm"])
+    assert r.returncode == 1
+    assert "plugins/agami/scripts/sm" in r.stdout
+    # The failure must say how to clear it, including the waiver — a gate whose message doesn't
+    # name its own escape hatch gets cleared by deleting the job.
+    assert "no-changelog" in r.stdout
+
+
+def test_cli_exits_0_when_the_changelog_moved():
+    r = _run(["plugins/agami/scripts/sm", CHANGELOG])
+    assert r.returncode == 0
+
+
+def test_cli_ignores_blank_lines():
+    # `git diff --name-only` output piped through a shell can carry a trailing newline.
+    r = _run(["plugins/agami/scripts/sm", "", "  ", CHANGELOG])
+    assert r.returncode == 0

--- a/tests/test_changelog_gate.py
+++ b/tests/test_changelog_gate.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO = Path(__file__).resolve().parent.parent
 GATE = REPO / "dev" / "changelog_gate.py"
 
@@ -135,3 +137,43 @@ def test_cli_ignores_blank_lines():
     # `git diff --name-only` output piped through a shell can carry a trailing newline.
     r = _run(["plugins/agami/scripts/sm", "", "  ", CHANGELOG])
     assert r.returncode == 0
+
+
+# --- the workflow that drives it ---------------------------------------------------------------
+#
+# Two properties of the YAML decide whether the gate works at all, and neither is visible from the
+# Python. Both were review findings against the first version of this PR.
+
+
+def _workflow() -> dict:
+    yaml = pytest.importorskip("yaml")
+    return yaml.safe_load((REPO / ".github" / "workflows" / "changelog.yml").read_text())
+
+
+def _triggers(wf: dict) -> dict:
+    """The workflow's `on:` block. YAML 1.1 resolves a bare `on` to the boolean True, so PyYAML
+    keys it under `True` and not `"on"` — GitHub reads it correctly either way, but a test that
+    looked up `"on"` would KeyError on a perfectly good workflow."""
+    return wf["on"] if "on" in wf else wf[True]
+
+
+def test_the_waiver_label_can_actually_clear_the_check():
+    # `on: pull_request` defaults to [opened, synchronize, reopened]. Without `labeled`, applying
+    # `no-changelog` queues no run and the red check stands; re-running from the UI replays the
+    # original payload, where the label is still absent. The documented escape hatch would then have
+    # no way to clear the gate short of an empty commit.
+    types = _triggers(_workflow())["pull_request"]["types"]
+    assert "labeled" in types and "unlabeled" in types
+
+
+def test_the_gate_cannot_fail_open_on_a_broken_git_diff():
+    # A bare `run:` is `bash -e {0}` with NO pipefail, so `git diff | python3` reports only python's
+    # status. A failed diff would feed empty stdin, print "nothing shipped changed" and exit 0 — the
+    # gate passing while having checked nothing.
+    step = next(
+        s
+        for s in _workflow()["jobs"]["changelog"]["steps"]
+        if "changelog_gate.py" in str(s.get("run", ""))
+    )
+    assert step.get("shell") == "bash", "pipefail only applies under an explicit shell"
+    assert "pipefail" in step["run"]


### PR DESCRIPTION
Closes the process gap 0.7.0 exposed.

## Why

Ninety commits landed between `v0.6.9` and `v0.7.0` with an **empty `[Unreleased]` section**. A minor release — two new skills, four new library modules, a new CI exit contract — reached the cut with no notes at all; nothing told a user that `/agami-eval` or `/agami-save-golden` existed.

Reconstructing them from nine merged PRs was slow, and worse, it was **wrong in a way writing-at-the-time wouldn't have been**: the notes shipped a `--out` flag that `run_golden_eval.py` does not have. Review caught it. The author of that script never would have written it — a summary composed weeks later describes what someone remembers building rather than what shipped.

## The rule

A PR touching `plugins/` or `packages/` must also touch `CHANGELOG.md`.

**Deliberately not gated:** `tests/`, a package's own `tests/`, `docs/`, `dev/`, workflows, root markdown. None reach a user's machine on an install. This narrowness is the design: a gate that fires on a test-only change gets waived by habit inside a week, and then the release it exists to protect ships with no notes anyway.

**Escape hatch:** the `no-changelog` label (created on the repo). A label rather than a magic string in the title or body, because it survives a force-push and shows in the PR timeline — waiving is auditable rather than invisible. The failure message names it, since a gate that doesn't explain its own exit gets cleared by deleting the job.

## Shape

The decision is a pure function in `dev/changelog_gate.py`, so it's unit-tested rather than asserted in YAML; the CI job only supplies the changed paths (`git diff --name-only origin/<base>...HEAD`, three dots so files `main` changed under us aren't attributed to the PR).

**13 tests, both directions** — what it catches and what it lets through. The second set matters more: they're what stops a future widening from quietly turning this into noise.

Verified against the real backlog rather than only synthetic input:

```
$ git diff --name-only v0.6.9..fc02cfd | python3 dev/changelog_gate.py
✗ changelog gate: these change what we ship, but CHANGELOG.md was not touched:
    packages/agami-core/src/semantic_model/comparator.py
    ... 22 files ...
exit=1
```

This PR touches only `dev/`, `tests/`, `.github/` and `CONTRIBUTING.md`, so it does not trip its own gate — which is the intended behaviour, not an oversight.

## Two adjacent fixes it made necessary

- **`dev/` added to the ruff targets.** It now holds gate logic CI executes, not just local helpers. It was already clean, so this costs nothing.
- **CI's hardcoded ruff targets aligned with `dev.py`'s `TARGETS`.** They had drifted — CI linted `plugins packages tests` while `dev.py` also linted `dev.py`. So `dev.py` was checked locally and not in the gate, which is backwards from the stated principle that CI and local run the same rules.

## Verification

`uv run dev.py check` — **5422 passed** (up 13), 12 skipped; ruff check + format clean; gitleaks clean.