### PR TITLE
release: 0.7.1 — a deployment can require thread_id

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-09-04
+
+One opt-in change, off by default: a deployment can require the `thread_id` that links a
+conversation's tool calls together. Nothing about the served tool surface moves unless the flag is
+set.
+
 ### Added
 
 - **A deployment can require `thread_id`, so conversations stop fragmenting in the activity log.**

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.7.0"
+version = "0.7.1"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts 0.7.1 so the `thread_id` requirement (#255) can be picked up downstream.

One opt-in change since 0.7.0, **off by default**. `AGAMI_REQUIRE_THREAD_ID` promotes `thread_id` from an optional tool property to a required one on every tool that declares it, so a conversation stops fragmenting when the model omits the id that links its calls.

Measured on a real client: **0 of 8** calls carried the id before, **9 of 9** after.

Nothing about the served tool surface moves unless the flag is set — the schema is validated before dispatch, so a call omitting a required property fails rather than degrading, which is why it has to be observed on a client before being rolled forward. `test_the_served_surface_is_unchanged_while_the_flag_is_off` pins that.

Version bumped in `.claude-plugin/marketplace.json` (both entries), `plugins/agami/.claude-plugin/plugin.json` and `packages/agami-core/pyproject.toml`; `[Unreleased]` promoted to `[0.7.1]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)