### PR TITLE
release: 0.8.0 — the server decides which calls are one conversation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.7.1",
+    "version": "0.8.0",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-09-05
+
+One change: the server decides which tool calls belong to one conversation, instead of asking the
+model for an id it cannot supply reliably. `tool_calls` gains a column and the Activity view groups
+by it; nothing existing is removed and no argument, return shape or refusal rule moves.
+
 ### Added
 
 - **The server decides which tool calls are one conversation, instead of asking the model.**

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.7.1"
+version = "0.8.0"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts 0.8.0 so #259 can be consumed downstream.

`tool_calls` gains `conversation_id`, decided when the call is recorded from the authenticated actor, their organization and the clock. `list_sessions` groups by it, falling back to the old `(actor, thread_id)` pairing for rows written before the column existed.

**MINOR, not patch** — a new column and a change to how sessions group are both observable by a consumer. Nothing is removed: `thread_id` is still recorded, and a reader of it keeps reading it.

Version bumped in `.claude-plugin/marketplace.json` (both entries), `plugins/agami/.claude-plugin/plugin.json` and `packages/agami-core/pyproject.toml`; `[Unreleased]` promoted to `[0.8.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)