### PR TITLE
The import door reads a spreadsheet rather than asking for a conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Changed
+
+- **`/agami-save-golden` reads a spreadsheet instead of asking you to convert one.** The import door
+  refused an `.xlsx` and told the user to open it in Excel and Save As → CSV. Now Claude reads the
+  workbook and writes the sheet out as a CSV itself, which is the same move the skill already made
+  for a table pasted into chat.
+
+  The reason for the old refusal was that `golden_author.py` cannot open a workbook — true, and
+  unchanged: it is stdlib-only, and a marketplace install ships the plugin with nothing to
+  pip-install into. But that was an argument about the script, not about the skill. `agami-connect`
+  has always read a customer's existing definitions this way, with the deterministic step never
+  opening the file. One parser, one place a column can be misread, and one less conversion for the
+  person whose question bank lives in Excel — which is where question banks live.
+
+  When more than one sheet holds data the skill asks which, rather than guessing, and formulas are
+  flattened to their values.
+
 ## [0.8.0] — 2026-09-05
 
 One change: the server decides which tool calls belong to one conversation, instead of asking the

--- a/plugins/agami/skills/agami-save-golden/SKILL.md
+++ b/plugins/agami/skills/agami-save-golden/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agami-save-golden
-description: "Writes golden-dataset items for a profile through two doors. The import door turns a question bank — a CSV, or a table pasted into chat — into items written unconfirmed, after the parsed rows have been shown and agreed to. The save door writes one question, the statement that answered it and the result the person accepted, as a confirmed item with its receipt. The curation door applies the changes queued on the golden-dataset explorer page, which may weaken a claim and may never grant one. Every write goes through agami-core's writer, is re-read by the runner's own reader before it is kept, and is append-only: a write that would change an item that already exists stops and shows the before and the after. This skill writes only; it never runs or scores a dataset."
+description: "Writes golden-dataset items for a profile through two doors. The import door turns a question bank — a spreadsheet, a CSV, or a table pasted into chat — into items written unconfirmed, after the parsed rows have been shown and agreed to. The save door writes one question, the statement that answered it and the result the person accepted, as a confirmed item with its receipt. The curation door applies the changes queued on the golden-dataset explorer page, which may weaken a claim and may never grant one. Every write goes through agami-core's writer, is re-read by the runner's own reader before it is kept, and is append-only: a write that would change an item that already exists stops and shows the before and the after. This skill writes only; it never runs or scores a dataset."
 when_to_use: "Use when the user says 'save this as a golden question', 'add this to the golden dataset', 'import my question bank', 'turn this spreadsheet into a golden dataset', 'this answer is correct — remember it as ground truth', 'show me the golden datasets', 'what does this dataset not test', 'apply my queued changes', or '/agami-save-golden <dataset>' — any ask to record a question, or a bank of questions, that the model should be scored against later. Also use when the user replies with a back-channel block from a previously-rendered golden-dataset explorer page (first line `profile: <name>`, then `golden-ops:` and a JSON array, ending `done`) — paste it and nothing else is needed. Requires agami-connect to have been run first (needs a profile with a semantic model). To RUN a dataset and see the verdicts, use `/agami-eval` instead: that skill reads and scores, this one writes and never runs or scores."
 argument-hint: "[dataset-name]"
 ---
@@ -67,14 +67,18 @@ Route on what the user brought, and say which door you are opening:
 
 ### 2a — Get a CSV
 
-The parser reads **one format**, and that is deliberate: one parser is one place where a column can be misread.
+The **script** reads one format, and that is deliberate: one parser is one place where a column can be misread. Everything below therefore ends at a CSV on disk. What changes is who writes it.
 
 - **A `.csv` path** — use it as given.
-- **A `.xlsx` / `.xls` path** — refuse and say how to get past it. Do not try to read it, and do not guess at its contents:
-
-  > I can't read `.xlsx` directly. Open it in Excel (or Numbers / Google Sheets) and **Save As → CSV UTF-8**, then re-invoke me with the `.csv` path.
-
 - **A table pasted into chat** — write it out as a CSV with the **Write tool** and then parse that file. One parser, one code path, and the file is also the thing the user can fix and re-run. Per [`shared/invocation-conventions.md`](../../shared/invocation-conventions.md): **never a heredoc, never `python3 -c`, never a shell variable** — quoting mangles the commas and quotes that are the whole point of a CSV. Write it to `/tmp/agami-golden-pasted-<ts>.csv` and tell the user where it went.
+- **A `.xlsx` / `.xls` path** — **read the workbook yourself and write the sheet out as a CSV**, exactly as you would a pasted table, then parse that file. The script cannot open a workbook and is not being asked to: it is stdlib-only, and a marketplace install ships `plugins/agami/` with nothing to pip-install into. You can read one, and doing it here is the same move the pasted-table branch already makes — it keeps the single parser and asks nothing of the user.
+
+  Two things to get right, and they are the reason this is worth a paragraph:
+
+  - **More than one sheet holds data → ask which.** Name the sheets and let the user pick. Never guess: importing the wrong tab writes a bank of questions nobody meant to ask, under ids derived from them, and the append-only rule then makes each one a confirmation prompt to undo.
+  - **Flatten formulas to their values.** A question column is text and a cell holding a formula is not a question. If a cell resolves to an error, treat that row as unreadable and let the parser skip it rather than importing the error text.
+
+  This is [`agami-connect`](../agami-connect/SKILL.md)'s stance on the same problem — Claude reads the document, the deterministic step never opens it — rather than a new one.
 
 The sheet needs a header row with a **question column** — `question`, `query`, `nl question`, `prompt` or `ask` (case, underscores and hyphens all fold). Optional columns: `id`, `expected` / `expected value` / `answer`, `sql` / `statement`, `tags`. A header the contract does not know is left alone — matching is exact, never fuzzy, so an analyst's note column costs nothing.
 
@@ -251,7 +255,7 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
 | Exit `2` | Cannot start. Read the `agami-save-golden:` line on stderr — it names the cause. Nothing was written; a rolled-back write left the previous bytes exactly as they were. |
 | `agami-save-golden: this file is empty` / `no column here holds the question` / `this file has no header row` | The sheet's question column can't be identified. The refusal lists every header it read — quote it back, ask which column holds the question, and have them rename it (or add a header row) and re-invoke. Never guess at column 0: a bank of ids imported as questions fails every future run in a way that looks exactly like a model regression. |
 | `agami-save-golden: N row(s) were skipped` on a successful parse | A warning, not a stop. List every entry in `skipped` with its row number and reason before asking for the import — a question silently missing from a dataset is the failure this line exists to prevent. |
-| A `.xlsx` / `.xls` path | Refuse with the Save As → CSV UTF-8 instruction (Phase 2a). Do not attempt to read it and do not reconstruct its contents from memory. |
+| A `.xlsx` / `.xls` path | Read the workbook and write the chosen sheet out as a CSV, then parse that (Phase 2a). Ask which sheet when more than one holds data, and flatten formulas to values. Never reconstruct a workbook's contents from memory — if you cannot read the file, say so rather than inventing rows. |
 | `agami-save-golden: this item does not say how its answer was confirmed` | `confirmed_by.method` was blank. Ask how the result was checked and re-write the item JSON — provenance is most of what a receipt is for. |
 | `agami-save-golden: '<name>' is not a usable dataset name` / `profile name` | The stem or the profile was a path, not a name. Ask for the plain name (`orders`, not `orders/2024` or `../orders`) and re-invoke. Nothing was read and nothing was written. |
 | `agami-save-golden: dataset '<name>' names the file rather than the dataset` | The extension was typed too. The stem *is* the dataset's name, so pass `orders`, not `orders.yaml`. Re-invoke; nothing was written. |

--- a/plugins/agami/skills/agami-save-golden/SKILL.md
+++ b/plugins/agami/skills/agami-save-golden/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agami-save-golden
-description: "Writes golden-dataset items for a profile through two doors. The import door turns a question bank — a spreadsheet, a CSV, or a table pasted into chat — into items written unconfirmed, after the parsed rows have been shown and agreed to. The save door writes one question, the statement that answered it and the result the person accepted, as a confirmed item with its receipt. The curation door applies the changes queued on the golden-dataset explorer page, which may weaken a claim and may never grant one. Every write goes through agami-core's writer, is re-read by the runner's own reader before it is kept, and is append-only: a write that would change an item that already exists stops and shows the before and the after. This skill writes only; it never runs or scores a dataset."
+description: "Writes golden-dataset items for a profile through three doors. The import door turns a question bank — a spreadsheet, a CSV, or a table pasted into chat — into items written unconfirmed, after the parsed rows have been shown and agreed to. The save door writes one question, the statement that answered it and the result the person accepted, as a confirmed item with its receipt. The curation door applies the changes queued on the golden-dataset explorer page, which may weaken a claim and may never grant one. Every write goes through agami-core's writer, is re-read by the runner's own reader before it is kept, and is append-only: a write that would change an item that already exists stops and shows the before and the after. This skill writes only; it never runs or scores a dataset."
 when_to_use: "Use when the user says 'save this as a golden question', 'add this to the golden dataset', 'import my question bank', 'turn this spreadsheet into a golden dataset', 'this answer is correct — remember it as ground truth', 'show me the golden datasets', 'what does this dataset not test', 'apply my queued changes', or '/agami-save-golden <dataset>' — any ask to record a question, or a bank of questions, that the model should be scored against later. Also use when the user replies with a back-channel block from a previously-rendered golden-dataset explorer page (first line `profile: <name>`, then `golden-ops:` and a JSON array, ending `done`) — paste it and nothing else is needed. Requires agami-connect to have been run first (needs a profile with a semantic model). To RUN a dataset and see the verdicts, use `/agami-eval` instead: that skill reads and scores, this one writes and never runs or scores."
 argument-hint: "[dataset-name]"
 ---
@@ -13,8 +13,9 @@ You are writing to the answer key. Goal: get a question — or a bank of them �
 
 | Door | Input | What it writes | Can it gate a run? |
 |---|---|---|---|
-| **Import** | A CSV of questions, or a table pasted into chat | Items with `sql_confirmed: false` | No |
+| **Import** | A spreadsheet or CSV of questions, or a table pasted into chat | Items with `sql_confirmed: false` | No |
 | **Save** | One question, the statement that answered it, the result the person accepted | One item with `sql_confirmed: true`, its statement and its receipt | Yes |
+| **Curation** | The back-channel block from the explorer page | Tags, strictness, question edits, removals, and the **withdrawal** of confirmation | No — it can weaken a claim and may never grant one |
 
 An imported item **has no statement until somebody runs it and saves the answer through the save door.** That is the intended shape, not a gap to close: an import is a list of the questions this team cares about, and a question with no verified answer is an honest in-progress case that reports and cannot gate.
 
@@ -78,7 +79,7 @@ The **script** reads one format, and that is deliberate: one parser is one place
   - **More than one sheet holds data → ask which.** Name the sheets and let the user pick. Never guess: importing the wrong tab writes a bank of questions nobody meant to ask, under ids derived from them, and the append-only rule then makes each one a confirmation prompt to undo.
   - **Flatten formulas to their values.** A question column is text and a cell holding a formula is not a question. If a cell resolves to an error, treat that row as unreadable and let the parser skip it rather than importing the error text.
 
-  This is [`agami-connect`](../agami-connect/SKILL.md)'s stance on the same problem — Claude reads the document, the deterministic step never opens it — rather than a new one.
+  The pattern is [`agami-connect`](../agami-connect/SKILL.md)'s — Claude reads a customer's existing definitions with the Read tool and the deterministic step never opens the file. It is the *pattern* that is borrowed and not the coverage: connect asks for a PDF when handed a workbook and proceeds without it, so `.xlsx` is not already read there. Reading one here is new; doing the reading in the skill rather than in the script is not.
 
 The sheet needs a header row with a **question column** — `question`, `query`, `nl question`, `prompt` or `ask` (case, underscores and hyphens all fold). Optional columns: `id`, `expected` / `expected value` / `answer`, `sql` / `statement`, `tags`. A header the contract does not know is left alone — matching is exact, never fuzzy, so an analyst's note column costs nothing.
 


### PR DESCRIPTION
Closes #261.

The import door refused an `.xlsx` and told the user to open it in Excel and Save As → CSV. Now Claude reads the workbook and writes the sheet out as a CSV itself.

## Why the recorded reason didn't hold

AH-109 justified the refusal as follows:

> `openpyxl` is not available to a plugin script … Refusing an `.xlsx` with "save as CSV" is what `agami-connect/SKILL.md` and `agami-query/SKILL.md` already do, so this is the repo's existing stance rather than a new one.

The first half is correct and unchanged by this PR — `golden_author.py` stays stdlib-only and CSV-only, and no dependency is added anywhere. But it is an argument about the **script**, not about the **skill**.

The second half does not survive a read of the two skills it cites:

- **`agami-connect` invites a spreadsheet** ("A metrics / KPI list — a spreadsheet, CSV, or doc") and handles a workbook by asking for a PDF and *proceeding without the file* if none arrives. It never says "save as CSV". Critically, in that step **Claude reads the document with the Read tool and no script opens it.**
- **`agami-query`'s mention is about export.** "Export to Excel" routes to a CSV because a CSV opens natively in Excel. Output-side, not precedent for an input refusal.

So the house stance for ingesting a user's existing material is *Claude reads it, the deterministic step never sees the file.* This skill already did exactly that for a table pasted into chat. The workbook case is the same step with a different source.

## Why it matters

The feature exists because hand-authoring YAML left most profiles with zero items that can gate a run. AH-109's own motivation section says it plainly:

> An analyst keeps the question bank in Excel, because that is where question banks live.

Asking for a format conversion before they can start reintroduces friction at the one moment the feature is meant to remove it. And the import door is the lowest-consequence ingestion surface in the product — everything it writes is `sql_confirmed: false` and can never gate a run — yet it was the only one with a hard refusal.

## What is preserved

- **One parser.** The workbook becomes a CSV before anything parses it, so there is still exactly one place a column can be misread.
- **No new dependency**, in the package or the plugin. `golden_author.py` is untouched.
- **The contract**: imported items still land unconfirmed, append-only is unchanged, and the reader remains the only validator.
- **The rendered-rows-then-explicit-yes gate** before any write is unchanged.

The two things the old friction genuinely bought are kept, as questions rather than as a refusal: the skill asks which sheet when more than one holds data, and flattens formulas to their values. A cell that resolves to an error is left for the parser to skip rather than imported as error text.

## Scope

Documentation only — `agami-save-golden/SKILL.md` (Phase 2a, its error-handling row, and the frontmatter description) plus a CHANGELOG entry. No behaviour in any script changes, and the existing 65 tests over this skill and its writer pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)