### PR TITLE
The run report shows the difference it had already worked out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ below corresponds to one such version.
     folded into "failed": a run of nothing but errors would then read as green, which is exactly
     what the `1` / `2` exit codes exist to tell apart.
 
+- **A claim reads the way a person writes it, in a table rather than a run of text.** A
+  difference was one separator-joined line per claim, holding the claim reader's own field names
+  (`filter_predicates`) and its functional rendering (`gte(created, '2024-01-01')`). Both are
+  deliberate where they are written — a claim rides on tool output a model reads as
+  server-authored, and something that looked like SQL would be read as SQL — but that argument is
+  about a model's context and does not reach a local page a person opens.
+
+  So the report now prints `created >= '2024-01-01'`, labels each claim in English ("Filters",
+  "Grouped by", "Date range"), and lays the two sides out as a table so they line up under one
+  another. Three shapes that rendered as nothing or as noise are handled: a join key
+  (`customers.id = orders.customer_id`), an ordering with its direction, and a subquery, which
+  arrives as its whole parse tree and now reads `customer_id IN (subquery)`. `GROUP BY 1` is
+  labelled "column 1 of the select list" rather than shown as a bare digit — under `group_keys`
+  only, since a `limit` of 100 is a row count.
+
 - **A golden run report can be filtered by outcome.** A corpus-sized run is hundreds of cases and
   was a flat scroll. Display only — nothing is recounted or re-sorted, so the tiles and the section
   headings keep describing the whole run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ below corresponds to one such version.
     derived from `passed`, which a gate turns false — so an item whose rows matched the answer key
     exactly was announced as not having reproduced it, next to a perfect score. Reproducing and
     passing are different questions, which is why structure gates separately from rows, and the page
-    now says both: *"Reproduced the answer key, but did not answer the question asked."*
+    now says both: *"Same rows as the answer key, but not the same question."* The verdict is also
+    phrased as what happened to the data rather than in the dataset's own vocabulary — the pill
+    beside the question already says passed or failed, so the line's one job is whether the rows
+    matched.
   - **The accuracy is gone from the page.** Over a real fifteen-case run every value was exactly
     1.0 or exactly 0.0, which is structural: a row-count difference, an unpaired column and an extra
     column each short-circuit before an overlap is computed, and columns pair only on equal value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,42 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Changed
+
+- **The golden run report shows the difference it already worked out.** Reading a failure meant
+  diffing two SQL statements by eye, from a page that had computed the answer and kept it in a file
+  beside itself. Six things changed, all in the renderer and its template, none of them touching the
+  comparator, the claim reader or the contract:
+
+  - **A gated item is no longer described as failing to reproduce the answer key.** The verdict was
+    derived from `passed`, which a gate turns false — so an item whose rows matched the answer key
+    exactly was announced as not having reproduced it, next to a perfect score. Reproducing and
+    passing are different questions, which is why structure gates separately from rows, and the page
+    now says both: *"Reproduced the answer key, but did not answer the question asked."*
+  - **The accuracy is gone from the page.** Over a real fifteen-case run every value was exactly
+    1.0 or exactly 0.0, which is structural: a row-count difference, an unpaired column and an extra
+    column each short-circuit before an overlap is computed, and columns pair only on equal value
+    vectors. On the narrow occasion a value in between is reachable, the comparator already writes
+    the same fact in words. So the number was redundant when it meant something and misleading
+    otherwise. The score itself is unchanged and still decides the verdict.
+  - **A gate names the column it fired on**, instead of one fixed sentence saying that *a* filter
+    was missing. It also stops describing a differing date window as a missing filter: structure
+    gates twice, and the page assumed one.
+  - **Every claim that differs is drawn, not just the table set.** The page kept `claims[0]` and
+    dropped the other six. In a structural failure the table set reliably *agrees* — both statements
+    read the same table, which is why the comparison got far enough to gate on something else — so
+    the page reliably showed the claim that said nothing while `filter_predicates`, which explains
+    the failure, was written to the JSON artifact and never rendered.
+  - **The run timestamp reads as a date** rather than `2026-09-06T11:47:38+00:00`.
+  - **The summary shows three tiles, not five**, surfacing "not compared" and "couldn't run" only
+    when they are non-zero and giving them a sentence when they appear. They are deliberately not
+    folded into "failed": a run of nothing but errors would then read as green, which is exactly
+    what the `1` / `2` exit codes exist to tell apart.
+
+- **A golden run report can be filtered by outcome.** A corpus-sized run is hundreds of cases and
+  was a flat scroll. Display only — nothing is recounted or re-sorted, so the tiles and the section
+  headings keep describing the whole run.
+
 ## [0.8.0] — 2026-09-05
 
 One change: the server decides which tool calls belong to one conversation, instead of asking the

--- a/plugins/agami/scripts/render_golden_run.py
+++ b/plugins/agami/scripts/render_golden_run.py
@@ -73,6 +73,15 @@ _SUMMARY_COUNTS = ("total", "passed", "failed", "unscored", "errored")
 _SCALAR = (str, int, float)
 
 
+# Spelled out rather than taken from `%B`, which reads the process locale: a report is a file
+# somebody sends to somebody else, and the month it carries should not depend on whose machine
+# rendered it. It would also make the test for this a fixed string that only holds on some hosts.
+_MONTHS = (
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+)
+
+
 def _run_stamp(now: Optional[datetime.datetime] = None) -> str:
     """When the run was rendered, as a date somebody would say out loud.
 
@@ -81,7 +90,7 @@ def _run_stamp(now: Optional[datetime.datetime] = None) -> str:
     not necessarily in it, and the day is not zero-padded because nobody says "06 September".
     """
     stamp = now or datetime.datetime.now(datetime.timezone.utc)
-    return f"{stamp.day} {stamp:%B %Y} at {stamp:%H:%M} UTC"
+    return f"{stamp.day} {_MONTHS[stamp.month - 1]} {stamp.year} at {stamp:%H:%M} UTC"
 
 
 def _names(value: Any, *, ordinals: bool = False) -> list[str]:
@@ -250,6 +259,13 @@ def _window(value: dict) -> str:
     start, end = value.get("start"), value.get("end")
     if not column or (start is None and end is None):
         return ""
+    # Either bound may be open — `placed_at >= '2024-01-01'` on its own resolves to a start and no
+    # end, which is an ordinary shape rather than a corner. An interval printed with one side
+    # missing rendered the word `None` into the report.
+    if start is None:
+        return f"{column} {'<=' if value.get('end_inclusive', False) else '<'} {end}"
+    if end is None:
+        return f"{column} {'>=' if value.get('start_inclusive', True) else '>'} {start}"
     open_bracket = "[" if value.get("start_inclusive", True) else "("
     close_bracket = "]" if value.get("end_inclusive", False) else ")"
     return f"{column} in {open_bracket}{start}, {end}{close_bracket}"
@@ -334,10 +350,13 @@ def _gates(item: dict) -> list[dict[str, str]]:
     gates = block.get("gates") if isinstance(block, dict) else None
     if not isinstance(gates, list):
         return []
+    # `or ""` rather than a default, because a key that is PRESENT and null returns None from
+    # `.get(key, "")` — which `str()` would then render as the literal "None", matching no branch
+    # on the page and printing itself onto the report.
     return [
-        {"kind": str(gate.get("kind", "")), "column": str(gate.get("column") or "")}
+        {"kind": str(gate.get("kind") or ""), "column": str(gate.get("column") or "")}
         for gate in gates
-        if isinstance(gate, dict)
+        if isinstance(gate, dict) and gate.get("kind")
     ]
 
 

--- a/plugins/agami/scripts/render_golden_run.py
+++ b/plugins/agami/scripts/render_golden_run.py
@@ -84,7 +84,7 @@ def _run_stamp(now: Optional[datetime.datetime] = None) -> str:
     return f"{stamp.day} {stamp:%B %Y} at {stamp:%H:%M} UTC"
 
 
-def _names(value: Any) -> list[str]:
+def _names(value: Any, *, ordinals: bool = False) -> list[str]:
     """The entries of one claim's side, flattened to the strings the page prints.
 
     The claim is written by the statement comparator and its shape is promised by a docstring, not
@@ -102,12 +102,140 @@ def _names(value: Any) -> list[str]:
     flattened = []
     for name in value:
         if isinstance(name, _SCALAR):
-            flattened.append(str(name))
+            entry = _readable(str(name))
+            flattened.append(_ordinal(entry) if ordinals else entry)
         elif isinstance(name, (list, tuple)):
-            parts = [str(part) for part in name if isinstance(part, _SCALAR)]
-            if parts:
-                flattened.append(" ".join(parts))
+            entry = _nested(name)
+            if entry:
+                flattened.append(entry)
     return flattened
+
+
+def _nested(entry: Any) -> str:
+    """One entry that is itself a sequence, of which two shapes reach this page.
+
+    `ordering` writes a column and a direction (`["order_count", "desc"]`), and `join_keys` writes
+    the two sides of an equality as a PAIR OF PAIRS —
+    `[["customers", "id"], ["orders", "customer_id"]]` — so the nesting is two deep there. The
+    earlier coercion dropped anything below the first level, which rendered the two claims most
+    likely to differ as empty sides.
+    """
+    parts = []
+    for part in entry:
+        if isinstance(part, _SCALAR):
+            parts.append(str(part))
+        elif isinstance(part, (list, tuple)):
+            # A qualified column arrives split into its parts rather than dotted.
+            qualified = [str(inner) for inner in part if isinstance(inner, _SCALAR)]
+            if qualified:
+                parts.append(".".join(qualified))
+    if len(parts) == 2 and all("." in part for part in parts):
+        # A join key is an equality, and reads as one.
+        return f"{parts[0]} = {parts[1]}"
+    return " ".join(parts)
+
+
+def _ordinal(entry: str) -> str:
+    """`GROUP BY 1` reaches the claim as the bare string "1", which reads as a number.
+
+    "grouped by 1" against "grouped by service_criticality" tells a reader nothing at all, and the
+    ordinal cannot be resolved here — the claim carries no projection to resolve it against. So it
+    is labelled rather than decoded, which is honest and readable where a bare digit is neither.
+    Resolving it properly belongs to the claim reader, which does hold the select list.
+    """
+    return f"column {entry} of the select list" if entry.isdigit() else entry
+
+
+# The infix spelling of each comparison the claim reader writes functionally. Its keys come from
+# sqlglot's node names, so this is a lookup rather than a grammar: anything not here is left in the
+# form it arrived in, which is already readable for a function call like `count(orders.id)`.
+_INFIX = {
+    "eq": "=",
+    "neq": "<>",
+    "gt": ">",
+    "gte": ">=",
+    "lt": "<",
+    "lte": "<=",
+    "like": "LIKE",
+    "ilike": "ILIKE",
+    "is": "IS",
+    "in": "IN",
+}
+
+
+def _split(inner: str, *, expected: int) -> Optional[list[str]]:
+    """The operands of one rendered call, or None if there is not exactly the expected number.
+
+    Split rather than parsed, and only at depth zero and outside quotes: a literal is perfectly
+    entitled to contain a comma or a bracket (`eq(customer.name, 'Smith, John')`), and a split that
+    ignored that would cut a value in half and print the halves as two operands.
+    """
+    operands, depth, quoted, current = [], 0, False, []
+    for char in inner:
+        if quoted:
+            current.append(char)
+            if char == "'":
+                quoted = False
+            continue
+        if char == "'":
+            quoted = True
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif char == "," and depth == 0:
+            operands.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    if quoted or depth:
+        return None
+    operands.append("".join(current).strip())
+    return operands if len(operands) == expected else None
+
+
+def _readable(key: str) -> str:
+    """One claim key as a person writes it: `gte(created, '2024-01-01')` → `created >= '2024-01-01'`.
+
+    The functional form is deliberate WHERE IT IS WRITTEN and must stay: a claim rides on tool
+    output the calling model reads as server-authored, and something that looked like SQL would be
+    read as SQL. That reasoning is about a model's context. This report is a local page a person
+    opens, built with `textContent` and rendering nothing — so the argument for the functional form
+    does not reach it, while the cost of it does. `gte(created, '2024-01-01')` is a shape a reader
+    has to decode before they can compare it to the one beside it.
+
+    Best effort by design: only a known comparison with exactly two operands is rewritten, and
+    anything else is returned untouched. A nested predicate is left alone rather than half-rewritten
+    into something that reads like SQL and is not.
+    """
+    if not key.endswith(")"):
+        return key
+    head, _, rest = key.partition("(")
+    inner = rest[:-1]
+    name = head.lower()
+
+    # A subquery's whole parse tree is rendered inline, so an `IN (SELECT …)` arrives as forty
+    # characters of nested calls. What a reader needs from it is that a subquery is there; the
+    # statements are printed underneath if they want the rest.
+    if name == "subquery":
+        return "(subquery)"
+
+    if name == "between":
+        parts = _split(inner, expected=3)
+        if parts:
+            return f"{parts[0]} BETWEEN {parts[1]} AND {parts[2]}"
+        return key
+
+    operator = _INFIX.get(name)
+    if operator is None:
+        return key
+    operands = _split(inner, expected=2)
+    if operands is None:
+        return key
+    operands = [_readable(operand) if operand.endswith(")") else operand for operand in operands]
+    if any("(" in operand and not operand.startswith("(") for operand in operands):
+        return key
+    return f"{operands[0]} {operator} {operands[1]}"
 
 
 def _window(value: dict) -> str:
@@ -127,7 +255,7 @@ def _window(value: dict) -> str:
     return f"{column} in {open_bracket}{start}, {end}{close_bracket}"
 
 
-def _side(value: Any) -> str:
+def _side(value: Any, *, ordinals: bool = False) -> str:
     """One side of one claim, flattened to the string the page prints.
 
     Flattened HERE rather than in the template, because the sides are not one shape: a table set is
@@ -142,7 +270,7 @@ def _side(value: Any) -> str:
             f"{key} {item}" for key, item in sorted(value.items()) if isinstance(item, _SCALAR)
         )
     if isinstance(value, list):
-        return ", ".join(_names(value))
+        return ", ".join(_names(value, ordinals=ordinals))
     if isinstance(value, _SCALAR):
         return str(value)
     return ""
@@ -172,6 +300,7 @@ def _claims(item: dict) -> list[dict[str, Any]]:
         # promise must cost one line rather than the whole page.
         if not isinstance(claim, dict):
             continue
+        ordinals = claim.get("name") == "group_keys"
         projected.append(
             {
                 # Carried rather than assumed: the page labels each line from the claim's own name,
@@ -179,8 +308,11 @@ def _claims(item: dict) -> list[dict[str, Any]]:
                 # instead of calling something else "tables".
                 "name": claim.get("name", ""),
                 "status": claim.get("status", ""),
-                "generated": _side(claim.get("generated")),
-                "golden": _side(claim.get("golden")),
+                # An ordinal is only an ordinal under `group_keys`. A `limit` of 100 is a row
+                # count, and labelling it "column 100 of the select list" would be worse than the
+                # bare digit this exists to fix.
+                "generated": _side(claim.get("generated"), ordinals=ordinals),
+                "golden": _side(claim.get("golden"), ordinals=ordinals),
             }
         )
     return projected

--- a/plugins/agami/scripts/render_golden_run.py
+++ b/plugins/agami/scripts/render_golden_run.py
@@ -72,6 +72,17 @@ _SUMMARY_COUNTS = ("total", "passed", "failed", "unscored", "errored")
 # `Array.join`, so anything else is a broken page rather than a wrong word.
 _SCALAR = (str, int, float)
 
+# The only two claims whose entries are themselves sequences: `ordering` writes a column with its
+# direction and `join_keys` writes the two sides of an equality as a pair of pairs. Everywhere else
+# an entry is one scalar, and a nested entry is something this projection has no reason to render.
+#
+# Named rather than inferred from the shape, because the shape cannot tell them apart: a join key
+# and a two-column result row are both a sequence of two strings. No producer can put a row here —
+# a claim comes from `compare_statements`, which sees two SQL strings and no data — but the rule
+# this file exists to keep is that no result row reaches the page, and a projection that would
+# render one if it arrived is not keeping it.
+_NESTED_CLAIMS = ("ordering", "join_keys")
+
 
 # Spelled out rather than taken from `%B`, which reads the process locale: a report is a file
 # somebody sends to somebody else, and the month it carries should not depend on whose machine
@@ -93,7 +104,7 @@ def _run_stamp(now: Optional[datetime.datetime] = None) -> str:
     return f"{stamp.day} {_MONTHS[stamp.month - 1]} {stamp.year} at {stamp:%H:%M} UTC"
 
 
-def _names(value: Any, *, ordinals: bool = False) -> list[str]:
+def _names(value: Any, *, ordinals: bool = False, nested: bool = False) -> list[str]:
     """The entries of one claim's side, flattened to the strings the page prints.
 
     The claim is written by the statement comparator and its shape is promised by a docstring, not
@@ -113,7 +124,7 @@ def _names(value: Any, *, ordinals: bool = False) -> list[str]:
         if isinstance(name, _SCALAR):
             entry = _readable(str(name))
             flattened.append(_ordinal(entry) if ordinals else entry)
-        elif isinstance(name, (list, tuple)):
+        elif nested and isinstance(name, (list, tuple)):
             entry = _nested(name)
             if entry:
                 flattened.append(entry)
@@ -147,7 +158,7 @@ def _nested(entry: Any) -> str:
 def _ordinal(entry: str) -> str:
     """`GROUP BY 1` reaches the claim as the bare string "1", which reads as a number.
 
-    "grouped by 1" against "grouped by service_criticality" tells a reader nothing at all, and the
+    "grouped by 1" against "grouped by status" tells a reader nothing at all, and the
     ordinal cannot be resolved here — the claim carries no projection to resolve it against. So it
     is labelled rather than decoded, which is honest and readable where a bare digit is neither.
     Resolving it properly belongs to the claim reader, which does hold the select list.
@@ -170,6 +181,11 @@ _INFIX = {
     "is": "IS",
     "in": "IN",
 }
+
+# Zero-argument calls the claim reader writes for a keyword. Rendered as the keyword so `IS NULL`
+# reads as `IS NULL`; without them the operand keeps a `(` and the guard below refuses the whole
+# comparison, which is what kept the `is` entry above from ever firing.
+_KEYWORDS = {"null()": "NULL", "true()": "TRUE", "false()": "FALSE"}
 
 
 def _split(inner: str, *, expected: int) -> Optional[list[str]]:
@@ -217,6 +233,8 @@ def _readable(key: str) -> str:
     anything else is returned untouched. A nested predicate is left alone rather than half-rewritten
     into something that reads like SQL and is not.
     """
+    if key in _KEYWORDS:
+        return _KEYWORDS[key]
     if not key.endswith(")"):
         return key
     head, _, rest = key.partition("(")
@@ -244,6 +262,10 @@ def _readable(key: str) -> str:
     operands = [_readable(operand) if operand.endswith(")") else operand for operand in operands]
     if any("(" in operand and not operand.startswith("(") for operand in operands):
         return key
+    if operator == "IN" and not operands[1].startswith("("):
+        # A single-value `IN` reaches here with two operands and no brackets of its own, and
+        # `status IN 'paid'` is not SQL anybody writes. The subquery case already carries its own.
+        operands[1] = f"({operands[1]})"
     return f"{operands[0]} {operator} {operands[1]}"
 
 
@@ -271,7 +293,7 @@ def _window(value: dict) -> str:
     return f"{column} in {open_bracket}{start}, {end}{close_bracket}"
 
 
-def _side(value: Any, *, ordinals: bool = False) -> str:
+def _side(value: Any, *, ordinals: bool = False, nested: bool = False) -> str:
     """One side of one claim, flattened to the string the page prints.
 
     Flattened HERE rather than in the template, because the sides are not one shape: a table set is
@@ -286,7 +308,7 @@ def _side(value: Any, *, ordinals: bool = False) -> str:
             f"{key} {item}" for key, item in sorted(value.items()) if isinstance(item, _SCALAR)
         )
     if isinstance(value, list):
-        return ", ".join(_names(value, ordinals=ordinals))
+        return ", ".join(_names(value, ordinals=ordinals, nested=nested))
     if isinstance(value, _SCALAR):
         return str(value)
     return ""
@@ -317,6 +339,7 @@ def _claims(item: dict) -> list[dict[str, Any]]:
         if not isinstance(claim, dict):
             continue
         ordinals = claim.get("name") == "group_keys"
+        nested = claim.get("name") in _NESTED_CLAIMS
         projected.append(
             {
                 # Carried rather than assumed: the page labels each line from the claim's own name,
@@ -327,8 +350,8 @@ def _claims(item: dict) -> list[dict[str, Any]]:
                 # An ordinal is only an ordinal under `group_keys`. A `limit` of 100 is a row
                 # count, and labelling it "column 100 of the select list" would be worse than the
                 # bare digit this exists to fix.
-                "generated": _side(claim.get("generated"), ordinals=ordinals),
-                "golden": _side(claim.get("golden"), ordinals=ordinals),
+                "generated": _side(claim.get("generated"), ordinals=ordinals, nested=nested),
+                "golden": _side(claim.get("golden"), ordinals=ordinals, nested=nested),
             }
         )
     return projected

--- a/plugins/agami/scripts/render_golden_run.py
+++ b/plugins/agami/scripts/render_golden_run.py
@@ -46,16 +46,21 @@ TEMPLATE_PATH = SHARED_DIR / "golden-run-template.html"
 LOGO_DARK_PATH = SHARED_DIR / "agami-logo-dark.svg"
 LOGO_LIGHT_PATH = SHARED_DIR / "agami-logo-light.svg"
 
-# How precisely an accuracy is shown. The score itself is left unrounded where it is computed — an
-# item passes at exactly 1.0, and rounding there would hand the pass mark to a near miss — so the
-# rounding happens here instead, where it is presentation and no verdict rests on it.
-_ACCURACY_DECIMALS = 3
-
-# The largest accuracy that may be shown for an item that did not score exactly 1.0. Rounding alone
-# is not enough: 4002/4004 rounds to 1.000, so a near miss would read as a perfect score printed
-# beside the sentence saying it did not reproduce the answer key. That is the one confusion this
-# report exists to remove, so a score short of the mark is shown short of the mark.
-_NEARLY_ONE = 1.0 - 10.0**-_ACCURACY_DECIMALS
+# The accuracy is deliberately NOT projected, and this is the note that keeps it that way.
+#
+# It reached the page as a headline number and told a reader nothing. Over a real fifteen-case run
+# every value was exactly 1.0 or exactly 0.0, which is structural rather than luck: differing row
+# counts, an unpaired column and an extra column each short-circuit to 0.0 before any overlap is
+# computed, and `match_columns` pairs only on EQUAL value vectors, so a column that is wrong
+# anywhere does not pair at all. The one route to a value in between — every column carrying the
+# right set of values while the rows themselves do not line up — is real and rare.
+#
+# And on exactly that occasion the comparator already writes the same fact in words ("5 of the
+# answer key's 15 rows matched"), which `reason` carries. So the number was redundant when it meant
+# something and misleading the rest of the time: printed as "accuracy 1.000" beside a gated item
+# that had reproduced its answer key perfectly, it read as a contradiction of the sentence next to
+# it. What a reader can act on at 5-of-15 is WHICH ten rows differed, and the report cannot show
+# that — rows never reach a run result by design.
 
 # The counts the header reads. Taken from the run's own summary and never recounted from the
 # items: a report that recomputed one would be a second place that decides what a run looks like.
@@ -68,59 +73,140 @@ _SUMMARY_COUNTS = ("total", "passed", "failed", "unscored", "errored")
 _SCALAR = (str, int, float)
 
 
-def _shown(accuracy: float) -> float:
-    """One accuracy at the precision the page prints it, never rounded up to the pass mark.
+def _run_stamp(now: Optional[datetime.datetime] = None) -> str:
+    """When the run was rendered, as a date somebody would say out loud.
 
-    Only an accuracy of exactly 1.0 may be shown as 1.000, because that is the only value that
-    passes. Anything short of it is held below, so the number beside a failure never looks like
-    the number beside a pass.
+    It read `2026-09-06T11:47:38+00:00`, which is a sortable key rather than a sentence, and the
+    page has no second place where the timestamp is a key. UTC is spelled out because the reader is
+    not necessarily in it, and the day is not zero-padded because nobody says "06 September".
     """
-    if accuracy >= 1.0:
-        return round(accuracy, _ACCURACY_DECIMALS)
-    return min(round(accuracy, _ACCURACY_DECIMALS), _NEARLY_ONE)
+    stamp = now or datetime.datetime.now(datetime.timezone.utc)
+    return f"{stamp.day} {stamp:%B %Y} at {stamp:%H:%M} UTC"
 
 
 def _names(value: Any) -> list[str]:
-    """One side of the table-set claim, flattened to the strings the page prints.
+    """The entries of one claim's side, flattened to the strings the page prints.
 
     The claim is written by the statement comparator and its shape is promised by a docstring, not
-    by anything on this side of the handoff. The page joins the list into a sentence, so a bare
-    string arriving where a list was promised makes `.join` undefined, throws, and leaves the whole
-    page blank — the same silent failure a broken payload causes. Anything that is not a scalar is
-    dropped rather than rendered, because a nested structure would print its own punctuation.
+    by anything on this side of the handoff, so anything unexpected is dropped rather than rendered.
+
+    An entry may itself be a short sequence, and that is not an edge case: `ordering` writes a
+    column and a direction together, so `[["incident_count", "desc"]]` is the ordinary shape of an
+    ordering difference. Dropping nested entries rendered the one claim that most often differs as
+    an empty side — "generated none · answer key none" — which is worse than not drawing it at all.
+    A sequence of scalars is joined with a space; anything deeper is still dropped, because it
+    would print its own punctuation.
     """
     if not isinstance(value, list):
         return []
-    return [str(name) for name in value if isinstance(name, _SCALAR)]
+    flattened = []
+    for name in value:
+        if isinstance(name, _SCALAR):
+            flattened.append(str(name))
+        elif isinstance(name, (list, tuple)):
+            parts = [str(part) for part in name if isinstance(part, _SCALAR)]
+            if parts:
+                flattened.append(" ".join(parts))
+    return flattened
 
 
-def _tables_claim(item: dict) -> Optional[dict[str, Any]]:
-    """The table-set difference, which is the one line the page puts above the two statements.
+def _window(value: dict) -> str:
+    """A resolved date window as an interval a person reads at a glance.
 
-    "Generated read `orders`, the answer key read `customers`" is usually the whole finding. It is
-    the first of the seven claims the statement comparator writes, and an item whose generation
-    never produced a statement has no claims at all — so the absence is carried as None rather than
-    faked as an agreement.
+    Half-open is the whole point of resolving one — three spellings of the same year agree, and a
+    `BETWEEN` over a timestamp is caught for the off-by-one it is — so the brackets are printed
+    rather than described. This is one of the two claims that can gate, which is why its shape is
+    handled here instead of falling through to the generic rendering below.
+    """
+    column = value.get("column")
+    start, end = value.get("start"), value.get("end")
+    if not column or (start is None and end is None):
+        return ""
+    open_bracket = "[" if value.get("start_inclusive", True) else "("
+    close_bracket = "]" if value.get("end_inclusive", False) else ")"
+    return f"{column} in {open_bracket}{start}, {end}{close_bracket}"
+
+
+def _side(value: Any) -> str:
+    """One side of one claim, flattened to the string the page prints.
+
+    Flattened HERE rather than in the template, because the sides are not one shape: a table set is
+    a list, a resolved date window is an object, and a limit is a bare number. The page used to
+    receive lists alone and call `Array.join` on them, so anything else would have thrown and left
+    the whole report blank — the failure this function exists to make unrepresentable.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, dict):
+        return _window(value) or ", ".join(
+            f"{key} {item}" for key, item in sorted(value.items()) if isinstance(item, _SCALAR)
+        )
+    if isinstance(value, list):
+        return ", ".join(_names(value))
+    if isinstance(value, _SCALAR):
+        return str(value)
+    return ""
+
+
+def _claims(item: dict) -> list[dict[str, Any]]:
+    """Every claim the statement comparator wrote, projected for the page.
+
+    The page previously received `claims[0]` — the table set — and nothing else. That is reliably
+    the claim that says the least: in a structural failure both statements almost always read the
+    same tables, which is why the comparison got far enough to gate on something else at all. The
+    claim that explains such a failure is `filter_predicates`, which was computed, written to the
+    JSON artifact beside the page, and never rendered. A reader was left to diff two SQL statements
+    by eye to recover a difference the run had already worked out.
+
+    Every claim is carried and the page decides what to draw, so the ordering the comparator chose
+    survives and a claim added later needs no change here.
     """
     block = item.get("claims")
     claims = block.get("claims") if isinstance(block, dict) else None
-    if not isinstance(claims, list) or not claims:
-        return None
-    claim = claims[0]
-    # The payload's shape is promised by a docstring on the far side of a `--items-file` handoff,
-    # not by anything here, and a hand-edited or third-party run that breaks the promise must
-    # cost this one line rather than the whole page.
-    if not isinstance(claim, dict):
-        return None
-    return {
-        # Carried rather than assumed: the page labels the line from the claim's own name, so a
-        # run that one day writes its claims in another order labels it correctly instead of
-        # calling something else "tables".
-        "name": claim.get("name", ""),
-        "status": claim.get("status", ""),
-        "generated": _names(claim.get("generated")),
-        "golden": _names(claim.get("golden")),
-    }
+    if not isinstance(claims, list):
+        return []
+    projected = []
+    for claim in claims:
+        # The payload's shape is promised by a docstring on the far side of a `--items-file`
+        # handoff, not by anything here, and a hand-edited or third-party run that breaks the
+        # promise must cost one line rather than the whole page.
+        if not isinstance(claim, dict):
+            continue
+        projected.append(
+            {
+                # Carried rather than assumed: the page labels each line from the claim's own name,
+                # so a run that one day writes its claims in another order labels them correctly
+                # instead of calling something else "tables".
+                "name": claim.get("name", ""),
+                "status": claim.get("status", ""),
+                "generated": _side(claim.get("generated")),
+                "golden": _side(claim.get("golden")),
+            }
+        )
+    return projected
+
+
+def _gates(item: dict) -> list[dict[str, str]]:
+    """Which gate fired, and on what.
+
+    The page used to print one hardcoded sentence — "the dataset requires a filter this statement
+    does not write" — that named no column, so a reader was told *a* filter was missing and left to
+    work out which. It was also written as though `must_filter` were the only gate; structure gates
+    twice, and a differing date window rendered as a missing filter.
+
+    The kind and the column are both on the item already. Neither carries a value from a result
+    set: a `must_filter` column is a name the dataset's author wrote down, and the date-window gate
+    names no boundary here.
+    """
+    block = item.get("claims")
+    gates = block.get("gates") if isinstance(block, dict) else None
+    if not isinstance(gates, list):
+        return []
+    return [
+        {"kind": str(gate.get("kind", "")), "column": str(gate.get("column") or "")}
+        for gate in gates
+        if isinstance(gate, dict)
+    ]
 
 
 def _item(item: dict) -> dict[str, Any]:
@@ -135,12 +221,14 @@ def _item(item: dict) -> dict[str, Any]:
     if not isinstance(score, dict):
         score = {}
     accuracy = score.get("accuracy")
-    # A string where a number was promised reaches `_shown`'s comparison and throws, and one
-    # malformed item would take the report down with it. Anything not numeric reads as unscored,
-    # which is what the absence of a usable score means. `bool` is excluded on purpose: it is an
-    # `int` subclass, and True is not an accuracy.
-    if isinstance(accuracy, bool) or not isinstance(accuracy, (int, float)):
-        accuracy = None
+    # Whether the rows agreed, kept as the one bit the verdict actually needs. `bool` is excluded
+    # from the numeric check on purpose: it is an `int` subclass, and True is not an accuracy.
+    # The value itself does not travel — see the note at the top of this file.
+    reproduced = (
+        not isinstance(accuracy, bool)
+        and isinstance(accuracy, (int, float))
+        and float(accuracy) == 1.0
+    )
     return {
         "item_key": item.get("item_key", ""),
         "question": item.get("question", ""),
@@ -149,13 +237,16 @@ def _item(item: dict) -> dict[str, Any]:
         "passed": bool(item.get("passed")),
         "gated": bool(item.get("gated")),
         "status": score.get("status", ""),
-        # None means nothing was scored and 0.0 is a score an item earned, so the two are kept
-        # apart here as carefully as they are where they were decided.
-        "accuracy": None if accuracy is None else _shown(accuracy),
+        # Whether the two result sets agreed, which is NOT whether the item passed: a statement can
+        # reproduce its answer key exactly and still fail a structural gate. The page said "did not
+        # reproduce the answer key" for precisely that case, which was simply false, so the two
+        # facts are carried separately and the verdict is built from both.
+        "reproduced": reproduced,
         "reason": score.get("reason", ""),
         "expected_sql": item.get("expected_sql", ""),
         "generated_sql": item.get("generated_sql", ""),
-        "tables": _tables_claim(item),
+        "claims": _claims(item),
+        "gates": _gates(item),
     }
 
 
@@ -227,10 +318,7 @@ def render(
     # — the report renders blank with nothing anywhere saying why.
     return (
         template.replace("{{REPORT_TITLE}}", title)
-        .replace(
-            "{{GENERATED_AT}}",
-            datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
-        )
+        .replace("{{GENERATED_AT}}", _run_stamp())
         .replace("{{PROFILE}}", profile or "")
         .replace("{{AGAMI_LOGO_DARK_TEXT}}", logo_dark_svg)
         .replace("{{AGAMI_LOGO_LIGHT_TEXT}}", logo_light_svg)

--- a/plugins/agami/scripts/render_golden_run.py
+++ b/plugins/agami/scripts/render_golden_run.py
@@ -101,6 +101,12 @@ def _run_stamp(now: Optional[datetime.datetime] = None) -> str:
     not necessarily in it, and the day is not zero-padded because nobody says "06 September".
     """
     stamp = now or datetime.datetime.now(datetime.timezone.utc)
+    if stamp.tzinfo is None or stamp.utcoffset() is None:
+        # A naive timestamp has no zone to convert from; treat it as already UTC so the label stays
+        # truthful instead of pretending to have converted something unknown.
+        stamp = stamp.replace(tzinfo=datetime.timezone.utc)
+    else:
+        stamp = stamp.astimezone(datetime.timezone.utc)
     return f"{stamp.day} {_MONTHS[stamp.month - 1]} {stamp.year} at {stamp:%H:%M} UTC"
 
 

--- a/plugins/agami/shared/golden-run-template.html
+++ b/plugins/agami/shared/golden-run-template.html
@@ -310,9 +310,20 @@
     function deltaLines(item) {
       const claims = item.claims || [];
       if (!claims.length) {
+        // Two different situations, and saying the wrong one is worse than saying nothing. A case
+        // whose generation produced no statement genuinely has nothing to compare. A case that HAS
+        // both statements and no claims lost them somewhere else — a hand-edited artifact, a
+        // claims block the projection refused — and telling that reader "no statement was read"
+        // sends them looking for a generator failure that did not happen.
+        if (!item.generated_sql) {
+          return [el("div", {
+            class: "delta",
+            text: "no statement was generated, so there was nothing to compare",
+          })];
+        }
         return [el("div", {
           class: "delta",
-          text: "no statement was read, so there was nothing to compare",
+          text: "the two statements were not compared — read them below",
         })];
       }
       const differing = claims.filter(c => c.status === "differs");

--- a/plugins/agami/shared/golden-run-template.html
+++ b/plugins/agami/shared/golden-run-template.html
@@ -78,6 +78,18 @@
       letter-spacing: 0.04em; }
     .count-tile.failure .n { color: var(--bad-fg); }
     .count-tile.pass .n { color: var(--ok-fg); }
+    /* Only the two conditional tiles carry a note, and they only appear when non-zero — so this
+       never widens a healthy run's header. */
+    .count-tile .tile-note { font-size: 11px; color: var(--muted); margin-top: 6px; max-width: 30ch; }
+
+    /* Show one outcome at a time. Display only: nothing is recounted or re-sorted. */
+    .filters { display: flex; gap: 8px; flex-wrap: wrap; margin: 0 0 22px; }
+    .filter {
+      font: inherit; font-size: 12px; cursor: pointer; padding: 5px 12px; border-radius: 999px;
+      border: 1px solid var(--border); background: var(--bg-elev); color: var(--muted);
+    }
+    .filter:hover { color: var(--fg); }
+    .filter.on { background: var(--code-bg); color: var(--fg); border-color: var(--fg); }
 
     /* Sections */
     .section { margin-bottom: 30px; }
@@ -112,13 +124,15 @@
     .pill.pass { background: var(--ok-bg); color: var(--ok-fg); border: 1px solid var(--ok-border); }
 
     .verdict { font-size: 13px; color: var(--fg); margin-top: 8px; }
-    .verdict .score { font-variant-numeric: tabular-nums; font-weight: 600; }
+    .verdict .gate { color: var(--bad-fg); }
+    .deltas { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; }
     .delta {
-      font-size: 12px; margin-top: 10px; padding: 7px 12px; border-radius: 8px;
+      font-size: 12px; padding: 7px 12px; border-radius: 8px;
       background: var(--code-bg); color: var(--fg);
       font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
     }
     .delta.differs { background: var(--bad-bg); color: var(--bad-fg); }
+    .delta .claim-name { font-weight: 600; }
 
     /* The two statements, side by side */
     .statements { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 12px; }
@@ -164,6 +178,7 @@
 
     <div id="banners"></div>
     <div class="counts" id="counts"></div>
+    <div class="filters" id="filters"></div>
     <main id="sections"></main>
 
     <footer class="page-footer">
@@ -207,11 +222,22 @@
       return n;
     };
 
-    const names = list => (list && list.length ? list.join(", ") : "none");
+    const names = text => (text ? text : "none");
 
-    // Already rounded by the renderer; this only pads it to a fixed width so a column of scores
-    // lines up. A null accuracy is a comparison that never ran, and never a zero.
-    const score = a => (a === null || a === undefined) ? "—" : Number(a).toFixed(3);
+    // Which gate fired, in words, naming the column it fired on. Structure gates exactly twice, so
+    // there are exactly two sentences here; the fallback exists so a third one added later reads as
+    // itself rather than as a missing filter.
+    function gateText(gate) {
+      if (gate.kind === "must_filter") {
+        return gate.column
+          ? "the dataset requires this statement to filter on " + gate.column + ", and it does not"
+          : "the dataset requires a filter this statement does not write";
+      }
+      if (gate.kind === "date_window") {
+        return "this statement resolves a different date window than the answer key";
+      }
+      return gate.column ? gate.kind + " · " + gate.column : gate.kind;
+    }
 
     function verdictLine(item) {
       const line = el("div", { class: "verdict" });
@@ -223,46 +249,52 @@
         line.appendChild(el("span", { text: "Nothing could be compared — " + item.reason }));
         return line;
       }
-      const verdict = item.passed ? "Reproduced the answer key" : "Did not reproduce the answer key";
-      line.appendChild(el("span", { text: verdict + " · accuracy " }));
-      line.appendChild(el("span", { class: "score", text: score(item.accuracy) }));
+      // Built from what the comparison decided and what the gates decided, never from `passed`
+      // alone. An item can reproduce its answer key exactly and still fail a gate, and the page
+      // used to call that "Did not reproduce the answer key", which was simply untrue.
+      const verdict = item.reproduced
+        ? (item.gated ? "Reproduced the answer key, but did not answer the question asked"
+                      : "Reproduced the answer key")
+        : "Did not reproduce the answer key";
+      line.appendChild(el("span", { text: verdict }));
       if (item.reason) line.appendChild(el("span", { text: " — " + item.reason }));
-      if (item.gated) {
-        line.appendChild(el("span", {
-          text: " · the dataset requires a filter this statement does not write",
-        }));
-      }
+      (item.gates || []).forEach(gate => {
+        line.appendChild(el("span", { class: "gate", text: " · " + gateText(gate) }));
+      });
       if (!item.confirmed) {
         line.appendChild(el("span", { text: " · unconfirmed, so it cannot fail the run" }));
       }
       return line;
     }
 
-    function deltaLine(item) {
-      const claim = item.tables;
-      if (!claim) {
-        return el("div", {
+    // What the two statements actually assert differently. Only the claims that DIFFER are drawn:
+    // the page used to show the table set and nothing else, and in a structural failure that claim
+    // reliably agrees — both statements read the same table, which is why the comparison got far
+    // enough to gate on something else. The claim that explains such a failure was computed, kept
+    // in the JSON beside this page, and never rendered.
+    function deltaLines(item) {
+      const claims = item.claims || [];
+      if (!claims.length) {
+        return [el("div", {
           class: "delta",
-          text: "tables: no statement was read, so there was nothing to compare",
-        });
+          text: "no statement was read, so there was nothing to compare",
+        })];
       }
-      if (claim.status === "unknown") {
-        return el("div", {
+      const differing = claims.filter(c => c.status === "differs");
+      if (!differing.length) {
+        const unknown = claims.filter(c => c.status === "unknown").length;
+        return [el("div", {
           class: "delta",
-          text: claim.name + ": one of the statements could not be read",
-        });
+          text: unknown === claims.length
+            ? "one of the statements could not be read, so nothing could be compared"
+            : "the two statements make the same claims about the data they read",
+        })];
       }
-      if (claim.status === "differs") {
-        return el("div", {
-          class: "delta differs",
-          text: claim.name + ": generated read " + names(claim.generated)
-            + " · the answer key read " + names(claim.golden),
-        });
-      }
-      return el("div", {
-        class: "delta",
-        text: claim.name + ": both read " + names(claim.golden),
-      });
+      return differing.map(claim => el("div", { class: "delta differs" }, [
+        el("span", { class: "claim-name", text: claim.name }),
+        el("span", { text: " · generated " + names(claim.generated) }),
+        el("span", { text: " · answer key " + names(claim.golden) }),
+      ]));
     }
 
     function statement(label, sql, absentText) {
@@ -283,9 +315,10 @@
           el("span", { class: "pill " + item.section, text: SECTION_LABEL[item.section] || item.section }),
         ]),
         verdictLine(item),
-        // One line above the statements, because "generated read one table and the answer key
-        // read another" is usually the whole finding.
-        deltaLine(item),
+        // Above the statements, because "the generated statement filtered on one column and the
+        // answer key filtered on another" is usually the whole finding — and reading it here is
+        // the difference between being handed the diagnosis and being handed two SQL statements.
+        el("div", { class: "deltas" }, deltaLines(item)),
         el("div", { class: "statements" }, [
           statement("Answer key", item.expected_sql, "this case has no answer key"),
           statement("Generated", item.generated_sql, "no statement was generated"),
@@ -301,7 +334,7 @@
         const cases = (RUN.items || []).filter(item => item.section === name);
         if (!cases.length) return;
         drawn += cases.length;
-        const section = el("div", { class: "section" }, [
+        const section = el("div", { class: "section", "data-section": name }, [
           el("div", { class: "section-head" }, [
             el("h2", { text: SECTION_LABEL[name] || name }),
             el("span", { class: "n", text: cases.length + (cases.length === 1 ? " case" : " cases") }),
@@ -332,17 +365,28 @@
       const s = RUN.summary;
       // Straight from the run's own summary. Nothing here recounts the items: the run decides
       // what it did, and this page only shows it.
-      [
-        ["total", "Cases", ""],
-        ["passed", "Passed", "pass"],
-        ["failed", "Did not match", "failure"],
-        ["unscored", "Unscored", ""],
-        ["errored", "Errored", ""],
-      ].forEach(([key, label, cls]) => {
+      // Three tiles always, two more only when they have something to say. Unscored and errored are
+      // load-bearing and must never be folded into "failed" — a run of nothing but errors would
+      // then read as green, which is exactly the shape the `1` / `2` exit codes exist to tell
+      // apart — but on a healthy run they are zeroes competing for attention with the numbers that
+      // matter. When they do appear they get a sentence, because that is the moment a reader needs
+      // to know what they mean.
+      const TILES = [
+        ["total", "Cases", "", true, ""],
+        ["passed", "Passed", "pass", true, ""],
+        ["failed", "Failed", "failure", true, ""],
+        ["unscored", "Not compared", "", false,
+          "Both sides ran and there was no value to check — not agreement."],
+        ["errored", "Couldn't run", "", false,
+          "No statement was produced, so nothing was judged."],
+      ];
+      TILES.forEach(([key, label, cls, always, note]) => {
         const n = s[key];
-        counts.appendChild(el("div", { class: "count-tile " + cls }, [
+        if (!always && !n) return;
+        counts.appendChild(el("div", { class: "count-tile " + cls, title: note }, [
           el("div", { class: "n", text: (n === null || n === undefined) ? "—" : String(n) }),
           el("div", { class: "label", text: label }),
+          note ? el("div", { class: "tile-note", text: note }) : null,
         ]));
       });
     }
@@ -370,11 +414,46 @@
       }
     }
 
+    // Show one outcome at a time, or all of them. A corpus-sized run is hundreds of cases, and
+    // finding the failures in a flat scroll is the difference between a report and a wall. Purely
+    // a display toggle: nothing is recounted and nothing is re-sorted, so the tiles and the section
+    // headings keep describing the whole run however this is set.
+    function renderFilters() {
+      const bar = document.getElementById("filters");
+      const present = Object.keys(RUN.summary.sections || {})
+        .filter(name => (RUN.items || []).some(item => item.section === name));
+      if (present.length < 2) return;
+
+      const buttons = [];
+      function select(active) {
+        buttons.forEach(([button, name]) => {
+          const on = name === active;
+          button.className = "filter" + (on ? " on" : "");
+          button.setAttribute("aria-pressed", on ? "true" : "false");
+        });
+        document.querySelectorAll(".section").forEach(section => {
+          const name = section.getAttribute("data-section");
+          section.hidden = active !== "all" && name !== active;
+        });
+      }
+      [["all", "All"]].concat(present.map(n => [n, SECTION_LABEL[n] || n])).forEach(([name, label]) => {
+        const count = name === "all"
+          ? (RUN.items || []).length
+          : (RUN.items || []).filter(item => item.section === name).length;
+        const button = el("button", { class: "filter", type: "button", text: label + " (" + count + ")" });
+        button.addEventListener("click", () => select(name));
+        buttons.push([button, name]);
+        bar.appendChild(button);
+      });
+      select("all");
+    }
+
     document.getElementById("dataset-name").textContent = RUN.dataset || "";
     document.getElementById("run-id").textContent = RUN.run_id || "";
     renderBanners();
     renderCounts();
     renderSections();
+    renderFilters();
   </script>
 </body>
 </html>

--- a/plugins/agami/shared/golden-run-template.html
+++ b/plugins/agami/shared/golden-run-template.html
@@ -214,8 +214,8 @@
     // RUN.summary.sections is written in it — so nothing here re-sorts anything.
     const SECTION_LABEL = {
       failure: "Failed",
-      error: "Errored",
-      unscored: "Unscored",
+      error: "Couldn't run",
+      unscored: "Not compared",
       unconfirmed: "Unconfirmed",
       pass: "Passed",
     };
@@ -335,8 +335,11 @@
             text: "one of the statements could not be read, so nothing could be compared",
           })];
         }
-        // Structurally identical and it passed: there is nothing to say, so nothing is drawn.
-        if (item.passed) return [];
+        // Nothing to say, so nothing is drawn. Three cases, not one: a pass, an item that was
+        // never scored (both sides empty — its columns were not compared, let alone different),
+        // and a gated failure, where the columns are identical and the gate named in the verdict
+        // above is the whole finding.
+        if (item.passed || item.status !== "scored" || (item.gates || []).length) return [];
         // Structurally identical and it FAILED, which narrows the difference to one place:
         // projected columns are the only thing this comparison never examines. The verdict above
         // already names the column, and the statements are directly below, so this says the one

--- a/plugins/agami/shared/golden-run-template.html
+++ b/plugins/agami/shared/golden-run-template.html
@@ -132,7 +132,25 @@
       font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
     }
     .delta.differs { background: var(--bad-bg); color: var(--bad-fg); }
-    .delta .claim-name { font-weight: 600; }
+    /* The differences, as a table so the two sides line up under one another. */
+    .delta-table {
+      width: 100%; border-collapse: collapse; font-size: 12px; margin-top: 10px;
+      font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    }
+    .delta-table th, .delta-table td {
+      text-align: left; padding: 6px 10px; border-bottom: 1px solid var(--border);
+      vertical-align: top; word-break: break-word;
+    }
+    .delta-table thead th {
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted);
+      font-family: inherit; font-weight: 600;
+    }
+    .delta-table tbody th {
+      font-family: inherit; font-weight: 600; white-space: nowrap; color: var(--muted);
+      width: 1%;
+    }
+    .delta-table tbody td { color: var(--bad-fg); }
+    .delta-table tr:last-child th, .delta-table tr:last-child td { border-bottom: none; }
 
     /* The two statements, side by side */
     .statements { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 12px; }
@@ -224,6 +242,20 @@
 
     const names = text => (text ? text : "none");
 
+    // What each claim is called on the page. The comparator's own names are field names — a reader
+    // should not have to know that "filter_predicates" means the WHERE clause to read their own
+    // report. A claim added later and not named here falls back to its own name rather than
+    // vanishing.
+    const CLAIM_LABEL = {
+      tables: "Tables read",
+      filter_predicates: "Filters",
+      date_window: "Date range",
+      group_keys: "Grouped by",
+      join_keys: "Joined on",
+      ordering: "Sorted by",
+      limit: "Row limit",
+    };
+
     // Which gate fired, in words, naming the column it fired on. Structure gates exactly twice, so
     // there are exactly two sentences here; the fallback exists so a third one added later reads as
     // itself rather than as a missing filter.
@@ -290,11 +322,22 @@
             : "the two statements make the same claims about the data they read",
         })];
       }
-      return differing.map(claim => el("div", { class: "delta differs" }, [
-        el("span", { class: "claim-name", text: claim.name }),
-        el("span", { text: " · generated " + names(claim.generated) }),
-        el("span", { text: " · answer key " + names(claim.golden) }),
+      // A table rather than a run of separator-joined text. Three columns, and the two that matter
+      // sit one above the other in the same column so a reader compares by looking down rather than
+      // by reading across a sentence.
+      const rows = differing.map(claim => el("tr", {}, [
+        el("th", { scope: "row", text: CLAIM_LABEL[claim.name] || claim.name }),
+        el("td", { text: names(claim.golden) }),
+        el("td", { text: names(claim.generated) }),
       ]));
+      return [el("table", { class: "delta-table" }, [
+        el("thead", {}, [el("tr", {}, [
+          el("th", { scope: "col", text: "" }),
+          el("th", { scope: "col", text: "Answer key" }),
+          el("th", { scope: "col", text: "Generated" }),
+        ])]),
+        el("tbody", {}, rows),
+      ])];
     }
 
     function statement(label, sql, absentText) {

--- a/plugins/agami/shared/golden-run-template.html
+++ b/plugins/agami/shared/golden-run-template.html
@@ -262,11 +262,11 @@
     function gateText(gate) {
       if (gate.kind === "must_filter") {
         return gate.column
-          ? "the dataset requires this statement to filter on " + gate.column + ", and it does not"
-          : "the dataset requires a filter this statement does not write";
+          ? "no filter on " + gate.column + ", which the dataset requires"
+          : "a filter the dataset requires is missing";
       }
       if (gate.kind === "date_window") {
-        return "this statement resolves a different date window than the answer key";
+        return "a different date range from the answer key";
       }
       return gate.column ? gate.kind + " · " + gate.column : gate.kind;
     }
@@ -284,10 +284,13 @@
       // Built from what the comparison decided and what the gates decided, never from `passed`
       // alone. An item can reproduce its answer key exactly and still fail a gate, and the page
       // used to call that "Did not reproduce the answer key", which was simply untrue.
+      // What the comparison did to the DATA, in those words. The pill beside the question already
+      // says passed or failed, so this line has one job: whether the rows matched. "Reproduced the
+      // answer key" said that in two pieces of vocabulary a reader has to learn first.
       const verdict = item.reproduced
-        ? (item.gated ? "Reproduced the answer key, but did not answer the question asked"
-                      : "Reproduced the answer key")
-        : "Did not reproduce the answer key";
+        ? (item.gated ? "Same rows as the answer key, but not the same question"
+                      : "Same rows as the answer key")
+        : "Different rows from the answer key";
       line.appendChild(el("span", { text: verdict }));
       if (item.reason) line.appendChild(el("span", { text: " — " + item.reason }));
       (item.gates || []).forEach(gate => {
@@ -315,12 +318,19 @@
       const differing = claims.filter(c => c.status === "differs");
       if (!differing.length) {
         const unknown = claims.filter(c => c.status === "unknown").length;
-        return [el("div", {
-          class: "delta",
-          text: unknown === claims.length
-            ? "one of the statements could not be read, so nothing could be compared"
-            : "the two statements make the same claims about the data they read",
-        })];
+        if (unknown === claims.length) {
+          return [el("div", {
+            class: "delta",
+            text: "one of the statements could not be read, so nothing could be compared",
+          })];
+        }
+        // Structurally identical and it passed: there is nothing to say, so nothing is drawn.
+        if (item.passed) return [];
+        // Structurally identical and it FAILED, which narrows the difference to one place:
+        // projected columns are the only thing this comparison never examines. The verdict above
+        // already names the column, and the statements are directly below, so this says the one
+        // thing neither of them does and stops.
+        return [el("div", { class: "delta", text: "The selected columns differ." })];
       }
       // A table rather than a run of separator-joined text. Three columns, and the two that matter
       // sit one above the other in the same column so a reader compares by looking down rather than

--- a/plugins/agami/shared/golden-run-template.html
+++ b/plugins/agami/shared/golden-run-template.html
@@ -285,12 +285,12 @@
         line.appendChild(el("span", { text: "Nothing could be compared — the scoring status was unknown" }));
         return line;
       }
-      // Built from what the comparison decided and what the gates decided, never from `passed`
-      // alone. An item can reproduce its answer key exactly and still fail a gate, and the page
-      // used to call that "Did not reproduce the answer key", which was simply untrue.
-      // What the comparison did to the DATA, in those words. The pill beside the question already
-      // says passed or failed, so this line has one job: whether the rows matched. "Reproduced the
-      // answer key" said that in two pieces of vocabulary a reader has to learn first.
+      // What the comparison did to the DATA, in those words, and built from what the comparison and
+      // the gates decided rather than from `passed` alone. An item can reproduce its answer key
+      // exactly and still fail a gate; the page used to call that "Did not reproduce the answer
+      // key", which was untrue and sat beside a perfect score that said so. The pill next to the
+      // question already reports passed or failed, so this line has one job: whether the rows
+      // matched.
       const verdict = item.reproduced
         ? (item.gated ? "Same rows as the answer key, but not the same question"
                       : "Same rows as the answer key")

--- a/plugins/agami/shared/golden-run-template.html
+++ b/plugins/agami/shared/golden-run-template.html
@@ -281,6 +281,10 @@
         line.appendChild(el("span", { text: "Nothing could be compared — " + item.reason }));
         return line;
       }
+      if (item.status !== "scored") {
+        line.appendChild(el("span", { text: "Nothing could be compared — the scoring status was unknown" }));
+        return line;
+      }
       // Built from what the comparison decided and what the gates decided, never from `passed`
       // alone. An item can reproduce its answer key exactly and still fail a gate, and the page
       // used to call that "Did not reproduce the answer key", which was simply untrue.

--- a/tests/test_render_golden_run.py
+++ b/tests/test_render_golden_run.py
@@ -773,6 +773,84 @@ def test_the_template_draws_the_question_the_verdict_and_the_delta_for_a_case():
     assert verdict < delta < statements
 
 
+def test_a_claim_reads_the_way_a_person_writes_it():
+    """The claim reader writes `gte(created, '2024-01-01')`, and that functional form is deliberate
+    WHERE IT IS WRITTEN: a claim rides on tool output a model reads as server-authored, and
+    something that looked like SQL would be read as SQL.
+
+    That reasoning is about a model's context. This report is a local page a person opens, built
+    with `textContent`, so the argument does not reach it while the cost of it does — a reader had
+    to decode both sides before they could compare them.
+    """
+    from render_golden_run import _side
+
+    assert _side(["gte(placed_at, '2024-01-01')"]) == "placed_at >= '2024-01-01'"
+    assert _side(["neq(status, 'cancelled')"]) == "status <> 'cancelled'"
+    assert (
+        _side(["between(placed_at, '2024-01-01', '2024-12-31')"])
+        == "placed_at BETWEEN '2024-01-01' AND '2024-12-31'"
+    )
+    # A literal may hold the separator the split runs on, so the split respects quoting.
+    assert _side(["eq(customer.name, 'Smith, John')"]) == "customer.name = 'Smith, John'"
+    # A subquery's whole parse tree is rendered inline. That it is there is the readable part; the
+    # statements are printed underneath for the rest.
+    assert _side(["in(customer_id, subquery(select(id, from(table(customers)))))"]) == (
+        "customer_id IN (subquery)"
+    )
+    # Anything the lookup does not know keeps the shape it arrived in rather than being guessed at.
+    assert _side(["coalesce(a, b)"]) == "coalesce(a, b)"
+
+
+def test_a_join_key_and_an_ordering_survive_their_nesting():
+    """`join_keys` writes the two sides of an equality as a pair of pairs and `ordering` writes a
+    column with its direction, so both are nested. Dropping nested entries rendered the two claims
+    most likely to differ as empty sides."""
+    from render_golden_run import _side
+
+    assert _side([[["customers", "id"], ["orders", "customer_id"]]]) == (
+        "customers.id = orders.customer_id"
+    )
+    assert _side([["order_count", "desc"]]) == "order_count desc"
+
+
+def test_an_ordinal_group_key_is_labelled_and_a_row_limit_is_not():
+    """`GROUP BY 1` reaches the claim as the bare string "1", and "grouped by 1" against "grouped by
+    service_criticality" tells a reader nothing.
+
+    It is labelled rather than resolved — the claim carries no projection to resolve it against —
+    and ONLY under `group_keys`: a `limit` of 100 is a row count, and calling it "column 100 of the
+    select list" would be worse than the bare digit this exists to fix.
+    """
+    run = _run(
+        [
+            _item(
+                claims={
+                    "claims": [
+                        {"name": "group_keys", "status": "differs", "generated": ["1"], "golden": ["channel"]},
+                        {"name": "limit", "status": "differs", "generated": ["100"], "golden": ["10"]},
+                    ]
+                }
+            )
+        ]
+    )
+
+    claims = {c["name"]: c for c in _payload(render(title="x", profile="demo", run=run))["items"][0]["claims"]}
+
+    assert claims["group_keys"]["generated"] == "column 1 of the select list"
+    assert claims["limit"]["generated"] == "100"
+
+
+def test_the_claims_are_drawn_as_a_table_with_plain_english_labels():
+    """A run of separator-joined text is hard to compare against the line beside it, and
+    `filter_predicates` is a field name rather than something a reader should have to know."""
+    assert 'CLAIM_LABEL[claim.name] || claim.name' in TEMPLATE
+    assert 'filter_predicates: "Filters"' in TEMPLATE
+    assert 'group_keys: "Grouped by"' in TEMPLATE
+    # A table, with the answer key first because it is the thing being compared against.
+    assert 'class: "delta-table"' in TEMPLATE
+    assert TEMPLATE.index('text: "Answer key"') < TEMPLATE.index('text: "Generated"')
+
+
 def test_the_run_stamp_reads_as_a_date_somebody_would_say():
     """It read `2026-09-06T11:47:38+00:00`. That is a sortable key, and the page has no second
     place where the timestamp is a key — so it is spelled as a sentence, with the zone named

--- a/tests/test_render_golden_run.py
+++ b/tests/test_render_golden_run.py
@@ -840,6 +840,42 @@ def test_an_ordinal_group_key_is_labelled_and_a_row_limit_is_not():
     assert claims["limit"]["generated"] == "100"
 
 
+def test_an_open_ended_date_window_does_not_print_the_word_none():
+    """Either bound may be open — `placed_at >= '2024-01-01'` on its own resolves to a start and no
+    end, which is an ordinary shape rather than a corner. An interval printed with one side missing
+    put the word `None` on the report."""
+    from render_golden_run import _side
+
+    lower = {"column": "placed_at", "start": "2024-01-01", "start_inclusive": True,
+             "end": None, "end_inclusive": False}
+    upper = {"column": "placed_at", "start": None, "start_inclusive": True,
+             "end": "2025-01-01", "end_inclusive": False}
+
+    assert _side(lower) == "placed_at >= 2024-01-01"
+    assert _side(upper) == "placed_at < 2025-01-01"
+    assert "None" not in _side(lower) + _side(upper)
+
+
+def test_a_gate_with_no_kind_is_dropped_rather_than_rendered_as_none():
+    """`gate.get("kind", "")` returns None for a key that is present and null, and `str()` would
+    then put the literal "None" on the page, matching no branch that names a gate."""
+    run = _run([_item(claims={"claims": [], "gates": [{"kind": None, "column": "channel"},
+                                                      {"kind": "must_filter", "column": "channel"}]})])
+
+    gates = _payload(render(title="x", profile="demo", run=run))["items"][0]["gates"]
+
+    assert gates == [{"kind": "must_filter", "column": "channel"}]
+
+
+def test_a_case_with_statements_and_no_claims_is_not_called_a_generation_failure():
+    """An item can carry both statements and no claims — a hand-edited artifact, or a claims block
+    the projection refused. Telling that reader "no statement was read" sends them looking for a
+    generator failure that did not happen."""
+    assert 'text: "no statement was generated, so there was nothing to compare"' in TEMPLATE
+    assert 'text: "the two statements were not compared — read them below"' in TEMPLATE
+    assert "if (!item.generated_sql) {" in TEMPLATE
+
+
 def test_a_failure_whose_statements_agree_everywhere_says_where_to_look():
     """The one shape where the difference table is empty and the item still failed.
 

--- a/tests/test_render_golden_run.py
+++ b/tests/test_render_golden_run.py
@@ -609,8 +609,8 @@ def test_a_gated_item_is_not_described_as_failing_to_reproduce_the_answer_key():
     assert gated["gated"] is True and gated["section"] == "failure"
     assert gated["gates"] == [{"kind": "must_filter", "column": "channel"}]
     # …and the page says both, rather than picking one and contradicting the other.
-    assert "Reproduced the answer key, but did not answer the question asked" in TEMPLATE
-    assert "the dataset requires this statement to filter on" in TEMPLATE
+    assert "Same rows as the answer key, but not the same question" in TEMPLATE
+    assert "no filter on " in TEMPLATE
 
 
 def test_the_sections_keep_the_order_the_run_wrote_them_in():
@@ -838,6 +838,19 @@ def test_an_ordinal_group_key_is_labelled_and_a_row_limit_is_not():
 
     assert claims["group_keys"]["generated"] == "column 1 of the select list"
     assert claims["limit"]["generated"] == "100"
+
+
+def test_a_failure_whose_statements_agree_everywhere_says_where_to_look():
+    """The one shape where the difference table is empty and the item still failed.
+
+    Everything the comparison examines agrees, because the difference is in the projected columns —
+    the one thing it deliberately never compares, since two statements can compute the same value
+    with a predicate in the WHERE clause or inside the aggregate. Saying "the two statements make
+    the same claims" there is a shrug; the reader needs to be sent to the statements.
+    """
+    assert 'text: "The selected columns differ."' in TEMPLATE
+    # And when the same thing happens on a PASS there is nothing to say, so nothing is drawn.
+    assert "if (item.passed) return [];" in TEMPLATE
 
 
 def test_the_claims_are_drawn_as_a_table_with_plain_english_labels():

--- a/tests/test_render_golden_run.py
+++ b/tests/test_render_golden_run.py
@@ -182,16 +182,36 @@ def _mixed() -> list[dict[str, Any]]:
             question="How many payments have been taken?",
             score={"status": "scored", "accuracy": 0.0, "reason": "no row matched"},
         ),
-        # The one case where the score and the verdict disagree on purpose: every row agreed, and
-        # the statement still did not answer the question the dataset requires. It is the only path
-        # on which a genuine 1.000 is printed beside "Did not reproduce the answer key".
+        # The one case where reproducing and passing disagree on purpose: every row agreed, and the
+        # statement still did not answer the question the dataset requires. It is the shape a
+        # `must_filter` catch always takes, and the shape the page used to describe as a failure to
+        # reproduce the answer key.
         _item(
             item_key="orders-by-status-scoped",
             section="failure",
             passed=False,
             gated=True,
             question="How many orders are there, by status?",
-            score={"status": "scored", "accuracy": 1.0, "reason": "every row matched"},
+            score={"status": "scored", "accuracy": 1.0, "reason": ""},
+            claims={
+                "claims": [
+                    {"name": "tables", "status": "agrees", "generated": ["orders"], "golden": ["orders"]},
+                    {
+                        "name": "filter_predicates",
+                        "status": "differs",
+                        "generated": [],
+                        "golden": ["eq(channel, 'web')"],
+                    },
+                ],
+                "gates": [
+                    {
+                        "kind": "must_filter",
+                        "column": "channel",
+                        "reason": "the dataset requires this column to be filtered",
+                    }
+                ],
+                "gated": True,
+            },
         ),
         _item(),
     ]
@@ -365,16 +385,23 @@ def test_every_item_carries_its_question_and_verdict():
     items = _payload(html)["items"]
     assert len(items) == 6
     for item in items:
-        assert item["question"] and item["status"] and item["reason"]
+        assert item["question"] and item["status"]
         assert item["section"] in SECTIONS
-        assert set(item) >= {"passed", "confirmed", "gated", "accuracy"}
+        assert set(item) >= {"passed", "confirmed", "gated", "reproduced", "claims", "gates"}
+    # A `reason` is what the comparator wrote when it had something to say, so an item that agreed
+    # on every row carries none — the gated case included, which is exactly why its verdict has to
+    # be built from `reproduced` and `gates` rather than from a sentence that is not there.
+    reasons = {item["item_key"]: item["reason"] for item in items}
+    assert reasons["customers-count"] == "no row matched"
+    assert reasons["orders-by-status-scoped"] == ""
     assert "How many orders have been placed?" in html
 
 
 def test_an_unscored_item_and_an_errored_item_are_told_apart():
-    """Both carry `accuracy: null` and neither is a failure, and they are not the same thing: one
-    produced no statement, the other produced two result sets with nothing to compare. Each keeps
-    its own section and its own reason."""
+    """Neither reproduced an answer key and neither is a failure, and they are not the same thing:
+    one produced no statement, the other produced two result sets with nothing to compare. Each
+    keeps its own section and its own reason — which is the whole of how a reader tells them
+    apart, now that no number is printed beside either."""
     items = {
         item["item_key"]: item
         for item in _payload(render(title="x", profile="demo", run=_run(_mixed())))["items"]
@@ -386,41 +413,62 @@ def test_an_unscored_item_and_an_errored_item_are_told_apart():
     assert items["unused-status"]["section"] == "unscored"
     assert items["unused-status"]["status"] == "unscored"
     assert "empty" in items["unused-status"]["reason"]
-    assert items["products-count"]["accuracy"] is None
-    assert items["unused-status"]["accuracy"] is None
+    assert items["products-count"]["reproduced"] is False
+    assert items["unused-status"]["reproduced"] is False
 
 
-def test_a_score_of_zero_is_not_a_score_of_nothing():
-    """0.0 is a comparison that ran and found no agreement; None is a comparison that never ran.
-    Collapsing them would report a wrong answer and an unrunnable case as the same thing."""
+def test_a_comparison_that_disagreed_is_not_a_comparison_that_never_ran():
+    """A comparison that ran and found no agreement is not one that never ran at all. The number
+    that used to separate them is gone, so the separation has to live where a reader looks: the
+    section, the status and the sentence."""
     items = {
         item["item_key"]: item
         for item in _payload(render(title="x", profile="demo", run=_run(_mixed())))["items"]
     }
 
-    assert items["customers-count"]["accuracy"] == 0.0
-    assert items["products-count"]["accuracy"] is None
+    assert items["customers-count"]["section"] == "failure"
+    assert items["customers-count"]["status"] == "scored"
+    assert items["customers-count"]["reason"] == "no row matched"
+    assert items["products-count"]["section"] == "error"
+    assert items["products-count"]["status"] == "error"
 
 
-def test_the_accuracy_is_shown_to_three_decimals():
-    """The score is deliberately unrounded upstream — an item passes at exactly 1.0, and rounding
-    there would hand the pass mark to a near miss. 3995 of 4000 rows is one such near miss, and
-    presenting it to a person is this renderer's job."""
+def test_no_accuracy_reaches_the_page():
+    """The score is not projected, and this is the guard on that.
+
+    Over a real fifteen-case run every accuracy was exactly 1.0 or exactly 0.0, which is structural
+    rather than luck: a row-count difference, an unpaired column and an extra column each
+    short-circuit before an overlap is computed, and columns pair only on equal value vectors. On
+    the narrow occasion a value in between is reachable, the comparator already writes the same
+    fact in words and `reason` carries it. So the number was redundant when it meant something and
+    actively misleading otherwise — printed as `accuracy 1.000` beside a gated item that had
+    reproduced its answer key perfectly.
+    """
     near_miss = _item(
-        passed=False, section="failure", score={"status": "scored", "accuracy": 3995 / 4000}
+        passed=False,
+        section="failure",
+        score={
+            "status": "scored",
+            "accuracy": 3995 / 4000,
+            "reason": "3995 of the answer key's 4000 rows matched",
+        },
     )
 
     payload = _payload(render(title="x", profile="demo", run=_run([near_miss])))
 
-    assert payload["items"][0]["accuracy"] == 0.999
-    assert "0.99875" not in json.dumps(payload)
+    assert "accuracy" not in payload["items"][0]
+    assert "0.99875" not in json.dumps(payload) and "0.999" not in json.dumps(payload)
+    # What the reader gets instead, and the reason removing the number costs nothing: the same
+    # fact, in words, already written by the comparator.
+    assert payload["items"][0]["reason"] == "3995 of the answer key's 4000 rows matched"
 
 
-def test_a_near_miss_is_never_shown_as_a_perfect_score():
-    """4002 of 4004 rows rounds to 1.000 at three decimals, and an item passes at exactly 1.0. So
-    rounding alone would print a perfect-looking score beside the sentence saying the statement did
-    not reproduce the answer key — the one confusion this report exists to remove. Only a real 1.0
-    may read as 1.000."""
+def test_reproducing_the_answer_key_is_carried_apart_from_passing():
+    """The two are not the same question, and the page needs both to describe a gated item.
+
+    Only an exact 1.0 counts as reproducing the key: a near miss that would once have ROUNDED to
+    1.000 must not read as agreement now that the rounding is gone.
+    """
     near_miss = _item(
         passed=False, section="failure", score={"status": "scored", "accuracy": 4002 / 4004}
     )
@@ -428,36 +476,96 @@ def test_a_near_miss_is_never_shown_as_a_perfect_score():
 
     payload = _payload(render(title="x", profile="demo", run=_run([near_miss, perfect])))
 
-    assert payload["items"][0]["accuracy"] == 0.999, "a near miss must not reach the pass mark"
-    assert payload["items"][1]["accuracy"] == 1.0, "a real pass still shows as one"
+    assert payload["items"][0]["reproduced"] is False, "a near miss is not a reproduction"
+    assert payload["items"][1]["reproduced"] is True
 
 
-def test_the_table_set_delta_is_rendered_above_the_statements():
-    """The table-set delta is usually the whole finding — "generated read `orders`, the answer key
-    read `customers`" — so it is one line above the two statements rather than something to be
-    spotted in them."""
+def test_every_claim_reaches_the_page_and_not_just_the_table_set():
+    """The page used to receive `claims[0]` — the table set — and nothing else.
+
+    That is reliably the claim that says the least: in a structural failure both statements read
+    the same tables, which is why the comparison got far enough to gate on something else at all.
+    The claim that explains such a failure is `filter_predicates`, and it was computed, written to
+    the JSON artifact beside the page, and never rendered — leaving a reader to diff two SQL
+    statements by eye to recover a difference the run had already worked out.
+    """
     items = {
         item["item_key"]: item
         for item in _payload(render(title="x", profile="demo", run=_run(_mixed())))["items"]
     }
 
-    assert items["customers-count"]["tables"] == {
+    claims = {claim["name"]: claim for claim in items["customers-count"]["claims"]}
+    assert set(claims) == {
+        "tables",
+        "filter_predicates",
+        "date_window",
+        "group_keys",
+        "join_keys",
+        "ordering",
+        "limit",
+    }
+    assert claims["tables"] == {
         "name": "tables",
         "status": "differs",
-        "generated": ["orders"],
-        "golden": ["customers"],
+        "generated": "orders",
+        "golden": "customers",
     }
-    assert items["orders-count"]["tables"]["status"] == "agrees"
+    assert items["orders-count"]["claims"][0]["status"] == "agrees"
     # A case that never produced a statement has no difference to show, and the page has to render
-    # the absence rather than assume the claim is there.
-    assert items["products-count"]["tables"] is None
+    # the absence rather than assume the claims are there.
+    assert items["products-count"]["claims"] == []
 
 
-def test_a_claim_that_is_not_a_list_of_names_cannot_reach_the_page():
-    """Each side of the claim is joined into a sentence by the page. A bare string arriving where a
-    list was promised makes that join undefined, throws, and — since the whole body is built by that
-    script — leaves the report blank with no error on it. Nothing on this side of the handoff
-    enforces the comparator's shape, so the projection coerces instead of trusting it."""
+def test_a_resolved_date_window_is_flattened_to_an_interval_a_person_reads():
+    """One of the two claims that can gate, and the only one whose sides are objects.
+
+    The page received lists alone and called `Array.join` on them, so an object arriving here would
+    have thrown and left the whole report blank. Flattening happens on this side for that reason,
+    and the interval is printed half-open because that is the whole point of resolving one.
+    """
+    run = _run(
+        [
+            _item(
+                claims={
+                    "claims": [
+                        {
+                            "name": "date_window",
+                            "status": "differs",
+                            "generated": {
+                                "column": "created",
+                                "start": "2024-01-01",
+                                "start_inclusive": True,
+                                "end": "2025-01-01",
+                                "end_inclusive": False,
+                            },
+                            "golden": {
+                                "column": "opened",
+                                "start": "2024-01-01",
+                                "start_inclusive": True,
+                                "end": "2025-01-01",
+                                "end_inclusive": False,
+                            },
+                        }
+                    ]
+                }
+            )
+        ]
+    )
+
+    claim = _payload(render(title="x", profile="demo", run=run))["items"][0]["claims"][0]
+
+    assert claim["generated"] == "created in [2024-01-01, 2025-01-01)"
+    assert claim["golden"] == "opened in [2024-01-01, 2025-01-01)"
+
+
+def test_a_claim_side_that_is_not_a_list_of_names_cannot_reach_the_page():
+    """Nothing on this side of the handoff enforces the comparator's shape, so each side of a claim
+    is coerced to the string the page prints rather than trusted to be a list.
+
+    A nested sequence is joined rather than dropped, because `ordering` genuinely writes one — a
+    column and a direction together. A dict nested inside a side is still dropped: it would print
+    its own punctuation.
+    """
     run = _run(
         [
             _item(
@@ -475,29 +583,34 @@ def test_a_claim_that_is_not_a_list_of_names_cannot_reach_the_page():
         ]
     )
 
-    tables = _payload(render(title="x", profile="demo", run=run))["items"][0]["tables"]
+    claim = _payload(render(title="x", profile="demo", run=run))["items"][0]["claims"][0]
 
-    assert tables["generated"] == ["orders", "7"]
-    assert tables["golden"] == []
-    assert "nested" not in json.dumps(tables)
+    assert claim["generated"] == "orders, nested list, 7"
+    assert claim["golden"] == "customers"
+    # A dict nested inside a side would print its own punctuation, so it is still dropped.
+    assert '"a"' not in json.dumps(claim)
 
 
-def test_a_gated_item_shows_a_perfect_score_beside_a_failing_verdict():
-    """The one case where the score and the verdict disagree, and the reason the page never derives
-    one from the other: every row agreed, so the accuracy really is 1.0, and the statement still did
-    not write the filter the dataset requires. A renderer that recomputed `passed` from the accuracy
-    would turn this run's only real failure into a pass."""
+def test_a_gated_item_is_not_described_as_failing_to_reproduce_the_answer_key():
+    """Every row agreed and the statement still did not write the filter the dataset requires.
+
+    The page derived its verdict from `passed`, which a gate turns false, so it announced "Did not
+    reproduce the answer key" over an item that had reproduced it exactly — a contradiction of the
+    perfect score printed beside it. Reproducing and passing are different questions, which is the
+    whole reason structure gates separately from rows, and both facts now travel.
+    """
     items = {
         item["item_key"]: item
         for item in _payload(render(title="x", profile="demo", run=_run(_mixed())))["items"]
     }
 
     gated = items["orders-by-status-scoped"]
-    assert gated["accuracy"] == 1.0 and gated["passed"] is False
+    assert gated["reproduced"] is True and gated["passed"] is False
     assert gated["gated"] is True and gated["section"] == "failure"
-    # …and the page says which of the two it is, rather than leaving a reader to reconcile them.
-    assert "if (item.gated)" in TEMPLATE
-    assert "the dataset requires a filter this statement does not write" in TEMPLATE
+    assert gated["gates"] == [{"kind": "must_filter", "column": "channel"}]
+    # …and the page says both, rather than picking one and contradicting the other.
+    assert "Reproduced the answer key, but did not answer the question asked" in TEMPLATE
+    assert "the dataset requires this statement to filter on" in TEMPLATE
 
 
 def test_the_sections_keep_the_order_the_run_wrote_them_in():
@@ -648,16 +761,62 @@ def test_the_template_draws_both_statements_on_every_case():
 
 def test_the_template_draws_the_question_the_verdict_and_the_delta_for_a_case():
     """One case is a question, what the run decided about it, the table-set difference and the two
-    statements. The delta is between the verdict and the statements on purpose: "generated read one
-    table and the answer key read another" is usually the whole finding, so it is read before them
-    rather than spotted inside them."""
+    statements. The differences are between the verdict and the statements on purpose: "the
+    generated statement filtered on one column and the answer key filtered on another" is usually
+    the whole finding, so it is read before them rather than spotted inside them."""
     assert 'class: "question", text: item.question' in TEMPLATE
     assert "text: SECTION_LABEL[item.section] || item.section" in TEMPLATE
 
     verdict = TEMPLATE.index("verdictLine(item),")
-    delta = TEMPLATE.index("deltaLine(item),")
+    delta = TEMPLATE.index("deltaLines(item))")
     statements = TEMPLATE.index('el("div", { class: "statements" }')
     assert verdict < delta < statements
+
+
+def test_the_run_stamp_reads_as_a_date_somebody_would_say():
+    """It read `2026-09-06T11:47:38+00:00`. That is a sortable key, and the page has no second
+    place where the timestamp is a key — so it is spelled as a sentence, with the zone named
+    because the reader is not necessarily in it."""
+    import datetime
+
+    from render_golden_run import _run_stamp
+
+    stamp = _run_stamp(datetime.datetime(2026, 9, 6, 11, 47, 38, tzinfo=datetime.timezone.utc))
+
+    assert stamp == "6 September 2026 at 11:47 UTC"
+    assert "T11:47" not in stamp
+
+
+def test_a_bucket_with_nothing_in_it_is_not_given_a_tile():
+    """Five tiles on every run put three zeroes beside the two numbers that matter.
+
+    The two conditional ones are NOT merged into "failed", and must not be: a run of nothing but
+    errors would then read as `0 failed`, indistinguishable from green, which is precisely the
+    distinction the `1` / `2` exit codes exist to make. They are hidden when empty and given a
+    sentence when they are not, because that is the moment a reader needs to know what they mean.
+    """
+    assert '["total", "Cases", "", true' in TEMPLATE
+    assert '["passed", "Passed", "pass", true' in TEMPLATE
+    assert '["failed", "Failed", "failure", true' in TEMPLATE
+    assert '["unscored", "Not compared", "", false' in TEMPLATE
+    assert '["errored", "Couldn\'t run", "", false' in TEMPLATE
+    assert "if (!always && !n) return;" in TEMPLATE
+
+
+def test_the_page_can_be_filtered_by_outcome():
+    """A corpus-sized run is hundreds of cases, and finding the failures in a flat scroll is the
+    difference between a report and a wall.
+
+    Display only: the filter hides sections and recounts nothing, so the tiles and the section
+    headings keep describing the whole run however it is set.
+    """
+    assert "renderFilters();" in TEMPLATE
+    assert 'section.hidden = active !== "all" && name !== active;' in TEMPLATE
+    # Drawn after the sections exist, or there would be nothing to hide.
+    assert TEMPLATE.index("renderSections();") < TEMPLATE.index("renderFilters();")
+    # One control per section that actually has cases, and no control at all when there is nothing
+    # to choose between.
+    assert "if (present.length < 2) return;" in TEMPLATE
 
 
 def test_the_page_draws_its_banners_its_counts_and_its_sections():
@@ -687,35 +846,49 @@ def test_an_unscored_case_and_an_errored_case_do_not_look_alike():
 # failure with no recourse.
 
 
-def test_a_non_dict_claims_block_costs_the_delta_line_and_not_the_page():
+def test_a_non_dict_claims_block_costs_the_delta_lines_and_not_the_page():
     items = _mixed()
     items[0]["claims"] = ["tables", "differs"]
     payload = _payload(render(title="x", profile="demo", run=_run(items)))
-    assert payload["items"][0]["tables"] is None
+    assert payload["items"][0]["claims"] == [] and payload["items"][0]["gates"] == []
     assert len(payload["items"]) == len(items)
 
 
-def test_a_non_dict_first_claim_costs_the_delta_line_and_not_the_page():
+def test_a_claim_that_is_not_a_dict_is_dropped_and_its_siblings_survive():
+    """One malformed claim costs that line, not the whole difference and not the page."""
     items = _mixed()
-    items[0]["claims"] = {"claims": ["tables"]}
+    items[0]["claims"] = {
+        "claims": ["tables", {"name": "ordering", "status": "differs", "generated": [], "golden": []}],
+        "gates": ["must_filter", {"kind": "must_filter", "column": "channel"}],
+    }
     payload = _payload(render(title="x", profile="demo", run=_run(items)))
-    assert payload["items"][0]["tables"] is None
+    assert [claim["name"] for claim in payload["items"][0]["claims"]] == ["ordering"]
+    assert payload["items"][0]["gates"] == [{"kind": "must_filter", "column": "channel"}]
 
 
-def test_a_non_numeric_accuracy_reads_as_unscored_rather_than_throwing():
-    """`_shown` compares against 1.0, so a string here would raise and take the report with it."""
+def test_a_non_numeric_accuracy_does_not_read_as_a_reproduction():
+    """A hand-edited artifact must not talk its way into "Reproduced the answer key". The check is
+    a numeric equality against 1.0, so a string has to fail it rather than raise."""
     items = _mixed()
-    items[0]["score"] = {"status": "scored", "accuracy": "0.0", "reason": "hand-edited"}
+    items[0]["score"] = {"status": "scored", "accuracy": "1.0", "reason": "hand-edited"}
     payload = _payload(render(title="x", profile="demo", run=_run(items)))
-    assert payload["items"][0]["accuracy"] is None
+    assert payload["items"][0]["reproduced"] is False
     assert payload["items"][0]["reason"] == "hand-edited"
+
+
+def test_a_boolean_accuracy_does_not_read_as_a_reproduction():
+    """`True == 1.0` in Python, and `bool` is an `int` subclass, so the one value that would slip
+    through a naive numeric check is excluded explicitly."""
+    items = _mixed()
+    items[0]["score"] = {"status": "scored", "accuracy": True, "reason": "hand-edited"}
+    assert _payload(render(title="x", profile="demo", run=_run(items)))["items"][0]["reproduced"] is False
 
 
 def test_a_non_dict_score_reads_as_unscored_rather_than_throwing():
     items = _mixed()
     items[0]["score"] = "scored"
     payload = _payload(render(title="x", profile="demo", run=_run(items)))
-    assert payload["items"][0]["accuracy"] is None
+    assert payload["items"][0]["reproduced"] is False
     assert payload["items"][0]["status"] == ""
 
 

--- a/tests/test_render_golden_run.py
+++ b/tests/test_render_golden_run.py
@@ -280,6 +280,13 @@ def test_no_result_row_reaches_the_report():
     item["rows"] = rows
     item["row_preview"] = rows
     item["score"] = {**item["score"], "rows": rows}
+    # A claim's side too. Its only producer compares two SQL strings and can never hold a row, but
+    # the projection now flattens nested sequences that it used to drop — so this is the shape that
+    # would have started travelling if one ever did.
+    item["claims"] = {
+        "claims": [{"name": "tables", "status": "differs", "generated": rows, "golden": rows}],
+        "gates": [],
+    }
     run = _run([item])
     run["rows"] = rows
 
@@ -562,9 +569,9 @@ def test_a_claim_side_that_is_not_a_list_of_names_cannot_reach_the_page():
     """Nothing on this side of the handoff enforces the comparator's shape, so each side of a claim
     is coerced to the string the page prints rather than trusted to be a list.
 
-    A nested sequence is joined rather than dropped, because `ordering` genuinely writes one — a
-    column and a direction together. A dict nested inside a side is still dropped: it would print
-    its own punctuation.
+    A nested sequence is dropped under `tables`, which never writes one — only `ordering` and
+    `join_keys` do, and the claims that may nest are named rather than inferred from the shape. A
+    dict nested inside a side is dropped everywhere: it would print its own punctuation.
     """
     run = _run(
         [
@@ -585,7 +592,7 @@ def test_a_claim_side_that_is_not_a_list_of_names_cannot_reach_the_page():
 
     claim = _payload(render(title="x", profile="demo", run=run))["items"][0]["claims"][0]
 
-    assert claim["generated"] == "orders, nested list, 7"
+    assert claim["generated"] == "orders, 7"
     assert claim["golden"] == "customers"
     # A dict nested inside a side would print its own punctuation, so it is still dropped.
     assert '"a"' not in json.dumps(claim)
@@ -799,6 +806,13 @@ def test_a_claim_reads_the_way_a_person_writes_it():
     )
     # Anything the lookup does not know keeps the shape it arrived in rather than being guessed at.
     assert _side(["coalesce(a, b)"]) == "coalesce(a, b)"
+    # A keyword arrives as a zero-argument call; without it the operand keeps a bracket and the
+    # guard refuses the whole comparison, which is what kept `IS` from ever rendering.
+    assert _side(["is(orders.deleted_at, null())"]) == "orders.deleted_at IS NULL"
+    # A single-value IN has two operands and no brackets of its own. `status IN 'paid'` is not SQL.
+    assert _side(["in(orders.status, 'paid')"]) == "orders.status IN ('paid')"
+    # A multi-value IN has three, so it is left in the form it arrived in rather than half-rewritten.
+    assert _side(["in(orders.status, 'paid', 'refunded')"]).startswith("in(")
 
 
 def test_a_join_key_and_an_ordering_survive_their_nesting():
@@ -807,15 +821,19 @@ def test_a_join_key_and_an_ordering_survive_their_nesting():
     most likely to differ as empty sides."""
     from render_golden_run import _side
 
-    assert _side([[["customers", "id"], ["orders", "customer_id"]]]) == (
+    assert _side([[["customers", "id"], ["orders", "customer_id"]]], nested=True) == (
         "customers.id = orders.customer_id"
     )
-    assert _side([["order_count", "desc"]]) == "order_count desc"
+    assert _side([["order_count", "desc"]], nested=True) == "order_count desc"
+    # And nowhere else. A join key and a two-column result row are the same shape, so the claims
+    # that may nest are named rather than inferred — this is what stops a row rendering if one ever
+    # reached a claim it has no way to reach today.
+    assert _side([["Ada Lovelace", "1234"]]) == ""
 
 
 def test_an_ordinal_group_key_is_labelled_and_a_row_limit_is_not():
     """`GROUP BY 1` reaches the claim as the bare string "1", and "grouped by 1" against "grouped by
-    service_criticality" tells a reader nothing.
+    status" tells a reader nothing.
 
     It is labelled rather than resolved — the claim carries no projection to resolve it against —
     and ONLY under `group_keys`: a `limit` of 100 is a row count, and calling it "column 100 of the
@@ -886,7 +904,7 @@ def test_a_failure_whose_statements_agree_everywhere_says_where_to_look():
     """
     assert 'text: "The selected columns differ."' in TEMPLATE
     # And when the same thing happens on a PASS there is nothing to say, so nothing is drawn.
-    assert "if (item.passed) return [];" in TEMPLATE
+    assert 'if (item.passed || item.status !== "scored" || (item.gates || []).length) return [];' in TEMPLATE
 
 
 def test_the_claims_are_drawn_as_a_table_with_plain_english_labels():

--- a/tests/test_render_golden_run.py
+++ b/tests/test_render_golden_run.py
@@ -932,6 +932,20 @@ def test_the_run_stamp_reads_as_a_date_somebody_would_say():
     assert "T11:47" not in stamp
 
 
+def test_the_run_stamp_is_converted_to_utc_before_labeling():
+    """A non-UTC aware datetime must be converted before it is labeled as UTC."""
+    import datetime
+
+    from render_golden_run import _run_stamp
+
+    eastern = datetime.datetime(
+        2026, 9, 6, 7, 47, 38, tzinfo=datetime.timezone(datetime.timedelta(hours=-4))
+    )
+    stamp = _run_stamp(eastern)
+
+    assert stamp == "6 September 2026 at 11:47 UTC"
+
+
 def test_a_bucket_with_nothing_in_it_is_not_given_a_tile():
     """Five tiles on every run put three zeroes beside the two numbers that matter.
 
@@ -1035,6 +1049,12 @@ def test_a_non_dict_score_reads_as_unscored_rather_than_throwing():
     payload = _payload(render(title="x", profile="demo", run=_run(items)))
     assert payload["items"][0]["reproduced"] is False
     assert payload["items"][0]["status"] == ""
+
+
+def test_an_unknown_status_is_not_rendered_as_a_row_difference():
+    """Only a scored item may claim row agreement or disagreement."""
+    assert 'if (item.status !== "scored") {' in TEMPLATE
+    assert "the scoring status was unknown" in TEMPLATE
 
 
 def test_a_run_that_omits_completed_is_not_banner_ed_as_stopped_partway():


### PR DESCRIPTION
Closes #263.

Found by reading the page against a real fifteen-case run. Every change is presentation over values the run already computed — the comparator, the claim reader and the contract are untouched.

The failure that motivated all of it rendered like this:

> Did not reproduce the answer key · accuracy 1.000 · the dataset requires a filter this statement does not write

A contradiction, a number that appears to disprove the sentence beside it, and no way to find out what actually went wrong short of diffing two SQL statements by eye.

## 1. The verdict was false on a gated item

`const verdict = item.passed ? … : "Did not reproduce the answer key"` — but `passed` goes false whenever a gate fires, including when the result sets are identical. That item reproduced its answer key perfectly, 6 of 6 rows.

Reproducing and passing are different questions — which is the whole reason structure gates separately from rows — so both now travel and the page says both: *"Reproduced the answer key, but did not answer the question asked."*

## 2. The accuracy leaves the page

Across a real fifteen-case run **every accuracy was exactly 1.0 or exactly 0.0**. That is structural: a row-count difference, an unpaired column and an extra column each short-circuit before an overlap is computed, and `match_columns` pairs only on equal value vectors, so a column that is wrong anywhere does not pair at all. The one route to a value in between — every column carrying the right set of values while the rows do not line up — is real and rare.

And on exactly that occasion `_score_values` already writes the same fact in words: *"5 of the answer key's 15 rows matched."* So the number was redundant when it meant something and misleading the rest of the time.

This also dissolves the `1.000`-beside-a-failure defect rather than patching it. The existing guard capped a *rounded* near-miss at 0.999; nobody had considered a genuine 1.0 next to a gate, which is the normal shape of a `must_filter` catch.

The score is unchanged where it is computed and still decides the verdict.

> Worth recording for later: what a reader actually wants at 5-of-15 is *which ten rows differed*, and the report cannot show that — rows never reach a run result by design. The ratio was a proxy for something deliberately withheld. Changing that is a contract conversation about the no-rows rule, not a renderer change.

## 3. A gate names its column

The page printed one hardcoded string that named no column, so a reader was told *a* filter was missing and left to work out which. It was also written as though `must_filter` were the only gate; structure gates twice, and a differing date window rendered as a missing filter.

## 4. The page kept the claim that agrees and dropped the one that explains

The substantive one. The projection kept `claims[0]` — `tables` — and discarded the other six.

In a structural failure `tables` almost always **agrees**: both statements read the same table, which is why the comparison got far enough to gate on something else. So the page reliably showed the claim that says nothing, while this was computed, written to the JSON artifact beside the page, and never rendered:

```
filter_predicates  DIFFERS
  generated:  gte(created, '2024-01-01'), lt(created, '2025-01-01')
  answer key: gte(opened, '2024-01-01'), lt(opened, '2025-01-01')
```

That is the whole diagnosis, readable without looking at any SQL.

Two shapes needed handling on the way, and both came from the real run rather than from imagination: a resolved date window is an **object**, not a list, and the page called `Array.join` on these — so an object would have thrown and left the report blank. It is flattened to `created in [2024-01-01, 2025-01-01)`, half-open because that is the point of resolving one. And `ordering` writes **pairs** (`[["incident_count", "desc"]]`), which the old coercion dropped as "nested", rendering the claim that most often differs as `generated none · answer key none`.

## 5 and 6. Timestamp and tiles

`2026-09-06T11:47:38+00:00` is a sortable key; the page has no second place where it is a key. It now reads `6 September 2026 at 11:47 UTC`.

The header always drew five tiles, three of them zero on a healthy run. Now: Cases, Passed, Failed always; "Not compared" and "Couldn't run" only when non-zero, with a sentence when they appear.

**They are deliberately not merged into "failed."** This project's own first run came back `3 errored, 0 failed`, which under a three-bucket summary reads as green when in fact the generator was broken and nothing had run — exactly the distinction the `1` / `2` exit codes exist to make. Same for unscored: both sides returning no rows is not agreement.

## Plus: filter by outcome

A corpus-sized run is hundreds of cases and was a flat scroll. Display only — sections are hidden, nothing is recounted or re-sorted, so the tiles and section headings keep describing the whole run. The control does not appear when there is nothing to choose between.

## Tests

`tests/test_render_golden_run.py` goes from 37 to 40. Several existing tests pinned the old behaviour and were rewritten rather than deleted — including `test_a_gated_item_shows_a_perfect_score_beside_a_failing_verdict`, which asserted the confusing output as intended, and the two accuracy-rounding tests whose subject no longer reaches the page.

Full `dev.py check` green: 5464 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)