### PR TITLE
An answer key is checked against the profile's own examples before it is written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Changed
+
+- **A reconcile run now teaches as well as tests.** Its only write was promoting agreeing rows to a
+  golden dataset. Nothing went to the curated example library — the one path there was the referral
+  to `agami-save-correction` when a number *disagreed*. So a run that proved twelve statements
+  correct against the customer's own dashboard taught agami nothing from any of them, while an
+  argument taught it something.
+
+  Agreeing rows are now split between the two. They cannot go to both: an item that is also an
+  example ranks first for its own question, the model reproduces it, and the test can only ever
+  pass. They came from one dashboard, so they are the same family of question, which is exactly what
+  makes holding some back meaningful.
+
+  **The product does the splitting.** Which rows should teach depends on what the example library
+  already covers, and asking a user that is asking them to guess at a library they have never
+  opened. `sm examples --query` already answers it: its `high_confidence` flag is the product's own
+  judgement of "we have a close example for this", so a row it does not cover teaches and a row it
+  does becomes a test. Below four agreeing rows nothing is split, and a profile with an empty
+  library teaches with at least half.
+
+  **The user still makes one decision, and it is not the split** — one yes for the batch, with the
+  breakdown shown. Saying what went where is mandatory rather than decorative: adding examples
+  changes how agami answers future questions, and that must not happen silently behind a button
+  that says "keep these numbers".
+
+  A promoted row passes `--confirm-convention` to the save door. The statement being saved is the
+  one agami generated *from* those examples minutes earlier, so the convention check would ask the
+  person to confirm a departure they never made.
+
 ## [0.8.0] — 2026-09-05
 
 One change: the server decides which tool calls belong to one conversation, instead of asking the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,15 @@ below corresponds to one such version.
   depart from convention, and that is sometimes exactly why one is written.
 
   Only three claims can stop a save — the tables read, the filters written, the resolved date window
-  — because those are the ones that change which rows are counted. And the check is total: no model,
-  no CLI, a profile mid-rebuild, all return no opinion rather than blocking a correct answer from
-  being written down.
+  — because those are the ones that change which rows are counted. A save only stops when the CLI
+  itself reports `high_confidence`, so a library that does not cover the question has no opinion to
+  hold anyone to. And the check is total: no model, no CLI, a profile mid-rebuild, all return no
+  opinion rather than blocking a correct answer from being written down, and the whole check is
+  bounded by one wall-clock budget rather than a timeout per subject area.
+
+  `agami-reconcile` is taught the second meaning of exit `1` in the same change, since a promotion
+  that met it and answered with `--confirm-replace` would loop on a payload with no before and
+  after to render.
 
 - **`/agami-eval` says what a pass rate is not.** A run scores a generator with every tool switched
   off and one attempt, because that isolation is what keeps it from reading the answer key. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Added
+
+- **Saving a golden item checks it against the profile's own examples first.** The curated example
+  library is where a team's conventions live — which of two equally correct date columns they answer
+  with, how they phrase a join — and it is what agami reads when it answers a question for real.
+  Nothing in the write path had ever looked at it, so an answer key could contradict the convention
+  and then fail every future run while blaming the model.
+
+  That is measured rather than imagined. On the first real dataset authored against a live
+  warehouse, nine of fifteen items failed and six were one mistake: the keys filtered on one
+  timestamp column where that profile's examples used another, 24 times out of 36.
+
+  The save door now ranks the nearest example for the question, reads both statements, and stops
+  with exit `1` and a `needs_confirmation_convention` payload when they disagree — before writing,
+  because a warning that arrives after the key is on disk is a warning about a file somebody now has
+  to decide whether to undo. `--confirm-convention` writes it anyway: a golden item may legitimately
+  depart from convention, and that is sometimes exactly why one is written.
+
+  Only three claims can stop a save — the tables read, the filters written, the resolved date window
+  — because those are the ones that change which rows are counted. And the check is total: no model,
+  no CLI, a profile mid-rebuild, all return no opinion rather than blocking a correct answer from
+  being written down.
+
+- **`/agami-eval` says what a pass rate is not.** A run scores a generator with every tool switched
+  off and one attempt, because that isolation is what keeps it from reading the answer key. The
+  agent that answers the same question in production has four tools and can iterate. A dataset is
+  also deliberately not a random sample. So a run measures regression, and quoting its pass rate as
+  agami's accuracy is wrong in both directions.
+
 ## [0.8.0] — 2026-09-05
 
 One change: the server decides which tool calls belong to one conversation, instead of asking the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ below corresponds to one such version.
   already covers, and asking a user that is asking them to guess at a library they have never
   opened. `sm examples --query` already answers it: its `high_confidence` flag is the product's own
   judgement of "we have a close example for this", so a row it does not cover teaches and a row it
-  does becomes a test. Below four agreeing rows nothing is split, and a profile with an empty
-  library teaches with at least half.
+  does becomes a test. Below four agreeing rows nothing is split, and never more than half the
+  batch is sent to the examples so onboarding runs still write tests.
 
   **The user still makes one decision, and it is not the split** — one yes for the batch, with the
   breakdown shown. Saying what went where is mandatory rather than decorative: adding examples

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -95,6 +95,22 @@ except ImportError as exc:
 # about itself.
 _PREFIX = "agami-save-golden:"
 
+# The semantic-model CLI, beside this script in every layout the plugin ships in. Shelled out to
+# rather than called in-process for the reason `run_golden_eval` gives: `agami-query` reaches the
+# ranker THROUGH this CLI, and an in-process call would be a second route to the same library.
+_SM = Path(__file__).resolve().parent / "sm"
+
+# How many curated examples the convention check reads per subject area. One is enough: the check
+# asks whether this statement departs from the way the team already answers questions like it, and
+# the nearest example is the answer to that. More would be a survey.
+_CONVENTION_TOP_K = 1
+
+# Which claims a divergence from convention is reported for. Deliberately not all seven: two
+# statements answering one question legitimately differ in ordering, limit and grouping, and
+# reporting those would make the check noise a person learns to click through. These three are the
+# ones that change WHICH ROWS are counted, which is what an answer key is for.
+_CONVENTION_CLAIMS = ("tables", "filter_predicates", "date_window")
+
 # What an exit code means. `_NEEDS_CONFIRMATION` belongs to the write door: a change the person has
 # not agreed to yet is neither a success nor a breakage, and a pipeline that treats it as either
 # would be wrong in both directions.
@@ -644,12 +660,122 @@ def _import(
     )
 
 
+def _nearest_example(profile: str, question: str) -> Optional[dict]:
+    """The curated example nearest this question, across every subject area, or None.
+
+    `sm examples --query` is the product's own ranker and the one `agami-query` reaches through, so
+    the example this returns is the one the generator would most likely be shown when the question
+    is asked for real. Every area is ranked and the best kept, because the CLI reads one library at
+    a time and a save is not told which area a question belongs to.
+
+    Total by construction. Every failure here — no model, no CLI, a profile mid-rebuild — returns
+    None, because this check exists to inform a write and must never be the reason one cannot
+    happen.
+    """
+    root = agami_paths.profile_dir(profile)
+    try:
+        areas = _sm_json("areas", str(root))
+        if not isinstance(areas, list):
+            return None
+        best: tuple[float, dict] = (0.0, {})
+        for area in areas:
+            name = (area or {}).get("name") if isinstance(area, dict) else None
+            if not name:
+                continue
+            ranked = _sm_json(
+                "examples", str(root), "--area", str(name),
+                "--query", question, "--top-k", str(_CONVENTION_TOP_K),
+            )
+            for match in (ranked or {}).get("matches") or []:
+                score = match.get("score") or 0.0
+                if score > best[0] and (match.get("example") or {}).get("sql"):
+                    best = (score, match["example"])
+        return best[1] or None
+    except Exception:
+        return None
+
+
+def _sm_json(*args: str) -> Any:
+    """One semantic-model CLI command, or None if it did not answer with JSON."""
+    import subprocess
+
+    done = subprocess.run(
+        ["bash", str(_SM), *args], capture_output=True, text=True, check=False, timeout=120
+    )
+    if done.returncode != 0:
+        return None
+    try:
+        return json.loads(done.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _dialect(profile: str) -> str:
+    """The profile's own engine, or the generic grammar when it cannot be resolved.
+
+    Falling back rather than giving up, because the alternative is worse than a slightly less
+    precise parse: resolving the dialect needs the whole model to load, and a profile mid-rebuild
+    would silently switch this check OFF at exactly the moment somebody is authoring against it.
+    Both statements are parsed the same way either way, which is what the comparison needs.
+    """
+    try:
+        from semantic_model import loader
+        from semantic_model.sql_dialect import resolve_datasource_dialect
+
+        return resolve_datasource_dialect(loader.load_datasource(agami_paths.profile_dir(profile)))
+    except Exception:
+        return ""
+
+
+def _convention_divergence(profile: str, question: str, sql: str) -> Optional[dict]:
+    """How this statement departs from the way the team already answers questions like it.
+
+    The gap this closes was measured rather than imagined. On the first real dataset authored
+    against a live warehouse, fifteen items were written and nine failed — six of them one mistake:
+    the answer keys filtered on one timestamp column where that profile's own examples used another,
+    24 times out of 36. The generator read those examples, followed the convention, and was marked
+    wrong six times by a key that had never looked at them. Nothing in the write path had.
+
+    Reported and never enforced. A golden item may legitimately depart from convention — that is
+    sometimes exactly why one is written — so this returns what differs and the caller asks. And it
+    is total for the same reason `_nearest_example` is: a check that could refuse a save would be a
+    new way to fail to write down a correct answer.
+    """
+    try:
+        example = _nearest_example(profile, question)
+    except Exception:
+        return None
+    if not example:
+        return None
+    try:
+        from semantic_model.golden_claims import compare_statements
+
+        diff = compare_statements(sql, str(example["sql"]), dialect=_dialect(profile))
+        claims = diff.as_dict().get("claims") or []
+    except Exception:
+        return None
+
+    differing = [
+        claim
+        for claim in claims
+        if claim.get("name") in _CONVENTION_CLAIMS and claim.get("status") == "differs"
+    ]
+    if not differing:
+        return None
+    return {
+        "example_question": str(example.get("question") or ""),
+        "example_sql": str(example["sql"]),
+        "claims": differing,
+    }
+
+
 def _save(
     profile: str,
     stem: str,
     item_path: str,
     *,
     confirm_replace: bool,
+    confirm_convention: bool,
     description: Optional[str],
 ) -> int:
     """Write one answer somebody looked at and accepted.
@@ -698,6 +824,25 @@ def _save(
     for key in ("match", "bounds", "must_filter"):
         if payload.get(key):
             fields[key] = payload[key]
+
+    # Before the write and not after it. A warning that arrives once the answer key is on disk is a
+    # warning about a file the reader now has to decide whether to undo, and the append-only rule
+    # makes undoing it a second confirmation. This is the only door it runs on: an import writes no
+    # statement, and curation may not write one.
+    if not confirm_convention:
+        divergence = _convention_divergence(profile, payload["query"], payload["sql"])
+        if divergence:
+            print(
+                json.dumps(
+                    {
+                        "dataset": stem,
+                        "added": [],
+                        "needs_confirmation_convention": divergence,
+                    },
+                    indent=2,
+                )
+            )
+            return _NEEDS_CONFIRMATION
 
     return _write_items(
         profile,
@@ -858,6 +1003,7 @@ def _dispatch(args: argparse.Namespace) -> int:
             args.dataset,
             args.item,
             confirm_replace=args.confirm_replace,
+            confirm_convention=args.confirm_convention,
             description=args.description,
         )
 
@@ -883,6 +1029,11 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     save_cmd = sub.add_parser("save", help="Write one confirmed answer, statement and receipt.")
     save_cmd.add_argument("--item", required=True, help="the accepted answer, as JSON")
+    save_cmd.add_argument(
+        "--confirm-convention",
+        action="store_true",
+        help="write it even though it departs from the profile's own examples",
+    )
     _add_write_args(save_cmd)
 
     apply_cmd = sub.add_parser("apply", help="Apply the explorer page's queued actions.")

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -105,6 +105,13 @@ _SM = Path(__file__).resolve().parent / "sm"
 # the nearest example is the answer to that. More would be a survey.
 _CONVENTION_TOP_K = 1
 
+# One wall-clock bound for the WHOLE check, not per call. The ranking runs one `sm` invocation per
+# subject area, and each of those resolves an interpreter and may shell out to `pip install` on a
+# miss — so a per-call timeout multiplies by the number of areas and a save door can sit silently
+# for minutes before deciding it has no opinion. A few seconds is the right order for something
+# advisory standing between a person and a write they have already decided on.
+_CONVENTION_BUDGET_S = 8.0
+
 # Which claims a divergence from convention is reported for. Deliberately not all seven: two
 # statements answering one question legitimately differ in ordering, limit and grouping, and
 # reporting those would make the check noise a person learns to click through. These three are the
@@ -668,39 +675,61 @@ def _nearest_example(profile: str, question: str) -> Optional[dict]:
     is asked for real. Every area is ranked and the best kept, because the CLI reads one library at
     a time and a save is not told which area a question belongs to.
 
-    Total by construction. Every failure here — no model, no CLI, a profile mid-rebuild — returns
-    None, because this check exists to inform a write and must never be the reason one cannot
-    happen.
+    Allowed to raise. `_convention_divergence` is the single place that turns any failure here — no
+    model, no CLI, a profile mid-rebuild — into "no opinion", because this check exists to inform a
+    write and must never be the reason one cannot happen. Two guards would mean the outer one was
+    unreachable and the test aiming at it was testing nothing.
     """
+    import time
+
+    deadline = time.monotonic() + _CONVENTION_BUDGET_S
     root = agami_paths.profile_dir(profile)
-    try:
-        areas = _sm_json("areas", str(root))
-        if not isinstance(areas, list):
-            return None
-        best: tuple[float, dict] = (0.0, {})
-        for area in areas:
-            name = (area or {}).get("name") if isinstance(area, dict) else None
-            if not name:
-                continue
-            ranked = _sm_json(
-                "examples", str(root), "--area", str(name),
-                "--query", question, "--top-k", str(_CONVENTION_TOP_K),
-            )
-            for match in (ranked or {}).get("matches") or []:
-                score = match.get("score") or 0.0
-                if score > best[0] and (match.get("example") or {}).get("sql"):
-                    best = (score, match["example"])
-        return best[1] or None
-    except Exception:
+    areas = _sm_json("areas", str(root), timeout_s=_CONVENTION_BUDGET_S)
+    if not isinstance(areas, list):
         return None
+    best: tuple[float, dict] = (0.0, {})
+    for area in areas:
+        name = (area or {}).get("name") if isinstance(area, dict) else None
+        if not name:
+            continue
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            # Out of budget with areas left to rank. Whatever was found so far still stands — a
+            # partial ranking can only under-report a departure, never invent one.
+            break
+        ranked = _sm_json(
+            "examples", str(root), "--area", str(name),
+            "--query", question, "--top-k", str(_CONVENTION_TOP_K),
+            timeout_s=remaining,
+        )
+        # `high_confidence` is the CLI's own answer to "does this library cover this question",
+        # computed from the same threshold `agami-query` trusts. Without it this check has no
+        # relevance floor at all: the ranker scores EVERY example and returns its top-k
+        # unconditionally, so an unrelated question comes back as the winner — measured at 0.606
+        # for two questions sharing nothing but their shape. `tables` is one of the claims that can
+        # stop a save, and an unrelated example differs on tables essentially always, so every save
+        # on a profile without a near-identical curated question would stop and ask the author to
+        # confirm a departure from a question they were not answering.
+        if not (ranked or {}).get("high_confidence"):
+            continue
+        for match in (ranked or {}).get("matches") or []:
+            score = match.get("score") or 0.0
+            if score > best[0] and (match.get("example") or {}).get("sql"):
+                best = (score, match["example"])
+    return best[1] or None
 
 
-def _sm_json(*args: str) -> Any:
-    """One semantic-model CLI command, or None if it did not answer with JSON."""
+def _sm_json(*args: str, timeout_s: float) -> Any:
+    """One semantic-model CLI command, or None if it did not answer with JSON in time.
+
+    The question reaches the child as one element of an argv LIST — never a shell string — so a
+    label carrying a quote, a backtick or a `$(…)` is one argument rather than something the shell
+    reads. `sm` itself passes `"$@"` through with no `eval`.
+    """
     import subprocess
 
     done = subprocess.run(
-        ["bash", str(_SM), *args], capture_output=True, text=True, check=False, timeout=120
+        ["bash", str(_SM), *args], capture_output=True, text=True, check=False, timeout=timeout_s
     )
     if done.returncode != 0:
         return None

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -728,9 +728,17 @@ def _sm_json(*args: str, timeout_s: float) -> Any:
     """
     import subprocess
 
-    done = subprocess.run(
-        ["bash", str(_SM), *args], capture_output=True, text=True, check=False, timeout=timeout_s
-    )
+    try:
+        done = subprocess.run(
+            ["bash", str(_SM), *args], capture_output=True, text=True, check=False,
+            timeout=max(timeout_s, 0.1),
+        )
+    except subprocess.TimeoutExpired:
+        # `subprocess.run` RAISES on a timeout rather than returning, so without this the one
+        # outcome the budget exists to produce would leave through a different door than every
+        # other failure — skipping the partial-ranking path below and making this function's own
+        # contract false.
+        return None
     if done.returncode != 0:
         return None
     try:
@@ -754,6 +762,22 @@ def _dialect(profile: str) -> str:
         return resolve_datasource_dialect(loader.load_datasource(agami_paths.profile_dir(profile)))
     except Exception:
         return ""
+
+
+def _existing_item(profile: str, stem: str, item_id: str) -> Optional[GoldenItem]:
+    """The item this save would replace, or None if it would add one.
+
+    Read here as well as in `_write_items` because the convention stop happens BEFORE the write,
+    and a caller sent away with only half the questions comes back to the other half.
+    """
+    try:
+        datasets, _ = load_golden_datasets(profile)
+    except Exception:
+        return None
+    found = next((dataset for dataset in datasets if dataset.name == stem), None)
+    if found is None:
+        return None
+    return next((item for item in found.test_cases if item.id == item_id), None)
 
 
 def _convention_divergence(profile: str, question: str, sql: str) -> Optional[dict]:
@@ -858,25 +882,33 @@ def _save(
     # warning about a file the reader now has to decide whether to undo, and the append-only rule
     # makes undoing it a second confirmation. This is the only door it runs on: an import writes no
     # statement, and curation may not write one.
+    item = GoldenItem(**fields)
     if not confirm_convention:
         divergence = _convention_divergence(profile, payload["query"], payload["sql"])
         if divergence:
-            print(
-                json.dumps(
-                    {
-                        "dataset": stem,
-                        "added": [],
-                        "needs_confirmation_convention": divergence,
-                    },
-                    indent=2,
-                )
-            )
+            payload_out: dict[str, Any] = {
+                "dataset": stem,
+                "added": [],
+                "needs_confirmation_convention": divergence,
+            }
+            # Both questions in one payload when both apply, so they can be asked together and
+            # answered with both flags. Emitting only this one sent a caller round a loop: they
+            # answer the departure, `_write_items` then asks about the replacement, they answer
+            # THAT with `--confirm-replace` alone, and the departure is asked again. The skill's
+            # own exit-code table already promised a payload could carry more than one key; this
+            # is the code catching up with it.
+            existing = _existing_item(profile, stem, item.id)
+            if existing is not None:
+                payload_out["needs_confirmation"] = [
+                    {"id": item.id, "before": _item_doc(existing), "after": _item_doc(item)}
+                ]
+            print(json.dumps(payload_out, indent=2))
             return _NEEDS_CONFIRMATION
 
     return _write_items(
         profile,
         stem,
-        [GoldenItem(**fields)],
+        [item],
         confirm_replace=confirm_replace,
         description=description,
     )

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -728,9 +728,16 @@ def _sm_json(*args: str, timeout_s: float) -> Any:
     """
     import subprocess
 
-    done = subprocess.run(
-        ["bash", str(_SM), *args], capture_output=True, text=True, check=False, timeout=timeout_s
-    )
+    try:
+        done = subprocess.run(
+            ["bash", str(_SM), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     if done.returncode != 0:
         return None
     try:
@@ -861,15 +868,40 @@ def _save(
     if not confirm_convention:
         divergence = _convention_divergence(profile, payload["query"], payload["sql"])
         if divergence:
+            stop = {
+                "dataset": stem,
+                "added": [],
+                "needs_confirmation_convention": divergence,
+            }
+            if not confirm_replace:
+                path = _datasets_dir(profile) / f"{stem}.yaml"
+                if path.exists():
+                    datasets, res = load_golden_datasets(profile)
+                    if not _our_faults(res, stem):
+                        found = next((dataset for dataset in datasets if dataset.name == stem), None)
+                        existing = (
+                            next(
+                                (
+                                    item
+                                    for item in found.test_cases
+                                    if item.id == fields["id"]
+                                ),
+                                None,
+                            )
+                            if found is not None
+                            else None
+                        )
+                        if existing is not None:
+                            stop["path"] = str(path)
+                            stop["needs_confirmation"] = [
+                                {
+                                    "id": fields["id"],
+                                    "before": _item_doc(existing),
+                                    "after": _item_doc(GoldenItem(**fields)),
+                                }
+                            ]
             print(
-                json.dumps(
-                    {
-                        "dataset": stem,
-                        "added": [],
-                        "needs_confirmation_convention": divergence,
-                    },
-                    indent=2,
-                )
+                json.dumps(stop, indent=2)
             )
             return _NEEDS_CONFIRMATION
 

--- a/plugins/agami/skills/agami-eval/SKILL.md
+++ b/plugins/agami/skills/agami-eval/SKILL.md
@@ -175,6 +175,16 @@ End the turn.
 
 ---
 
+## What a pass rate is, and is not
+
+**A run measures regression, not accuracy.** Say so if anyone asks "how accurate is agami?" and reaches for this number.
+
+Two reasons, and both are structural rather than fixable here. The generator in a run is handed the question and the model's context in one prompt, with **every tool switched off** and one attempt to answer — that isolation is what stops it reading the answer key, and it is the whole reason a score means anything. An agent answering the same question for real has `get_datasource_schema`, `get_prompt_examples`, `execute_sql` and `list_datasources`, and can look something up, try a statement and refine it. So a run scores a strictly weaker generator than the one that ships, and an item can fail here that production would get right on its second look.
+
+And a golden dataset is not a random sample. It is the questions somebody would be embarrassed to get wrong, which is exactly what makes it useful and exactly what makes its pass rate unrepresentative. "12 of 15 passed" means *those twelve still work*. It does not mean 80%.
+
+---
+
 ## Hard rules
 
 1. **Never paste SQL in chat.** The script prints no statement, and the artifact is a path you hand over, not a source to quote — **do not read it out of the artifact** to show the user what the model wrote. They open the file.

--- a/plugins/agami/skills/agami-reconcile/SKILL.md
+++ b/plugins/agami/skills/agami-reconcile/SKILL.md
@@ -221,7 +221,7 @@ bash "$AGAMI_PLUGIN_ROOT/scripts/sm" examples "$ROOT" --area <area> --query "<th
 Two adjustments, and both are about not splitting something too small to split:
 
 - **Fewer than four agreeing rows → all of them become golden items.** A split of three leaves too little on either side to be worth the explanation.
-- **An empty example library → teach with at least half.** A profile with nothing curated needs teaching more than gating, and every row will read as novel anyway.
+- **Never send more than half the batch to the examples.** This is a cap, not a preference, and it is the rule that makes the split survive an empty library: with nothing curated, every row reads as novel and the base rule would teach with all of them, leaving the golden dataset empty. That is exactly the profile reconcile is aimed at, and an onboarding run that writes no test at all has failed at the thing it was asked to do. When the cap bites, keep the highest-scoring rows as examples and the rest as tests.
 
 **Make the offer once, here, after the summary. Never per row.** A per-row prompt turns a twelve-number reconcile into twelve interruptions and buries the mismatches, which are the point of the run.
 

--- a/plugins/agami/skills/agami-reconcile/SKILL.md
+++ b/plugins/agami/skills/agami-reconcile/SKILL.md
@@ -288,6 +288,8 @@ The method line is what somebody consults a year later to find out where this it
 
 #### If the item already exists
 
+**Read which payload the `1` carries before you answer it — there are two, and the wrong flag clears neither.** A `needs_confirmation_convention` payload means the statement departs from the profile's own curated examples; on a promotion that is expected and not interesting, because the statement being saved is the one agami generated *from* those examples minutes ago. Pass `--confirm-convention` for it. Everything below is the other payload.
+
 Exit `1`, a `needs_confirmation` payload, and **nothing written**. Render the `before` AND the `after` for every id — the item on disk and the one that would take its place — ask, and only on an explicit yes re-run the **same command with `--confirm-replace` appended**. **Never pass `--confirm-replace` pre-emptively**: the flag means one thing, that a person saw both sides and said yes, and passing it before that has happened makes the stop decorative.
 
 A replacement is wholesale — the item sent is the item written — so read the `before` and carry forward whatever it holds that still applies (its `tags`, a `must_filter`) into the item JSON before you re-run. On a no, say the file is untouched and stop.
@@ -328,6 +330,7 @@ End the turn. The user typically:
 | User says "reconcile my dashboard" but attaches nothing | Ask for the screenshot (or CSV / pasted numbers) per Phase 0.4 — don't proceed without the expected numbers. |
 | A promotion exits `0` | Written. Report `added` / `replaced` and the path, and say the dataset can be run with "run the evals". |
 | A promotion exits `1` with `needs_confirmation` | Nothing was written. Render the `before` and the `after` for every id, carry forward the `tags` / `must_filter` the `before` holds, ask, and re-run with `--confirm-replace` only on an explicit yes. On a no, the file is untouched. |
+| A promotion exits `1` with `needs_confirmation_convention` | The statement departs from the profile's own examples. On a promotion this is expected — the statement is the one agami generated from those examples — so re-run with `--confirm-convention`. Do not render it as a decision for the user; it is a decision this skill has already made. |
 | A promotion exits `2` | Cannot start. The `agami-save-golden:` line on stderr names the cause. Nothing was written; a rolled-back write left the previous bytes exactly as they were. |
 | A promotion exits `2` saying the question moves with time and the answer key doesn't | **Rename the question, don't re-anchor the statement.** Ask which window it meant, rewrite the question to name it ("…in August 2026"), and re-run with the SQL exactly as it ran. Anchoring the SQL to `CURRENT_DATE` clears the lint and bands a sliding window around one day's value — a false alarm at the next run. |
 

--- a/plugins/agami/skills/agami-reconcile/SKILL.md
+++ b/plugins/agami/skills/agami-reconcile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agami-reconcile
 description: "Reconciles known (label, expected_value) numbers from an existing dashboard against agami's answers. Input can be a SCREENSHOT of a Metabase / Power BI / Tableau / Looker dashboard (Claude's vision extracts the pairs), a CSV, or numbers pasted inline — the user doesn't need to know which; they can just ask. For each pair, the skill generates a matching NL question, runs it through the active profile's semantic model, diffs actual vs expected, and surfaces matches in green and mismatches in red with drill-down receipts. The strongest onboarding demo for a skeptical data engineer — either we agree with their numbers (trust earned via evidence) or we surface a real definitional disagreement (trust earned via transparency)."
-when_to_use: "Use when the user says 'reconcile against this dashboard', 'do these numbers match?', 'validate against my Tableau export', '/agami-reconcile <csv>', drops a screenshot of a BI dashboard (Metabase/Power BI/Tableau/Looker/spreadsheet) and asks agami to reproduce the numbers, or pastes a CSV / table of known numbers. Also use after a run, when the user says 'keep these as golden questions' or 'promote these to a golden dataset' — the rows that agreed become an answer key later runs are scored against. Requires agami-connect to have been run first (need a semantic model + examples library). A high-leverage validation surface for a skeptical data team — reproduce their dashboard numbers, or surface the definitional gap."
+when_to_use: "Use when the user says 'reconcile against this dashboard', 'do these numbers match?', 'validate against my Tableau export', '/agami-reconcile <csv>', drops a screenshot of a BI dashboard (Metabase/Power BI/Tableau/Looker/spreadsheet) and asks agami to reproduce the numbers, or pastes a CSV / table of known numbers. Also use after a run, when the user says 'keep these as golden questions' or 'promote these to a golden dataset' — the rows that agreed are split between the examples agami reads when answering and the answer key later runs are scored against. Requires agami-connect to have been run first (need a semantic model + examples library). A high-leverage validation surface for a skeptical data team — reproduce their dashboard numbers, or surface the definitional gap."
 argument-hint: "<screenshot | path-to-csv | pasted numbers>"
 ---
 
@@ -198,11 +198,41 @@ Don't dump every match's drill-down — they're not interesting. The matches bui
 
 ### 3e — Offer promotion
 
-The rows that agreed are the most reusable thing this run produced: a question, the statement that answered it, and a number the user's own dashboard already vouches for. That is what a golden dataset is made of — the answer key `/agami-eval` replays later to catch a regression — so offer to keep them.
+The rows that agreed are the most reusable thing this run produced: a question, the statement that answered it, and a number the user's own dashboard already vouches for. Nothing else in the product carries evidence from outside agami. So keep them — and keep them in **both** of the places they are worth keeping.
+
+**They are worth two different things, and one row cannot be both.**
+
+- A **golden item** tests the model: a later run tells you if that number drifts.
+- A **prompt example** teaches it: questions like it get answered this way from now on.
+
+A row written to both is a test grading its own study material — the example ranks first for its own question, the model reproduces it, and the item can only ever pass. So the batch is split rather than duplicated. They came from one dashboard, so they are the same family of question, which is exactly what makes holding some back meaningful.
+
+**You do the splitting, not the user.** Which rows should teach depends on what the example library already covers, which is not something anybody can answer without reading it. `sm examples --query` already answers it, and its `high_confidence` flag is the product's own judgement of "we have a close example for this".
+
+For each agreeing row, rank its question across the areas:
+
+```bash
+bash "$AGAMI_PLUGIN_ROOT/scripts/sm" examples "$ROOT" --area <area> --query "<the row's question>" --top-k 1
+```
+
+- **`high_confidence: false`** → the library does not cover this shape. **Teach with it** — it goes to the examples.
+- **`high_confidence: true`** → already covered, so another example adds nothing. **Test with it** — it goes to the golden dataset.
+
+Two adjustments, and both are about not splitting something too small to split:
+
+- **Fewer than four agreeing rows → all of them become golden items.** A split of three leaves too little on either side to be worth the explanation.
+- **An empty example library → teach with at least half.** A profile with nothing curated needs teaching more than gating, and every row will read as novel anyway.
 
 **Make the offer once, here, after the summary. Never per row.** A per-row prompt turns a twelve-number reconcile into twelve interruptions and buries the mismatches, which are the point of the run.
 
-> Ten of these agreed. Want to keep them as golden questions? I'll write each one with the statement that produced it and a ±<the run's tolerance> band around the number, so a later run tells you if any of them drifts.
+**Say what goes where. This is not optional.** Writing to the examples changes how agami answers future questions, and that must not happen silently behind a button that says "keep these numbers". One line, in what it does for them:
+
+> Ten of these agreed — I'll keep all ten.
+> **Four as examples**, so questions like them get answered this way from now on.
+> **Six as tests**, with a ±<the run's tolerance> band, so you're told if any of those numbers move.
+> Save all ten?
+
+Someone who presses enter without reading gets the right outcome; someone who reads it learns the distinction by watching it happen, which is the only way anybody will. The override is one line — "let me choose" — and not twelve prompts.
 
 **Only rows whose `status` is `match` are offered.** That is the run's own tolerance — `reconcile.diff` decided it back in Phase 2c, and it is the only notion of agreement this skill has, so nothing here re-judges a number. One predicate drops `mismatch` and `error` together, and with them the `missing_expected` and `missing_actual` rows — those are `reconcile.diff`'s own reasons rather than a row status, and a row that could not be diffed never reached `match` either. **A row with no statement is never offered**: an error row carries `sql: null` (Phase 2d), so there is nothing to replay and nothing worth promoting.
 
@@ -229,7 +259,7 @@ So the offer edits the **question**, with the person's answer to "which window?"
 
 **Ask which window it means in the offer, before anything is written** — not after the refusal lands. A batch is written one row at a time (below), so a refusal on the seventh row arrives with six items already on disk: **items already written stay written, and nothing is rolled back**. The cheat sheet's exit-`2` row is the fallback for a question that slips through, not the plan.
 
-#### What gets written, per kept row
+#### What gets written, per row kept as a test
 
 Write the item with the **Write tool** — never a heredoc, never `python3 -c`, per [`shared/invocation-conventions.md`](../../shared/invocation-conventions.md) — to `/tmp/agami-golden-item-<ts>.json`:
 
@@ -269,6 +299,28 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
 `<stem>` is the dataset's **filename stem** — one plain name (`reconciled`), never a path and never `reconciled.yaml`. Ask which dataset once, for the whole batch.
 
 **One call per kept row.** The door takes one item, not an array — ten kept rows are ten runs of that command, each with its own item file. The dataset is asked once; the writing is a loop.
+
+**Pass `--confirm-convention` on a promoted row.** The save door checks a statement against the profile's own examples and stops when they disagree, which is right when somebody is authoring a key by hand. Here it is redundant and wrong: the statement being saved is the one agami itself generated *from* those examples minutes ago, and a stop would ask the person to confirm a convention they never departed from.
+
+#### What gets written, per row kept as an example
+
+Write the pair with the **Write tool** to `/tmp/agami-reconciled-example-<ts>.json` — a JSON **array**, one entry per row going to the examples:
+
+```json
+[{"question": "What was total revenue in Q3 2025?", "sql": "<the row's `sql`, verbatim>",
+  "tables": ["<from the row's statement>"], "source": "reconcile", "status": "confirmed",
+  "created_at": "<ISO8601 UTC>"}]
+```
+
+Then the packaged writer, which dedups by question and creates the library if it is absent:
+
+```bash
+bash "$AGAMI_PLUGIN_ROOT/scripts/sm" add-example "$ROOT" --area <area> --file /tmp/agami-reconciled-example-<ts>.json
+```
+
+`<area>` is the subject area whose tables the statement reads — the same choice `agami-save-correction` makes, and the same writer. **Do not hand-edit `examples.yaml`**, and do not invent a second way in.
+
+`status: "confirmed"` is honest here in a way it rarely is: the number was verified against a source outside agami. That is stronger evidence than the recollection behind most curated examples.
 
 #### `confirmed_by.method` — two shapes, kept apart
 
@@ -310,7 +362,7 @@ End the turn. The user typically:
 
 1. **No automatic question generation for ambiguous labels.** If the label is too short or too vague (e.g., `Total`, `Number`, `Value`), surface to the user: *"Row 5's label is just 'Total' — too ambiguous to translate to a question. Skipping. Add more context to the CSV (e.g., `Total Revenue Q3` instead of `Total`) and re-run."* Don't guess.
 2. **Receipt is non-optional.** Every per-row run MUST produce a chart-template HTML report with the trust receipt — that's what the drill-down link points at, and it's what makes mismatches actionable. If the underlying query path can't produce a receipt (legacy pre-trust-layer model), refuse with: *"This profile pre-dates the trust-layer launch. Re-run `/agami-connect` to enable receipts, then retry."*
-3. **Don't write to the semantic model from this skill.** Reconcile reads + diffs; it never mutates a metric, a join, a column or any other part of the model. If a definitional disagreement surfaces and the user wants to update the metric, route them through `/agami-save-correction`. **The one write this skill can make is Phase 3e's promotion, and it is not a model write:** a golden dataset is the answer key that *tests* the model, not the model itself. It goes through `golden_author.py save` — that door and nothing else, never a hand-edited YAML — by exactly two routes, with the person's yes in front of either: a row this run scored as agreeing, accepted through Phase 3e's offer, or a row it scored as a mismatch that the person has explicitly resolved in agami's favour.
+3. **Don't write to the semantic model from this skill.** Reconcile reads + diffs; it never mutates a metric, a join, a column or any other part of the model. If a definitional disagreement surfaces and the user wants to update the metric, route them through `/agami-save-correction`. **The writes this skill can make are Phase 3e's, and neither is a model write:** a golden dataset is the answer key that *tests* the model, and the prompt-example library is what the model *reads* — neither is the model's own definitions, and this skill still never touches a metric, a join, a column or a default filter. Both writes go through the packaged writers — `golden_author.py save` and `sm add-example`, those doors and nothing else, never a hand-edited YAML — and both need the person's yes in front of them. A row reaches either one by exactly two routes: this run scored it as agreeing, or it scored a mismatch that the person has explicitly resolved in agami's favour. **No row goes to both**, which is the whole reason Phase 3e splits the batch rather than duplicating it.
 4. **CSV stays local.** Don't upload, don't summarize-and-send. The reconcile run produces local artifacts (the per-query chart HTML, and `/tmp/agami-reconcile-results-*.jsonl`, which now carries the statement behind every row as well as its numbers) and nothing leaves the machine. A promoted row stays local too: the save door writes into the profile's own `golden_datasets/` directory on this machine.
 
 ---

--- a/plugins/agami/skills/agami-save-golden/SKILL.md
+++ b/plugins/agami/skills/agami-save-golden/SKILL.md
@@ -163,6 +163,16 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
   > /tmp/agami-golden-save-<ts>.json
 ```
 
+**A statement that departs from this profile's own examples stops here too**, with exit `1` and a `needs_confirmation_convention` payload. The library of curated examples is where a team's conventions live — which of two equally correct date columns they answer with, how they phrase a join — and it is what agami reads when it answers the question for real. An answer key that contradicts it will fail every future run and blame the model.
+
+The payload carries the nearest example's question and statement, and the claims that differ. **Show both statements and ask**, in one line:
+
+> Your examples for this kind of question filter on `created`; this one uses `opened`. Save it anyway?
+
+**It is a question and never a refusal.** A golden item may legitimately depart from convention — that is sometimes exactly why one is written. On an explicit yes, re-run the same command with `--confirm-convention` appended. On a no, nothing was written, and the fix is usually to the statement rather than to the dataset.
+
+Only three claims can stop a save this way — the tables read, the filters written, and the resolved date window — because those are the ones that change *which rows are counted*. Two statements answering one question differ in ordering and limit all the time, and stopping for those would make this a prompt people learn to click through.
+
 **A relative question over a frozen answer key is refused here**, with exit `2`: *"how many orders in the last 7 days?"* names a window that slides forward and SQL pinned to a fixed date does not. Either anchor the statement to the current date (`CURRENT_DATE - INTERVAL '7 days'`, the dialect's spelling) or rewrite the question to name the window it means (`…in Q1 2024?`), then re-invoke. Do not save it and plan to fix it later — the whole point of refusing at save time is that the one person who can still fix it is here.
 
 ---
@@ -211,7 +221,7 @@ Exit codes are Phase 4's, unchanged. On `1` the payload carries `needs_confirmat
 **Read the exit code before the payload.** Both write doors share it:
 
 - **`0`** — written. Report `added` / `replaced` and the path.
-- **`1`** — **needs confirmation.** Nothing was written. Not a failure and not a success; a pipeline that treated it as either would be wrong in both directions. **This is the only thing that produces `1`** — every other outcome, expected or not, is `2` with a sentence on stderr — so a `1` always carries a `needs_confirmation` payload and is never a crash. If you ever see `1` with no such payload, stop and report it rather than re-running with `--confirm-replace`.
+- **`1`** — **needs confirmation.** Nothing was written. Not a failure and not a success; a pipeline that treated it as either would be wrong in both directions. **This is the only thing that produces `1`** — every other outcome, expected or not, is `2` with a sentence on stderr — so a `1` always carries one of the two confirmation payloads (`needs_confirmation` for a replacement or removal, `needs_confirmation_convention` for a departure from the profile's examples) and is never a crash. If you ever see `1` with neither, stop and report it rather than re-running with a confirm flag.
 - **`2`** — cannot start. The stderr line (prefix `agami-save-golden:`) says why. Nothing was written, or a failed write was rolled back to the bytes that were there before.
 
 On `1`, the payload carries `needs_confirmation`: a list of `{id, before, after}`. **Render both sides** — a markdown table or two fenced blocks per id, the existing item and the one that would take its place. "This id already exists" is not enough for anyone to decide with: the thing being overwritten is an answer key, and they have to see what they would lose.

--- a/plugins/agami/skills/agami-save-golden/SKILL.md
+++ b/plugins/agami/skills/agami-save-golden/SKILL.md
@@ -221,10 +221,20 @@ Exit codes are Phase 4's, unchanged. On `1` the payload carries `needs_confirmat
 **Read the exit code before the payload.** Both write doors share it:
 
 - **`0`** — written. Report `added` / `replaced` and the path.
-- **`1`** — **needs confirmation.** Nothing was written. Not a failure and not a success; a pipeline that treated it as either would be wrong in both directions. **This is the only thing that produces `1`** — every other outcome, expected or not, is `2` with a sentence on stderr — so a `1` always carries one of the two confirmation payloads (`needs_confirmation` for a replacement or removal, `needs_confirmation_convention` for a departure from the profile's examples) and is never a crash. If you ever see `1` with neither, stop and report it rather than re-running with a confirm flag.
+- **`1`** — **needs confirmation.** Nothing was written. Not a failure and not a success; a pipeline that treated it as either would be wrong in both directions. **This is the only thing that produces `1`** — every other outcome, expected or not, is `2` with a sentence on stderr — so a `1` is never a crash.
+
+  **Read which key the payload carries before you answer it. There are three, and they take different flags:**
+
+  | Key | What it means | Clears with |
+  |---|---|---|
+  | `needs_confirmation` | A write would replace an item that already exists. Carries `{id, before, after}`. | `--confirm-replace` |
+  | `needs_confirmation_removals` | A queued action would delete an item. Carries `{id, before}` and no `after`. | `--confirm-replace` |
+  | `needs_confirmation_convention` | The statement departs from the profile's own examples. Carries the nearest example and the claims that differ. | `--confirm-convention` |
+
+  A payload may carry more than one — a replacement whose statement also departs needs both flags. If you ever see `1` with none of the three, stop and report it rather than re-running with a flag.
 - **`2`** — cannot start. The stderr line (prefix `agami-save-golden:`) says why. Nothing was written, or a failed write was rolled back to the bytes that were there before.
 
-On `1`, the payload carries `needs_confirmation`: a list of `{id, before, after}`. **Render both sides** — a markdown table or two fenced blocks per id, the existing item and the one that would take its place. "This id already exists" is not enough for anyone to decide with: the thing being overwritten is an answer key, and they have to see what they would lose.
+On a `needs_confirmation` payload — a list of `{id, before, after}` — **render both sides** — a markdown table or two fenced blocks per id, the existing item and the one that would take its place. "This id already exists" is not enough for anyone to decide with: the thing being overwritten is an answer key, and they have to see what they would lose.
 
 **A replacement is wholesale** — the item that is written is the item you sent, so anything the existing one carries and yours does not (its `tags`, a `must_filter`, a `match`) is gone. Read the `before` and carry forward what still applies before you ask; that is also what the user is agreeing to when they look at the two sides.
 
@@ -258,6 +268,8 @@ python3 "$AGAMI_PLUGIN_ROOT/scripts/golden_author.py" save \
 |---|---|
 | Exit `0` | Written. Report `added` / `replaced` and the path. After an import, say plainly that nothing can gate yet. |
 | Exit `1` with `needs_confirmation` | Nothing was written. Render the before and the after for every id, ask, and re-run with `--confirm-replace` only on an explicit yes. On a no, say the file is untouched and stop. |
+| Exit `1` with `needs_confirmation_removals` | Nothing was written. Render each removal's question and answer key — not its id — ask, and re-run with `--confirm-replace` on an explicit yes. |
+| Exit `1` with `needs_confirmation_convention` | Nothing was written. Show the nearest example's statement beside the one being saved, say which claims differ, and ask. On a yes re-run with `--confirm-convention`. On a no the fix is usually to the statement, not to the dataset. |
 | Exit `2` | Cannot start. Read the `agami-save-golden:` line on stderr — it names the cause. Nothing was written; a rolled-back write left the previous bytes exactly as they were. |
 | `agami-save-golden: this file is empty` / `no column here holds the question` / `this file has no header row` | The sheet's question column can't be identified. The refusal lists every header it read — quote it back, ask which column holds the question, and have them rename it (or add a header row) and re-invoke. Never guess at column 0: a bank of ids imported as questions fails every future run in a way that looks exactly like a model regression. |
 | `agami-save-golden: N row(s) were skipped` on a successful parse | A warning, not a stop. List every entry in `skipped` with its row number and reason before asking for the import — a question silently missing from a dataset is the failure this line exists to prevent. |

--- a/tests/test_ah111_reconcile_promotion_skill.py
+++ b/tests/test_ah111_reconcile_promotion_skill.py
@@ -126,7 +126,7 @@ def test_the_offer_carries_the_runs_own_tolerance_and_never_a_hardcoded_one():
     """The offer is told to pass the tolerance the run diffed with, so every literal in the section
     has to be that placeholder. A hardcoded ±1% in the sentence said out loud, in the provenance
     line or in the band command makes a `tolerance=5%` run offer a band it did not agree on."""
-    assert "±<the run's tolerance> band around the number" in OFFER
+    assert "±<the run's tolerance> band" in OFFER
     assert "agreed within ±<the run's tolerance>" in OFFER
     assert "--tolerance <the run's tolerance>" in OFFER
     assert "0.01" not in OFFER
@@ -276,13 +276,16 @@ def test_hard_rule_3_still_forbids_mutating_the_semantic_model():
     )[0]
     assert "never mutates a metric, a join, a column" in rule
     assert "/agami-save-correction" in rule
-    # …and the carve-out is exactly one door, with the person's yes in front of it. It names BOTH
+    # …and the carve-out is two doors now, with the person's yes in front of both. It names BOTH
     # routes: a hard rule is the most authoritative prose in a skill, so one that named only the
     # offer would have a model refuse the resolution write the rest of Phase 3e requires.
     assert "golden_author.py save" in rule
-    assert "with the person's yes in front of either" in rule
-    assert "a row this run scored as agreeing" in rule
+    assert "sm add-example" in rule
+    assert "both need the person's yes in front of them" in rule
+    assert "this run scored it as agreeing" in rule
     assert "resolved in agami's favour" in rule
+    # The split is what keeps a row out of both, and the hard rule is where that is unmissable.
+    assert "No row goes to both" in rule
 
 
 def test_the_roadmap_no_longer_promises_the_half_this_slice_shipped():
@@ -363,3 +366,68 @@ def test_phases_3a_to_3d_read_exactly_as_they_did():
         "Don't dump every match's drill-down — they're not interesting. The matches build the "
         "case; the mismatches drive the conversation." in SKILL
     )
+
+
+# --- The split (#265) ----------------------------------------------------------------------------
+#
+# A reconcile run proves statements correct against evidence from outside agami, and only half of
+# that value was kept: agreeing rows became tests and taught the model nothing. They cannot be both,
+# because an item that is also an example grades its own study material — so the batch is split.
+
+
+def test_the_agreeing_rows_are_split_between_teaching_and_testing():
+    """Both destinations, and the reason one row cannot be both."""
+    assert "**golden item** tests the model" in OFFER
+    assert "**prompt example** teaches it" in OFFER
+    assert "grading its own study material" in OFFER
+    assert "the batch is split rather than duplicated" in OFFER
+
+
+def test_the_product_does_the_splitting_and_not_the_user():
+    """Which rows should teach depends on what the example library already covers, which nobody can
+    answer without reading it. `high_confidence` is the product's own judgement of that, so the
+    split is a lookup rather than a question."""
+    assert "You do the splitting, not the user." in OFFER
+    assert "high_confidence" in OFFER
+    assert "sm" in OFFER and "--query" in OFFER
+    # Both directions are stated, or the rule is half a rule.
+    assert "`high_confidence: false`" in OFFER and "Teach with it" in OFFER
+    assert "`high_confidence: true`" in OFFER and "Test with it" in OFFER
+
+
+def test_a_batch_too_small_to_split_is_not_split():
+    """A split of three leaves too little on either side to be worth the explanation, and a profile
+    with nothing curated needs teaching more than gating."""
+    assert "Fewer than four agreeing rows" in OFFER
+    assert "An empty example library" in OFFER
+
+
+def test_the_user_makes_one_decision_and_it_is_not_the_split():
+    """A per-row prompt turns a twelve-number reconcile into twelve interruptions. The override
+    exists and is one line, not twelve."""
+    assert "Make the offer once, here, after the summary. Never per row." in OFFER
+    assert "Save all ten?" in OFFER
+    assert "let me choose" in OFFER
+
+
+def test_what_went_where_is_said_out_loud():
+    """Writing to the examples changes how agami answers future questions. The split may be
+    automatic; it must not be invisible."""
+    assert "Say what goes where. This is not optional." in OFFER
+    assert "so questions like them get answered this way from now on" in OFFER
+    assert "so you're told if any of those numbers move" in OFFER
+
+
+def test_a_promoted_row_does_not_re_ask_the_convention_question():
+    """The save door checks a statement against the profile's examples, which is right when somebody
+    is authoring a key by hand. Here the statement being saved is the one agami generated FROM those
+    examples minutes ago."""
+    assert "--confirm-convention" in OFFER
+    assert "a convention they never departed from" in OFFER
+
+
+def test_an_example_is_written_through_the_packaged_writer():
+    """One writer, and never a hand-edited library — the same door `agami-save-correction` uses."""
+    assert "add-example" in OFFER
+    assert "Do not hand-edit `examples.yaml`" in OFFER
+    assert '"source": "reconcile"' in OFFER

--- a/tests/test_ah111_reconcile_promotion_skill.py
+++ b/tests/test_ah111_reconcile_promotion_skill.py
@@ -399,7 +399,11 @@ def test_a_batch_too_small_to_split_is_not_split():
     """A split of three leaves too little on either side to be worth the explanation, and a profile
     with nothing curated needs teaching more than gating."""
     assert "Fewer than four agreeing rows" in OFFER
-    assert "An empty example library" in OFFER
+    # A cap and not a preference: an empty library reads every row as novel, so a floor on the
+    # teaching side would send all of them there and write no test at all — on exactly the profile
+    # this skill is aimed at.
+    assert "Never send more than half the batch to the examples." in OFFER
+    assert "an onboarding run that writes no test at all has failed" in OFFER
 
 
 def test_the_user_makes_one_decision_and_it_is_not_the_split():

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -1201,18 +1201,80 @@ def test_a_key_that_matches_the_convention_is_written_without_a_question(
 
 
 def test_the_check_never_costs_a_save_when_it_cannot_run(tmp_path, monkeypatch, capsys):
-    """Total by construction. No model, no CLI, a profile mid-rebuild — every one of them returns no
-    opinion, because a check that could refuse a save would be a new way to fail to write down a
-    correct answer."""
+    """Total at the caller. No model, no CLI, a profile mid-rebuild — every one returns no opinion,
+    because a check that could refuse a save would be a new way to fail to write down a correct
+    answer.
 
-    def _explodes(profile, question):
-        raise RuntimeError("no model here")
+    Aimed at the real path rather than at `_nearest_example`: the CLI itself is what is absent on a
+    machine this fails on, so the failure is injected at the subprocess and allowed to propagate up
+    through the ranking exactly as it would in the field.
+    """
 
-    monkeypatch.setattr(golden_author, "_nearest_example", _explodes)
+    def _no_cli(*args, **kwargs):
+        raise FileNotFoundError("bash: no such file")
+
+    monkeypatch.setattr(golden_author, "_sm_json", _no_cli)
 
     code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
 
     assert code == 0 and _items(tmp_path)[0].expected.sql == SQL
+
+
+def test_the_question_reaches_the_ranker_as_one_argument_and_never_a_shell_string(monkeypatch):
+    """The one place user text crosses into a subprocess in this file.
+
+    A dashboard label reaches the promotion path from a screenshot, so a question can carry a quote,
+    a backtick or a `$(…)`. Pinned rather than trusted: correct-and-unpinned is how the eval's own
+    environment allowlist shipped missing a name it needed.
+    """
+    import subprocess
+
+    seen = {}
+
+    def _record(argv, **kwargs):
+        seen["argv"], seen["kwargs"] = argv, kwargs
+        return subprocess.CompletedProcess(argv, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _record)
+    hostile = "How many `whoami` orders $(id) in 'Q1'?"
+
+    golden_author._sm_json("examples", "/root", "--query", hostile, timeout_s=1.0)
+
+    assert seen["argv"][0] == "bash", "a list argv, so no shell parses any of this"
+    assert hostile in seen["argv"], "the question is one element, not spliced into a string"
+    assert seen["kwargs"].get("shell") is not True
+    assert seen["kwargs"]["timeout"] == 1.0
+
+
+def test_an_unrelated_example_is_not_treated_as_the_convention(tmp_path, monkeypatch, capsys):
+    """The check needs a relevance floor or it stops every save.
+
+    The ranker scores every example and returns its top-k unconditionally, so a question sharing
+    nothing but its shape still comes back as the winner. `tables` is one of the claims that can
+    stop a save and an unrelated example differs on tables essentially always — so without the
+    floor, a profile with no near-identical curated question stops on every write and asks the
+    author about a question they were not answering.
+    """
+    calls = []
+
+    def _ranked(*args, **kwargs):
+        calls.append(args)
+        if args[0] == "areas":
+            return [{"name": "orders"}]
+        # What the CLI returns for a question its library does not cover: a best match, and its own
+        # judgement that the match is not close enough to be one.
+        return {
+            "high_confidence": False,
+            "matches": [{"score": 0.606, "example": {"question": "Anything else?",
+                                                     "sql": "SELECT COUNT(*) FROM suppliers"}}],
+        }
+
+    monkeypatch.setattr(golden_author, "_sm_json", _ranked)
+
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+
+    assert code == 0, "an unrelated example is not a convention to be held to"
+    assert _items(tmp_path)[0].expected.sql == SQL
 
 
 def test_only_the_claims_that_change_which_rows_are_counted_are_reported(

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -1119,3 +1119,118 @@ def test_a_dataset_name_carrying_a_separator_is_refused_by_this_door_too(
     assert code == 2
     assert "dataset" in err
     assert neighbour.exists()
+
+
+# --- The convention check (#264) ----------------------------------------------------------------
+#
+# Measured rather than imagined. On the first real dataset authored against a live warehouse, nine
+# of fifteen items failed and six were one mistake: the answer keys filtered on one timestamp column
+# where that profile's own examples used another, 24 times out of 36. The generator read those
+# examples, followed the convention, and was marked wrong by a key that had never looked at them.
+
+
+def _example(sql: str, question: str = QUERY):
+    """Stand in for the ranker, which shells out to a CLI these tests do not have."""
+    return {"question": question, "sql": sql}
+
+
+def test_a_key_that_departs_from_the_profiles_examples_stops_before_writing(
+    tmp_path, monkeypatch, capsys
+):
+    """The write is held, not undone. A warning that arrives once the answer key is on disk is a
+    warning about a file the reader now has to decide whether to undo — and the append-only rule
+    makes undoing it a second confirmation."""
+    monkeypatch.setattr(
+        golden_author,
+        "_nearest_example",
+        lambda profile, question: _example(
+            "SELECT COUNT(*) AS order_count FROM orders WHERE created_at >= '2024-01-01'"
+        ),
+    )
+    item = _item_file(
+        tmp_path,
+        sql="SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= '2024-01-01'",
+    )
+
+    code, payload, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(item))
+
+    assert code == golden_author._NEEDS_CONFIRMATION
+    assert payload["added"] == []
+    divergence = payload["needs_confirmation_convention"]
+    assert divergence["example_sql"].count("created_at")
+    assert [claim["name"] for claim in divergence["claims"]] == ["filter_predicates"]
+    # Nothing reached disk, so there is nothing for the person to undo if they say no.
+    assert not (tmp_path / PROFILE / "golden_datasets").exists()
+
+
+def test_the_departure_is_written_once_somebody_says_it_is_deliberate(
+    tmp_path, monkeypatch, capsys
+):
+    """Reported and never enforced. A golden item may legitimately depart from convention — that is
+    sometimes exactly why one is written — so the check asks and the person decides."""
+    monkeypatch.setattr(
+        golden_author,
+        "_nearest_example",
+        lambda profile, question: _example(
+            "SELECT COUNT(*) AS order_count FROM orders WHERE created_at >= '2024-01-01'"
+        ),
+    )
+    item = _item_file(
+        tmp_path,
+        sql="SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= '2024-01-01'",
+    )
+
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(item, "orders", "--confirm-convention"))
+
+    assert code == 0
+    assert _items(tmp_path)[0].expected.sql.count("placed_at")
+
+
+def test_a_key_that_matches_the_convention_is_written_without_a_question(
+    tmp_path, monkeypatch, capsys
+):
+    """The check has to be silent when there is nothing to say, or it becomes a prompt people learn
+    to click through."""
+    monkeypatch.setattr(
+        golden_author, "_nearest_example", lambda profile, question: _example(SQL)
+    )
+
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+
+    assert code == 0 and _items(tmp_path)[0].expected.sql == SQL
+
+
+def test_the_check_never_costs_a_save_when_it_cannot_run(tmp_path, monkeypatch, capsys):
+    """Total by construction. No model, no CLI, a profile mid-rebuild — every one of them returns no
+    opinion, because a check that could refuse a save would be a new way to fail to write down a
+    correct answer."""
+
+    def _explodes(profile, question):
+        raise RuntimeError("no model here")
+
+    monkeypatch.setattr(golden_author, "_nearest_example", _explodes)
+
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+
+    assert code == 0 and _items(tmp_path)[0].expected.sql == SQL
+
+
+def test_only_the_claims_that_change_which_rows_are_counted_are_reported(
+    tmp_path, monkeypatch, capsys
+):
+    """Two statements answering one question legitimately differ in ordering and limit, and
+    reporting those would make the check noise a person learns to click through."""
+    monkeypatch.setattr(
+        golden_author,
+        "_nearest_example",
+        lambda profile, question: _example(
+            "SELECT status, COUNT(*) AS n FROM orders GROUP BY status ORDER BY n DESC LIMIT 5"
+        ),
+    )
+    item = _item_file(
+        tmp_path, sql="SELECT status, COUNT(*) AS n FROM orders GROUP BY status ORDER BY status"
+    )
+
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(item))
+
+    assert code == 0, "ordering and limit alone are not a departure worth stopping for"

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -1296,3 +1296,69 @@ def test_only_the_claims_that_change_which_rows_are_counted_are_reported(
     code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(item))
 
     assert code == 0, "ordering and limit alone are not a departure worth stopping for"
+
+
+def test_a_departure_that_is_also_a_replacement_asks_both_questions_at_once(
+    tmp_path, monkeypatch, capsys
+):
+    """Or the caller goes round a loop.
+
+    Answering the departure lets the write proceed, `_write_items` then asks about the replacement,
+    and answering THAT with `--confirm-replace` alone runs the convention check again. Two prompts
+    that each re-arm the other. The exit-code table already promised a payload could carry more than
+    one key; this is the code keeping that promise.
+    """
+    monkeypatch.setattr(
+        golden_author, "_nearest_example", lambda profile, question: _example(SQL)
+    )
+    # An item on disk first, so the second save is a replacement.
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+    assert code == 0
+
+    monkeypatch.setattr(
+        golden_author,
+        "_nearest_example",
+        lambda profile, question: _example(
+            "SELECT COUNT(*) AS order_count FROM orders WHERE created_at >= '2024-01-01'"
+        ),
+    )
+    item = _item_file(
+        tmp_path, sql="SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= '2024-01-01'"
+    )
+
+    code, payload, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(item))
+
+    assert code == golden_author._NEEDS_CONFIRMATION
+    assert "needs_confirmation_convention" in payload
+    # …and the replacement, in the same breath, with both sides to render.
+    assert [entry["id"] for entry in payload["needs_confirmation"]] == [
+        "how-many-orders-have-been-placed"
+    ]
+    assert payload["needs_confirmation"][0]["before"]["expected"]["sql"] == SQL
+    assert "placed_at" in payload["needs_confirmation"][0]["after"]["expected"]["sql"]
+
+    # Both flags together, and it writes.
+    code, _, _ = _run(
+        tmp_path, monkeypatch, capsys,
+        _save_argv(item, "orders", "--confirm-convention", "--confirm-replace"),
+    )
+    assert code == 0 and "placed_at" in _items(tmp_path)[0].expected.sql
+
+
+def test_a_departure_on_a_new_item_asks_only_about_the_departure(tmp_path, monkeypatch, capsys):
+    """There is no replacement to ask about, so the payload does not invent one."""
+    monkeypatch.setattr(
+        golden_author,
+        "_nearest_example",
+        lambda profile, question: _example(
+            "SELECT COUNT(*) AS order_count FROM orders WHERE created_at >= '2024-01-01'"
+        ),
+    )
+    item = _item_file(
+        tmp_path, sql="SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= '2024-01-01'"
+    )
+
+    _, payload, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(item))
+
+    assert "needs_confirmation_convention" in payload
+    assert "needs_confirmation" not in payload

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -1220,6 +1220,18 @@ def test_the_check_never_costs_a_save_when_it_cannot_run(tmp_path, monkeypatch, 
     assert code == 0 and _items(tmp_path)[0].expected.sql == SQL
 
 
+def test_a_timed_out_ranker_call_returns_no_opinion(monkeypatch):
+    """The timeout contract is advisory silence, not an exception escaping the save door."""
+    import subprocess
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(kwargs.get("args") or args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+
+    assert golden_author._sm_json("examples", "/root", "--query", QUERY, timeout_s=1.0) is None
+
+
 def test_the_question_reaches_the_ranker_as_one_argument_and_never_a_shell_string(monkeypatch):
     """The one place user text crosses into a subprocess in this file.
 
@@ -1275,6 +1287,32 @@ def test_an_unrelated_example_is_not_treated_as_the_convention(tmp_path, monkeyp
 
     assert code == 0, "an unrelated example is not a convention to be held to"
     assert _items(tmp_path)[0].expected.sql == SQL
+
+
+def test_a_replacement_that_also_departs_from_convention_requests_both_confirmations(
+    tmp_path, monkeypatch, capsys
+):
+    """One stop should let the caller ask once and re-run with both flags."""
+    _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+    monkeypatch.setattr(
+        golden_author,
+        "_nearest_example",
+        lambda profile, question: _example(
+            "SELECT COUNT(*) AS order_count FROM orders WHERE created_at >= '2024-01-01'"
+        ),
+    )
+    replacement = _item_file(
+        tmp_path,
+        sql="SELECT COUNT(*) AS order_count FROM orders WHERE placed_at >= '2024-01-01'",
+    )
+
+    code, payload, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(replacement))
+
+    assert code == golden_author._NEEDS_CONFIRMATION
+    assert payload["needs_confirmation"][0]["id"] == "how-many-orders-have-been-placed"
+    assert payload["needs_confirmation"][0]["before"]["expected"]["sql"] == SQL
+    assert payload["needs_confirmation"][0]["after"]["expected"]["sql"].count("placed_at")
+    assert payload["needs_confirmation_convention"]["example_sql"].count("created_at")
 
 
 def test_only_the_claims_that_change_which_rows_are_counted_are_reported(

--- a/tests/test_golden_authoring_e2e.py
+++ b/tests/test_golden_authoring_e2e.py
@@ -419,7 +419,7 @@ RECONCILE_SKILL = (
 
 def _documented_promotion_item() -> dict:
     """The skill's own item block, with the two placeholders filled the way a run fills them."""
-    section = RECONCILE_SKILL.split("#### What gets written, per kept row")[1]
+    section = RECONCILE_SKILL.split("#### What gets written, per row kept as a test")[1]
     item = json.loads(section.split("```json")[1].split("```")[0])
     item["sql"] = Q3_REVENUE_SQL
     item["confirmed_by"]["method"] = item["confirmed_by"]["method"].replace(


### PR DESCRIPTION
Closes #264.

## The gap, measured

The curated example library is where a team's conventions live — which of two equally correct date columns they answer with, how they phrase a join. It is what agami reads when it answers a question for real. **Nothing in the write path had ever looked at it.**

On the first real golden dataset authored against a live warehouse, fifteen items were written and nine failed. Six were **one mistake**: the answer keys filtered on one timestamp column where that profile's own curated examples overwhelmingly used another.

The generator read those examples, followed the convention they carry, and was marked wrong six times by a key that had never looked at them. The two columns in question describe the same event a short interval apart, so at the grain those questions asked, the run was not surfacing a real disagreement at all.

## What this adds

`save` ranks the nearest example for the question through `sm examples --query` — the same ranker `agami-query` reaches for, so it sees what the generator would be shown — reads both statements through the claim reader, and stops with exit `1` and a `needs_confirmation_convention` payload when they disagree.

**Before the write, not after.** A warning that arrives once the answer key is on disk is a warning about a file the reader now has to decide whether to undo, and the append-only rule makes undoing it a second confirmation. It reuses the exit code and the shape the replacement stop already uses.

**A question, never a refusal.** `--confirm-convention` writes it anyway. A golden item may legitimately depart from convention — that is sometimes exactly why one is written — so the person decides and the software asks.

**Three claims can stop a save, four cannot.** Tables, filters and the resolved date window change *which rows are counted*. Ordering, limit and grouping differ between two correct answers all the time, and stopping for those would make this a prompt people learn to click through.

**Total by construction.** No model, no CLI, a profile mid-rebuild, an unparseable example — every one returns no opinion. A check that could refuse a save would be a new way to fail to write down a correct answer. The dialect falls back to the generic grammar rather than giving up, so a profile mid-rebuild does not silently switch the check off at exactly the moment somebody is authoring against it.

## Also: what a pass rate is not

The issue's second half, recorded in `agami-eval/SKILL.md` rather than changed.

A run's generator has **every tool switched off** and one attempt — that isolation is what stops it reading the answer key and is the whole reason a score means anything. An agent answering the same question in production has `get_datasource_schema`, `get_prompt_examples`, `execute_sql` and `list_datasources`, and can look something up and refine. So a run scores a strictly weaker generator than the one that ships.

And a golden dataset is not a random sample — it is the questions somebody would be embarrassed to get wrong. "12 of 15 passed" means those twelve still work. It does not mean 80%.

Not changed here, deliberately: giving the child the production tool surface would need a sandbox that cannot reach the dataset, which is closer to what the hosted server already exposes than to anything the local path can build honestly.

## Tests

Five new in `tests/test_golden_authoring.py` — a departure stops before writing and leaves no file to undo, `--confirm-convention` writes it, a matching key is written silently, a check that raises never costs the save, and ordering/limit alone are not a departure. Full `dev.py check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
