### PR TITLE
Allowlist the Copilot coding agent for the CLA gate

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -49,7 +49,13 @@ jobs:
           # First-party maintainers are not gated. Add specific bot logins
           # (e.g. dependabot[bot]) here explicitly if/when bots open PRs — a
           # leading-wildcard like *[bot] is not reliably matched by the action.
-          allowlist: ashwin-agami,sandeep-agami
+          #
+          # `copilot-swe-agent[bot]` is the GitHub Copilot coding agent. It does not open PRs of
+          # its own here: it pushes commits to a maintainer's existing branch when asked to act on
+          # its own review comments, and those commits already carry a maintainer as
+          # `Co-authored-by`. It cannot sign a CLA, so without this line every branch it touches is
+          # blocked with no way forward but rewriting its commits by hand.
+          allowlist: ashwin-agami,sandeep-agami,copilot-swe-agent[bot]
           custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
           custom-notsigned-prcomment: >-
             Thank you for your contribution. Before we can merge it, please read our


### PR DESCRIPTION
Unblocks #268, #269 and #270, which are all red on `cla-assistant` and have no route forward without this.

## What happened

Copilot's coding agent acted on its own review comments and pushed a fix commit to each of three branches. Those commits are authored by `copilot-swe-agent[bot]`, which the CLA gate does not recognise — and a bot cannot post the signing comment.

| Branch | Bot commit |
|---|---|
| `fix-263-run-report` | `73ad937` — UTC normalisation, unknown-status verdict |
| `fix-264-examples-check` | `bdf1ce9` — timeout contract, combined confirmation stop |
| `fix-265-reconcile-split` | `12cca4d` — changelog aligned with the implemented cap |

All three are real fixes that were reviewed and kept. On #269 the agent's version was better than the one written alongside it and was merged in preference.

## Why the allowlist is the right lever

The workflow file already asks for exactly this, in its own comment:

> First-party maintainers are not gated. Add specific bot logins (e.g. `dependabot[bot]`) here explicitly if/when bots open PRs — a leading-wildcard like `*[bot]` is not reliably matched by the action.

This agent does not open pull requests of its own here. It pushes to a maintainer's existing branch, when asked, and its commits already carry a maintainer as `Co-authored-by` — so the contribution arrives with a human attached to it either way.

The alternative is rewriting the agent's commits with a human author on every branch it ever touches, which is not a policy so much as a recurring chore.

## Note on ordering

This must land on `main` before it helps those three PRs. The workflow runs under `pull_request_target`, so the copy that executes is the **base** branch's, not the head's. After it merges, a `recheck` comment on each blocked PR re-runs the gate.

No shipped code changes, so no CHANGELOG entry — `.github/` is outside the gate's watched prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)