### PR TITLE
release: 0.8.1 — golden datasets, after their first real run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-09-07
+
+Everything below came out of running the golden-dataset feature against a live warehouse for the
+first time. One fix is the difference between the feature working and not working at all; the rest
+is what a first real run and its review turned up.
+
+
 ### Added
 
 - **Saving a golden item checks it against the profile's own examples first.** The curated example

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.8.0"
+version = "0.8.1"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts 0.8.1. Bumps the four version fields across three files and rolls `[Unreleased]` into `[0.8.1]`; no code changes.

## What ships

| PR | Change |
|---|---|
| #266 | The eval's generator can authenticate — `USER` was missing from its environment allowlist, so every case errored for anyone on a subscription rather than an API key |
| #268 | The run report: a false verdict on gated items, the accuracy dropped, gates name their column, the claims that differ are drawn, plus timestamp, tiles and an outcome filter |
| #269 | An answer key is checked against the profile's own examples before it is written, and a reconcile run now teaches as well as tests |

#266 is the one that needs PyPI: it changed `packages/agami-core/`, and a marketplace install reaches that code through the published package. The rest is plugin-side and rides the version bump.

## After merge

Cut a GitHub Release tagged `v0.8.1`. `release-pypi.yml` and `release-image.yml` both fire on `release: published`, and the PyPI job fails the publish if the tag does not match `packages/agami-core/pyproject.toml` — which this PR sets to 0.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)