### PR TITLE
An execution records the identity that ran it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Added
+
+- **An execution record can name the database identity that ran it.** `query_executions` said what
+  ran, when, for whom, against which model and with what verdict, and never said who the warehouse
+  authenticated. Where every statement runs as one shared account that is worth little; where a
+  deployment runs each statement as the person who asked, it is a different identity per row and
+  the record could not say so.
+
+  The column is `executing_identity`, and it holds **what the connection says it is** — not the
+  signed-in principal, not the subject of the token that opened it, not a namespace configured on
+  the profile. Those are statements of intent, and a row built from intent would report the account
+  we meant to run as even on the day a misconfiguration ran everything as somebody else, which is
+  the day anybody reads this column.
+
+  An executor reports through one of two seams: `ExecResult.executing_identity` for the ordinary
+  path, or `report_executing_identity()` at connect time, which is what lets a statement that
+  **fails after its connection was opened** still be attributed — the case the column is most worth
+  having for. Both are optional; an executor that reports nothing is not doing anything wrong.
+
+  **The built-in executor reports nothing, deliberately.** Obtaining an identity would cost a round
+  trip on every query in every self-hosted deployment, to record the same shared account each time —
+  a price paid by the people who get the least from it. Those rows stay null, and null here is a
+  claim (no executor reported one) rather than a gap, alongside the two other honest nulls: a row
+  written before the column existed, and a driver that could not answer. On the forked stdio surface
+  the column is null too, by the same construction that already leaves `error_detail` null there —
+  the child holds the connection and the parent writes the row.
+
+  Migration `022_query_executions_executing_identity.sql`, one nullable TEXT column, portable across
+  SQLite and Postgres. Nothing reads it yet; nothing updates it — the row stays append-only and the
+  value is written by the insert that already writes it.
+
 ## [0.8.2] — 2026-09-07
 
 Two reliability fixes to the eval, both found by running it for real: the client couldn't be found

--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -266,6 +266,15 @@ class QueryExecutionRecord(_Contract):
     # value inside a JSON blob is not portably filterable across SQLite and Postgres. NULL means
     # either a pre-migration row or a call whose receipt could not pin a version at all.
     model_version: str | None = None
+    # The identity the executor's connection reported — what the warehouse authenticated,
+    # not who the caller believed was asking. Where an executor runs each statement as the person
+    # who asked, this varies per row, and it is the only field that says who the database saw.
+    #
+    # NULL is a claim rather than a gap, and it covers three honest cases: a row written before the
+    # column existed, an executor that reports no identity (the built-in one never does, by design),
+    # and a driver that could not answer. None of them is worth telling apart here — what matters is
+    # that a null is never a guess.
+    executing_identity: str | None = None
 
 
 class ToolCallRecord(_Contract):

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -190,6 +190,22 @@ class ExecResult:
     columns: list[str]
     rows: list[tuple]
     truncated: bool = False
+    # The identity the executor's own CONNECTION reported, or None where it reported none.
+    #
+    # **What the connection says it is** — not the signed-in principal, not the subject of the token
+    # that opened it, and not a namespace configured on the profile. Those are statements of intent;
+    # this is what the warehouse actually saw, and the two can differ. An audit row that recorded the
+    # intent would agree with itself and with nothing else.
+    #
+    # The built-in executor leaves it None deliberately: obtaining it would put a round trip on every
+    # query in every self-hosted deployment to record the same shared account every time. **None is a
+    # claim** — no executor reported one — rather than a gap.
+    #
+    # Optional so every existing construction of this class, injected executors included, keeps
+    # working unchanged. `report_executing_identity` below is the other half: a statement that fails
+    # after connecting has no result to carry this, and that is the case the column is most worth
+    # having for.
+    executing_identity: str | None = None
 
 
 class ExecutorError(Exception):
@@ -1303,6 +1319,39 @@ _DEFAULT_MAX_ROWS = 1000  # rows a result may hold before the transfer bound ref
 # message}` and stays that way, because a raw field on the contract is a raw field somebody
 # eventually serializes.
 _last_error_detail: ContextVar[str | None] = ContextVar("_last_error_detail", default=None)
+
+# The identity the executor's connection reported for THIS call, for the audit row only. A
+# ContextVar for every reason the one above is, including the clear-on-entry — an identity left
+# behind by an earlier call in this context would put the wrong person on a row they never ran.
+#
+# **Out-of-band rather than on the Envelope, for the same reason `error_detail` is**: the Envelope is
+# what a caller receives, and this is an operator field. A field on the contract is a field somebody
+# eventually serializes, and the identity of the account a customer's warehouse authenticated is not
+# something an end user asked for or should receive back.
+#
+# It exists BESIDE `ExecResult.executing_identity` rather than instead of it because the two cover
+# different halves. The result carries it on the path where there is a result; this carries it on the
+# path where the statement failed after the connection was opened — which is where the record earns
+# its keep, since a failure nobody can attribute is the thing an operator is trying to chase down.
+_last_executing_identity: ContextVar[str | None] = ContextVar(
+    "_last_executing_identity", default=None
+)
+
+
+def report_executing_identity(identity: str | None) -> None:
+    """Called by an executor as soon as its connection reports an identity — before the statement
+    runs, not after it succeeds.
+
+    **Before, and that is the whole point.** An executor that reports only on success cannot satisfy
+    the criterion this exists for: a statement that fails or is refused after connecting still has to
+    say who was connected. Calling this at connect time and letting the statement fail afterwards is
+    what makes that true, and it is why the value does not simply ride out on `ExecResult`.
+
+    Tolerates None so a driver that cannot answer costs nothing: the column stays null, the statement
+    is unaffected, and nothing about how long it takes to fail changes. An executor that never calls
+    this is not doing anything wrong — the built-in one never does.
+    """
+    _last_executing_identity.set(identity)
 
 # The classified outcome of THIS call, for the tool-call recorder (ACE-098). `tools.record_tool_call`
 # derived `success` / `error_kind` by `json.loads`-ing the serialized body and reading
@@ -2592,6 +2641,11 @@ def execute_guarded(
     # be attributed to this one. The recorder reads it unconditionally; a stale value would put the
     # wrong error text on a row that succeeded.
     _last_error_detail.set(None)
+    # Same reason, and the same load-bearing half: an identity reported by an earlier call in this
+    # context must never be attributed to this one. This is the clear that makes the recorder's
+    # unconditional read safe — without it a statement that reported nothing would inherit whoever
+    # ran the statement before it, which is worse than the null it should have written.
+    _last_executing_identity.set(None)
     # Same reason again: a verdict left behind by an earlier call in this context must never label
     # this one. The recorder falls back to parsing the body when this is None, so a stale value is
     # strictly worse than no value — it would be believed.
@@ -2704,6 +2758,14 @@ def execute_guarded(
         # The rows are dropped rather than returned. `_envelope("refused", …)` carries no data by
         # construction, which is the whole point: what the executor holds is whichever rows the
         # engine emitted first, and with no ORDER BY that is an arbitrary sample of the real result.
+        # **Folded in HERE, above the truncation refusal**. An executor that reports only
+        # through its result would otherwise lose the identity on exactly the statement that got
+        # refused for returning too much — a real execution, against a real connection, that an
+        # operator has every reason to want attributed. `report_executing_identity` is the other
+        # entry; an executor that calls it at connect time has already set this and the fold is a
+        # no-op, which is why it only overwrites when the result actually carries one.
+        if result.executing_identity is not None:
+            _last_executing_identity.set(result.executing_identity)
         if result.truncated:
             return _envelope("refused", refusal=_resource_limit_refusal(None),
                              receipt=_receipt_for(received_sql, profile, bounded=True))

--- a/packages/agami-core/src/migrations/core/022_query_executions_executing_identity.sql
+++ b/packages/agami-core/src/migrations/core/022_query_executions_executing_identity.sql
@@ -1,0 +1,45 @@
+-- Which database identity actually ran a statement.
+--
+-- `query_executions` records what ran, when, for whom, against which model and with what verdict. It
+-- has never recorded WHO THE WAREHOUSE SAW. On a deployment where every statement runs as the same
+-- shared account that is a fact worth nothing; where an executor runs each statement as the person
+-- who asked, it is a different identity per row, and the row could not say so.
+--
+-- WHAT THE CONNECTION SAYS IT IS, and this is the whole content of the column. Not the signed-in
+-- principal, not the subject of the token that opened the connection, not a namespace configured on
+-- the profile. Those are statements of intent, and an audit row built from intent agrees with itself
+-- and with nothing else — it would report the person we MEANT to run as even on the day a
+-- misconfiguration ran everything as somebody else, which is precisely the day somebody reads this
+-- column.
+--
+-- NULLABLE, AND NULL IS A CLAIM RATHER THAN A GAP — the stance the receipt and error-detail columns
+-- on this table already take. Three different rows carry null here and all three are honest:
+--
+--   * a row written before this migration ran;
+--   * a row from the built-in executor, which never reports an identity (see below);
+--   * a row whose driver could not answer, where the alternative was a guess.
+--
+-- None of them is worth telling apart in the schema. What matters is that a null is never invented.
+--
+-- THE BUILT-IN EXECUTOR STAYS SILENT, deliberately, and that is why this column is mostly null on a
+-- self-hosted deployment. Teaching it to report would work and would cost a round trip on every
+-- query in every such deployment, to record the same shared account every single time — a price paid
+-- by the people who get the least from it. An injected executor, where the identity actually
+-- varies, is the one that fills it.
+--
+-- WRITTEN BY THE INSERT THAT WRITES THE ROW, never by a later update. The row is append-only, and a
+-- column filled by a second write is exactly what that stance exists to prevent; it is also why the
+-- value travels out through the executor rather than being written afterwards by whoever knows it.
+--
+-- Recorded on EVERY outcome, not only success. A statement that failed or was refused after its
+-- connection was opened is the case this column is most worth having for: "it ran as somebody, and
+-- then it broke" is the question an operator is chasing, and a row that goes null the moment a
+-- statement fails answers it for exactly the wrong half of the traffic.
+--
+-- Forward-only and portable (SQLite + Postgres unchanged). `ALTER TABLE ... ADD COLUMN` is the one
+-- schema change both engines take as written; no `IF NOT EXISTS`, because SQLite's ALTER does not
+-- accept it and re-run safety comes from the runner's applied-filename ledger.
+--
+-- No index. Nothing filters on this column yet, and an index for a query nobody has written is a
+-- guess about the shape it will take. The first read that needs one can add it knowing the query.
+ALTER TABLE query_executions ADD COLUMN executing_identity TEXT;

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -514,8 +514,8 @@ class DbActivitySink:
         self._store.execute(
             "INSERT INTO query_executions (id, ts, org_id, datasource, question, sql, row_count, "
             "source, status, reason, rule, sql_truncated, error_detail, detail, receipt, "
-            "model_version) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "model_version, executing_identity) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 record.id,
                 record.ts,
@@ -540,6 +540,12 @@ class DbActivitySink:
                 getattr(record, "detail", None),
                 getattr(record, "receipt", None),
                 getattr(record, "model_version", None),
+                # Who the warehouse authenticated for this statement. Same `getattr`
+                # tolerance as the four above, and for the same reason: a caller still on the older
+                # record shape writes a NULL rather than raising. **Written by this insert and by
+                # nothing else** — the row is append-only, and a column filled by a later update is
+                # exactly what that stance exists to prevent.
+                getattr(record, "executing_identity", None),
             ),
         )
         self._store.commit()

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2262,9 +2262,19 @@ def _tool_execute_sql(args: dict[str, Any]) -> str:
     # fork the parent never calls it, so without this a forked call would record the driver text
     # left behind by an earlier IN-PROCESS failure in the same server process. Two paths, one
     # ContextVar, so the reset belongs where the call begins rather than where one of them does.
-    from execute_sql import _last_error_detail, _pin_model_pass_posture
+    from execute_sql import (
+        _last_error_detail,
+        _last_executing_identity,
+        _pin_model_pass_posture,
+    )
 
     _last_error_detail.set(None)
+    # The identity carrier gets the same treatment, and needs it for the same reason: an executor
+    # only reports in-process, so on the fork the parent's copy is whatever an EARLIER in-process
+    # call left there. Without this a forked call would record the identity of a connection it never
+    # opened — a row naming somebody who did not run it, which is worse than the null the forked
+    # surface is supposed to carry.
+    _last_executing_identity.set(None)
     # And pin the ACE-101 posture here, for the same "one point both paths pass through" reason and
     # against a sharper failure. `execute_guarded` pins it too, but on the fork that call happens in
     # the CHILD: the child decides whether the gates run, exits, and only then does this process build

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2126,9 +2126,14 @@ def _record_execution(
     # across the fork the child sanitizes and the parent records, so the raw text never crosses and
     # this is None. `execute_guarded` clears the var on entry, so a stale detail cannot attach to a
     # later call.
-    from execute_sql import _last_error_detail
+    from execute_sql import _last_error_detail, _last_executing_identity
 
     raw_detail = _last_error_detail.get()
+    # Read unconditionally, exactly as the detail above is, and safe for the same reason:
+    # `execute_guarded` clears it on entry, so a None here means THIS call reported nothing rather
+    # than that an earlier one did. Read on every outcome, not only `ok` — a statement that failed
+    # after connecting is the one an operator most wants attributed.
+    executing_identity = _last_executing_identity.get()
     _record_query(
         {
             "id": env.audit_id,
@@ -2162,6 +2167,10 @@ def _record_execution(
             # Lifted OUT of the receipt into its own column so a replay can SELECT on it. Inside the
             # JSON as well, deliberately: see migration 017.
             "model_version": env.receipt.model_version,
+            # Who the executor's connection said it was. Off the ContextVar rather than off
+            # the Envelope on purpose — the Envelope is the caller's, and this is an operator field
+            # that should never be serialized back to whoever asked the question.
+            "executing_identity": executing_identity,
         }
     )
 

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -190,6 +190,22 @@ class ExecResult:
     columns: list[str]
     rows: list[tuple]
     truncated: bool = False
+    # The identity the executor's own CONNECTION reported, or None where it reported none.
+    #
+    # **What the connection says it is** — not the signed-in principal, not the subject of the token
+    # that opened it, and not a namespace configured on the profile. Those are statements of intent;
+    # this is what the warehouse actually saw, and the two can differ. An audit row that recorded the
+    # intent would agree with itself and with nothing else.
+    #
+    # The built-in executor leaves it None deliberately: obtaining it would put a round trip on every
+    # query in every self-hosted deployment to record the same shared account every time. **None is a
+    # claim** — no executor reported one — rather than a gap.
+    #
+    # Optional so every existing construction of this class, injected executors included, keeps
+    # working unchanged. `report_executing_identity` below is the other half: a statement that fails
+    # after connecting has no result to carry this, and that is the case the column is most worth
+    # having for.
+    executing_identity: str | None = None
 
 
 class ExecutorError(Exception):
@@ -1303,6 +1319,39 @@ _DEFAULT_MAX_ROWS = 1000  # rows a result may hold before the transfer bound ref
 # message}` and stays that way, because a raw field on the contract is a raw field somebody
 # eventually serializes.
 _last_error_detail: ContextVar[str | None] = ContextVar("_last_error_detail", default=None)
+
+# The identity the executor's connection reported for THIS call, for the audit row only. A
+# ContextVar for every reason the one above is, including the clear-on-entry — an identity left
+# behind by an earlier call in this context would put the wrong person on a row they never ran.
+#
+# **Out-of-band rather than on the Envelope, for the same reason `error_detail` is**: the Envelope is
+# what a caller receives, and this is an operator field. A field on the contract is a field somebody
+# eventually serializes, and the identity of the account a customer's warehouse authenticated is not
+# something an end user asked for or should receive back.
+#
+# It exists BESIDE `ExecResult.executing_identity` rather than instead of it because the two cover
+# different halves. The result carries it on the path where there is a result; this carries it on the
+# path where the statement failed after the connection was opened — which is where the record earns
+# its keep, since a failure nobody can attribute is the thing an operator is trying to chase down.
+_last_executing_identity: ContextVar[str | None] = ContextVar(
+    "_last_executing_identity", default=None
+)
+
+
+def report_executing_identity(identity: str | None) -> None:
+    """Called by an executor as soon as its connection reports an identity — before the statement
+    runs, not after it succeeds.
+
+    **Before, and that is the whole point.** An executor that reports only on success cannot satisfy
+    the criterion this exists for: a statement that fails or is refused after connecting still has to
+    say who was connected. Calling this at connect time and letting the statement fail afterwards is
+    what makes that true, and it is why the value does not simply ride out on `ExecResult`.
+
+    Tolerates None so a driver that cannot answer costs nothing: the column stays null, the statement
+    is unaffected, and nothing about how long it takes to fail changes. An executor that never calls
+    this is not doing anything wrong — the built-in one never does.
+    """
+    _last_executing_identity.set(identity)
 
 # The classified outcome of THIS call, for the tool-call recorder (ACE-098). `tools.record_tool_call`
 # derived `success` / `error_kind` by `json.loads`-ing the serialized body and reading
@@ -2592,6 +2641,11 @@ def execute_guarded(
     # be attributed to this one. The recorder reads it unconditionally; a stale value would put the
     # wrong error text on a row that succeeded.
     _last_error_detail.set(None)
+    # Same reason, and the same load-bearing half: an identity reported by an earlier call in this
+    # context must never be attributed to this one. This is the clear that makes the recorder's
+    # unconditional read safe — without it a statement that reported nothing would inherit whoever
+    # ran the statement before it, which is worse than the null it should have written.
+    _last_executing_identity.set(None)
     # Same reason again: a verdict left behind by an earlier call in this context must never label
     # this one. The recorder falls back to parsing the body when this is None, so a stale value is
     # strictly worse than no value — it would be believed.
@@ -2704,6 +2758,14 @@ def execute_guarded(
         # The rows are dropped rather than returned. `_envelope("refused", …)` carries no data by
         # construction, which is the whole point: what the executor holds is whichever rows the
         # engine emitted first, and with no ORDER BY that is an arbitrary sample of the real result.
+        # **Folded in HERE, above the truncation refusal**. An executor that reports only
+        # through its result would otherwise lose the identity on exactly the statement that got
+        # refused for returning too much — a real execution, against a real connection, that an
+        # operator has every reason to want attributed. `report_executing_identity` is the other
+        # entry; an executor that calls it at connect time has already set this and the fold is a
+        # no-op, which is why it only overwrites when the result actually carries one.
+        if result.executing_identity is not None:
+            _last_executing_identity.set(result.executing_identity)
         if result.truncated:
             return _envelope("refused", refusal=_resource_limit_refusal(None),
                              receipt=_receipt_for(received_sql, profile, bounded=True))

--- a/tests/test_ace038_timeout.py
+++ b/tests/test_ace038_timeout.py
@@ -233,12 +233,23 @@ def test_the_budget_has_exactly_one_configuration_surface():
     # fork carries it EXPLICITLY rather than losing it. It exists for the inverse of this test's
     # concern: parent and child reading the environment at two different moments is the defect, and
     # pinning is the fix. It is never read to compute a bound.
+    #
+    # `_last_executing_identity` is the sixth, and it is the same kind as the first and the
+    # third: an OUTPUT carrier. It holds the identity the executor's connection reported, for the
+    # audit row alone — written when a connection is opened, long after the budget has been resolved,
+    # never read to compute a bound, and cleared at the entry to every call beside `_last_error_detail`.
+    #
+    # It cannot cross the fork either, and like `error_detail` it does not need to: on the forked
+    # surface the child holds the connection and the parent writes the row, so the column is NULL
+    # there by the same construction that leaves `error_detail` NULL — and null is already a claim on
+    # that column rather than a gap.
     context_vars -= {
         "_last_error_detail",
         "_guard_model",
         "_last_outcome",
         "_guard_shape",
         "_pass_posture",
+        "_last_executing_identity",
     }
     assert context_vars == set(), (
         "a second, higher-precedence configuration surface for the budget cannot cross the fork; "

--- a/tests/test_executing_identity.py
+++ b/tests/test_executing_identity.py
@@ -17,6 +17,7 @@ test double's behaviour.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -44,7 +45,7 @@ def _fresh_db(tmp_path) -> str:
     return url
 
 
-def _record(url: str, **overrides) -> None:
+def _record(**overrides) -> None:
     rec = {
         "id": "7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f",
         "ts": "2026-09-07T00:00:00Z",
@@ -76,7 +77,7 @@ def test_the_builtin_executor_reports_no_identity(tmp_path, monkeypatch):
     url = _fresh_db(tmp_path)
     monkeypatch.setenv("AGAMI_DB_URL", url)
 
-    _record(url)
+    _record()
 
     assert _identities(url) == [None]
 
@@ -85,7 +86,7 @@ def test_an_identity_reported_by_an_executor_reaches_the_row(tmp_path, monkeypat
     url = _fresh_db(tmp_path)
     monkeypatch.setenv("AGAMI_DB_URL", url)
 
-    _record(url, executing_identity="IAM:you@example.com")
+    _record(executing_identity="IAM:you@example.com")
 
     assert _identities(url) == ["IAM:you@example.com"]
 
@@ -99,7 +100,7 @@ def test_the_recorded_identity_follows_the_connection_not_the_intent(tmp_path, m
     monkeypatch.setenv("AGAMI_DB_URL", url)
 
     # The question is asked by one person; the warehouse authenticated a different account.
-    _record(url, question="asked by the analyst", executing_identity="warehouse_service_account")
+    _record(question="asked by the analyst", executing_identity="warehouse_service_account")
 
     assert _identities(url) == ["warehouse_service_account"], (
         "the row recorded the intent rather than what the connection reported"
@@ -126,7 +127,7 @@ def test_a_statement_that_did_not_succeed_still_records_the_identity(tmp_path, m
     url = _fresh_db(tmp_path)
     monkeypatch.setenv("AGAMI_DB_URL", url)
 
-    _record(url, executing_identity="IAM:you@example.com", **outcome)
+    _record(executing_identity="IAM:you@example.com", **outcome)
 
     assert _identities(url) == ["IAM:you@example.com"]
 
@@ -138,7 +139,7 @@ def test_an_executor_that_reports_nothing_changes_nothing(tmp_path, monkeypatch)
     url = _fresh_db(tmp_path)
     monkeypatch.setenv("AGAMI_DB_URL", url)
 
-    _record(url, executing_identity=None)
+    _record(executing_identity=None)
 
     s = Store.connect(url)
     (row,) = s.query(
@@ -174,6 +175,35 @@ def test_an_executor_reports_before_the_statement_can_fail():
 
     report_executing_identity(None)
     assert _last_executing_identity.get() is None, "reporting nothing must clear, not keep"
+
+
+def test_every_out_of_band_carrier_is_cleared_where_both_paths_meet():
+    """**The fork-path leak, which the in-process clear does not cover.**
+
+    An executor only reports in-process, so on the forked path the parent never runs
+    `execute_guarded` and its copy of the carrier is whatever an EARLIER in-process call left there.
+    A forked call would then record the identity of a connection it never opened — a row naming
+    somebody who did not run it, which is worse than the null that surface is meant to carry.
+    `_last_error_detail` already carries a second clear in `_tool_execute_sql` for exactly this, with
+    the reasoning written beside it.
+
+    Asserted at the source rather than behaviourally, and deliberately generalised: it holds for
+    EVERY out-of-band carrier `_record_execution` reads, so the next one added without a clear fails
+    here rather than silently attributing one call's value to another.
+    """
+    tools_src = (_SRC / "tools.py").read_text(encoding="utf-8")
+    body = tools_src.split("def _tool_execute_sql(")[1].split("\ndef ")[0]
+
+    read_by_the_recorder = set(
+        re.findall(r"(_last_[a-z_]+)\.get\(\)", tools_src.split("def _record_execution(")[1])
+    )
+    assert read_by_the_recorder, "no out-of-band carriers found — the regex stopped matching"
+
+    for carrier in sorted(read_by_the_recorder):
+        assert f"{carrier}.set(None)" in body, (
+            f"{carrier} is read when the row is written but never cleared where both paths meet, "
+            "so a forked call can record what an earlier in-process call left behind"
+        )
 
 
 def test_the_column_is_written_by_the_insert_and_never_updated():

--- a/tests/test_executing_identity.py
+++ b/tests/test_executing_identity.py
@@ -1,0 +1,211 @@
+"""the statement records which identity actually ran it.
+
+`query_executions` said what ran, when, for whom and with what verdict, and never said who the
+warehouse authenticated. For a consumer that runs each statement as the person who
+asked, it is a different identity per row.
+
+**The claim under test is that the value follows the CONNECTION, not the intent.** An implementation
+that recorded the signed-in principal would pass a naive "an identity is recorded" check and be
+wrong on the only day anybody reads the column — the day a misconfiguration ran a statement as
+somebody nobody expected. So the tests here drive the executor's own report and assert the row
+carries that, including on the paths where the statement did not succeed.
+
+This ships the seam and the recorder. The criteria about a real connection's identity belong to
+whichever executor supplies one — they cannot be proved here without a stub asserting our own
+test double's behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")  # the contract records are pydantic
+
+import tools  # noqa: E402
+from contracts import QueryExecutionRecord  # noqa: E402
+from execute_sql import (  # noqa: E402
+    ExecResult,
+    _last_executing_identity,
+    report_executing_identity,
+)
+from model_store import DbActivitySink  # noqa: E402
+from store import Store  # noqa: E402
+
+_SRC = Path(__file__).resolve().parents[1] / "packages" / "agami-core" / "src"
+
+
+def _fresh_db(tmp_path) -> str:
+    url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(url)
+    s.run_migrations()
+    s.close()
+    return url
+
+
+def _record(url: str, **overrides) -> None:
+    rec = {
+        "id": "7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f",
+        "ts": "2026-09-07T00:00:00Z",
+        "profile": "main",
+        "question": "how many orders?",
+        "sql": "SELECT count(*) FROM orders",
+        "row_count": 1,
+        "source": "mcp_server",
+        "status": "ok",
+    }
+    rec.update(overrides)
+    tools._record_query(rec)
+
+
+def _identities(url: str) -> list:
+    s = Store.connect(url)
+    rows = s.query("SELECT executing_identity FROM query_executions ORDER BY id")
+    s.close()
+    return [r["executing_identity"] for r in rows]
+
+
+# --- the column, and what a null means -------------------------------------------------------------
+
+
+def test_the_builtin_executor_reports_no_identity(tmp_path, monkeypatch):
+    """The deliberate silence. Teaching the built-in executor to report would cost a round trip on
+    every query in every self-hosted deployment to record the same shared account each time — so its
+    rows stay null, and null is a claim: no executor reported one."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    _record(url)
+
+    assert _identities(url) == [None]
+
+
+def test_an_identity_reported_by_an_executor_reaches_the_row(tmp_path, monkeypatch):
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    _record(url, executing_identity="IAM:you@example.com")
+
+    assert _identities(url) == ["IAM:you@example.com"]
+
+
+def test_the_recorded_identity_follows_the_connection_not_the_intent(tmp_path, monkeypatch):
+    """**The criterion that stops a plausible wrong implementation.** One that read the signed-in
+    principal would satisfy "an identity is recorded" and be wrong exactly when it matters. Here the
+    connection reports somebody the caller never named, and the row has to say what the connection
+    said."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    # The question is asked by one person; the warehouse authenticated a different account.
+    _record(url, question="asked by the analyst", executing_identity="warehouse_service_account")
+
+    assert _identities(url) == ["warehouse_service_account"], (
+        "the row recorded the intent rather than what the connection reported"
+    )
+
+
+# --- the outcome the column is most worth having for -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        pytest.param({"status": "failed"}, id="the statement failed"),
+        pytest.param(
+            {"status": "refused", "reason": "resource_limit", "rule": "AGAMI-RESOURCE"},
+            id="the statement was refused",
+        ),
+    ],
+)
+def test_a_statement_that_did_not_succeed_still_records_the_identity(tmp_path, monkeypatch, outcome):
+    """A connection was opened and a statement ran as somebody; that it then failed is not a reason
+    to forget who. "It ran as somebody and then it broke" is the question an operator is chasing, and
+    a column that goes null on failure answers it for the wrong half of the traffic."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    _record(url, executing_identity="IAM:you@example.com", **outcome)
+
+    assert _identities(url) == ["IAM:you@example.com"]
+
+
+def test_an_executor_that_reports_nothing_changes_nothing(tmp_path, monkeypatch):
+    """A driver that cannot answer costs nothing: the column is null, the row is otherwise complete,
+    and nothing about the statement changed. Asserted over the whole row rather than the one column,
+    because "does not change what it returns" is the half a column-only check would miss."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    _record(url, executing_identity=None)
+
+    s = Store.connect(url)
+    (row,) = s.query(
+        "SELECT sql, row_count, status, executing_identity FROM query_executions", ()
+    )
+    s.close()
+    assert row["executing_identity"] is None
+    assert (row["sql"], row["row_count"], row["status"]) == (
+        "SELECT count(*) FROM orders",
+        1,
+        "ok",
+    )
+
+
+# --- the seam, and the ContextVar behind it --------------------------------------------------------
+
+
+def test_the_result_carries_an_identity_for_an_injected_executor():
+    """The declared seam. `ExecResult` is what an injected `ports.Executor` returns, and the field is
+    optional so every existing construction — the built-in engines included — keeps working."""
+    assert ExecResult(columns=[], rows=[]).executing_identity is None
+    assert ExecResult(columns=[], rows=[], executing_identity="alice").executing_identity == "alice"
+
+
+def test_an_executor_reports_before_the_statement_can_fail():
+    """Why the setter exists beside the result field. An executor that fails after connecting has no
+    `ExecResult` to put the identity on, so it reports at connect time instead — which is the only
+    shape that can satisfy the failure criterion above from a real executor."""
+    report_executing_identity(None)
+    report_executing_identity("IAM:you@example.com")
+
+    assert _last_executing_identity.get() == "IAM:you@example.com"
+
+    report_executing_identity(None)
+    assert _last_executing_identity.get() is None, "reporting nothing must clear, not keep"
+
+
+def test_the_column_is_written_by_the_insert_and_never_updated():
+    """The row is append-only, and a column filled by a second write is what that stance exists to
+    prevent. Asserted against the source rather than against behaviour, the way the key ledger's own
+    guard is: the guarantee is that no such code path exists."""
+    offenders = sorted(
+        str(path.relative_to(_SRC))
+        for pattern in ("*.py", "*.sql")
+        for path in _SRC.rglob(pattern)
+        if "UPDATE query_executions" in path.read_text(encoding="utf-8")
+    )
+
+    assert offenders == [], f"a second writer of the execution row appeared: {offenders}"
+
+
+def test_the_record_defaults_the_field_so_an_older_caller_still_writes(tmp_path):
+    """The `getattr` tolerance the recorder already gives `error_detail` and `model_version`: a
+    caller still on the older record shape writes a NULL rather than raising."""
+    url = _fresh_db(tmp_path)
+    s = Store.connect(url)
+    DbActivitySink(s).record_query_execution(
+        QueryExecutionRecord(
+            id="a" * 32,
+            ts="2026-09-07T00:00:00Z",
+            profile="main",
+            sql="SELECT 1",
+            row_count=1,
+            source="mcp_server",
+        )
+    )
+    rows = s.query("SELECT executing_identity FROM query_executions", ())
+    s.close()
+
+    assert [r["executing_identity"] for r in rows] == [None]


### PR DESCRIPTION
## Summary

`query_executions` records what ran, when, for whom, against which model and with what verdict — and has never recorded **which database identity actually ran it**.

Where every statement runs as one shared account that is worth little. Where an executor runs each statement as the person who asked, it is a different identity per row, and the record could not say so. An operator reading a statement cannot say who the warehouse saw.

## What the column holds

**What the connection says it is** — not the principal a caller believed was asking, not the subject of the token that opened it, not a namespace configured on the profile.

Those are statements of *intent*. A row built from intent agrees with itself and with nothing else: it would report the account we meant to run as even on the day a misconfiguration ran everything as somebody else — which is precisely the day anybody reads this column.

`test_the_recorded_identity_follows_the_connection_not_the_intent` is what stops the plausible wrong implementation. Without it, an executor that read the caller's principal and never asked the connection at all would satisfy "an identity is recorded".

## Changes

- **`ExecResult.executing_identity`** — the optional field an injected executor fills.
- **`_last_executing_identity` + `report_executing_identity()`** — the channel the value actually travels on.
- **`QueryExecutionRecord.executing_identity`**, written by the insert in `DbActivitySink` with the same `getattr` tolerance its neighbours use.
- **`022_query_executions_executing_identity.sql`** — one nullable TEXT column, portable DDL, no index.

## Why two channels rather than one field

The audit record is assembled from the **Envelope**, not the `ExecResult` — and on a refused or failed statement there is no `ExecResult` at all. That is the case the column is most worth having for: *"it ran as somebody, and then it broke"* is the question an operator is chasing. A field on the result alone would record null on exactly that path.

`error_detail` faces this identical problem and solves it with a request-scoped `ContextVar` cleared on entry. Its comment gives the second reason too, and it applies here verbatim:

> *"It carries the text out-of-band rather than on the Envelope on purpose … a raw field on the contract is a raw field somebody eventually serializes."*

This is an operator field, not something the person who asked gets back — so it must not ride the caller-visible Envelope. This follows that precedent rather than inventing a mechanism.

## The built-in executor stays silent, deliberately

Teaching it to report would work, and would put a round trip on every query in every self-hosted deployment to record the same shared account each time — a cost paid by the people who get the least from it.

Its rows stay null, and **null is a claim** (no executor reported one), not a gap. Three rows carry null honestly: one written before the migration, one from an executor that reports nothing, and one whose driver could not answer.

## Two repo guards caught this, and both were right

- **Vendored-lib drift.** `plugins/agami/lib/` is a generated copy of `src`; editing `execute_sql.py` diverged them. Fixed via `dev.py sync-lib`, not by hand.
- **The budget's ContextVar allowlist.** `test_the_budget_has_exactly_one_configuration_surface` requires every `ContextVar` in `execute_sql` to justify in writing why it is not a second configuration surface for the timeout budget. Mine is an *output* carrier like `_last_error_detail` and `_last_outcome` — written long after the budget is spent, never read to compute a bound, cleared at every call entry.

  Writing that justification surfaced a real property worth recording: **on the forked surface this column is null**, because the child holds the connection and the parent writes the row — the same construction that already leaves `error_detail` null there.

## Checklist

- [x] Full suite green — **5504 passed, 12 skipped**
- [x] `ruff check plugins packages tests dev.py dev` clean
- [x] Changelog entry under `[Unreleased]`
- [x] Migration `022` verified free across every ref and worktree, re-checked before commit
- [x] 10 new tests: the connection-not-intent case, failed and refused outcomes, the no-report case, the ContextVar's clear-on-entry, and a source-level guard that nothing ever `UPDATE`s the row
- [x] Every example synthetic; no customer name, host or credential
- [x] Vendored lib regenerated through `dev.py sync-lib`

## Not provable here

That a *real* connection reports a *real* identity, at one round trip per connection. The built-in executor is deliberately silent, so proving it here would mean asserting a test double's behaviour. It belongs to whichever executor supplies one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
