### PR TITLE
An execution records the warehouse's own id for the statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ below corresponds to one such version.
 
 ### Added
 
+- **An execution record can name the warehouse's own id for the statement.** Some engines mint a
+  per-execution id, and it is the key to their own logs — the plan the statement got, how long it
+  queued, how much it scanned. Recording it lets somebody follow a row from here into a system this
+  database does not own and cannot replicate.
+
+  The column is `warehouse_query_id`, and this side treats it as **opaque**: nothing joins on it,
+  parses it or fails without it. That is a limit on purpose rather than an unfinished thought — the
+  moment the value means something here it becomes a thing that can disagree with the warehouse, and
+  a pointer that argues with what it points at is worse than one that says nothing.
+
+  **Which engines can answer is not decided in this library.** No database type or engine list
+  appears in the recorder or the seam: an executor that can name its statement reports one through
+  `ExecResult.warehouse_query_id` or `report_warehouse_query_id()`, and one that cannot never does.
+  Adding an engine is therefore a change where the connection lives, with no migration and no change
+  to the record — and there is a test asserting the field carries no engine name near it.
+
+  Named for the concept rather than for whichever warehouse was first, because a vendor-named column
+  becomes a schema change the day a second engine has one. Null where the engine has none, where the
+  executor did not ask, or where the ask failed — all four nulls, the pre-migration row included,
+  are claims rather than gaps.
+
+  Migration `023_query_executions_warehouse_query_id.sql`, one nullable TEXT column, portable across
+  SQLite and Postgres. Nothing reads it yet; nothing updates it.
+
 - **An execution record can name the database identity that ran it.** `query_executions` said what
   ran, when, for whom, against which model and with what verdict, and never said who the warehouse
   authenticated. Where every statement runs as one shared account that is worth little; where a

--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -275,6 +275,15 @@ class QueryExecutionRecord(_Contract):
     # and a driver that could not answer. None of them is worth telling apart here — what matters is
     # that a null is never a guess.
     executing_identity: str | None = None
+    # The warehouse's own id for this statement, where the engine mints one and the executor could
+    # read it. A pointer into somebody else's system: nothing here joins on it, validates it or
+    # fails without it, and its whole worth is that a person holding it can find the statement in
+    # the cluster's logs and see what it actually did.
+    #
+    # Named for the concept rather than for any one engine, so the first time a second engine has
+    # such an id it is an executor that learns to report rather than a column that has to be added.
+    # NULL where the engine has none, where the executor did not ask, or where the ask failed.
+    warehouse_query_id: str | None = None
 
 
 class ToolCallRecord(_Contract):

--- a/packages/agami-core/src/execute_sql.py
+++ b/packages/agami-core/src/execute_sql.py
@@ -206,6 +206,20 @@ class ExecResult:
     # after connecting has no result to carry this, and that is the case the column is most worth
     # having for.
     executing_identity: str | None = None
+    # The warehouse's own id for this statement, where the engine has one. Some engines mint a
+    # per-execution id a person can look up in the cluster's own logs; most do not, and one that
+    # cannot answer is never asked rather than asked and found wanting.
+    #
+    # **A pointer into somebody else's system, opaque on this side.** Nothing here joins on it,
+    # validates it or fails without it — its whole worth is that a person holding it can find the
+    # statement in the cluster's own logs and see the plan, the runtime and the queue it waited in.
+    # Naming the concept rather than the engine is deliberate: a `redshift_query_id` column becomes a
+    # schema change the first time a second engine has one.
+    #
+    # None where the engine has no such id, where the lookup says not to ask, or where the ask
+    # failed — three cases that share one honest rendering, because inventing an id that points at
+    # nothing is worse than admitting there is none.
+    warehouse_query_id: str | None = None
 
 
 class ExecutorError(Exception):
@@ -1352,6 +1366,33 @@ def report_executing_identity(identity: str | None) -> None:
     this is not doing anything wrong — the built-in one never does.
     """
     _last_executing_identity.set(identity)
+
+
+# The warehouse's own id for the statement THIS call ran, for the audit row only. Same kind as the
+# two above and clear-cut for the same reason: an id left behind by an earlier call would point a
+# reader at a statement this row is not about, which is worse than pointing them nowhere.
+_last_warehouse_query_id: ContextVar[str | None] = ContextVar(
+    "_last_warehouse_query_id", default=None
+)
+
+
+def report_warehouse_query_id(query_id: str | None) -> None:
+    """Called by an executor that can name the statement it just ran, in the warehouse's own terms.
+
+    **Whether an engine can is a property of the engine, not of this module.** Nothing here asks,
+    branches on a database type, or knows which engines have such an id — an executor that can
+    answer reports, and one that cannot never calls this. That is what keeps adding an engine a
+    matter for whoever owns the connection rather than a change here.
+
+    Reported as late as the statement allows and as early as the answer is stable, which is the
+    executor's judgement to make: on some engines the id readable after a result has been consumed
+    belongs to the fetch rather than to the statement, and only the executor is in a position to
+    know when it is reading the right one.
+
+    Tolerates None so an engine with nothing to say costs nothing: the column stays null, and null
+    is a claim rather than a gap.
+    """
+    _last_warehouse_query_id.set(query_id)
 
 # The classified outcome of THIS call, for the tool-call recorder (ACE-098). `tools.record_tool_call`
 # derived `success` / `error_kind` by `json.loads`-ing the serialized body and reading
@@ -2646,6 +2687,9 @@ def execute_guarded(
     # unconditional read safe — without it a statement that reported nothing would inherit whoever
     # ran the statement before it, which is worse than the null it should have written.
     _last_executing_identity.set(None)
+    # And the same for the statement's id in the warehouse's own terms: a pointer left behind by an
+    # earlier call would send a reader to the wrong statement, with nothing on the row to say so.
+    _last_warehouse_query_id.set(None)
     # Same reason again: a verdict left behind by an earlier call in this context must never label
     # this one. The recorder falls back to parsing the body when this is None, so a stale value is
     # strictly worse than no value — it would be believed.
@@ -2766,6 +2810,8 @@ def execute_guarded(
         # no-op, which is why it only overwrites when the result actually carries one.
         if result.executing_identity is not None:
             _last_executing_identity.set(result.executing_identity)
+        if result.warehouse_query_id is not None:
+            _last_warehouse_query_id.set(result.warehouse_query_id)
         if result.truncated:
             return _envelope("refused", refusal=_resource_limit_refusal(None),
                              receipt=_receipt_for(received_sql, profile, bounded=True))

--- a/packages/agami-core/src/migrations/core/023_query_executions_warehouse_query_id.sql
+++ b/packages/agami-core/src/migrations/core/023_query_executions_warehouse_query_id.sql
@@ -1,0 +1,44 @@
+-- The warehouse's own id for a statement, where the engine mints one.
+--
+-- Some engines give every statement they run an internal id, and that id is the key to their own
+-- logs: the plan it chose, how long it queued, how much it scanned, why it was slow. An operator
+-- holding one can answer questions this database cannot, because the answers live in a system we do
+-- not own and do not replicate.
+--
+-- A POINTER INTO SOMEBODY ELSE'S SYSTEM, AND OPAQUE ON THIS SIDE. Nothing here joins on it, parses
+-- it, validates its shape or fails without it. It is written down and handed over. That is a
+-- deliberate limit rather than an unfinished thought: the moment this column means something to us
+-- it becomes a thing that can disagree with the warehouse, and a pointer that argues with what it
+-- points at is worse than one that says nothing.
+--
+-- NAMED FOR THE CONCEPT, NOT FOR AN ENGINE. A column named after whichever warehouse happened to be
+-- first becomes a schema change the day a second engine has one — and this table would then carry
+-- two columns meaning the same thing for different vendors, which is how a record stops being
+-- readable. There is also an unrelated `query_id` in the chart path; the qualified name keeps the
+-- two apart in every conversation about either.
+--
+-- NULLABLE, AND NULL IS A CLAIM RATHER THAN A GAP. Four honest nulls share this column:
+--
+--   * a row written before this migration ran;
+--   * an engine that has no such id at all, which is most of them;
+--   * an executor that did not ask, because asking costs a round trip nobody should pay blind;
+--   * an ask that failed, where the alternative was to invent a pointer to nothing.
+--
+-- WHICH ENGINES CAN ANSWER IS NOT DECIDED HERE. Nothing in this schema, and nothing in the recorder,
+-- knows which warehouses mint an id. An executor that can name its statement reports one; one that
+-- cannot never does. Adding an engine is therefore a matter for whoever owns the connection, and
+-- costs no migration and no change to the record — which is the whole reason the column is one
+-- nullable TEXT field rather than anything cleverer.
+--
+-- WRITTEN BY THE INSERT THAT WRITES THE ROW, never by a later update — the same append-only stance
+-- the rest of this table keeps, and the reason the value travels out through the executor rather
+-- than being written afterwards by whoever went looking for it.
+--
+-- Recorded on EVERY outcome, not only success. A statement that failed or was refused is the one an
+-- operator most wants to look up in the warehouse's logs, because that is where the reason lives.
+--
+-- Forward-only and portable (SQLite + Postgres unchanged). No `IF NOT EXISTS` — SQLite's ALTER does
+-- not accept it, and re-run safety comes from the runner's applied-filename ledger.
+--
+-- No index. Nothing filters on it; it is read by a person who already has the row in front of them.
+ALTER TABLE query_executions ADD COLUMN warehouse_query_id TEXT;

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -514,8 +514,8 @@ class DbActivitySink:
         self._store.execute(
             "INSERT INTO query_executions (id, ts, org_id, datasource, question, sql, row_count, "
             "source, status, reason, rule, sql_truncated, error_detail, detail, receipt, "
-            "model_version, executing_identity) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "model_version, executing_identity, warehouse_query_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 record.id,
                 record.ts,
@@ -546,6 +546,9 @@ class DbActivitySink:
                 # nothing else** — the row is append-only, and a column filled by a later update is
                 # exactly what that stance exists to prevent.
                 getattr(record, "executing_identity", None),
+                # The statement's id in the warehouse's own terms, on the same terms as the one
+                # above: written by this insert, tolerated as absent, and never filled later.
+                getattr(record, "warehouse_query_id", None),
             ),
         )
         self._store.commit()

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2274,6 +2274,7 @@ def _tool_execute_sql(args: dict[str, Any]) -> str:
     from execute_sql import (
         _last_error_detail,
         _last_executing_identity,
+        _last_warehouse_query_id,
         _pin_model_pass_posture,
     )
 
@@ -2284,6 +2285,9 @@ def _tool_execute_sql(args: dict[str, Any]) -> str:
     # opened — a row naming somebody who did not run it, which is worse than the null the forked
     # surface is supposed to carry.
     _last_executing_identity.set(None)
+    # And the statement's id in the warehouse's own terms, for the same reason: a pointer left by an
+    # earlier in-process call would send a reader to a different statement entirely.
+    _last_warehouse_query_id.set(None)
     # And pin the ACE-101 posture here, for the same "one point both paths pass through" reason and
     # against a sharper failure. `execute_guarded` pins it too, but on the fork that call happens in
     # the CHILD: the child decides whether the gates run, exits, and only then does this process build

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2126,7 +2126,11 @@ def _record_execution(
     # across the fork the child sanitizes and the parent records, so the raw text never crosses and
     # this is None. `execute_guarded` clears the var on entry, so a stale detail cannot attach to a
     # later call.
-    from execute_sql import _last_error_detail, _last_executing_identity
+    from execute_sql import (
+        _last_error_detail,
+        _last_executing_identity,
+        _last_warehouse_query_id,
+    )
 
     raw_detail = _last_error_detail.get()
     # Read unconditionally, exactly as the detail above is, and safe for the same reason:
@@ -2134,6 +2138,7 @@ def _record_execution(
     # than that an earlier one did. Read on every outcome, not only `ok` — a statement that failed
     # after connecting is the one an operator most wants attributed.
     executing_identity = _last_executing_identity.get()
+    warehouse_query_id = _last_warehouse_query_id.get()
     _record_query(
         {
             "id": env.audit_id,
@@ -2171,6 +2176,10 @@ def _record_execution(
             # the Envelope on purpose — the Envelope is the caller's, and this is an operator field
             # that should never be serialized back to whoever asked the question.
             "executing_identity": executing_identity,
+            # The statement's id in the warehouse's own terms, where the executor could name it.
+            # Off the ContextVar for the same reason as the identity beside it: an operator field,
+            # and the Envelope belongs to the caller.
+            "warehouse_query_id": warehouse_query_id,
         }
     )
 

--- a/plugins/agami/lib/execute_sql.py
+++ b/plugins/agami/lib/execute_sql.py
@@ -206,6 +206,20 @@ class ExecResult:
     # after connecting has no result to carry this, and that is the case the column is most worth
     # having for.
     executing_identity: str | None = None
+    # The warehouse's own id for this statement, where the engine has one. Some engines mint a
+    # per-execution id a person can look up in the cluster's own logs; most do not, and one that
+    # cannot answer is never asked rather than asked and found wanting.
+    #
+    # **A pointer into somebody else's system, opaque on this side.** Nothing here joins on it,
+    # validates it or fails without it — its whole worth is that a person holding it can find the
+    # statement in the cluster's own logs and see the plan, the runtime and the queue it waited in.
+    # Naming the concept rather than the engine is deliberate: a `redshift_query_id` column becomes a
+    # schema change the first time a second engine has one.
+    #
+    # None where the engine has no such id, where the lookup says not to ask, or where the ask
+    # failed — three cases that share one honest rendering, because inventing an id that points at
+    # nothing is worse than admitting there is none.
+    warehouse_query_id: str | None = None
 
 
 class ExecutorError(Exception):
@@ -1352,6 +1366,33 @@ def report_executing_identity(identity: str | None) -> None:
     this is not doing anything wrong — the built-in one never does.
     """
     _last_executing_identity.set(identity)
+
+
+# The warehouse's own id for the statement THIS call ran, for the audit row only. Same kind as the
+# two above and clear-cut for the same reason: an id left behind by an earlier call would point a
+# reader at a statement this row is not about, which is worse than pointing them nowhere.
+_last_warehouse_query_id: ContextVar[str | None] = ContextVar(
+    "_last_warehouse_query_id", default=None
+)
+
+
+def report_warehouse_query_id(query_id: str | None) -> None:
+    """Called by an executor that can name the statement it just ran, in the warehouse's own terms.
+
+    **Whether an engine can is a property of the engine, not of this module.** Nothing here asks,
+    branches on a database type, or knows which engines have such an id — an executor that can
+    answer reports, and one that cannot never calls this. That is what keeps adding an engine a
+    matter for whoever owns the connection rather than a change here.
+
+    Reported as late as the statement allows and as early as the answer is stable, which is the
+    executor's judgement to make: on some engines the id readable after a result has been consumed
+    belongs to the fetch rather than to the statement, and only the executor is in a position to
+    know when it is reading the right one.
+
+    Tolerates None so an engine with nothing to say costs nothing: the column stays null, and null
+    is a claim rather than a gap.
+    """
+    _last_warehouse_query_id.set(query_id)
 
 # The classified outcome of THIS call, for the tool-call recorder (ACE-098). `tools.record_tool_call`
 # derived `success` / `error_kind` by `json.loads`-ing the serialized body and reading
@@ -2646,6 +2687,9 @@ def execute_guarded(
     # unconditional read safe — without it a statement that reported nothing would inherit whoever
     # ran the statement before it, which is worse than the null it should have written.
     _last_executing_identity.set(None)
+    # And the same for the statement's id in the warehouse's own terms: a pointer left behind by an
+    # earlier call would send a reader to the wrong statement, with nothing on the row to say so.
+    _last_warehouse_query_id.set(None)
     # Same reason again: a verdict left behind by an earlier call in this context must never label
     # this one. The recorder falls back to parsing the body when this is None, so a stale value is
     # strictly worse than no value — it would be believed.
@@ -2766,6 +2810,8 @@ def execute_guarded(
         # no-op, which is why it only overwrites when the result actually carries one.
         if result.executing_identity is not None:
             _last_executing_identity.set(result.executing_identity)
+        if result.warehouse_query_id is not None:
+            _last_warehouse_query_id.set(result.warehouse_query_id)
         if result.truncated:
             return _envelope("refused", refusal=_resource_limit_refusal(None),
                              receipt=_receipt_for(received_sql, profile, bounded=True))

--- a/tests/test_ace038_timeout.py
+++ b/tests/test_ace038_timeout.py
@@ -243,6 +243,12 @@ def test_the_budget_has_exactly_one_configuration_surface():
     # surface the child holds the connection and the parent writes the row, so the column is NULL
     # there by the same construction that leaves `error_detail` NULL — and null is already a claim on
     # that column rather than a gap.
+    #
+    # `_last_warehouse_query_id` is the seventh, and it is the same kind again: an OUTPUT carrier
+    # holding the warehouse's own id for the statement this call ran, for the audit row alone.
+    # Written when an executor can name its statement, never read to compute a bound, and cleared at
+    # the entry to every call beside the two above. Like them it cannot cross the fork, and like them
+    # it does not need to — the column is null on that surface by the same construction.
     context_vars -= {
         "_last_error_detail",
         "_guard_model",
@@ -250,6 +256,7 @@ def test_the_budget_has_exactly_one_configuration_surface():
         "_guard_shape",
         "_pass_posture",
         "_last_executing_identity",
+        "_last_warehouse_query_id",
     }
     assert context_vars == set(), (
         "a second, higher-precedence configuration surface for the budget cannot cross the fork; "

--- a/tests/test_warehouse_query_id.py
+++ b/tests/test_warehouse_query_id.py
@@ -1,0 +1,219 @@
+"""The warehouse's own id for a statement, recorded where an engine mints one.
+
+Some engines give every statement an internal id, and it is the key to their own logs — the plan,
+the queue time, the bytes scanned. Recording it lets an operator follow a row into a system this
+database does not own.
+
+**It is a pointer, and this side treats it as opaque.** Nothing joins on it, parses it or fails
+without it, and the tests here hold that line deliberately: they assert the value written is the
+value reported, and never that it looks like anything in particular. A test that asserted a shape
+would be this codebase inventing a claim about somebody else's identifier.
+
+Which engines can answer is not decided here, and there is a test for that too — nothing in the
+recorder or the schema knows which warehouses mint an id, so adding one is a matter for whoever owns
+the connection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")  # the contract records are pydantic
+
+import tools  # noqa: E402
+from contracts import QueryExecutionRecord  # noqa: E402
+from execute_sql import (  # noqa: E402
+    ExecResult,
+    _last_warehouse_query_id,
+    report_warehouse_query_id,
+)
+from model_store import DbActivitySink  # noqa: E402
+from store import Store  # noqa: E402
+
+_SRC = Path(__file__).resolve().parents[1] / "packages" / "agami-core" / "src"
+
+
+def _fresh_db(tmp_path) -> str:
+    url = "sqlite://" + str(tmp_path / "agami.db")
+    s = Store.connect(url)
+    s.run_migrations()
+    s.close()
+    return url
+
+
+def _record(url: str, **overrides) -> None:
+    rec = {
+        "id": "3f9a1c047b2e4d819c55e0a2b6d7f118",
+        "ts": "2026-09-07T00:00:00Z",
+        "profile": "main",
+        "question": "how many orders?",
+        "sql": "SELECT count(*) FROM orders",
+        "row_count": 1,
+        "source": "mcp_server",
+        "status": "ok",
+    }
+    rec.update(overrides)
+    tools._record_query(rec)
+
+
+def _ids(url: str) -> list:
+    s = Store.connect(url)
+    rows = s.query("SELECT warehouse_query_id FROM query_executions ORDER BY id")
+    s.close()
+    return [r["warehouse_query_id"] for r in rows]
+
+
+# --- the column, and what a null means -------------------------------------------------------------
+
+
+def test_an_engine_that_mints_no_id_records_null(tmp_path, monkeypatch):
+    """Most engines have no such id. Null is a claim — nothing was reported — rather than a gap, and
+    it is the same null as an executor that chose not to ask."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    _record(url)
+
+    assert _ids(url) == [None]
+
+
+def test_an_id_an_executor_reports_reaches_the_row(tmp_path, monkeypatch):
+    """Written down and handed over. Asserted as equality with what was reported and nothing more:
+    the value is somebody else's identifier, and a test that checked its shape would be this
+    codebase inventing a claim about it."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    _record(url, warehouse_query_id="a-warehouse-statement-id")
+
+    assert _ids(url) == ["a-warehouse-statement-id"]
+
+
+def test_an_opaque_id_is_stored_verbatim(tmp_path, monkeypatch):
+    """Engines disagree about what an id even is — an integer on one, a uuid on another, a prefixed
+    string on a third. Whatever arrives is what is written, because normalising it here would be a
+    guess that makes the pointer stop resolving."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    for i, given in enumerate(("1234567890", "01af-3c22-9d10", "statement/2026/09/07#4")):
+        _record(url, id=f"{i:032d}", warehouse_query_id=given)
+
+    assert _ids(url) == ["1234567890", "01af-3c22-9d10", "statement/2026/09/07#4"]
+
+
+# --- the outcomes an operator most wants to look up ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        pytest.param({"status": "failed"}, id="the statement failed"),
+        pytest.param(
+            {"status": "refused", "reason": "resource_limit", "rule": "AGAMI-RESOURCE"},
+            id="the statement was refused",
+        ),
+    ],
+)
+def test_a_statement_that_did_not_succeed_still_records_its_id(tmp_path, monkeypatch, outcome):
+    """The row an operator most wants to follow into the warehouse's logs is the one that went
+    wrong — that is where the reason lives. A column that goes null on failure is empty for exactly
+    the traffic it was added for."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    _record(url, warehouse_query_id="a-warehouse-statement-id", **outcome)
+
+    assert _ids(url) == ["a-warehouse-statement-id"]
+
+
+def test_an_executor_that_reports_no_id_changes_nothing(tmp_path, monkeypatch):
+    """A failure to obtain the id leaves the column null and does not change what the statement
+    returned. Asserted over the whole row, because "changes nothing else" is the half a column-only
+    check would miss."""
+    url = _fresh_db(tmp_path)
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+
+    _record(url, warehouse_query_id=None)
+
+    s = Store.connect(url)
+    (row,) = s.query("SELECT sql, row_count, status, warehouse_query_id FROM query_executions", ())
+    s.close()
+    assert row["warehouse_query_id"] is None
+    assert (row["sql"], row["row_count"], row["status"]) == (
+        "SELECT count(*) FROM orders",
+        1,
+        "ok",
+    )
+
+
+# --- the seam, and what this side deliberately does not know ---------------------------------------
+
+
+def test_the_result_carries_an_id_for_an_injected_executor():
+    """The second field on the seam, in the shape of the first. Optional, so every existing
+    construction keeps working."""
+    assert ExecResult(columns=[], rows=[]).warehouse_query_id is None
+    assert ExecResult(columns=[], rows=[], warehouse_query_id="x").warehouse_query_id == "x"
+
+
+def test_an_executor_reports_the_id_itself():
+    """Reported through a setter as well as through the result, so an executor can name the
+    statement at the moment the answer is stable rather than only where a result exists."""
+    report_warehouse_query_id(None)
+    report_warehouse_query_id("a-warehouse-statement-id")
+
+    assert _last_warehouse_query_id.get() == "a-warehouse-statement-id"
+
+    report_warehouse_query_id(None)
+    assert _last_warehouse_query_id.get() is None, "reporting nothing must clear, not keep"
+
+
+def test_nothing_here_decides_which_engines_have_an_id():
+    """**The property that keeps adding an engine free.** No database type, driver name or engine
+    list appears in the recorder or the seam — an executor that can name its statement reports one,
+    and one that cannot never calls. Asserted against the source, because the guarantee is that no
+    such branch exists rather than that today's branches are correct."""
+    for module in ("model_store.py", "contracts.py"):
+        text = (_SRC / module).read_text(encoding="utf-8")
+        assert "warehouse_query_id" in text, f"{module} should carry the field"
+        for engine in ("redshift", "snowflake", "bigquery", "postgres", "mysql"):
+            assert engine not in text.lower().split("warehouse_query_id")[1][:400], (
+                f"{module} names {engine} near the field; which engines can answer is not decided here"
+            )
+
+
+def test_the_column_is_written_by_the_insert_and_never_updated():
+    """Append-only, like every other column on this row. Asserted against the source: the guarantee
+    is that no code path exists to fill it later."""
+    offenders = sorted(
+        str(path.relative_to(_SRC))
+        for pattern in ("*.py", "*.sql")
+        for path in _SRC.rglob(pattern)
+        if "UPDATE query_executions" in path.read_text(encoding="utf-8")
+    )
+
+    assert offenders == [], f"a second writer of the execution row appeared: {offenders}"
+
+
+def test_the_record_defaults_the_field_so_an_older_caller_still_writes(tmp_path):
+    """The same tolerance every optional column on this record has: a caller on the older shape
+    writes a NULL rather than raising."""
+    url = _fresh_db(tmp_path)
+    s = Store.connect(url)
+    DbActivitySink(s).record_query_execution(
+        QueryExecutionRecord(
+            id="b" * 32,
+            ts="2026-09-07T00:00:00Z",
+            profile="main",
+            sql="SELECT 1",
+            row_count=1,
+            source="mcp_server",
+        )
+    )
+    rows = s.query("SELECT warehouse_query_id FROM query_executions", ())
+    s.close()
+
+    assert [r["warehouse_query_id"] for r in rows] == [None]


### PR DESCRIPTION
> **Stacked on #273.** Base is `AH-118-the-statement-records-who-ran-it`, not `main` — this adds a second field in the shape that one establishes. Retarget once #273 merges.

## Summary

Some engines mint a per-execution id for every statement they run, and that id is the key to their own logs: the plan the statement got, how long it queued, how much it scanned. This records it, so somebody can follow a row from here into a system this database does not own and cannot replicate.

## A pointer, and opaque on this side

Nothing here joins on it, parses it, validates its shape or fails without it. It is written down and handed over.

That is a limit on purpose rather than an unfinished thought: the moment the value means something here, it becomes a thing that can *disagree* with the warehouse — and a pointer that argues with what it points at is worse than one that says nothing.

The tests hold the same line. They assert the value written is the value reported and never that it looks like anything in particular, because asserting a shape would be this codebase inventing a claim about somebody else's identifier. `test_an_opaque_id_is_stored_verbatim` drives an integer-ish string, a uuid-ish string and a slash-and-hash string through unchanged.

## Which engines can answer is not decided here

No database type, driver name or engine list appears in the seam or the recorder. An executor that can name its statement reports one; one that cannot never calls.

`test_nothing_here_decides_which_engines_have_an_id` asserts that **against the source**, not against behaviour — the property that keeps adding an engine free is the *absence* of a branch, not the correctness of today's branches. Adding one is a change where the connection lives: no migration, no schema change, no change to the record.

## Changes

- **`ExecResult.warehouse_query_id`** — the second optional field on the seam.
- **`_last_warehouse_query_id` + `report_warehouse_query_id()`** — the channel, mirroring the identity pair.
- **`QueryExecutionRecord.warehouse_query_id`**, written by the insert with the same `getattr` tolerance its neighbours use.
- **`023_query_executions_warehouse_query_id.sql`** — one nullable TEXT column, portable DDL, no index.

## Named for the concept, not the engine

A column named after whichever warehouse happened to be first becomes a schema change the day a second one has an id — and the table would then carry two columns meaning the same thing for different vendors, which is how a record stops being readable.

## Four honest nulls

A row written before the migration; an engine with no such id, which is most of them; an executor that did not ask, because asking costs a round trip nobody should pay blind; and an ask that failed, where the alternative was to invent a pointer to nothing. Null is a claim rather than a gap.

## Checklist

- [x] Full suite green — **5515 passed, 12 skipped**
- [x] `ruff check plugins packages tests dev.py dev` clean
- [x] Changelog entry under `[Unreleased]`
- [x] Migration `023` verified free across every ref and worktree
- [x] 11 new tests, including the opaque-value case, failed and refused outcomes, and the source-level guard that no engine is named near the field
- [x] The ContextVar allowlist entry carries its justification in writing, as that guard requires
- [x] Vendored lib regenerated through `dev.py sync-lib`

## Not provable here

That a real statement's id is recorded, and that **the id is the statement's rather than a later cursor operation's**. Both need an engine that mints one, and the executor that reads it. Recorded as owed rather than faked with a stub that would assert our own test double's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
