### PR TITLE
A tool call can record the model the client says it is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,32 @@ below corresponds to one such version.
   SQLite and Postgres. Nothing reads it yet; nothing updates it — the row stays append-only and the
   value is written by the insert that already writes it.
 
+- **A tool call can record the AI model the client says it is running.** The activity log recorded
+  who called, which tool, the statement and the outcome — everything the server observed — and never
+  what was driving. Over MCP the model belongs to the client and the server never sees it, so an
+  operator reading a run of unusually poor statements could not tell whether the client had moved to
+  a different model that week. That is the first question somebody asks, and the log had no answer.
+
+  `client_model` is an optional property on all four tools and a nullable column beside the other
+  self-reported ones. It is **evidence of a claim and never a fact**: models self-identify
+  unreliably, nothing checks the value, and nothing branches on it — it is never a basis for an
+  access decision, a bound, a bill or an audit conclusion. A client-controlled value that could
+  change what the server does would be far worse than an empty column, so a test asserts against the
+  source that no reader of it exists outside the record, the writer, the read list and the render.
+
+  There is deliberately **no list of known models** to check it against. A closed set would refuse a
+  model that shipped after the set was written, which is a certainty rather than a risk; storing what
+  was said, unvalidated and marked as unvalidated, is the only account that stays true. The admin
+  activity view shows it marked `· self-reported`, beside the agent's own framing.
+
+  Bounded by the writer at 200 characters — many times the longest honest model id — and with no
+  truncation flag, on the same reasoning the refusal detail already carries: nobody re-runs a model
+  id, so a flag would be a column false on every row ever written. Null is the ordinary case; a
+  client that reports nothing is behaving correctly, and so is one built before this existed.
+
+  Migration `024_tool_calls_client_model.sql`, one nullable TEXT column, portable across SQLite and
+  Postgres.
+
 ## [0.8.2] — 2026-09-07
 
 Two reliability fixes to the eval, both found by running it for real: the client couldn't be found

--- a/packages/agami-core/src/admin.py
+++ b/packages/agami-core/src/admin.py
@@ -292,9 +292,20 @@ def _call_card(c: dict[str, Any]) -> str:
     ds = ui.esc(c.get("datasource") or "—")
     lat = (str(c["execution_ms"]) + " ms") if c.get("execution_ms") is not None else ""
     rows_bit = f" · {c['row_count']} rows" if c.get("row_count") is not None else ""
+    # What the client said it was running (ACE-113), marked so nobody reads it as something the
+    # server observed. Absent on every call that reported none, which is the ordinary case, and
+    # through `_text` because a non-string column value would otherwise take the whole page down —
+    # `_session_drawer` joins every card into one string.
+    model = _text(c.get("client_model"))
+    model_bit = (
+        f'<div class="muted" style="font-size:13px;margin-top:6px">{ui.esc(model)} '
+        f'<span class="muted">· self-reported</span></div>'
+        if model
+        else ""
+    )
     return (
         '<div style="border-top:1px solid var(--line);padding:9px 0 11px">'
-        f"{head}{body}{_basis_block(c.get('basis'))}"
+        f"{head}{body}{_basis_block(c.get('basis'))}{model_bit}"
         f'<div class="muted" style="font-size:13px;margin-top:6px">{_utc(c["ts"])} · {ds} · '
         f"{lat} {_ok_pill(c['success'])}{rows_bit}</div></div>"
     )

--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -288,8 +288,11 @@ class QueryExecutionRecord(_Contract):
 
 class ToolCallRecord(_Contract):
     """One MCP tool call. Audit-grade fields (server-observed) are required-ish; the self-report fields
-    (user_question / agent_query / thread_id / client_model) are Claude-supplied and nullable
-    (best-effort)."""
+    (user_question / agent_query / thread_id / client_model) are CLIENT-supplied and nullable
+    (best-effort).
+
+    Client-supplied rather than Claude-supplied, which is what this said: any MCP client can call
+    these tools, and a contract that names one vendor reads as though the others were unsupported."""
 
     ts: str
     tool_name: str

--- a/packages/agami-core/src/contracts.py
+++ b/packages/agami-core/src/contracts.py
@@ -288,7 +288,8 @@ class QueryExecutionRecord(_Contract):
 
 class ToolCallRecord(_Contract):
     """One MCP tool call. Audit-grade fields (server-observed) are required-ish; the self-report fields
-    (user_question / agent_query / thread_id) are Claude-supplied and nullable (best-effort)."""
+    (user_question / agent_query / thread_id / client_model) are Claude-supplied and nullable
+    (best-effort)."""
 
     ts: str
     tool_name: str
@@ -329,4 +330,17 @@ class ToolCallRecord(_Contract):
     # claim and never a fact; nothing here checks `ref` against `sql`. NULL on every call that did
     # not send one, which is the ordinary case.
     basis: str | None = None
+    # The AI model the CLIENT says it is running (ACE-113). Over MCP the model belongs to the client
+    # and the server never sees it, so this is the only account of what was driving a call — which is
+    # the first thing somebody asks when a run of statements is worse than usual.
+    #
+    # Bounded by the writer (`tools.CLIENT_MODEL_MAX_CHARS`) and carrying no truncation flag, unlike
+    # `basis` above: the cap is many times the longest honest model id, so a cut means a caller
+    # already did something pathological rather than that a real value was too long.
+    #
+    # Self-reported like `user_question`/`agent_query`/`basis`, so it is evidence of a claim and
+    # never a fact. Nothing checks it against anything — there is no list of models to check it
+    # against, and one written down here would refuse a model that shipped after it. NULL on every
+    # call that did not send one, which is the ordinary case.
+    client_model: str | None = None
     org_id: str = "local"  # the tenant this call ran for; defaults to the single-tenant org

--- a/packages/agami-core/src/migrations/core/024_tool_calls_client_model.sql
+++ b/packages/agami-core/src/migrations/core/024_tool_calls_client_model.sql
@@ -1,0 +1,45 @@
+-- The AI model the client says it is running (ACE-113).
+--
+-- The log records who called, which tool, the statement and the outcome — everything the server
+-- observed. It has never recorded WHAT WAS DRIVING. Over MCP the model belongs to the client, and
+-- the server never sees it, so an operator reading a run of unusually poor statements cannot tell
+-- whether the client was on a different model that week. That is the first question somebody asks,
+-- and the log had no answer to it.
+--
+-- SELF-REPORTED, LIKE ITS NEIGHBOURS. This is the fourth best-effort column on this table, joining
+-- `user_question`, `agent_query` and `basis` in the tier 008 describes: the audit-grade columns are
+-- what the server observed and are always trustworthy; these are what the client said about itself.
+-- It is evidence of a claim and never a fact. A client can report anything, report nothing, or be
+-- wrong about itself — models self-identify unreliably — and this column is honest about that by
+-- being read as a claim rather than believed as a measurement.
+--
+-- NOTHING BRANCHES ON IT, and that is a rule rather than an accident of this slice being small. It
+-- is never a basis for an access decision, a bound, a bill or an audit conclusion. It is written,
+-- read back, and shown to a person who is told where it came from. A value a client controls must
+-- not be able to change what the server does, and the way to guarantee that is for nothing to
+-- consult it.
+--
+-- NOT CHECKED AGAINST ANYTHING. There is no list of known models here and there will not be one: a
+-- closed set would refuse a model that shipped after the set was written, which is a certainty
+-- rather than a risk. Storing what was said, unvalidated and marked as unvalidated, is the only
+-- account that stays true.
+--
+-- BOUNDED BY THE WRITER, at a cap many times the longest honest model id, and with no companion
+-- truncation flag. The flag on `query_executions.sql` earns its place because a cut statement reads
+-- as the whole one and a reviewer would re-run something that does not reproduce the decision.
+-- Nobody re-runs a model id, and at this cap a cut value means a caller already did something
+-- pathological — so the flag would be a column that is false on every row ever written. That is the
+-- same argument `_bounded_audit_detail` makes for its own single bounded string.
+--
+-- NULLABLE, AND NULL IS THE ORDINARY CASE rather than a defect. A client that reports nothing is
+-- behaving correctly; so is one built before this existed. Nothing degrades when the column is
+-- empty, which is what "best-effort" has to mean if the log is to stay usable for clients that
+-- report none of it.
+--
+-- Forward-only and portable (SQLite + Postgres unchanged). `ALTER TABLE ... ADD COLUMN` is the one
+-- schema change both engines take as written, and existing rows keep their history with a NULL
+-- here. No `IF NOT EXISTS` — SQLite's ALTER does not accept it, and re-run safety comes from the
+-- runner's applied-filename ledger.
+--
+-- No index. Nothing filters on it; it is read by a person who already has the row in front of them.
+ALTER TABLE tool_calls ADD COLUMN client_model TEXT;

--- a/packages/agami-core/src/model_store.py
+++ b/packages/agami-core/src/model_store.py
@@ -559,8 +559,8 @@ class DbActivitySink:
             "INSERT INTO tool_calls (id, ts, org_id, actor, tool_name, datasource, sql, row_count, "
             "execution_ms, success, error_kind, source, user_question, agent_query, thread_id, "
             "correlation_id, refusal_detail, refusal_remediation, audit_id, basis, "
-            "conversation_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "conversation_id, client_model) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 uuid4().hex,
                 record.ts,
@@ -597,6 +597,9 @@ class DbActivitySink:
                 # than raising — and NULL is a real value here: the local single-user path has no
                 # store to read a previous call from, so it derives nothing.
                 getattr(record, "conversation_id", None),
+                # The model the client says it is running (ACE-113). `getattr`-guarded like the five
+                # above, so an embedder on an older record shape writes NULL rather than raising.
+                getattr(record, "client_model", None),
             ),
         )
         self._store.commit()
@@ -612,7 +615,11 @@ _TOOL_CALL_COLS = (
     # The conversation the SERVER decided this call belongs to (021), which is what `list_sessions`
     # groups by now. `thread_id` stays selected beside it: it is still recorded, a consumer may still
     # read it, and on a row written before 021 it is the only grouping there is.
-    "refusal_detail, refusal_remediation, basis, conversation_id"
+    "refusal_detail, refusal_remediation, basis, conversation_id, "
+    # Selected as well as inserted, which is the half that is easy to miss: this list is narrower
+    # than the INSERT (`org_id` and `audit_id` are written and never read), so a column added to one
+    # and not the other is recorded faithfully and reaches no reader at all.
+    "client_model"
 )
 
 

--- a/packages/agami-core/src/tools.py
+++ b/packages/agami-core/src/tools.py
@@ -2075,6 +2075,35 @@ def _bounded_basis(raw: Any) -> str | None:
     return json.dumps({"entries": entries, "truncated": truncated})
 
 
+#: How much of a self-reported model id is stored (ACE-113). Many times the longest honest value —
+#: model ids run to a few tens of characters — for the reason the caps above are set that way: a
+#: bound well clear of any real value means a cut is a signal that something already went wrong,
+#: rather than a routine trim of legitimate content.
+CLIENT_MODEL_MAX_CHARS = 200
+
+
+def _bounded_client_model(raw: Any) -> str | None:
+    """The model the client says it is running, as it will be stored (ACE-113).
+
+    **The isinstance guard is not defensive padding.** This value arrives from JSON, where a client
+    may hand back a number, a list or an object as easily as a string; without the check a
+    `{"client_model": 7}` would be stored as the Python `repr` of an int and read later as though a
+    client had reported a model called "7". `_bounded_basis` guards its own fields for the same
+    reason.
+
+    None rather than an empty string when there is nothing to store, so a call that omits the
+    argument stays byte-identical to one made before the field existed.
+
+    No companion truncation flag, on the same argument `_bounded_audit_detail` makes below: the flag
+    on `sql` earns its place because a cut statement reads as the whole one and somebody would re-run
+    it. Nobody re-runs a model id, and at this cap a cut value is already a caller doing something
+    pathological — so the flag would be a column that is false on every row ever written.
+    """
+    if not isinstance(raw, str):
+        return None
+    return raw[:CLIENT_MODEL_MAX_CHARS] or None
+
+
 def _bounded_audit_detail(detail: str) -> str:
     """The refusal's detail as it will be stored (ACE-098).
 
@@ -2804,6 +2833,10 @@ def record_tool_call(
         # applies is not a bound. Joins the two self-reported columns above: same provenance, same
         # trust.
         "basis": _bounded_basis(args.get("basis")),
+        # The model the client says it is running. Read straight off the arguments like the two
+        # above rather than exposed as a caller override: an embedder knows its own thread and its
+        # own actor, but it is no better placed than we are to know what model the client is on.
+        "client_model": _bounded_client_model(args.get("client_model")),
         "thread_id": thread_id if thread_id is not None else args.get("thread_id"),
         "correlation_id": (  # the turn (one user question)
             correlation_id if correlation_id is not None else args.get("correlation_id")
@@ -2979,6 +3012,11 @@ _CORRELATION_ID_PROP = {
     "you make answering THAT question — lets the admin see 'user asked X → agent made N calls'. "
     "Start a fresh one when the user asks something new.",
 }
+_CLIENT_MODEL_PROP = {
+    "type": "string",
+    "description": "The AI model YOU are running, as you know it — recorded so an admin reading a "
+    "run of calls can see what was driving them. Your own best account of it; nothing checks it.",
+}
 _USER_QUESTION_PROP = {
     "type": "string",
     "description": "The user's question, VERBATIM, that this call helps answer — recorded so an admin "
@@ -3070,6 +3108,7 @@ TOOLS: dict[str, dict[str, Any]] = {
             "type": "object",
             "properties": {
                 "user_question": _USER_QUESTION_PROP,
+                "client_model": _CLIENT_MODEL_PROP,
                 "thread_id": _THREAD_ID_PROP,
                 "correlation_id": _CORRELATION_ID_PROP,
             },
@@ -3144,6 +3183,7 @@ TOOLS: dict[str, dict[str, Any]] = {
                     ),
                 },
                 "user_question": _USER_QUESTION_PROP,
+                "client_model": _CLIENT_MODEL_PROP,
                 "thread_id": _THREAD_ID_PROP,
                 "correlation_id": _CORRELATION_ID_PROP,
             },
@@ -3192,6 +3232,7 @@ TOOLS: dict[str, dict[str, Any]] = {
                     ),
                 },
                 "user_question": _USER_QUESTION_PROP,
+                "client_model": _CLIENT_MODEL_PROP,
                 "thread_id": _THREAD_ID_PROP,
                 "correlation_id": _CORRELATION_ID_PROP,
             },
@@ -3314,6 +3355,7 @@ TOOLS: dict[str, dict[str, Any]] = {
                     "query you run to answer one question — do not replace it with your refinement (that "
                     "goes in raw_query). Recorded so an admin sees what was actually asked.",
                 },
+                "client_model": _CLIENT_MODEL_PROP,
                 "thread_id": _THREAD_ID_PROP,
                 "correlation_id": _CORRELATION_ID_PROP,
                 # Deliberately a bare array: no `items` schema, no `maxItems`. The MCP SDK validates

--- a/tests/test_ace113_client_model.py
+++ b/tests/test_ace113_client_model.py
@@ -1,0 +1,251 @@
+"""ACE-113 — the client names the model it is running.
+
+Over MCP the model belongs to the client and the server never sees it, so the log could say who
+called and what they ran but never what was driving. An operator reading a run of unusually poor
+statements could not tell whether the client was on a different model that week.
+
+**The value is a claim, and every test here treats it as one.** It is bounded at the writer, stored
+unvalidated, marked self-reported where it renders, and — the property that matters most — consulted
+by nothing. A client-controlled value that could change what the server does would be a much worse
+thing than an empty column, so `test_nothing_in_the_package_branches_on_the_model` asserts against
+the source that no such reader exists rather than trusting that today's code happens not to have one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+import admin  # noqa: E402
+import tools  # noqa: E402
+from model_store import _TOOL_CALL_COLS  # noqa: E402
+from store import Store  # noqa: E402
+
+_SRC = Path(__file__).resolve().parents[1] / "packages" / "agami-core" / "src"
+
+A_MODEL = "a-model-id-1-2"
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    url = "sqlite://" + str(tmp_path / "calls.db")
+    monkeypatch.setenv("AGAMI_DB_URL", url)
+    s = Store.connect(url)
+    s.run_migrations()
+    s.close()
+    return url
+
+
+def _rows(url):
+    s = Store.connect(url)
+    rows = s.query("SELECT * FROM tool_calls ORDER BY ts")
+    s.close()
+    return rows
+
+
+def _record(client_model=None, **extra):
+    args = {"datasource": "SALES_DATA", "sql": "SELECT 1", **extra}
+    if client_model is not None:
+        args["client_model"] = client_model
+    tools.record_tool_call(
+        name="execute_sql",
+        arguments=args,
+        result_text='{"row_count": 1}',
+        execution_ms=4,
+        actor="jordan@example.com",
+    )
+
+
+# --- written, and read back ------------------------------------------------------------------------
+
+
+def test_a_reported_model_is_recorded(db):
+    _record(A_MODEL)
+
+    (row,) = _rows(db)
+    assert row["client_model"] == A_MODEL
+
+
+def test_a_call_reporting_nothing_records_null(db):
+    """The ordinary case. A client that says nothing is behaving correctly, and so is one built
+    before the column existed."""
+    _record()
+
+    (row,) = _rows(db)
+    assert row["client_model"] is None
+
+
+def test_the_stored_model_reaches_the_reader(db):
+    """**The half that is easy to miss.** The SELECT list is narrower than the INSERT — `org_id` and
+    `audit_id` are written and read by nobody — so a column added to one and not the other is
+    recorded faithfully and reaches no reader at all. Every DB round-trip test would still pass."""
+    assert "client_model" in _TOOL_CALL_COLS
+
+
+def test_sending_a_model_perturbs_no_other_column(db):
+    """An optional self-report must not change anything else about the row it rides on."""
+    _record()
+    _record(A_MODEL)
+
+    without, with_model = _rows(db)
+    assert set(without) == set(with_model)
+    differing = {k for k in without if without[k] != with_model[k]}
+    assert differing <= {"id", "ts", "client_model"}, differing
+
+
+# --- bounded at the writer -------------------------------------------------------------------------
+
+
+def test_an_over_long_model_is_cut_by_the_writer(db):
+    """Bounded here, not by the caller — a bound the caller applies is not a bound."""
+    _record("m" * (tools.CLIENT_MODEL_MAX_CHARS + 500))
+
+    (row,) = _rows(db)
+    assert len(row["client_model"]) == tools.CLIENT_MODEL_MAX_CHARS
+
+
+def test_the_cap_is_far_above_any_honest_model_id():
+    """Why there is no truncation flag. The cap is many times the longest real model id, so a cut
+    means a caller already did something pathological rather than that a real value was too long —
+    and a flag would be a column false on every row ever written."""
+    assert tools.CLIENT_MODEL_MAX_CHARS >= 5 * len(A_MODEL)
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [
+        pytest.param(7, id="an integer"),
+        pytest.param(1.5, id="a float"),
+        pytest.param(True, id="a boolean"),
+        pytest.param(["a", "b"], id="a list"),
+        pytest.param({"name": "x"}, id="an object"),
+        pytest.param("", id="an empty string"),
+    ],
+)
+def test_a_non_string_model_is_stored_as_null(db, junk):
+    """JSON hands back whatever the client sent. Without the isinstance guard a `7` would be stored
+    as the Python repr of an int and read later as though somebody had reported a model called "7"
+    — a fabricated claim, which is worse than the absence it replaced."""
+    _record(junk)
+
+    (row,) = _rows(db)
+    assert row["client_model"] is None
+
+
+# --- the tool schema -------------------------------------------------------------------------------
+
+
+def _schemas():
+    return {name: spec["inputSchema"] for name, spec in tools.TOOLS.items()}
+
+
+def test_the_prop_is_declared_optional_on_every_tool():
+    """Declared on all four, required by none. Declaring it is what makes it SENDABLE: every schema
+    is `additionalProperties: False`, so an undeclared property is refused rather than ignored."""
+    for name, schema in _schemas().items():
+        assert "client_model" in schema["properties"], name
+        assert "client_model" not in schema.get("required", []), name
+        assert schema.get("additionalProperties") is False, name
+
+
+def test_the_schema_constrains_nothing_the_sdk_could_refuse_the_call_over():
+    """**The bound lives in the writer, never in the schema.** The MCP SDK validates `inputSchema`
+    before the handler runs, so a `maxLength` or an `enum` here would refuse the whole query over an
+    optional note rather than trim it."""
+    for name, schema in _schemas().items():
+        prop = schema["properties"]["client_model"]
+        assert set(prop) <= {"type", "description"}, (name, prop)
+        assert prop["type"] == "string", name
+
+
+# --- rendered, marked, and harmless ----------------------------------------------------------------
+
+
+def _card(**call):
+    base = {
+        "ts": "2026-09-07T00:00:00Z",
+        "tool_name": "execute_sql",
+        "success": 1,
+        "sql": "SELECT 1",
+        "datasource": "SALES_DATA",
+    }
+    return admin._call_card({**base, **call})
+
+
+def test_the_card_marks_the_model_self_reported():
+    """Shown, and shown as a claim. An operator must never read it as something the server saw."""
+    html = _card(client_model=A_MODEL)
+
+    assert A_MODEL in html
+    assert "· self-reported" in html
+
+
+def test_a_call_reporting_no_model_renders_nothing_about_it():
+    """No dash, no placeholder, no line. Most calls report none, and a note on every one of them
+    would be noise on the surface an operator opened to read something else."""
+    html = _card()
+
+    assert "self-reported" not in html
+
+
+def test_the_rendered_model_is_escaped():
+    """A self-reported value is attacker-influenceable by definition."""
+    html = _card(client_model='<script>alert("x")</script>&')
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+    assert "&amp;" in html
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [pytest.param(7, id="an integer"), pytest.param(["x"], id="a list"), pytest.param({}, id="a dict")],
+)
+def test_a_malformed_model_does_not_take_the_page_down(junk):
+    """A column written by something other than this process — an older embedder, a hand-edited row
+    — must not cost the operator the whole log. The blast radius is the page rather than the card:
+    `_session_drawer` joins every card into one string, so one raise loses all of them."""
+    html = _card(client_model=junk)
+
+    assert "self-reported" not in html
+    assert "SELECT 1" in html, "the rest of the card still rendered"
+
+
+# --- the rule that keeps it a claim -----------------------------------------------------------------
+
+
+def test_nothing_in_the_package_branches_on_the_model():
+    """**A client-controlled value must not be able to change what the server does**, and the way to
+    guarantee that is for nothing to consult it. Asserted against the source rather than against
+    behaviour: the property is the absence of a reader, not the correctness of today's readers.
+
+    The four sites that may name it are the record, the writer, the SELECT list and the render. A
+    fifth is a decision somebody has to make deliberately, in front of this test.
+    """
+    allowed = {"contracts.py", "model_store.py", "tools.py", "admin.py"}
+    offenders = sorted(
+        str(path.relative_to(_SRC))
+        for path in _SRC.rglob("*.py")
+        if "client_model" in path.read_text(encoding="utf-8") and path.name not in allowed
+    )
+
+    assert offenders == [], f"a new reader of the self-reported model appeared: {offenders}"
+
+
+def test_the_record_defaults_the_field_so_an_older_caller_still_writes(db):
+    """The `getattr` tolerance every column after `correlation_id` already has: an embedder on an
+    older record shape writes NULL rather than raising."""
+    from contracts import ToolCallRecord
+    from model_store import DbActivitySink
+
+    s = Store.connect(db)
+    DbActivitySink(s).record_tool_call(
+        ToolCallRecord(ts="2026-09-07T00:00:00Z", tool_name="execute_sql", source="mcp_server")
+    )
+    rows = s.query("SELECT client_model FROM tool_calls", ())
+    s.close()
+
+    assert [r["client_model"] for r in rows] == [None]


### PR DESCRIPTION
Spec: ACE-113

## Summary

The activity log recorded who called, which tool, the statement and the outcome — everything the server observed — and never **what was driving**. Over MCP the model belongs to the client and the server never sees it, so an operator reading a run of unusually poor statements could not tell whether the client had moved to a different model that week.

This was specified once as `client_model` in ACE-013, folded into ACE-008 (which shipped the audit log and the three self-report fields), and carried in ACE-015's and ACE-016's out-of-scope lists as *"the self-reported client model (its own spec)"*. It keeps that name.

## A fourth best-effort column, not a new mechanism

`008_tool_calls.sql` already describes the two tiers: audit-grade columns are what the server observed and are always trustworthy; best-effort columns are what the client said about itself. `client_model` joins the second tier beside `user_question`, `agent_query` and `basis`, and every part of it reuses an existing pattern — the bound-at-the-writer shape, the shared-schema-prop shape, the render marker.

## Evidence of a claim, never a fact

Models self-identify unreliably. So nothing checks the value, and — the property that matters most — **nothing branches on it**. It is never a basis for an access decision, a bound, a bill or an audit conclusion.

A client-controlled value that could change what the server does would be far worse than an empty column, and the only way to guarantee it cannot is for nothing to consult it. `test_nothing_in_the_package_branches_on_the_model` asserts that **against the source** rather than against behaviour: only the record, the writer, the read list and the render may name the field, so a fifth site is a decision somebody has to make in front of a failing test.

There is deliberately **no list of known models** to validate against. A closed set would refuse a model that shipped after the set was written — a certainty, not a risk.

## Two things the shape depends on, neither obvious

**The SELECT list is narrower than the INSERT.** `model_store.py` inserts 22 columns and `_TOOL_CALL_COLS` selects 20 — `org_id` and `audit_id` are written and read by nobody. A column added to one and not the other is recorded faithfully and reaches no reader at all, with every DB round-trip test still passing. Both lists change, and a test pins it.

**The bound lives in the writer, never in the schema.** The MCP SDK validates `inputSchema` *before* the handler runs, so a `maxLength` there would refuse the whole query over an optional note rather than trim it. `test_the_schema_constrains_nothing_the_sdk_could_refuse_the_call_over` holds the property list to `{type, description}`.

## Changes

- **`ToolCallRecord.client_model`** — and the class docstring, which enumerates the tier and would otherwise start lying.
- **`CLIENT_MODEL_MAX_CHARS = 200` + `_bounded_client_model`** — with the `isinstance` guard, because JSON hands back whatever the client sent and `{"client_model": 7}` must store NULL rather than a Python `repr` that reads as a model called "7".
- **`_CLIENT_MODEL_PROP` on all four tools**, required by none. Declaring it is what makes it *sendable*: every schema is `additionalProperties: False`, so an undeclared property is refused rather than ignored.
- **The INSERT, `_TOOL_CALL_COLS`, and the call card** — rendered marked `· self-reported`, through `_text` so a non-string column value cannot take the whole page down (`_session_drawer` joins every card into one string).
- **`024_tool_calls_client_model.sql`** — one nullable TEXT column, portable DDL, no index.

## No truncation flag

The cap is many times the longest honest model id. The flag on `query_executions.sql` earns its place because a cut statement reads as the whole one and a reviewer would re-run something that does not reproduce the decision; nobody re-runs a model id, and at 200 characters a cut means a caller already did something pathological. A boolean here would be false on every row ever written — the argument `_bounded_audit_detail` already makes for its own single bounded string.

## Checklist

- [x] Full suite green — **5516 passed, 12 skipped**
- [x] `ruff check plugins packages tests dev.py dev` clean
- [x] Changelog entry under `[Unreleased]`
- [x] Migration `024` verified free across every ref and worktree, re-checked before commit
- [x] 22 new tests, including the source-level no-reader guard, the six-type non-string battery, escaping, and a malformed-value test asserting the rest of the card still renders
- [x] No existing test changed — checked; the neighbouring tests assert named keys, not key sets
- [x] Every example synthetic (`SALES_DATA`, `jordan@example.com`); no customer name, host or credential
- [x] `## Complexity tracking` is empty, and genuinely so — every part joins an existing pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
