### PR TITLE
The eval names its generator once, so the tests cannot be bypassed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ below corresponds to one such version.
   an unstartable client stops a run: a generator that starts and declines the probe is one answer
   short, which the loop already reports per item. `--skip-preflight` refuses the probe.
 
+- **The eval names its generator once, so the test suite cannot be talked out of substituting it.**
+  `run_golden_eval` constructed its generator in two places, and every test replaced the class by
+  the name those places used. Swapping the default meant editing the two construction sites — which
+  left the substitutions pointing at a class the command no longer named. Nothing failed: the suite
+  went on passing while spawning a real client, once per case, against the operator's own account.
+
+  The generator is now chosen at a single module-level name, `GENERATOR`, that both construction
+  sites and every test go through, so a changed default carries the substitutions with it. Two
+  tests hold that shut — one parses the command's own source and fails on any generator built
+  outside that name, the other pins what the name is currently set to, so moving it is a decision
+  someone makes rather than a diff that passes.
+
 ## [0.8.1] — 2026-09-07
 
 Everything below came out of running the golden-dataset feature against a live warehouse for the

--- a/plugins/agami/scripts/run_golden_eval.py
+++ b/plugins/agami/scripts/run_golden_eval.py
@@ -122,6 +122,14 @@ _PREFLIGHT_QUESTION = "How many rows are there in a table called t?"
 # would mean building that schema before knowing the client can run.
 _PREFLIGHT_SCHEMA = "t(id integer)"
 
+# Which generator this command runs, named once. Both construction sites below go through this
+# name, and so does every test that substitutes a scripted one — which is the whole point of it
+# being a name rather than the class itself. An attempt to swap the default edited the construction
+# sites and left the tests patching the class they no longer named: the suite went on passing while
+# spawning a real client per case against the operator's own account. A single name cannot drift
+# that way — change it here and the substitutions follow it, or they fail loudly.
+GENERATOR = ClaudeCliGenerator
+
 
 def _section(outcome: Any) -> str:
     """Which section an item is printed under.
@@ -965,7 +973,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             # uses. The run's schema is a CALLABLE that ranks the example library per question —
             # one `sm` subprocess per subject area — and spending that on a throwaway probe would
             # cost more than the loop it protects on a model with many areas.
-            probe = ClaudeCliGenerator(lambda _question: _PREFLIGHT_SCHEMA, timeout_s=args.timeout_s).generate(
+            probe = GENERATOR(lambda _question: _PREFLIGHT_SCHEMA, timeout_s=args.timeout_s).generate(
                 _PREFLIGHT_QUESTION, tools.resolved_org_id(), args.profile
             )
         except Exception:
@@ -1008,7 +1016,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     result = run_golden_dataset(
         dataset,
         profile=args.profile,
-        generator=ClaudeCliGenerator(
+        generator=GENERATOR(
             lambda question: _model_context(cached, question),
             timeout_s=args.timeout_s,
         ),

--- a/tests/test_ah106_eval_skill.py
+++ b/tests/test_ah106_eval_skill.py
@@ -257,7 +257,7 @@ def scripted(monkeypatch, sm) -> None:
     Takes `sm` too: a run that scripts the generator still builds a context first, and letting that
     reach the real CLI would spend a second per call to receive a fixture back.
     """
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Scripted)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Scripted)
 
 
 class _RecordedSm:
@@ -790,7 +790,7 @@ def test_a_generator_that_raises_stops_the_run_and_the_payload_says_so(
                 raise RuntimeError("the client fell over")
             return gr.GeneratedSql(sql=GENERATED[Q_PASS], error=None)
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _RaisesOnTheSecond)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _RaisesOnTheSecond)
     _write(artifacts, "mixed", MIXED_DATASET)
 
     code, payload, _ = _run(capsys, "--dataset", "mixed")
@@ -813,7 +813,7 @@ def test_a_run_where_every_item_errors_is_not_green(artifacts, monkeypatch, caps
         def generate(self, question, org, datasource):
             return gr.GeneratedSql(sql="", error="no statement was scripted for this question")
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _AnswersNothing)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _AnswersNothing)
     _write(artifacts, "mixed", MIXED_DATASET)
 
     code, payload, _ = _run(capsys, "--dataset", "mixed")
@@ -914,7 +914,7 @@ def test_the_generator_is_handed_every_section_and_the_timeout(artifacts, monkey
             seen["schema"] = schema
             seen["timeout_s"] = timeout_s
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Records)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Records)
     _write(artifacts, "green", PASSING_DATASET)
 
     _run(capsys, "--dataset", "green", "--timeout-s", "7")

--- a/tests/test_ah110_eval_command.py
+++ b/tests/test_ah110_eval_command.py
@@ -897,13 +897,16 @@ def test_no_generator_is_built_except_through_the_one_name():
     behaviour because the behaviour under a correct patch is indistinguishable from the bug.
     """
     tree = ast.parse(Path(run_golden_eval.__file__).read_text(encoding="utf-8"))
+    # Both callee shapes, because they are the same mistake written two ways: the class imported by
+    # name (`ClaudeCliGenerator(...)`) and the class reached through its module
+    # (`golden_run.ClaudeCliGenerator(...)`). A guard that only knew the first would pass the day
+    # somebody dropped the import and qualified the call instead.
     built = {
-        node.func.id
+        node.func.id if isinstance(node.func, ast.Name) else node.func.attr
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id.lower().endswith("generator")
+        if isinstance(node, ast.Call) and isinstance(node.func, (ast.Name, ast.Attribute))
     }
+    built = {name for name in built if name.lower().endswith("generator")}
 
     assert built <= {"GENERATOR"}, (
         f"{sorted(built - {'GENERATOR'})} is constructed directly — route it through GENERATOR, "

--- a/tests/test_ah110_eval_command.py
+++ b/tests/test_ah110_eval_command.py
@@ -15,6 +15,7 @@ statement the model happened to write.
 
 from __future__ import annotations
 
+import ast
 import json
 import shutil
 import sys
@@ -175,7 +176,7 @@ def artifacts(tmp_path, monkeypatch, warehouse) -> Path:
 @pytest.fixture()
 def scripted(monkeypatch) -> None:
     """Answer every question from a table instead of spawning the operator's client."""
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Scripted)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Scripted)
 
 
 def _write(art: Path, name: str, dataset: dict[str, Any]) -> None:
@@ -241,7 +242,7 @@ def test_a_run_that_stopped_partway_cannot_produce_a_verdict(artifacts, monkeypa
                 raise RuntimeError("the client fell over")
             return gr.GeneratedSql(sql=GENERATED[Q_PASS], error=None)
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _RaisesOnTheSecond)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _RaisesOnTheSecond)
     _write(artifacts, "stopped", {"test_cases": [PASSING_ITEM, FAILING_ITEM]})
 
     code, payload, _ = _run(capsys, "--dataset", "stopped")
@@ -265,7 +266,7 @@ def test_a_run_where_every_generation_errored_cannot_produce_a_verdict(
         def generate(self, question, org, datasource):
             return gr.GeneratedSql(sql="", error="no statement was scripted for this question")
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _AnswersNothing)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _AnswersNothing)
     _write(artifacts, "regressed", ONE_FAILURE)
 
     code, payload, _ = _run(capsys, "--dataset", "regressed")
@@ -302,7 +303,7 @@ def test_an_incomplete_run_with_failures_in_it_reports_the_broken_pipeline(
                 raise RuntimeError("the client fell over")
             return gr.GeneratedSql(sql=GENERATED[Q_FAIL], error=None)
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _RaisesAfterTheFirst)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _RaisesAfterTheFirst)
     _write(artifacts, "half", ONE_FAILURE)
 
     code, payload, _ = _run(capsys, "--dataset", "half")
@@ -379,7 +380,7 @@ def test_the_summary_line_says_when_the_run_did_not_complete(artifacts, monkeypa
         def generate(self, question, org, datasource):
             raise RuntimeError("the client fell over")
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _RaisesImmediately)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _RaisesImmediately)
     _write(artifacts, "stopped", ONE_FAILURE)
 
     _, _, err = _run(capsys, "--dataset", "stopped")
@@ -740,10 +741,10 @@ def test_a_run_that_produced_no_verdict_is_not_read_as_a_clean_one(artifacts, ca
         def generate(self, question, org, datasource):
             return gr.GeneratedSql(sql="", error="the generator did not answer")
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Silent)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Silent)
     assert _run(capsys, "--dataset", "mixed")[0] == 2
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Scripted)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Scripted)
     code, payload, err = _run(capsys, "--dataset", "mixed", "--rerun-failures")
 
     # No usable record exists, so it refuses rather than reporting a clean re-run.
@@ -768,10 +769,10 @@ def test_an_incomplete_run_is_not_read_as_a_failure_record(artifacts, capsys, mo
                 raise RuntimeError("the client fell over")
             return super().generate(question, org, datasource)
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Raises)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Raises)
     assert _run(capsys, "--dataset", "mixed")[0] == 2
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Scripted)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Scripted)
     code, _, err = _run(capsys, "--dataset", "mixed", "--rerun-failures")
 
     assert code == 2
@@ -829,7 +830,7 @@ def test_a_client_that_cannot_start_stops_the_run_before_it_costs_anything(
             spawned.append(question)
             return gr.GeneratedSql(sql="", error=gr._GENERATION_UNAVAILABLE)
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _NeverStarts)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _NeverStarts)
     _write(artifacts, "unreachable", ONE_FAILURE)
 
     code, payload, err = _run(capsys, "--dataset", "unreachable")
@@ -856,7 +857,7 @@ def test_a_generator_that_declines_the_probe_does_not_cancel_the_run(artifacts, 
                 return gr.GeneratedSql(sql="", error="no statement for that one")
             return gr.GeneratedSql(sql=GENERATED[Q_FAIL], error=None)
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _DeclinesTheProbe)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _DeclinesTheProbe)
     _write(artifacts, "fussy", ONE_FAILURE)
 
     code, payload, _ = _run(capsys, "--dataset", "fussy")
@@ -878,9 +879,41 @@ def test_the_probe_can_be_skipped(artifacts, monkeypatch, capsys):
             spawned.append(question)
             return gr.GeneratedSql(sql=GENERATED[Q_FAIL], error=None)
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Counts)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Counts)
     _write(artifacts, "trusted", ONE_FAILURE)
 
     _run(capsys, "--dataset", "trusted", "--skip-preflight")
 
     assert len(spawned) == len(ONE_FAILURE["test_cases"]), "one spawn per case, and no probe"
+
+
+def test_no_generator_is_built_except_through_the_one_name():
+    """Every test above substitutes `GENERATOR`, so a construction that bypasses that name is a
+    real client, spawned once per case, against whoever is running the suite.
+
+    That is not hypothetical: swapping the default once meant editing the construction sites and
+    leaving the substitutions pointing at a class nobody named any more. Nothing failed. The suite
+    stayed green for ten minutes of live generation. This reads the source rather than the
+    behaviour because the behaviour under a correct patch is indistinguishable from the bug.
+    """
+    tree = ast.parse(Path(run_golden_eval.__file__).read_text(encoding="utf-8"))
+    built = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id.lower().endswith("generator")
+    }
+
+    assert built <= {"GENERATOR"}, (
+        f"{sorted(built - {'GENERATOR'})} is constructed directly — route it through GENERATOR, "
+        "or every scripted substitution in this file silently becomes a live client"
+    )
+
+
+def test_the_default_generator_is_the_client_one():
+    """The seam's current setting, pinned so that changing it is a decision and not a diff.
+
+    Whoever moves this line is the person who most needs to read the one above it.
+    """
+    assert run_golden_eval.GENERATOR is gr.ClaudeCliGenerator

--- a/tests/test_golden_eval_e2e.py
+++ b/tests/test_golden_eval_e2e.py
@@ -277,7 +277,7 @@ def test_a_real_run_writes_a_report_with_both_statements_and_no_rows(
         def __init__(self, schema: str, *, timeout_s: float) -> None:
             super().__init__()
 
-    monkeypatch.setattr(run_golden_eval, "ClaudeCliGenerator", _Helper)
+    monkeypatch.setattr(run_golden_eval, "GENERATOR", _Helper)
     # The helper resolves the single-operator org, so it reads the org-less form of the DSN.
     monkeypatch.setenv("DATASOURCE_URL__AGAMI_EXAMPLE", f"sqlite:///{warehouse}")
 


### PR DESCRIPTION
`run_golden_eval` built its generator in two places, and every test replaced the class by the name those two places used. Swapping the default meant editing the construction sites — which left the substitutions naming a class the command no longer used. Nothing failed. The suite went on passing while spawning a real client, once per case, against the operator's own account.

The choice now has one name, `GENERATOR`, that both construction sites and all 17 substitutions go through, so a changed default takes the tests with it.

Two tests hold it shut:

- `test_no_generator_is_built_except_through_the_one_name` parses the command's own source and fails on any generator constructed outside that name — a source check rather than a behavioural one, because under a correct patch the bug and the fix are indistinguishable at runtime.
- `test_the_default_generator_is_the_client_one` pins what the name is currently set to, so whoever moves it reads the reason above it first.

No behaviour change: the default is the same class it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)