### PR TITLE
release: 0.8.2 — the eval finds its client, and can't be talked out of the real one

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-09-07
+
+Two reliability fixes to the eval, both found by running it for real: the client couldn't be found
+on a non-interactive shell's `PATH`, and the test suite could be talked out of substituting a
+scripted generator for the real one — silently, the way it already happened once.
+
 ### Fixed
 
 - **The eval finds the client where it installs, and says so early when it cannot.** A run whose

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.8.1"
+version = "0.8.2"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Two reliability fixes, both found by running the eval for real, both already merged and CI-green on `main`:

- **#276** — the client resolution + preflight probe. Fixes "the generator command could not be started" for anyone whose shell doesn't have `claude` on `PATH` (the failure mode that cost a 43-case run in the field).
- **#278** — the generator seam. Closes the gap that let the test suite silently substitute nothing at all, which is how the suite spawned a real `claude` client once per case against the operator's own account for ten minutes.

This PR is purely a version cut: bumps the 4 version fields to 0.8.2 (`marketplace.json` ×2, `plugin.json`, `pyproject.toml`) and finalizes the `Unreleased` changelog section. No new code. Once merged, tagging `v0.8.2` publishes to PyPI and refreshes the plugin marketplace cache.

Spec: none (release housekeeping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)