### PR TITLE
release: 0.8.3 — a statement records what ran it, and what was driving

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+## [0.8.3] — 2026-09-08
+
+Three additive fields on the activity record, each answering a different half of "what produced this
+answer?" — the database identity a statement ran as, the warehouse's own id for it, and the AI model
+a client says it is running. All three are nullable, written by the insert that already writes the
+row, and read by nothing that makes a decision.
+
 ### Added
 
 - **An execution record can name the warehouse's own id for the statement.** Some engines mint a

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.8.2"
+version = "0.8.3"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts `0.8.3`. Version-only — no behaviour changes in this PR; everything it releases is already on `main`.

## What this PR changes

| File | Change |
|---|---|
| `.claude-plugin/marketplace.json` | two `version` strings → `0.8.3` |
| `plugins/agami/.claude-plugin/plugin.json` | `version` → `0.8.3` |
| `packages/agami-core/pyproject.toml` | `version` → `0.8.3` |
| `CHANGELOG.md` | `[Unreleased]` cut to `[0.8.3] — 2026-09-08` |

The plugin `version` is what invalidates a host's plugin cache, which is why both files carry it and why they have to move together.

## What 0.8.3 releases

Three additive fields on the activity record, each answering a different half of *"what produced this answer?"*:

- **`query_executions.executing_identity`** — the database identity a statement actually ran as, taken from what the connection reports rather than from the signed-in principal. Where every statement runs as one shared account this is worth little; where a deployment runs each statement as the person who asked, it is a different identity per row and the record could not previously say so.
- **`query_executions.warehouse_query_id`** — the warehouse's own id for the statement, where the engine mints one. Opaque on this side: nothing joins on it, parses it, or fails without it.
- **`tool_calls.client_model`** — the AI model a client says it is running. Self-reported, stored unvalidated, marked as a claim where it renders, and consulted by nothing.

All three are nullable, written by the insert that already writes the row, and **read by nothing that makes a decision**. Migrations `022`, `023` and `024` are forward-only `ADD COLUMN`, portable across SQLite and Postgres unchanged.

## For consumers

`0.8.2` shipped without any of these, so a consumer that needs one wants a floor of `>=0.8.3`.

## Verification

- `ruff check plugins packages tests dev.py dev` — clean
- changelog gate — clean
- full suite — **5547 passed, 12 skipped, 0 failed**
- no stray `0.8.2` left in any version-carrying file

🤖 Generated with [Claude Code](https://claude.com/claude-code)