### PR TITLE
The eval's generator can start on Windows: SystemRoot reaches the child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ below corresponds to one such version.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The eval's generator can start on Windows.** The client's Windows runtime (Bun) needs
+  `SystemRoot` set to initialize WinSock before its first network call; without it the child exited
+  immediately on a message `stderr=subprocess.DEVNULL` discarded, so every item in a Windows run
+  errored identically with "the generator exited without answering" — indistinguishable from a real
+  client or model problem. `SystemRoot` joins the child's environment allowlist, inert everywhere
+  the key doesn't exist. (#280)
+
 ## [0.8.3] — 2026-09-08
 
 Three additive fields on the activity record, each answering a different half of "what produced this

--- a/packages/agami-core/src/semantic_model/golden_run.py
+++ b/packages/agami-core/src/semantic_model/golden_run.py
@@ -555,7 +555,15 @@ def client_argv() -> tuple[str, ...]:
 # Windows run errors identically with the one sentence that would explain it. It names a directory
 # every Windows process already has on its own environment, not a path the child gains a tool to
 # open, and it is simply absent from `os.environ` on every other platform, so it costs nothing there.
-_CHILD_ENV_KEYS = ("PATH", "HOME", "LANG", "LC_ALL", "USER", "ANTHROPIC_API_KEY", "SystemRoot")
+_CHILD_ENV_KEYS = (
+    "PATH",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "USER",
+    "ANTHROPIC_API_KEY",
+    "SystemRoot",
+)
 
 # Why a generation produced no statement. Fixed sentences, and the fixedness is the point: a client
 # can echo the whole prompt on stderr, and this text is rendered beside the item and persisted with

--- a/packages/agami-core/src/semantic_model/golden_run.py
+++ b/packages/agami-core/src/semantic_model/golden_run.py
@@ -547,7 +547,15 @@ def client_argv() -> tuple[str, ...]:
 # subscription operator's child starts, reports that it is not logged in, and exits — every item in
 # the run erroring with the one sentence that would explain it discarded by design. It names the
 # account rather than a path, so it opens nothing the flags above have not already closed.
-_CHILD_ENV_KEYS = ("PATH", "HOME", "LANG", "LC_ALL", "USER", "ANTHROPIC_API_KEY")
+#
+# `SystemRoot` is here for the same reason and was missed for the same reason: it is invisible on
+# every platform this list was written and tested on. The client's Windows runtime (Bun) needs it
+# set to initialize WinSock before it can make its first network call — without it the child exits
+# immediately on a message this same `stderr=subprocess.DEVNULL` discards, so every item in a
+# Windows run errors identically with the one sentence that would explain it. It names a directory
+# every Windows process already has on its own environment, not a path the child gains a tool to
+# open, and it is simply absent from `os.environ` on every other platform, so it costs nothing there.
+_CHILD_ENV_KEYS = ("PATH", "HOME", "LANG", "LC_ALL", "USER", "ANTHROPIC_API_KEY", "SystemRoot")
 
 # Why a generation produced no statement. Fixed sentences, and the fixedness is the point: a client
 # can echo the whole prompt on stderr, and this text is rendered beside the item and persisted with

--- a/tests/test_golden_run.py
+++ b/tests/test_golden_run.py
@@ -634,6 +634,23 @@ def test_the_child_can_authenticate_as_the_operator_who_started_the_run(spawn, m
     assert kwargs["env"]["USER"] == "operator"
 
 
+def test_the_child_can_make_a_network_request_on_windows(spawn, monkeypatch):
+    """`SystemRoot` reaches the child, because the client's Windows runtime (Bun) needs it set to
+    initialize WinSock before its first network call.
+
+    Without it the child exits immediately on `error: The %SystemRoot% environment variable is not
+    set`, a message `stderr=subprocess.DEVNULL` discards — so every item in a Windows run errors
+    with the one sentence that would explain it, indistinguishable from a real client or model
+    problem. Reported after every case on a Windows machine failed with `_GENERATION_EXITED`.
+    """
+    monkeypatch.setenv("SystemRoot", r"C:\Windows")
+
+    _cli_generator().generate(QUESTION, ORG, DATASOURCE)
+
+    _, kwargs = spawn.invocations[0]
+    assert kwargs["env"]["SystemRoot"] == r"C:\Windows"
+
+
 def test_the_child_environment_stays_an_allowlist(spawn, monkeypatch):
     """Whatever is added for the client's benefit, nothing that names the key or the warehouse may
     ride along. `USER` widened this tuple once; this is the guard that keeps the widening honest.
@@ -643,7 +660,15 @@ def test_the_child_environment_stays_an_allowlist(spawn, monkeypatch):
     widening could ever fail such a check. Naming the members is what makes adding one a deliberate
     edit to a test rather than a line nobody reads.
     """
-    assert gr._CHILD_ENV_KEYS == ("PATH", "HOME", "LANG", "LC_ALL", "USER", "ANTHROPIC_API_KEY")
+    assert gr._CHILD_ENV_KEYS == (
+        "PATH",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "USER",
+        "ANTHROPIC_API_KEY",
+        "SystemRoot",
+    )
     # And the shape of what may ever join them. The module's own docstring claims no datasource
     # credential has a name that could reach this tuple; this is that claim as a test, so a future
     # `PGPASSWORD` or `SNOWFLAKE_PASSWORD` fails here rather than shipping.


### PR DESCRIPTION
Fixes #280.

On Windows, `run_golden_eval.py` errored every single case with "the generator exited without answering" — even when the exact same `claude` invocation worked fine run manually.

**Root cause:** the client's Windows runtime (Bun) needs `SystemRoot` set to initialize WinSock before its first network call. `_child_env()`'s allowlist didn't carry it, so the child exited immediately on `error: The %SystemRoot% environment variable is not set`, a message `stderr=subprocess.DEVNULL` discards — surfacing uniformly as `_GENERATION_EXITED` on every item, indistinguishable from a real client or model problem.

**Fix:** add `SystemRoot` to `_CHILD_ENV_KEYS`, the same allowlist `USER` joined for the same reason (invisible on the platform the list was written and tested on). It's inert everywhere else — the key doesn't exist in `os.environ` off Windows.

Two tests: one pins the child receives it when set, one updates the allowlist-shape pin (`test_the_child_environment_stays_an_allowlist`) to the new literal tuple.

Spec: none (bug fix, reported and root-caused by @sandeep-agami)

🤖 Generated with [Claude Code](https://claude.com/claude-code)