### PR TITLE
The save door stops committing a query's result rows to git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ below corresponds to one such version.
   client or model problem. `SystemRoot` joins the child's environment allowlist, inert everywhere
   the key doesn't exist. (#280)
 
+- **The save door stops committing a query's result rows to git.** Confirming a golden-dataset item
+  wrote the confirmed query's actual result rows into a `recorded` block, into a path with no
+  gitignore exclusion — any real data a golden question's query returned ended up in version
+  control as a side effect of confirming an answer key. Nothing needed those rows: scoring
+  re-executes `expected.sql` live and never reads `recorded`, and the explorer already refused to
+  render row content for the same privacy reason. The save door now stamps only `recorded.at`. (#281)
+
 ## [0.8.3] — 2026-09-08
 
 Three additive fields on the activity record, each answering a different half of "what produced this

--- a/packages/agami-core/src/semantic_model/golden.py
+++ b/packages/agami-core/src/semantic_model/golden.py
@@ -33,10 +33,15 @@ MatchLevel = Literal["exact", "values", "shape", "bounded", "nonempty"]
 
 
 class GoldenRecorded(_Base):
-    """What the author saw when they wrote the case down.
+    """When the case was written down — never the comparison target, a run is judged against
+    `expected` alone.
 
-    This is a receipt, never the comparison target: a run is judged against `expected`, and
-    these numbers exist so a reviewer can see what the answer looked like on the day.
+    `columns`/`rows` stay on this model for one reason only: reading a file that already has them,
+    from before the save door stopped writing them. Nothing constructs a `GoldenRecorded` with
+    either populated any more — the golden-datasets directory has no gitignore exclusion, so a
+    populated `rows` here was a query's actual result rows committed to version control, and
+    nothing downstream needed them: scoring re-executes both statements live, and the explorer
+    already refused to render them for the same reason this stopped writing them.
     """
 
     columns: list[str] = Field(default_factory=list)

--- a/plugins/agami/scripts/golden_author.py
+++ b/plugins/agami/scripts/golden_author.py
@@ -842,7 +842,7 @@ def _save(
     """Write one answer somebody looked at and accepted.
 
     The only door that can produce an item able to gate a run, and everything that makes it one is
-    written here: the statement, `sql_confirmed`, the receipt of what the answer looked like, and
+    written here: the statement, `sql_confirmed`, the receipt of when the answer was accepted, and
     how it was confirmed. AH-111 is a caller of this door, not a second write path.
 
     `confirmed_by.method` is free text by AH-100's deliberate choice — a `Literal` would refuse
@@ -868,11 +868,15 @@ def _save(
         "query": payload["query"],
         "expected": GoldenExpected(sql=payload["sql"], sql_confirmed=True),
         "tags": payload.get("tags") or [],
-        "recorded": GoldenRecorded(
-            columns=recorded.get("columns") or [],
-            rows=recorded.get("rows") or [],
-            at=recorded.get("at") or now,
-        ),
+        # `columns`/`rows` never reach this door's output: the golden-datasets directory has no
+        # gitignore exclusion, scoring never reads them (`golden_run.py` re-executes both
+        # statements live), and the explorer already refuses to render them for the same reason
+        # (`render_golden_datasets.py`'s `_item` — "their own data" — shows only whether a receipt
+        # exists, not what it says). Carrying the caller's rows through here was the one place that
+        # promise was not kept: every confirmed item committed its query's actual result rows to
+        # version control. `at` is kept — a timestamp is not a data-handling problem, and it is
+        # still what "has a receipt" means to the explorer and to `_our_faults` below.
+        "recorded": GoldenRecorded(at=recorded.get("at") or now),
         "confirmed_by": GoldenConfirmedBy(
             method=method, at=(payload.get("confirmed_by") or {}).get("at") or now
         ),

--- a/plugins/agami/shared/golden-dataset-shape.md
+++ b/plugins/agami/shared/golden-dataset-shape.md
@@ -72,10 +72,6 @@ test_cases:
     match: exact
     must_filter: [status]
     recorded:
-      columns: [channel, order_count]
-      rows:
-        - [web, 812]
-        - [mobile, 517]
       at: '2026-01-14T09:00:00Z'
     tags: [orders, smoke]
     confirmed_by:
@@ -135,10 +131,12 @@ Alongside `expected`, an item takes six optional fields:
   (`must_filter: [status]` — not the predicate, just the column). A statement
   that does not filter on every column listed fails. This is how a case gates
   *how* the answer was reached, not just what it came to.
-- `recorded` — `columns` (a list of names), `rows` (a list of rows, each row
-  itself a list of values in `columns` order) and `at`: what the author saw on
-  the day. A receipt for a reviewer, **never the comparison target** — a run is
-  judged against `expected`.
+- `recorded` — `at`: when the answer was accepted. **Never the comparison
+  target** — a run is judged against `expected`, which is re-executed live at
+  score time, not against anything recorded here. It does not carry the
+  query's result rows: the golden-datasets directory has no gitignore
+  exclusion, so a row-carrying receipt would commit a query's actual result to
+  version control on every save.
 - `tags` — free text. `smoke` is a **convention** for the fast subset, not a
   keyword the reader knows or treats specially.
 - `confirmed_by` — `method` (required within the block, free text) and `at`:

--- a/plugins/agami/skills/agami-reconcile/SKILL.md
+++ b/plugins/agami/skills/agami-reconcile/SKILL.md
@@ -269,14 +269,13 @@ Write the item with the **Write tool** — never a heredoc, never `python3 -c`, 
   "sql": "<the row's `sql`, verbatim>",
   "match": "bounded",
   "bounds": {"min_rows": 1, "max_rows": 1, "min_value": 3851100.0, "max_value": 3928900.0},
-  "recorded": {"columns": ["total_revenue"], "rows": [[3890000]]},
   "tags": ["reconciled"],
   "confirmed_by": {"method": "reconciled against the finance dashboard on 2026-08-31; agreed within ±<the run's tolerance>"}
 }
 ```
 
 - **`id` is omitted on purpose.** The save door derives it from the question, exactly as the import door does, so a promotion lands **on** an already-imported question of the same wording rather than beside it as a second copy.
-- `sql` and `recorded` come from the row record (Phase 2d) as they stand. Neither is rebuilt here — the record kept them so that nobody would have to.
+- `sql` comes from the row record (Phase 2d) as it stands, verbatim. `recorded` is omitted — the save door stamps it itself and never takes it from this payload, because the golden-datasets directory has no gitignore exclusion and this row's `recorded` is the finance dashboard's own numbers.
 - `match: "bounded"` because a reconciled number is one that legitimately moves. `bounded` with no band is refused (exit `2`), which is why the band below is not optional.
 - **`bounds` comes from the helper, never from arithmetic written in prose:**
 

--- a/plugins/agami/skills/agami-save-golden/SKILL.md
+++ b/plugins/agami/skills/agami-save-golden/SKILL.md
@@ -142,14 +142,13 @@ Write the item with the **Write tool** as JSON — the same rule as any JSON fil
 {
   "query": "How many paid orders came through each channel in 2024?",
   "sql": "SELECT channel, COUNT(*) AS order_count FROM orders WHERE status = 'paid' AND placed_at >= '2024-01-01' AND placed_at < '2025-01-01' GROUP BY channel",
-  "recorded": { "columns": ["channel", "order_count"], "rows": [["web", 812], ["mobile", 517]] },
   "confirmed_by": { "method": "read on screen and accepted by the analyst who asked" },
   "tags": ["orders"]
 }
 ```
 
 - `id` is optional — derived from the question when absent, the same way the import door derives it, so saving an answer to an imported question lands on that item rather than beside it.
-- `recorded` is the **receipt**: what the answer looked like on the day. It is never the comparison target; a run is judged against `expected`. Take the columns and rows from the result the user just looked at.
+- `recorded` is stamped by the script itself and never taken from this payload — omit it. The golden-datasets directory has no gitignore exclusion, so the door does not write a query's result rows to it; a run is judged against `expected`, re-executed live at score time, never against anything recorded here.
 - `confirmed_by.method` is free text and is **required** — an answer key whose provenance is blank cannot be audited later, and the script refuses without it. Say how it was checked ("read on screen and accepted", "cross-checked against the finance close"), not who in a way that names a person.
 - `match` is optional and **defaults to `exact`, which is almost always the right answer**. Column pairing is by value at every level — neither a column's name nor its position is ever consulted — so "the names or the order might differ" is never a reason to loosen. `values` forgives exactly two things: a floating-point tail, and an extra column the question did not ask for. Reach for it when the answer carries a real float, and **not for a count or a result whose columns the question already names** — over-answering is the most common way a generated statement is wrong, and `values` is the level that forgives it. `bounded` takes a `bounds` block, for an answer that legitimately moves — see [`shared/golden-dataset-shape.md`](../../shared/golden-dataset-shape.md). `bounded` with no band is refused with exit `2`: a level with nothing to consult would keep passing forever.
 - `must_filter` gates *how* the answer was reached. Add it when the question only means what it says with a filter in place (`must_filter: [status]`).

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -499,10 +499,12 @@ def test_a_saved_answer_does_not_carry_its_result_rows_onto_disk(tmp_path, monke
     assert item.recorded.columns == [] and item.recorded.rows == []
     # And not merely absent from the parsed model — the keys themselves never reach the file, so a
     # person reading the YAML by eye sees no row data either (`_drop_empty` strips an empty
-    # `columns`/`rows` from the serialized doc, since `_save` never populates them).
-    raw = _dataset_file(tmp_path).read_text(encoding="utf-8")
-    assert "rows:" not in raw
-    assert "columns:" not in raw
+    # `columns`/`rows` from the serialized doc, since `_save` never populates them). Parsed rather
+    # than string-matched: a `bounds` block's own `min_rows`/`max_rows` keys would make a substring
+    # check on "rows:" fail even when `recorded` truly carries none.
+    raw = yaml.safe_load(_dataset_file(tmp_path).read_text(encoding="utf-8"))
+    (recorded,) = [case["recorded"] for case in raw["test_cases"] if case["id"] == item.id]
+    assert "rows" not in recorded and "columns" not in recorded
 
 
 def test_a_duplicate_save_declined_leaves_the_file_byte_identical(tmp_path, monkeypatch, capsys):

--- a/tests/test_golden_authoring.py
+++ b/tests/test_golden_authoring.py
@@ -464,11 +464,11 @@ def _save_argv(item_path: str, stem: str = "orders", *extra: str) -> list[str]:
 def test_a_saved_answer_carries_its_statement_and_receipt(tmp_path, monkeypatch, capsys):
     """SC-6. The one door that can produce an item able to gate a run.
 
-    All four parts have to survive the round trip together: without the statement there is nothing
-    to compare, without `sql_confirmed` the runner will not let the case gate, and without the
-    receipt a reviewer months later cannot see what the answer looked like on the day somebody
-    accepted it. `confirmed_by.method` is carried verbatim — AH-100 types it as free text on
-    purpose, so nothing here narrows it to a vocabulary.
+    The parts that have to survive the round trip: without the statement there is nothing to
+    compare, without `sql_confirmed` the runner will not let the case gate, and without the receipt
+    stamp a reviewer months later cannot see when somebody accepted this answer.
+    `confirmed_by.method` is carried verbatim — AH-100 types it as free text on purpose, so nothing
+    here narrows it to a vocabulary.
     """
     code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
     assert code == 0
@@ -476,12 +476,33 @@ def test_a_saved_answer_carries_its_statement_and_receipt(tmp_path, monkeypatch,
     assert item.id == "how-many-orders-have-been-placed"
     assert item.expected.sql_confirmed is True
     assert item.expected.sql == SQL
-    assert item.recorded.columns == ["order_count"] and item.recorded.rows == [[42]]
     assert item.confirmed_by.method == METHOD
     # Both stamps are set here rather than left None: a receipt that cannot say when it was taken
     # is not much of a receipt.
     assert item.recorded.at and item.confirmed_by.at
     assert item.match == "exact"
+
+
+def test_a_saved_answer_does_not_carry_its_result_rows_onto_disk(tmp_path, monkeypatch, capsys):
+    """#281. The golden-datasets directory has no gitignore exclusion, so a `recorded` carrying
+    the payload's rows was a query's actual result committed to version control on every save.
+
+    Scoring never reads `recorded` — a run re-executes `expected.sql` live and compares that
+    result, never anything recorded here — and the explorer already refuses to render row content
+    for the same reason (`render_golden_datasets.py`'s `_item`). This is that same refusal, at the
+    one place it actually mattered: the door does not carry the caller's `columns`/`rows` through,
+    regardless of what the payload sends.
+    """
+    code, _, _ = _run(tmp_path, monkeypatch, capsys, _save_argv(_item_file(tmp_path)))
+    assert code == 0
+    item = _items(tmp_path)[0]
+    assert item.recorded.columns == [] and item.recorded.rows == []
+    # And not merely absent from the parsed model — the keys themselves never reach the file, so a
+    # person reading the YAML by eye sees no row data either (`_drop_empty` strips an empty
+    # `columns`/`rows` from the serialized doc, since `_save` never populates them).
+    raw = _dataset_file(tmp_path).read_text(encoding="utf-8")
+    assert "rows:" not in raw
+    assert "columns:" not in raw
 
 
 def test_a_duplicate_save_declined_leaves_the_file_byte_identical(tmp_path, monkeypatch, capsys):

--- a/tests/test_golden_authoring_e2e.py
+++ b/tests/test_golden_authoring_e2e.py
@@ -183,9 +183,9 @@ def test_a_question_bank_imports_unconfirmed_and_one_verified_answer_confirms_it
     assert confirmed.expected.sql == PAID_BY_CHANNEL_SQL
     assert confirmed.match == "values"
     assert confirmed.tags == ["orders"]
-    # The receipt: what the answer looked like on the day, and how it was vouched for.
-    assert confirmed.recorded.columns == ["channel", "order_count"]
-    assert confirmed.recorded.rows == [["web", 812], ["mobile", 517]]
+    # The receipt: when the answer was accepted, and how it was vouched for. Not the payload's
+    # rows — #281, the save door never carries them onto disk.
+    assert confirmed.recorded.columns == [] and confirmed.recorded.rows == []
     assert confirmed.confirmed_by.method == METHOD
     assert confirmed.recorded.at and confirmed.confirmed_by.at
 
@@ -273,17 +273,18 @@ def test_an_agreeing_row_promotes_and_scores_on_its_own_next_run(tmp_path, monke
     # A reconciled number legitimately moves, so it is banded rather than pinned.
     assert promoted.match == "bounded"
     assert promoted.bounds.min_value < Q3_ACTUAL < promoted.bounds.max_value
-    # The receipt is the run's own recorded result, forwarded rather than rebuilt from a number.
-    assert promoted.recorded.columns == ["total_revenue"]
-    assert promoted.recorded.rows == [[Q3_ACTUAL]]
+    # The receipt is a timestamp, not the run's own result — #281, the save door never carries a
+    # payload's rows onto disk.
+    assert promoted.recorded.columns == [] and promoted.recorded.rows == []
     assert promoted.tags == ["reconciled"]
     # Provenance names the source, the day and the tolerance — the whole of what makes the claim
     # auditable later.
     for part in ("the finance dashboard", "2026-08-31", "±1%"):
         assert part in promoted.confirmed_by.method
 
-    # …and it passes its own next run.
-    result = ExecResult(columns=list(promoted.recorded.columns), rows=[(Q3_ACTUAL,)])
+    # …and it passes its own next run. Not against `promoted.recorded` — that never carried the
+    # column — but against the column the promoted statement itself names.
+    result = ExecResult(columns=["total_revenue"], rows=[(Q3_ACTUAL,)])
     score = compare_result_sets(
         result,
         result,
@@ -439,8 +440,9 @@ def test_the_item_the_skill_documents_is_the_item_the_save_door_reads(
     """
     item = _documented_promotion_item()
     assert set(item) <= _KEYS_THE_DOOR_READS, set(item) - _KEYS_THE_DOOR_READS
-    # The band in the block is the helper's own output, not arithmetic somebody wrote in prose.
-    assert item["bounds"] == reconcile.band(item["recorded"]["rows"][0][0], tolerance=TOLERANCE)
+    # The band in the block is the helper's own output, not arithmetic somebody wrote in prose —
+    # for the same worked value (`Q3_ACTUAL`) the block's own `band` command names.
+    assert item["bounds"] == reconcile.band(Q3_ACTUAL, tolerance=TOLERANCE)
 
     code, saved = _run(
         tmp_path,
@@ -471,8 +473,10 @@ def test_the_item_the_skill_documents_is_the_item_the_save_door_reads(
     assert promoted.expected.sql_confirmed is True
     assert promoted.match == item["match"]
     assert promoted.bounds.model_dump(exclude_none=True) == item["bounds"]
-    assert promoted.recorded.columns == item["recorded"]["columns"]
-    assert promoted.recorded.rows == [list(row) for row in item["recorded"]["rows"]]
+    # The block no longer documents a `recorded` key — #281, the save door never carried a
+    # payload's rows onto disk, so there is nothing left for the skill to tell a model to send.
+    assert "recorded" not in item
+    assert promoted.recorded.columns == [] and promoted.recorded.rows == []
     assert promoted.tags == item["tags"]
     assert promoted.confirmed_by.method == item["confirmed_by"]["method"]
 


### PR DESCRIPTION
Fixes #281.

Confirming a golden-dataset item via the save door wrote a `recorded` block — `columns`, `rows`, `at` — containing the actual rows returned by executing the confirmed query, into `<artifacts_dir>/<profile>/golden_datasets/<dataset>.yaml`, a path with no gitignore exclusion. Any real data a golden question's query returned ended up committed to version control as a side effect of confirming an answer key.

**Nothing needed those rows.** Scoring never reads `recorded` — every eval run re-executes `expected.sql` live and compares that result, never anything recorded here. The explorer already refused to render row content for the same reason (`render_golden_datasets.py`'s `_item`: *"their own data — a self-contained file full of rows is the kind of thing that gets pasted into a chat window. Whether a case has a receipt is what the page draws; what the receipt says is not."*). The persistence layer just never caught up to that stance.

**Fix:** the save door (`golden_author.py`'s `_save`) now stamps only `recorded.at`. `columns`/`rows` stay on the `GoldenRecorded` model so a file written before this fix still reads, but nothing constructs one with either populated any more — combined with the writer's existing `_drop_empty`, a new save's `recorded` block serializes as `{at: ...}` alone.

Also updated: the two skill docs (`agami-save-golden`, `agami-reconcile`) that told a model to populate `recorded.columns`/`rows` in the save payload — now a documented no-op, so the instruction is removed — and `golden-dataset-shape.md`'s description of the field.

**Out of scope, flagged rather than silently skipped:** any `recorded.rows` already committed to a real deployment's git history before this fix stays there — this closes the leak going forward, it does not scrub history. That's a per-deployment decision, not a code change.

Spec: none (bug fix, reported and root-caused by @sandeep-agami)

🤖 Generated with [Claude Code](https://claude.com/claude-code)