### PR TITLE
Source the eval's context from the product's own get_datasource_schema tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ below corresponds to one such version.
   re-executes `expected.sql` live and never reads `recorded`, and the explorer already refused to
   render row content for the same privacy reason. The save door now stamps only `recorded.at`. (#281)
 
+- **The eval sources its context from the product's own `get_datasource_schema` tool, not a
+  hand-rendered copy of it.** The script's own rendering of the whole semantic model measured ~60k
+  tokens per question on a live 22-area profile — a 43-case run cost ~2.6M tokens, enough to
+  exhaust a subscription twice. Worse than the cost: it scored a generator against a context no
+  real session ever sees, since the shipped product always narrows through this same tool. Calling
+  it in-process, with no `mode` forced so `auto` picks verbosity the way a real session does, cuts
+  token cost by roughly half and — verified live against a real warehouse, twice — reproduces the
+  correct join every time. Known gap: called this way, with no `dataset_names` narrowing, the tool
+  does not return join cardinality or entity aliases; a session that narrows to specific tables
+  sees more than this single unnarrowed call does. (#277)
+
 ### Changed
 
 - **Importing a question bank confirms the rows that already carry an answer.** A row with no `sql`

--- a/packages/agami-core/src/semantic_model/golden_run.py
+++ b/packages/agami-core/src/semantic_model/golden_run.py
@@ -48,6 +48,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import uuid
 from collections.abc import Sequence
@@ -672,47 +673,58 @@ class ClaudeCliGenerator:
         """One question in, one statement out — or a fixed sentence saying why there is not one."""
         schema = self.schema(question) if callable(self.schema) else self.schema
         prompt = _generation_prompt(question, org, datasource, schema)
-        try:
-            # A directory of its own, empty, thrown away afterwards. The child would otherwise start
-            # in whatever directory the eval was launched from, and a `CLAUDE.md`,
-            # `.claude/settings.json` or `.mcp.json` sitting there is project configuration the
-            # client reads. `--setting-sources ""` already refuses to load those; starting somewhere
-            # that has none of them means the two would have to fail together.
-            with tempfile.TemporaryDirectory(prefix="agami-generation-") as workdir:
-                # The prompt goes on STDIN rather than in the argument list: a schema is long, an
-                # argument list is bounded, and a process list is readable by other users on most
-                # systems.
-                completed = subprocess.run(
-                    list(client_argv()),
-                    input=prompt,
-                    stdout=subprocess.PIPE,
-                    # Discarded by the OS rather than captured and then not read. A client can
-                    # echo the whole prompt on stderr, and the prompt carries the model's
-                    # vocabulary; the fixed sentences this module relays are written here, never
-                    # taken from the child. Holding it in memory to ignore it is a copy of
-                    # something with no reader and one way to leak.
-                    stderr=subprocess.DEVNULL,
-                    text=True,
-                    timeout=self.timeout_s,
-                    env=_child_env(),
-                    cwd=workdir,
-                    check=False,
-                )
-        except subprocess.TimeoutExpired:
-            # `TimeoutExpired` carries the command and whatever output was captured before the kill.
-            # None of it is read.
-            return GeneratedSql(sql="", error=_GENERATION_TIMED_OUT)
-        except OSError:
-            # No client installed, or nothing executable at that name. `OSError.__str__`
-            # interpolates the path it tried, which is why the exception is not relayed.
-            return GeneratedSql(sql="", error=_GENERATION_UNAVAILABLE)
-        if completed.returncode != 0:
-            return GeneratedSql(sql="", error=_GENERATION_EXITED)
-        answer = _first_json_object(completed.stdout)
-        sql = answer.get("sql") if answer else None
-        if not isinstance(sql, str) or not sql.strip():
-            return GeneratedSql(sql="", error=_GENERATION_UNREADABLE)
-        return GeneratedSql(sql=sql.strip(), error=None)
+        return _spawn(prompt, list(client_argv()), self.timeout_s)
+
+
+
+def _spawn(prompt: str, argv: list[str], timeout_s: float) -> GeneratedSql:
+    """Run one client invocation and read one statement out of it.
+
+    Shared by both generators so the decisions below cannot drift apart: the empty working
+    directory, the prompt on stdin, the discarded stderr, and the four fixed sentences that are the
+    only thing a caller ever learns about a failure.
+    """
+    try:
+        # A directory of its own, empty, thrown away afterwards. The child would otherwise start
+        # in whatever directory the eval was launched from, and a `CLAUDE.md`,
+        # `.claude/settings.json` or `.mcp.json` sitting there is project configuration the
+        # client reads. `--setting-sources ""` already refuses to load those; starting somewhere
+        # that has none of them means the two would have to fail together.
+        with tempfile.TemporaryDirectory(prefix="agami-generation-") as workdir:
+            # The prompt goes on STDIN rather than in the argument list: a schema is long, an
+            # argument list is bounded, and a process list is readable by other users on most
+            # systems.
+            completed = subprocess.run(
+                argv,
+                input=prompt,
+                stdout=subprocess.PIPE,
+                # Discarded by the OS rather than captured and then not read. A client can
+                # echo the whole prompt on stderr, and the prompt carries the model's
+                # vocabulary; the fixed sentences this module relays are written here, never
+                # taken from the child. Holding it in memory to ignore it is a copy of
+                # something with no reader and one way to leak.
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=timeout_s,
+                env=_child_env(),
+                cwd=workdir,
+                check=False,
+            )
+    except subprocess.TimeoutExpired:
+        # `TimeoutExpired` carries the command and whatever output was captured before the kill.
+        # None of it is read.
+        return GeneratedSql(sql="", error=_GENERATION_TIMED_OUT)
+    except OSError:
+        # No client installed, or nothing executable at that name. `OSError.__str__`
+        # interpolates the path it tried, which is why the exception is not relayed.
+        return GeneratedSql(sql="", error=_GENERATION_UNAVAILABLE)
+    if completed.returncode != 0:
+        return GeneratedSql(sql="", error=_GENERATION_EXITED)
+    answer = _first_json_object(completed.stdout)
+    sql = answer.get("sql") if answer else None
+    if not isinstance(sql, str) or not sql.strip():
+        return GeneratedSql(sql="", error=_GENERATION_UNREADABLE)
+    return GeneratedSql(sql=sql.strip(), error=None)
 
 
 __all__ = [

--- a/packages/agami-core/src/semantic_model/golden_run.py
+++ b/packages/agami-core/src/semantic_model/golden_run.py
@@ -48,7 +48,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import uuid
 from collections.abc import Sequence

--- a/plugins/agami/scripts/run_golden_eval.py
+++ b/plugins/agami/scripts/run_golden_eval.py
@@ -424,27 +424,26 @@ def _fetch_context(root: Path, top_k: int, profile: str) -> dict:
 # letting the product decide.
 
 
-
 def _schema_from_the_product(profile: str, question: str) -> str:
     """The model as the shipped product describes it, rather than as this script renders it.
 
     Two things fall out of asking `get_datasource_schema` instead of assembling the answer here.
     The obvious one is size: this script's own rendering of a 22-area profile measured ~60k tokens
-    per question, and the tool's `summary` of the same model is ~10k. The one that matters more is
+    per question, and the tool's own `auto` verbosity of the same model measured ~56% smaller,
+    consistent across an aggregate, a join and a multi-table group-by. The one that matters more is
     that a golden run now scores a generator against the SAME description of the model the product
     hands its own generator — so a failure is a failure about SQL rather than about being given a
     context no real session ever sees.
 
-    Called in-process. The tool is a plain function over the model; going through MCP would add a
-    subprocess and a protocol to reach the same bytes.
+    Called in-process, through the tool's own typed entry point rather than the registry it is
+    filed under — a plain function over the model, so nothing here goes through MCP or a subprocess
+    to reach the same bytes.
     """
     # `query` is what makes the metrics come back with their `calculation` and `binding` rather
     # than as bare names — the tool does not narrow on it, it picks which metrics get full detail.
     # Without it a generator cannot reuse a binding verbatim, which is the thing F22 requires and
     # the reason a metric exists at all. It costs a few hundred characters.
-    return tools.TOOLS["get_datasource_schema"]["handler"](
-        {"datasource": profile, "query": question}
-    )
+    return tools.tool_get_datasource_schema({"datasource": profile, "query": question})
 
 
 # The second reason built from an answer-key column name, and the one that carries no structured

--- a/plugins/agami/scripts/run_golden_eval.py
+++ b/plugins/agami/scripts/run_golden_eval.py
@@ -353,15 +353,9 @@ def _model_context(cached: dict, question: str) -> str:
     context, then the examples. Only the last of these depends on the question; everything above it
     was fetched once for the run.
     """
-    sections = [cached["schema"]]
+    sections = [_schema_from_the_product(cached["profile"], question)]
     for heading, body in (
         ("What this datasource means, and what its codes stand for:", cached["org_context"]),
-        (
-            "Approved metrics — reuse a binding verbatim when the question names one:",
-            cached["metrics"],
-        ),
-        ("The words a reader uses for these things:", cached["entities"]),
-        ("How these tables join:", cached["relationships"]),
         (
             "Worked examples this team has confirmed, nearest first — follow their conventions:",
             _examples_text(cached["root"], cached["areas"], question, cached["top_k"]),
@@ -397,8 +391,8 @@ def _schema_text(bundles: list[dict]) -> str:
     return "\n".join(tables.values())
 
 
-def _fetch_context(root: Path, top_k: int) -> dict:
-    """The three `sm` calls that do not depend on the question, run once for the whole run.
+def _fetch_context(root: Path, top_k: int, profile: str) -> dict:
+    """The question-independent half of the generator's context, built once for the whole run.
 
     Cached because each costs about a second of interpreter start-up, and a per-item fetch would
     spend that on every case to receive the same bytes back. `examples` is the only one the question
@@ -407,19 +401,50 @@ def _fetch_context(root: Path, top_k: int) -> dict:
     areas = _sm("areas", str(root))
     if not areas:
         raise SmFailed("this profile declares no subject areas")
-    bundles = [_sm("bundle", str(root), "--area", area["name"]) for area in areas]
     return {
         "root": root,
         # Every area, because the ranker reads one library at a time and the question decides which
         # one matters — not the order `sm areas` happens to return.
         "areas": [area["name"] for area in areas],
         "top_k": top_k,
-        "schema": _schema_text(bundles),
+        "profile": profile,
+        # Kept, though the schema now comes from the tool. F22 records that the first live runs
+        # failed EVERY item because the generator was handed column names alone and guessed
+        # 'Invoice' where the data holds a code the profile's own glossary defines. The tool's
+        # payload does not carry that glossary on every profile, and ~4k tokens is a cheap price
+        # for the failure mode it prevents.
         "org_context": _sm("org-context", str(root), json_out=False).strip(),
-        "metrics": _metrics_text(bundles),
-        "entities": _entities_text(bundles),
-        "relationships": _relationships_text(bundles),
     }
+
+
+# No `mode` is passed, and that is the point rather than an omission. `auto` is what a real session
+# sends — the tool picks verbosity itself, under its own char budget, from how much is in scope.
+# Choosing `summary` here instead saved a further 2.5x and silently dropped join cardinality and
+# entity aliases, which is how a fan-out gets written and passes. Replicating the product means
+# letting the product decide.
+
+
+
+def _schema_from_the_product(profile: str, question: str) -> str:
+    """The model as the shipped product describes it, rather than as this script renders it.
+
+    Two things fall out of asking `get_datasource_schema` instead of assembling the answer here.
+    The obvious one is size: this script's own rendering of a 22-area profile measured ~60k tokens
+    per question, and the tool's `summary` of the same model is ~10k. The one that matters more is
+    that a golden run now scores a generator against the SAME description of the model the product
+    hands its own generator — so a failure is a failure about SQL rather than about being given a
+    context no real session ever sees.
+
+    Called in-process. The tool is a plain function over the model; going through MCP would add a
+    subprocess and a protocol to reach the same bytes.
+    """
+    # `query` is what makes the metrics come back with their `calculation` and `binding` rather
+    # than as bare names — the tool does not narrow on it, it picks which metrics get full detail.
+    # Without it a generator cannot reuse a binding verbatim, which is the thing F22 requires and
+    # the reason a metric exists at all. It costs a few hundred characters.
+    return tools.TOOLS["get_datasource_schema"]["handler"](
+        {"datasource": profile, "query": question}
+    )
 
 
 # The second reason built from an answer-key column name, and the one that carries no structured
@@ -998,7 +1023,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             return _CANNOT_START
 
     try:
-        cached = _fetch_context(agami_paths.profile_dir(args.profile), args.top_k)
+        cached = _fetch_context(agami_paths.profile_dir(args.profile), args.top_k, args.profile)
     except SmFailed as exc:
         # Before the first item rather than during one: a run whose context could not be built has
         # no generator, and reporting that as every item erroring would read as a model regression.
@@ -1013,13 +1038,14 @@ def main(argv: Optional[list[str]] = None) -> int:
     #
     # The cost is one model call on a healthy run, against N model calls and up to 2N warehouse
     # queries on a broken one.
+    generator = GENERATOR(
+        lambda question: _model_context(cached, question), timeout_s=args.timeout_s
+    )
+
     result = run_golden_dataset(
         dataset,
         profile=args.profile,
-        generator=GENERATOR(
-            lambda question: _model_context(cached, question),
-            timeout_s=args.timeout_s,
-        ),
+        generator=generator,
         executor=execute_sql.BUILTIN_EXECUTOR,
         # The deployment's own resolver, so this run scores a tenant's dataset against the warehouse
         # that tenant's credentials resolve to — `local` on the single-operator path.

--- a/tests/test_ah106_eval_skill.py
+++ b/tests/test_ah106_eval_skill.py
@@ -923,26 +923,31 @@ def test_the_generator_is_handed_every_section_and_the_timeout(artifacts, monkey
     context = seen["schema"]("How many orders?")
     # The vocabulary is now the product's own description of the model — `get_datasource_schema`,
     # the tool a real session calls — rather than a rendering assembled here. That is both why a run
-    # costs a third of what it did and why a failure is now a failure about SQL rather than about
+    # costs a fraction of what it did and why a failure is now a failure about SQL rather than about
     # being handed a context no session ever sees.
-    vocabulary = json.loads(context.split("\n\n")[0].split("\n{")[0] if False else
-                            context[: context.index("\n\n")] if "\n\n" in context else context)
+    vocabulary = json.loads(context[: context.index("\n\n")] if "\n\n" in context else context)
     assert vocabulary["datasource"] == PROFILE
-    assert vocabulary["mode"] == "summary", "the verbosity that made the saving"
+    # No `mode` is passed to the tool, on purpose: `auto` is what a real session sends, and it picks
+    # the verbosity itself from how much is in scope — `full` on a model this small, `summary` or
+    # `index` on a larger one. Asserting a specific mode here would be asserting a property of the
+    # sample model's size, not of this call; the call itself never names one.
+    assert vocabulary["mode"] in ("full", "summary", "index")
     assert "CustInvc -- a customer invoice" in context  # org-context, verbatim
-    # The metrics, entities and joins are no longer rendered here — they arrive inside the tool's
-    # own payload, in its shape. What has to survive the move is the SUBSTANCE, so that is what is
-    # asserted: a metric that cannot be reused verbatim is the failure F22 records, and a join
-    # without its cardinality is how a fan-out gets written.
+    # Metrics are no longer rendered here — they arrive inside the tool's own payload, in its shape.
+    # What has to survive the move is the SUBSTANCE, so that is what is asserted: a metric that
+    # cannot be reused verbatim is the failure F22 records.
     assert '"binding"' in context or '"calculation"' in context, "a metric must arrive reusable"
-    assert '"entities"' in context, "the words a reader uses for a thing"
-    # NOT asserted, because `summary` does not carry them: the entity aliases — the words a reader
-    # uses for a thing — are absent at this verbosity. That is a deliberate reduction and it is
-    # recorded in the CHANGELOG rather than discovered later.
+    # NOT asserted, and the absence is the finding: `get_datasource_schema` does not put entity
+    # aliases in its payload at all — only a count, in prose ("8 entities are defined in the
+    # model") — so a real session asking this same question never sees them here either. This
+    # script used to render the alias list from the bundles unconditionally, which meant a golden
+    # run judged a generator that knew more about the model's vocabulary than any real session does.
     # NOT asserted, and the absence is the finding: `get_datasource_schema` does not return join
-    # cardinality, so the product's own agent never sees it either. This script used to render it
-    # from the bundles, which meant a golden run judged a generator that knew more about fan-out
-    # than any real session does. Matching the product is the point; the gap is filed separately.
+    # cardinality when called this way — with no `dataset_names` narrowing — so a run that never
+    # narrows never sees it either, matching an agent that hasn't yet asked about specific tables.
+    # This script used to render cardinality from the bundles unconditionally, which meant a golden
+    # run judged a generator that knew more about fan-out than any real session does at this point
+    # in its own turn. Matching the product is the point; the two-call case is filed separately.
 
 
 def test_the_examples_are_ranked_for_the_question_being_asked(artifacts, scripted, sm, capsys):

--- a/tests/test_ah106_eval_skill.py
+++ b/tests/test_ah106_eval_skill.py
@@ -921,13 +921,28 @@ def test_the_generator_is_handed_every_section_and_the_timeout(artifacts, monkey
 
     assert seen["timeout_s"] == 7.0
     context = seen["schema"]("How many orders?")
-    # The first blank-line-delimited section is the vocabulary; the headings introduce the rest.
-    assert context.split("\n\n")[0] == "main.orders(status string -- paid or not)"
+    # The vocabulary is now the product's own description of the model — `get_datasource_schema`,
+    # the tool a real session calls — rather than a rendering assembled here. That is both why a run
+    # costs a third of what it did and why a failure is now a failure about SQL rather than about
+    # being handed a context no session ever sees.
+    vocabulary = json.loads(context.split("\n\n")[0].split("\n{")[0] if False else
+                            context[: context.index("\n\n")] if "\n\n" in context else context)
+    assert vocabulary["datasource"] == PROFILE
+    assert vocabulary["mode"] == "summary", "the verbosity that made the saving"
     assert "CustInvc -- a customer invoice" in context  # org-context, verbatim
-    assert "revenue -- (also: sales) -- SQL: SUM(total)" in context  # a metric's binding
-    assert "order -- (also: orders) -- maps to orders.id" in context  # an entity
-    assert "orders -> customers -- on orders.customer_id = customers.id" in context  # a join
-    assert "many_to_one" in context  # …with the cardinality that decides fan-out
+    # The metrics, entities and joins are no longer rendered here — they arrive inside the tool's
+    # own payload, in its shape. What has to survive the move is the SUBSTANCE, so that is what is
+    # asserted: a metric that cannot be reused verbatim is the failure F22 records, and a join
+    # without its cardinality is how a fan-out gets written.
+    assert '"binding"' in context or '"calculation"' in context, "a metric must arrive reusable"
+    assert '"entities"' in context, "the words a reader uses for a thing"
+    # NOT asserted, because `summary` does not carry them: the entity aliases — the words a reader
+    # uses for a thing — are absent at this verbosity. That is a deliberate reduction and it is
+    # recorded in the CHANGELOG rather than discovered later.
+    # NOT asserted, and the absence is the finding: `get_datasource_schema` does not return join
+    # cardinality, so the product's own agent never sees it either. This script used to render it
+    # from the bundles, which meant a golden run judged a generator that knew more about fan-out
+    # than any real session does. Matching the product is the point; the gap is filed separately.
 
 
 def test_the_examples_are_ranked_for_the_question_being_asked(artifacts, scripted, sm, capsys):
@@ -967,8 +982,12 @@ def test_the_question_independent_context_is_fetched_once_for_the_whole_run(
 
     subcommands = sm.subcommands()
     assert subcommands.count("areas") == 1
+    # `bundle` and `org-context` are gone: the model is described once, by the product's own tool,
+    # instead of being reassembled here out of one subprocess per subject area.
+    assert subcommands.count("bundle") == 0
+    # `org-context` stays: the tool's payload does not carry the profile's glossary on every
+    # profile, and that glossary is what stopped the first live runs guessing at coded values.
     assert subcommands.count("org-context") == 1
-    assert subcommands.count("bundle") == len(_RecordedSm.AREAS)
     # The ranking is the one call the question changes, and it reads one area's library at a time.
     assert subcommands.count("examples") == len(PASSING_DATASET["test_cases"]) * len(
         _RecordedSm.AREAS

--- a/tests/test_golden_run.py
+++ b/tests/test_golden_run.py
@@ -921,3 +921,4 @@ def test_a_client_that_cannot_be_found_still_fails_as_a_generation(monkeypatch, 
     generated = _cli_generator().generate(QUESTION, ORG, DATASOURCE)
 
     assert generated.sql == "" and generated.error == gr._GENERATION_UNAVAILABLE
+


### PR DESCRIPTION
Fixes #277.

The eval built the generator's context by hand-rendering the whole semantic model — every table, every column, at full detail — into every question's prompt. On a live 22-area profile that measured ~60k tokens per question; a 43-case run cost ~2.6M tokens, enough to exhaust a subscription twice in the field.

Worse than the cost: it meant the eval was scoring a generator against a context no real session ever sees. The shipped product asks `get_datasource_schema` — narrowed by area or by `dataset_names`, capped by a hard character budget — never the whole datasource at full verbosity. A failure here could be a context problem the real product doesn't have; a pass could be luck from an oversized prompt.

**The fix:** call `get_datasource_schema` in-process, the same way the product's own MCP tool does, with no `mode` forced — `auto` picks verbosity itself, same as a real session. `org-context` (glossary, coded-value legends) is still assembled once per run rather than per question — it isn't part of the tool's payload and F22 records that omitting it made every early item fail on a guessed code instead of the profile's own vocabulary.

**Measured savings**, 3 real Stanford ServiceNow questions, zero-token comparison (script rendering vs. the tool, same questions): ~56% fewer tokens per question, consistent across an aggregate, a join, and a multi-table group-by.

**Live-verified twice**, against Stanford's real Redshift warehouse, spawning the real client (no scripted stub):
- 3 questions (2026-09-08): the two-table join (`su-q11`) matched the answer key on every claim — tables, filters, join keys, grouping, ordering.
- 6 questions (2026-09-09), 3 new shapes added (a date-window filter, a list/threshold filter, a top-N ranking): the same join question matched again. The 3 new questions surfaced real gaps (a column not declared on the semantic model, a wrong table choice between two overlapping asset tables, an uninstructed `LIMIT`) — but none of those trace back to the context-sourcing change itself; they're SQL-generation and semantic-model completeness gaps that would show up under the old rendering too, and none of the 6 answer keys here are confirmed (one, `su-q13`, turned out to have the bug itself — see the live run's own report).

**Known, documented gap, not fixed by this PR:** `get_datasource_schema` called this way — with no `dataset_names` narrowing — does not return join cardinality or entity aliases; a real session that narrows to specific tables would see more than this single unnarrowed call does. The two-call case (narrow, then ask again) is a real question worth its own investigation, filed as a follow-up rather than blocking this fix on it.

**What also had to change to make this rebasable:** the WIP had its own test (`test_the_generator_is_handed_every_section_and_the_timeout`) that hard-coded `mode == "summary"`, contradicting the design decision right beside it (`auto` picks verbosity itself — on the small sample model that resolves to `full`). Also asserted `"entities"` arrives in the tool's payload, which it does not — only a count, in prose. Both fixed to assert what the tool actually returns rather than what an earlier draft assumed it would.

Verified against the full suite (`dev.py check`): the known 39 pre-existing failures (filed as #285, a local-environment test-isolation issue, unrelated to this change), zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)