### PR TITLE
release: 0.8.4 — the model knows who is asking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "The trust layer between AI and your data. A governed semantic model for AI-to-database access — every join approved, every metric signed off, every answer with a receipt. Local-first: no infra, no servers, no data leaves your machine.",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "pluginRoot": "./plugins",
     "tags": ["data", "sql", "governance", "trust-layer", "semantic-model", "local-first", "fair-code"],
     "repository": "https://github.com/AgamiAI/agami-core",
@@ -18,7 +18,7 @@
       "name": "agami-core",
       "source": "./plugins/agami",
       "description": "A governed trust layer between AI and your database: every join FK-derived or human-approved, every metric signed off, every answer with a receipt (the SQL, the model version, who vouched for each definition). Runs entirely on your machine via Claude's Bash / Read / Write tools — no MCP server or Python required if you have psql/mysql or DuckDB (an optional local MCP server is available for use from Claude Desktop).",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "keywords": ["database", "governance", "trust-layer", "semantic-model", "sql", "postgres", "snowflake"],
       "category": "data"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ is the source of truth a host installs against — bumping it is what invalidate
 user's plugin cache (see [CONTRIBUTING.md](CONTRIBUTING.md)). Each released section
 below corresponds to one such version.
 
-## [Unreleased]
+## [0.8.4] — 2026-09-12
 
 ### Fixed
 

--- a/packages/agami-core/pyproject.toml
+++ b/packages/agami-core/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agami-core"
-version = "0.8.3"
+version = "0.8.4"
 description = "agami-core — governed semantic model, the shared MCP TOOLS harness, and the unified local query executor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/plugins/agami/.claude-plugin/plugin.json
+++ b/plugins/agami/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agami-core",
   "description": "The trust layer between AI and your database, so an agent's answers are defensible. Every join, metric, and named filter is confidence-scored and either FK-derived or human-approved via a review dashboard. Every answer ships a SQL receipt showing what ran and which model version it used. Works across Postgres / MySQL / Snowflake / BigQuery / Redshift / SQL Server / Oracle / Databricks / Trino / DuckDB / SQLite. Local-first: credentials, schema, results never leave your machine.",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "author": {
     "name": "Agami AI",
     "email": "skills@agami.ai",


### PR DESCRIPTION
Cuts `0.8.4`. Version-only, no behaviour changes in this PR: everything it releases is already on `main`.

## What this PR changes

| File | Change |
|---|---|
| `.claude-plugin/marketplace.json` | two `version` strings → `0.8.4` |
| `plugins/agami/.claude-plugin/plugin.json` | `version` → `0.8.4` |
| `packages/agami-core/pyproject.toml` | `version` → `0.8.4` |
| `CHANGELOG.md` | `[Unreleased]` cut to `[0.8.4] — 2026-09-12` |

## What 0.8.4 releases

- **Tool results carry the verified caller's identity** (#292): the hosted HTTP transport adds `caller_identity` to every tool result that is a JSON object, and the server instructions tell the model to resolve "my / me / I / mine" against it.
- **The eval sources its context from the product's own `get_datasource_schema` tool** (#287).
- **Importing a question bank confirms the rows that already carry an answer** (#286).
- **The save door stops committing a query's result rows to git** (#284).
- **The eval's generator can start on Windows** (#283).

Publishing is a separate step: merging this ships nothing until a `v0.8.4` GitHub release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)